### PR TITLE
fix: lower integer scalar intrinsics (refs #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ is not part of the default fpm build.
   functions and subroutines with integer parameters and integer call
   expressions/statements. Integer procedure arguments use pointer parameters
   with copy-back for variable actual arguments.
+- The direct LIRIC session lowerer can compile integer scalar `abs`, `min`,
+  and `max` intrinsics inline through LIRIC integer operations, blocks, and
+  PHI values.
 - The direct LIRIC session path emits native executables and object files.
 - `ffc empty.f90 -o empty` emits a native executable; `ffc empty.f90 -c -o
   empty.o` emits an object file.
@@ -92,6 +95,7 @@ The current MVP support claim is:
 - real variables/arithmetic
 - block `if`
 - simple contained integer functions and subroutines with integer parameters
+- integer scalar `abs`, `min`, and `max` intrinsics
 - object/executable emission through LIRIC
 
 Arrays, allocatables, modules, derived types, full I/O, generics,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,6 +80,7 @@ Current supported language subset:
 - `if`
 - counted `do`
 - simple function/subroutine calls
+- integer scalar `abs`, `min`, and `max` intrinsics
 - minimal `print` runtime call
 
 Verification:
@@ -124,6 +125,8 @@ Tasks:
   statements
 - Done: lower integer procedure arguments through pointer parameters with
   copy-back for variable actual arguments
+- Done: lower integer scalar `abs`, `min`, and `max` intrinsics inline through
+  direct-session comparisons, branches, and PHI values
 - Tracked by #56: generalize non-terminating blocks/control flow with merge
   values.
 - Tracked by #50: lower richer non-integer function/subroutine signatures.
@@ -152,7 +155,7 @@ Decisions to document and test:
 - #50: non-integer pass-by-reference semantics and return values.
 - #51: character representation.
 - #52 and #53: array descriptors, allocatables, and pointers.
-- #61: intrinsic/runtime call surface.
+- Done for current subset: integer scalar `abs`, `min`, and `max` intrinsics.
 - #55: I/O runtime surface.
 
 Verification:

--- a/docs/SUPPORT_CONTRACT.md
+++ b/docs/SUPPORT_CONTRACT.md
@@ -32,6 +32,7 @@ The current implementation is a single-file, direct-session scalar subset.
 | `if` | Integer comparison `if` blocks with terminating branches or branches that assign mergeable integer values; scalar logical `if (flag)` conditions. |
 | `do` | Counted `do` loops with integer bounds and literal integer step. |
 | Procedures | Contained integer functions and subroutines with integer parameters only. Integer procedure actual arguments use pointer parameters with copy-back for variable actuals. |
+| Intrinsics | Integer scalar `abs`, `min`, and `max`, lowered inline with LIRIC integer comparison, branch, and PHI operations. |
 | `print` | Minimal scalar `print *, expr` through the current `printf` shim for integer expressions, real values, character literals, logical literals, real variables, and logical variables. |
 
 ## Unsupported Work
@@ -49,7 +50,6 @@ The current implementation is a single-file, direct-session scalar subset.
 | #58 | FortFront compiler query boundary | `ffc` no longer depends on FortFront arena internals for lowering decisions. |
 | #59 | Standard and Infer-mode conformance tests | Supported constructs have reference behavior tests against the intended standard and Infer-mode semantics. |
 | #60 | Derived types and component access | Simple derived type declarations, scalar components, assignment, and access are lowered and tested. |
-| #61 | Scalar intrinsic functions | The first supported scalar intrinsics are lowered with documented runtime or backend behavior. |
 
 Unsupported features must fail during parsing, semantic analysis, or lowering
 with a diagnostic. Silent partial lowering is a bug.

--- a/fpm.toml
+++ b/fpm.toml
@@ -103,6 +103,11 @@ source-dir = "test_mvp"
 main = "test_session_integer_subroutine_compiler.f90"
 
 [[test]]
+name = "test_session_integer_intrinsic_compiler"
+source-dir = "test_mvp"
+main = "test_session_integer_intrinsic_compiler.f90"
+
+[[test]]
 name = "test_counted_do_compiler"
 source-dir = "test_mvp"
 main = "test_counted_do_compiler.f90"

--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -9,7 +9,7 @@ module session_program_lowering
                          subroutine_def_node, get_subroutine_call_arg_indices, &
                          get_subroutine_call_name, is_subroutine_call_statement
     use liric_session_bindings, only: liric_session_t, liric_session_create, &
-                                      lr_operand_desc_t, LR_OP_ADD
+                                      lr_operand_desc_t, LR_OP_ADD, LR_OP_SUB
     use liric_session_control_bindings, only: create_liric_block, &
                                               emit_liric_br, &
                                               emit_liric_condbr, &
@@ -34,9 +34,18 @@ module session_program_lowering
     public :: lower_program_to_liric_object
 
     integer, parameter :: MAX_SYMBOLS = 64
+    integer, parameter :: MAX_PROCEDURES = 32
     integer, parameter :: VALUE_I32 = 1
     integer, parameter :: VALUE_F64 = 2
     integer, parameter :: VALUE_LOGICAL = 3
+    integer, parameter :: I32_INTRINSIC_NONE = 0
+    integer, parameter :: I32_INTRINSIC_ABS = 1
+    integer, parameter :: I32_INTRINSIC_MIN = 2
+    integer, parameter :: I32_INTRINSIC_MAX = 3
+    character(len=8), parameter :: I32_INTRINSIC_NAMES(3) = &
+        [character(len=8) :: 'abs', 'min', 'max']
+    integer, parameter :: I32_INTRINSIC_IDS(3) = &
+        [I32_INTRINSIC_ABS, I32_INTRINSIC_MIN, I32_INTRINSIC_MAX]
 
     type :: symbol_t
         character(len=64) :: name = ''
@@ -57,6 +66,8 @@ module session_program_lowering
         integer(c_int32_t) :: f64_print_format_id = -1_c_int32_t
         integer(c_int32_t) :: str_print_format_id = -1_c_int32_t
         integer :: string_literal_count = 0
+        character(len=64) :: integer_function_names(MAX_PROCEDURES)
+        integer :: integer_function_count = 0
         logical :: in_internal_function = .false.
         logical :: current_block_terminated = .false.
     end type lowering_context_t
@@ -113,6 +124,13 @@ contains
                                               context%f64_print_format_id, &
                                               context%str_print_format_id, &
                                               error_msg)) then
+            call context%session%destroy()
+            return
+        end if
+
+        call collect_internal_function_names(arena, root_index, context, &
+                                             error_msg)
+        if (len_trim(error_msg) > 0) then
             call context%session%destroy()
             return
         end if
@@ -180,7 +198,8 @@ contains
         type is (program_node)
             continue
         class default
-            error_msg = 'direct LIRIC session MVP only supports a top-level program unit'
+            error_msg = 'direct LIRIC session MVP only supports a top-level '// &
+                        'program unit'
             return
         end select
 
@@ -365,7 +384,8 @@ contains
         case ('logical')
             value_kind = VALUE_LOGICAL
         case default
-            error_msg = 'direct LIRIC session MVP only supports integer, real, and logical declarations'
+            error_msg = 'direct LIRIC session MVP only supports integer, real, '// &
+                        'and logical declarations'
         end select
     end subroutine declaration_value_kind
 
@@ -503,7 +523,8 @@ contains
         if (context%symbols(symbol_index)%has_address .and. &
             context%symbols(symbol_index)%is_reference) then
             if (context%symbols(symbol_index)%value_kind /= VALUE_I32) then
-                error_msg = 'direct LIRIC session only stores integer reference arguments'
+                error_msg = 'direct LIRIC session only stores integer '// &
+                            'reference arguments'
                 return
             end if
             if (.not. context%session%emit_i32_store( &
@@ -594,6 +615,7 @@ contains
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t), allocatable :: args(:)
         integer, allocatable :: copyback_indices(:)
+        integer :: intrinsic_id
 
         if (node%is_array_access) then
             error_msg = 'direct LIRIC session MVP does not support array access'
@@ -602,6 +624,19 @@ contains
         if (.not. allocated(node%name)) then
             error_msg = 'direct LIRIC session function call requires a name'
             return
+        end if
+
+        intrinsic_id = i32_intrinsic_id(node%name)
+        if (.not. is_contained_i32_function(context, node%name)) then
+            if (intrinsic_id /= I32_INTRINSIC_NONE) then
+                call lower_i32_intrinsic_call(arena, node, intrinsic_id, &
+                                              context, value, error_msg)
+                return
+            end if
+            if (node%is_intrinsic) then
+                call unsupported_intrinsic_error(node, error_msg)
+                return
+            end if
         end if
 
         if (allocated(node%arg_indices)) then
@@ -617,6 +652,8 @@ contains
                                                 error_msg)) return
         call copy_back_reference_args(context, args, copyback_indices, error_msg)
     end subroutine lower_i32_call
+
+    include 'session_program_lowering_intrinsics.inc'
 
     subroutine lower_subroutine_call(arena, node_index, context, error_msg)
         type(ast_arena_t), intent(in) :: arena
@@ -705,7 +742,8 @@ contains
 
         if (symbol_index > 0) then
             if (context%symbols(symbol_index)%value_kind /= VALUE_I32) then
-                error_msg = 'direct LIRIC session only passes integer arguments by reference'
+                error_msg = 'direct LIRIC session only passes integer '// &
+                            'arguments by reference'
                 return
             end if
         end if
@@ -784,7 +822,8 @@ contains
             if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, lhs, &
                                           rhs, value, error_msg)) return
         class default
-            error_msg = 'direct LIRIC session IF requires an integer comparison or logical expression'
+            error_msg = 'direct LIRIC session IF requires an integer '// &
+                        'comparison or logical expression'
         end select
     end subroutine lower_i1_condition
 
@@ -831,6 +870,29 @@ contains
             end if
         end do
     end function find_symbol
+
+    logical function same_name(lhs, rhs)
+        character(len=*), intent(in) :: lhs
+        character(len=*), intent(in) :: rhs
+
+        same_name = lowercase_text(lhs) == lowercase_text(rhs)
+    end function same_name
+
+    function lowercase_text(text) result(lowered)
+        character(len=*), intent(in) :: text
+        character(len=len_trim(text)) :: lowered
+        integer :: code
+        integer :: i
+
+        do i = 1, len(lowered)
+            code = iachar(text(i:i))
+            if (code >= iachar('A') .and. code <= iachar('Z')) then
+                lowered(i:i) = achar(code + 32)
+            else
+                lowered(i:i) = text(i:i)
+            end if
+        end do
+    end function lowercase_text
 
     subroutine set_empty(value)
         character(len=:), allocatable, intent(out) :: value

--- a/src_mvp/session_program_lowering_functions.inc
+++ b/src_mvp/session_program_lowering_functions.inc
@@ -1,3 +1,76 @@
+    subroutine collect_internal_function_names(arena, root_index, context, &
+                                               error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: root_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        context%integer_function_count = 0
+        context%integer_function_names = ''
+        call set_empty(error_msg)
+
+        select type (program => arena%entries(root_index)%node)
+        type is (program_node)
+            if (.not. allocated(program%body_indices)) return
+            do i = 1, size(program%body_indices)
+                select type (node => arena%entries(program%body_indices(i))%node)
+                type is (function_def_node)
+                    call register_internal_function_name(node, context, &
+                                                         error_msg)
+                    if (len_trim(error_msg) > 0) return
+                end select
+            end do
+        end select
+    end subroutine collect_internal_function_names
+
+    subroutine register_internal_function_name(node, context, error_msg)
+        type(function_def_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: next_index
+
+        if (.not. allocated(node%name)) then
+            error_msg = 'direct LIRIC session function requires a name'
+            return
+        end if
+        if (context%integer_function_count >= MAX_PROCEDURES) then
+            error_msg = 'too many contained functions for direct LIRIC session MVP'
+            return
+        end if
+        if (is_contained_i32_function(context, node%name)) then
+            error_msg = 'duplicate contained function: '//trim(node%name)
+            return
+        end if
+
+        next_index = context%integer_function_count + 1
+        context%integer_function_names(next_index) = trim(node%name)
+        context%integer_function_count = next_index
+        call set_empty(error_msg)
+    end subroutine register_internal_function_name
+
+    subroutine copy_internal_function_names(source, destination)
+        type(lowering_context_t), intent(in) :: source
+        type(lowering_context_t), intent(inout) :: destination
+
+        destination%integer_function_names = source%integer_function_names
+        destination%integer_function_count = source%integer_function_count
+    end subroutine copy_internal_function_names
+
+    logical function is_contained_i32_function(context, name)
+        type(lowering_context_t), intent(in) :: context
+        character(len=*), intent(in) :: name
+        integer :: i
+
+        is_contained_i32_function = .false.
+        do i = 1, context%integer_function_count
+            if (same_name(context%integer_function_names(i), name)) then
+                is_contained_i32_function = .true.
+                return
+            end if
+        end do
+    end function is_contained_i32_function
+
     subroutine lower_internal_functions(arena, root_index, context, error_msg)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: root_index
@@ -68,6 +141,7 @@
         context%f64_print_format_id = parent_context%f64_print_format_id
         context%str_print_format_id = parent_context%str_print_format_id
         context%string_literal_count = parent_context%string_literal_count
+        call copy_internal_function_names(parent_context, context)
         context%in_internal_function = .true.
 
         param_count = 0
@@ -117,6 +191,7 @@
         context%f64_print_format_id = parent_context%f64_print_format_id
         context%str_print_format_id = parent_context%str_print_format_id
         context%string_literal_count = parent_context%string_literal_count
+        call copy_internal_function_names(parent_context, context)
         context%in_internal_function = .true.
 
         param_count = 0

--- a/src_mvp/session_program_lowering_intrinsics.inc
+++ b/src_mvp/session_program_lowering_intrinsics.inc
@@ -1,0 +1,159 @@
+    subroutine lower_i32_intrinsic_call(arena, node, intrinsic_id, context, &
+                                        value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        integer, intent(in) :: intrinsic_id
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        select case (intrinsic_id)
+        case (I32_INTRINSIC_ABS)
+            call lower_i32_abs_intrinsic(arena, node, context, value, error_msg)
+        case (I32_INTRINSIC_MIN)
+            call lower_i32_minmax_intrinsic(arena, node, LR_CMP_SLE, context, &
+                                            value, error_msg)
+        case (I32_INTRINSIC_MAX)
+            call lower_i32_minmax_intrinsic(arena, node, LR_CMP_SGE, context, &
+                                            value, error_msg)
+        case default
+            call unsupported_intrinsic_error(node, error_msg)
+        end select
+    end subroutine lower_i32_intrinsic_call
+
+    subroutine lower_i32_abs_intrinsic(arena, node, context, value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: arg
+        type(lr_operand_desc_t) :: condition
+        type(lr_operand_desc_t) :: negative
+        type(lr_operand_desc_t) :: zero
+
+        if (.not. require_intrinsic_arg_count(node, 1, 1, error_msg)) return
+
+        call lower_i32_expression(arena, node%arg_indices(1), context, arg, &
+                                  error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        zero = context%session%i32_immediate(0_c_int64_t)
+        if (.not. emit_liric_i32_icmp(context%session, LR_CMP_SGE, arg, zero, &
+                                      condition, error_msg)) return
+        if (.not. context%session%emit_i32_binary(LR_OP_SUB, zero, arg, &
+                                                  negative, error_msg)) return
+        call select_i32_value(context, condition, arg, negative, value, &
+                              error_msg)
+    end subroutine lower_i32_abs_intrinsic
+
+    subroutine lower_i32_minmax_intrinsic(arena, node, predicate, context, &
+                                          value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        integer(c_int), intent(in) :: predicate
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: candidate
+        type(lr_operand_desc_t) :: condition
+        type(lr_operand_desc_t) :: selected
+        integer :: i
+
+        if (.not. require_intrinsic_arg_count(node, 2, MAX_SYMBOLS, &
+                                              error_msg)) return
+
+        call lower_i32_expression(arena, node%arg_indices(1), context, value, &
+                                  error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        do i = 2, size(node%arg_indices)
+            call lower_i32_expression(arena, node%arg_indices(i), context, &
+                                      candidate, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (.not. emit_liric_i32_icmp(context%session, predicate, value, &
+                                          candidate, condition, error_msg)) return
+            call select_i32_value(context, condition, value, candidate, &
+                                  selected, error_msg)
+            if (len_trim(error_msg) > 0) return
+            value = selected
+        end do
+    end subroutine lower_i32_minmax_intrinsic
+
+    subroutine select_i32_value(context, condition, true_value, false_value, &
+                                value, error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: condition
+        type(lr_operand_desc_t), intent(in) :: true_value
+        type(lr_operand_desc_t), intent(in) :: false_value
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer(c_int32_t) :: true_block
+        integer(c_int32_t) :: false_block
+        integer(c_int32_t) :: merge_block
+
+        true_block = create_liric_block(context%session)
+        false_block = create_liric_block(context%session)
+        merge_block = create_liric_block(context%session)
+
+        if (.not. emit_liric_condbr(context%session, condition, true_block, &
+                                    false_block, error_msg)) return
+
+        if (.not. set_liric_block(context%session, true_block, error_msg)) return
+        if (.not. emit_liric_br(context%session, merge_block, error_msg)) return
+
+        if (.not. set_liric_block(context%session, false_block, error_msg)) return
+        if (.not. emit_liric_br(context%session, merge_block, error_msg)) return
+
+        if (.not. set_liric_block(context%session, merge_block, error_msg)) return
+        context%current_block_id = merge_block
+        context%current_block_terminated = .false.
+        if (.not. emit_liric_i32_phi(context%session, true_value, true_block, &
+                                     false_value, false_block, value, &
+                                     error_msg)) return
+    end subroutine select_i32_value
+
+    logical function require_intrinsic_arg_count(node, min_count, max_count, &
+                                                 error_msg)
+        type(call_or_subscript_node), intent(in) :: node
+        integer, intent(in) :: min_count
+        integer, intent(in) :: max_count
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: arg_count
+
+        require_intrinsic_arg_count = .false.
+        arg_count = 0
+        if (allocated(node%arg_indices)) arg_count = size(node%arg_indices)
+        if (arg_count < min_count .or. arg_count > max_count) then
+            error_msg = 'invalid argument count for scalar intrinsic: '// &
+                        trim(node%name)
+            return
+        end if
+
+        call set_empty(error_msg)
+        require_intrinsic_arg_count = .true.
+    end function require_intrinsic_arg_count
+
+    integer function i32_intrinsic_id(name) result(intrinsic_id)
+        character(len=*), intent(in) :: name
+        integer :: i
+
+        intrinsic_id = I32_INTRINSIC_NONE
+        do i = 1, size(I32_INTRINSIC_NAMES)
+            if (same_name(name, I32_INTRINSIC_NAMES(i))) then
+                intrinsic_id = I32_INTRINSIC_IDS(i)
+                return
+            end if
+        end do
+    end function i32_intrinsic_id
+
+    subroutine unsupported_intrinsic_error(node, error_msg)
+        type(call_or_subscript_node), intent(in) :: node
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (allocated(node%name)) then
+            error_msg = 'unsupported scalar intrinsic: '//trim(node%name)
+        else
+            error_msg = 'unsupported scalar intrinsic'
+        end if
+    end subroutine unsupported_intrinsic_error

--- a/src_mvp/session_program_lowering_values.inc
+++ b/src_mvp/session_program_lowering_values.inc
@@ -143,7 +143,8 @@
             value = context%symbols(symbol_index)%value
             call set_empty(error_msg)
         class default
-            error_msg = 'direct LIRIC session MVP only supports logical literals and identifiers'
+            error_msg = 'direct LIRIC session MVP only supports logical '// &
+                        'literals and identifiers'
         end select
     end subroutine lower_logical_expression
 
@@ -194,6 +195,13 @@
             if (len_trim(error_msg) > 0) return
             if (.not. emit_liric_f64_binary(context%session, opcode, lhs, rhs, &
                                             value, error_msg)) return
+        type is (call_or_subscript_node)
+            if (node%is_intrinsic) then
+                call unsupported_intrinsic_error(node, error_msg)
+            else
+                error_msg = 'direct LIRIC session MVP does not support real '// &
+                            'function calls'
+            end if
         class default
             error_msg = 'direct LIRIC session MVP only supports real expressions'
         end select

--- a/test_mvp/test_session_integer_intrinsic_compiler.f90
+++ b/test_mvp/test_session_integer_intrinsic_compiler.f90
@@ -1,0 +1,128 @@
+program test_session_integer_intrinsic_compiler
+    use fortfront, only: compiler_frontend_options_t, &
+                         compiler_frontend_result_t, &
+                         compile_frontend_from_string, INPUT_MODE_STANDARD
+    use session_program_lowering, only: lower_program_to_liric_exe
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session integer intrinsic compiler test ==='
+
+    all_passed = .true.
+    if (.not. test_integer_intrinsic_values()) all_passed = .false.
+    if (.not. test_unsupported_intrinsic_diagnostic()) all_passed = .false.
+    if (.not. test_user_function_shadowing()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: integer intrinsics lower through direct LIRIC session'
+
+contains
+
+    logical function test_integer_intrinsic_values()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: x'//new_line('a')// &
+                                       '  integer :: y'//new_line('a')// &
+                                       '  x = abs(0 - 7)'//new_line('a')// &
+                                  '  y = min(x, 9, 4) + max(1, 2, 3)'//new_line('a')// &
+                                       '  stop y'//new_line('a')// &
+                                       'end program main'
+
+        test_integer_intrinsic_values = compile_and_expect_exit( &
+                                   source, '/tmp/ffc_session_integer_intrinsic_test', 7)
+    end function test_integer_intrinsic_values
+
+    logical function test_unsupported_intrinsic_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  stop mod(5, 2)'//new_line('a')// &
+                                       'end program main'
+        character(len=:), allocatable :: error_msg
+
+        test_unsupported_intrinsic_diagnostic = .false.
+        call compile_and_lower(source, &
+                               '/tmp/ffc_session_unsupported_intrinsic_test', &
+                               error_msg)
+        call execute_command_line( &
+            'rm -f /tmp/ffc_session_unsupported_intrinsic_test')
+
+        if (index(error_msg, 'unsupported scalar intrinsic: mod') <= 0) then
+            print *, 'FAIL: expected unsupported intrinsic diagnostic, got ', &
+                trim(error_msg)
+            return
+        end if
+
+        test_unsupported_intrinsic_diagnostic = .true.
+    end function test_unsupported_intrinsic_diagnostic
+
+    logical function test_user_function_shadowing()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: x'//new_line('a')// &
+                                       '  x = min(2, 3)'//new_line('a')// &
+                                       '  stop x'//new_line('a')// &
+                                       'contains'//new_line('a')// &
+                                       '  integer function min(a, b)'//new_line('a')// &
+                                       '    min = a + b'//new_line('a')// &
+                                       '  end function min'//new_line('a')// &
+                                       'end program main'
+
+        test_user_function_shadowing = compile_and_expect_exit( &
+                                    source, '/tmp/ffc_session_intrinsic_shadow_test', 5)
+    end function test_user_function_shadowing
+
+    logical function compile_and_expect_exit(source, exe_path, expected_status)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: exe_path
+        integer, intent(in) :: expected_status
+        character(len=:), allocatable :: error_msg
+        integer :: cmd_stat
+        integer :: exit_stat
+
+        compile_and_expect_exit = .false.
+        call execute_command_line('rm -f '//exe_path)
+        call compile_and_lower(source, exe_path, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: direct LIRIC lowering failed: ', trim(error_msg)
+            return
+        end if
+
+        call execute_command_line(exe_path, exitstat=exit_stat, &
+                                  cmdstat=cmd_stat)
+        call execute_command_line('rm -f '//exe_path)
+        if (cmd_stat /= 0) then
+            print *, 'FAIL: emitted executable did not run'
+            return
+        end if
+        if (exit_stat /= expected_status) then
+            print *, 'FAIL: executable exit status ', exit_stat
+            return
+        end if
+
+        compile_and_expect_exit = .true.
+    end function compile_and_expect_exit
+
+    subroutine compile_and_lower(source, exe_path, error_msg)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: exe_path
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: frontend_result
+
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+
+        call compile_frontend_from_string(source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            error_msg = 'FortFront rejected source: '// &
+                        trim(frontend_result%diagnostic_text)
+            return
+        end if
+
+        call lower_program_to_liric_exe(frontend_result%arena, &
+                                        frontend_result%root_index, exe_path, &
+                                        error_msg)
+    end subroutine compile_and_lower
+end program test_session_integer_intrinsic_compiler


### PR DESCRIPTION
## Requirements

REQ-001: Lower an explicit scalar intrinsic subset through direct LIRIC session lowering.
REQ-002: Support integer `abs`, `min`, and `max` with executable behavior.
REQ-003: Route intrinsic handling through a table-style dispatch, not ad hoc call fallback.
REQ-004: Preserve user-defined function call behavior for non-intrinsic calls.
REQ-005: Emit targeted diagnostics for FortFront-marked intrinsics outside the supported subset.
REQ-006: Document the supported intrinsic set and verification.

## Changes

- Adds inline integer `abs`, `min`, and `max` lowering through LIRIC compare, branch, and PHI operations.
- Keeps contained function names ahead of intrinsic dispatch so user functions with intrinsic names still call the contained procedure.
- Adds diagnostics for unsupported scalar intrinsics and documents the supported set (ref #61).

## Verification

Failing before implementation:

```text
LIBRARY_PATH=<liric-build> fpm test test_session_integer_intrinsic_compiler
...
symbol lookup error: undefined symbol: min
FAIL: emitted executable did not run
FAIL: expected unsupported intrinsic diagnostic, got
STOP 1
```

Passing after implementation:

```text
LIBRARY_PATH=<liric-build> fpm test test_session_integer_intrinsic_compiler
...
=== direct session integer intrinsic compiler test ===
PASS: integer intrinsics lower through direct LIRIC session
```

```text
LIBRARY_PATH=<liric-build> fpm test
Project is up to date
=== LIRIC session binding tests ===
PASS: LIRIC session binding tests
...
=== direct session integer intrinsic compiler test ===
PASS: integer intrinsics lower through direct LIRIC session
=== counted do compiler test ===
PASS: runtime counted DO loop lowers through direct LIRIC session
```

<!-- orchestrate: fully-resolved -->