### PR TITLE
fix: target unsupported diagnostics (refs #57)

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -108,6 +108,11 @@ source-dir = "test_mvp"
 main = "test_session_integer_intrinsic_compiler.f90"
 
 [[test]]
+name = "test_session_unsupported_diagnostics"
+source-dir = "test_mvp"
+main = "test_session_unsupported_diagnostics.f90"
+
+[[test]]
 name = "test_counted_do_compiler"
 source-dir = "test_mvp"
 main = "test_counted_do_compiler.f90"

--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -5,7 +5,7 @@ module session_program_lowering
                          call_or_subscript_node, declaration_node, do_loop_node, &
                          function_def_node, identifier_node, if_node, &
                          literal_node, parameter_declaration_node, &
-                         print_statement_node, program_node, stop_node, &
+                         print_statement_node, program_node, module_node, stop_node, &
                          subroutine_def_node, get_subroutine_call_arg_indices, &
                          get_subroutine_call_name, is_subroutine_call_statement
     use liric_session_bindings, only: liric_session_t, liric_session_create, &
@@ -197,9 +197,18 @@ contains
         select type (program => arena%entries(root_index)%node)
         type is (program_node)
             continue
+        type is (module_node)
+            call unsupported_feature_error('module program unit', &
+                                           program%line, program%column, &
+                                           'direct LIRIC session only lowers '// &
+                                           'top-level programs', error_msg)
+            return
         class default
-            error_msg = 'direct LIRIC session MVP only supports a top-level '// &
-                        'program unit'
+            call unsupported_feature_error('program unit', &
+                                           arena%get_node_line(root_index), &
+                                           arena%get_node_column(root_index), &
+                                           'direct LIRIC session only lowers '// &
+                                           'top-level programs', error_msg)
             return
         end select
 
@@ -321,6 +330,14 @@ contains
 
         integer :: value_kind
 
+        if (node%is_array) then
+            call unsupported_feature_error('array declaration', &
+                                           node%line, node%column, &
+                                           'fixed-size arrays are not supported '// &
+                                           'by direct LIRIC session', error_msg)
+            return
+        end if
+
         call declaration_value_kind(node, value_kind, error_msg)
         if (len_trim(error_msg) > 0) return
         if (node%is_multi_declaration .and. allocated(node%var_names)) then
@@ -346,9 +363,25 @@ contains
             error_msg = 'parameter declaration did not expose a name'
             return
         end if
+        if (node%is_array) then
+            call unsupported_feature_error('array parameter declaration', &
+                                           node%line, node%column, &
+                                           'array parameters are not supported '// &
+                                           'by direct LIRIC session', error_msg)
+            return
+        end if
         if (allocated(node%type_name)) then
             if (trim(node%type_name) /= 'integer') then
-                error_msg = 'direct LIRIC session MVP only supports integer parameters'
+                if (is_character_type_name(node%type_name)) then
+                    call unsupported_feature_error( &
+                        'character parameter declaration', &
+                        node%line, node%column, &
+                        'scalar character parameters are not supported '// &
+                        'by direct LIRIC session', error_msg)
+                else
+                    error_msg = 'direct LIRIC session MVP only supports '// &
+                                'integer parameters'
+                end if
                 return
             end if
         end if
@@ -376,6 +409,14 @@ contains
         value_kind = VALUE_I32
         call set_empty(error_msg)
         if (.not. allocated(node%type_name)) return
+        if (is_character_type_name(node%type_name)) then
+            call unsupported_feature_error('character variable declaration', &
+                                           node%line, node%column, &
+                                           'scalar character variables are not '// &
+                                           'supported by direct LIRIC session', &
+                                           error_msg)
+            return
+        end if
         select case (trim(node%type_name))
         case ('integer')
             value_kind = VALUE_I32
@@ -894,10 +935,37 @@ contains
         end do
     end function lowercase_text
 
+    logical function is_character_type_name(name)
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: lowered
+
+        lowered = lowercase_text(name)
+        is_character_type_name = lowered == 'character' .or. &
+                                 index(lowered, 'character(') == 1
+    end function is_character_type_name
+
     subroutine set_empty(value)
         character(len=:), allocatable, intent(out) :: value
 
         allocate (character(len=0) :: value)
     end subroutine set_empty
+
+    subroutine unsupported_feature_error(feature, line, column, limitation, &
+                                         error_msg)
+        character(len=*), intent(in) :: feature
+        integer, intent(in) :: line
+        integer, intent(in) :: column
+        character(len=*), intent(in) :: limitation
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=64) :: location
+
+        if (line > 0 .and. column > 0) then
+            write (location, '(" at line ",I0,", column ",I0)') line, column
+            error_msg = 'unsupported '//trim(feature)//trim(location)//': '// &
+                        trim(limitation)
+        else
+            error_msg = 'unsupported '//trim(feature)//': '//trim(limitation)
+        end if
+    end subroutine unsupported_feature_error
 
 end module session_program_lowering

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -13,6 +13,9 @@ program test_session_unsupported_diagnostics
     if (.not. test_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_character_declaration_diagnostic()) all_passed = .false.
     if (.not. test_module_diagnostic()) all_passed = .false.
+    if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
+    if (.not. test_cli_character_declaration_diagnostic()) all_passed = .false.
+    if (.not. test_cli_module_diagnostic()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: unsupported direct-session features emit diagnostics'
@@ -51,6 +54,38 @@ contains
             '/tmp/ffc_session_module_diagnostic_test')
     end function test_module_diagnostic
 
+    logical function test_cli_array_declaration_diagnostic()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            'end program main'
+
+        test_cli_array_declaration_diagnostic = expect_cli_error_contains( &
+            source, 'unsupported array declaration', &
+            '/tmp/ffc_cli_array_diagnostic_test')
+    end function test_cli_array_declaration_diagnostic
+
+    logical function test_cli_character_declaration_diagnostic()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=5) :: name'//new_line('a')// &
+            'end program main'
+
+        test_cli_character_declaration_diagnostic = expect_cli_error_contains( &
+            source, 'unsupported character variable declaration', &
+            '/tmp/ffc_cli_character_diagnostic_test')
+    end function test_cli_character_declaration_diagnostic
+
+    logical function test_cli_module_diagnostic()
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            'end module m'
+
+        test_cli_module_diagnostic = expect_cli_error_contains( &
+            source, 'unsupported module program unit', &
+            '/tmp/ffc_cli_module_diagnostic_test')
+    end function test_cli_module_diagnostic
+
     logical function expect_error_contains(source, expected, exe_path)
         character(len=*), intent(in) :: source
         character(len=*), intent(in) :: expected
@@ -79,6 +114,101 @@ contains
 
         expect_error_contains = .true.
     end function expect_error_contains
+
+    logical function expect_cli_error_contains(source, expected, stem)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        character(len=*), intent(in) :: stem
+        character(len=:), allocatable :: output
+        character(len=:), allocatable :: command
+        character(len=:), allocatable :: source_path
+        character(len=:), allocatable :: output_path
+        character(len=:), allocatable :: exe_path
+        integer :: exit_stat
+        integer :: cmd_stat
+
+        expect_cli_error_contains = .false.
+        source_path = stem//'.f90'
+        output_path = stem//'.out'
+        exe_path = stem//'.exe'
+        call execute_command_line('rm -f '//source_path//' '//output_path//' '// &
+                                  exe_path)
+        if (.not. write_source_file(source_path, source)) return
+
+        command = "sh -c 'exe=$(ls -t build/*/app/ffc 2>/dev/null | "// &
+                  "head -n 1); "// &
+                  "test -n ""$exe"" && ""$exe"" "// &
+                  source_path//' -o '//exe_path//' > '//output_path//" 2>&1'"
+        call execute_command_line(command, exitstat=exit_stat, cmdstat=cmd_stat)
+        output = read_text_file(output_path)
+        call execute_command_line('rm -f '//source_path//' '//output_path//' '// &
+                                  exe_path)
+
+        if (cmd_stat /= 0) then
+            print *, 'FAIL: ffc CLI command could not be executed'
+            return
+        end if
+        if (exit_stat == 0) then
+            print *, 'FAIL: unsupported source CLI exited successfully'
+            return
+        end if
+        if (index(output, expected) <= 0) then
+            print *, 'FAIL: expected CLI diagnostic substring ', expected
+            print *, '  got ', trim(output)
+            return
+        end if
+        if (index(output, 'line ') <= 0 .or. index(output, 'column ') <= 0) then
+            print *, 'FAIL: expected CLI line/column diagnostic, got ', &
+                trim(output)
+            return
+        end if
+
+        expect_cli_error_contains = .true.
+    end function expect_cli_error_contains
+
+    logical function write_source_file(path, source)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: source
+        integer :: unit
+        integer :: io_stat
+
+        write_source_file = .false.
+        open (newunit=unit, file=path, status='replace', action='write', &
+              iostat=io_stat)
+        if (io_stat /= 0) then
+            print *, 'FAIL: could not create source file ', path
+            return
+        end if
+
+        write (unit, '(A)', iostat=io_stat) source
+        close (unit)
+        if (io_stat /= 0) then
+            print *, 'FAIL: could not write source file ', path
+            return
+        end if
+
+        write_source_file = .true.
+    end function write_source_file
+
+    function read_text_file(path) result(text)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable :: text
+        character(len=512) :: line
+        integer :: unit
+        integer :: io_stat
+
+        text = ''
+        open (newunit=unit, file=path, status='old', action='read', &
+              iostat=io_stat)
+        if (io_stat /= 0) return
+
+        do
+            read (unit, '(A)', iostat=io_stat) line
+            if (io_stat /= 0) exit
+            text = text//trim(line)//new_line('a')
+        end do
+        close (unit)
+    end function read_text_file
 
     subroutine compile_and_lower(source, exe_path, error_msg)
         character(len=*), intent(in) :: source

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -1,0 +1,105 @@
+program test_session_unsupported_diagnostics
+    use fortfront, only: compiler_frontend_options_t, &
+                         compiler_frontend_result_t, &
+                         compile_frontend_from_string, INPUT_MODE_STANDARD
+    use session_program_lowering, only: lower_program_to_liric_exe
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session unsupported diagnostic test ==='
+
+    all_passed = .true.
+    if (.not. test_array_declaration_diagnostic()) all_passed = .false.
+    if (.not. test_character_declaration_diagnostic()) all_passed = .false.
+    if (.not. test_module_diagnostic()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: unsupported direct-session features emit diagnostics'
+
+contains
+
+    logical function test_array_declaration_diagnostic()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            'end program main'
+
+        test_array_declaration_diagnostic = expect_error_contains( &
+            source, 'unsupported array declaration', &
+            '/tmp/ffc_session_array_diagnostic_test')
+    end function test_array_declaration_diagnostic
+
+    logical function test_character_declaration_diagnostic()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=5) :: name'//new_line('a')// &
+            'end program main'
+
+        test_character_declaration_diagnostic = expect_error_contains( &
+            source, 'unsupported character variable declaration', &
+            '/tmp/ffc_session_character_diagnostic_test')
+    end function test_character_declaration_diagnostic
+
+    logical function test_module_diagnostic()
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            'end module m'
+
+        test_module_diagnostic = expect_error_contains( &
+            source, 'unsupported module program unit', &
+            '/tmp/ffc_session_module_diagnostic_test')
+    end function test_module_diagnostic
+
+    logical function expect_error_contains(source, expected, exe_path)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        character(len=*), intent(in) :: exe_path
+        character(len=:), allocatable :: error_msg
+
+        expect_error_contains = .false.
+        call compile_and_lower(source, exe_path, error_msg)
+        call execute_command_line('rm -f '//exe_path)
+
+        if (len_trim(error_msg) == 0) then
+            print *, 'FAIL: unsupported source lowered without error'
+            return
+        end if
+        if (index(error_msg, expected) <= 0) then
+            print *, 'FAIL: expected diagnostic substring ', expected
+            print *, '  got ', trim(error_msg)
+            return
+        end if
+        if (index(error_msg, 'line ') <= 0 .or. &
+            index(error_msg, 'column ') <= 0) then
+            print *, 'FAIL: expected line/column diagnostic, got ', &
+                trim(error_msg)
+            return
+        end if
+
+        expect_error_contains = .true.
+    end function expect_error_contains
+
+    subroutine compile_and_lower(source, exe_path, error_msg)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: exe_path
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: frontend_result
+
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+
+        call compile_frontend_from_string(source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            error_msg = 'FortFront rejected source: '// &
+                        trim(frontend_result%diagnostic_text)
+            return
+        end if
+
+        call lower_program_to_liric_exe(frontend_result%arena, &
+                                        frontend_result%root_index, exe_path, &
+                                        error_msg)
+    end subroutine compile_and_lower
+end program test_session_unsupported_diagnostics


### PR DESCRIPTION
## Requirements

- REQ-001 (ref #57): unsupported arrays, modules, and character variables produce targeted diagnostics instead of generic lowering messages.
- REQ-002 (ref #57): diagnostics include line/column when FortFront node locations are available.
- REQ-003 (ref #57): negative behavior tests assert diagnostic substrings and error behavior.
- REQ-004 (ref #57): unsupported inputs keep failing instead of being partially lowered.

This is targeted progress for the listed unsupported features; broader source-location coverage across every lowering diagnostic remains outside this patch.

## Verification

Failing before:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
FAIL: unsupported source lowered without error
FAIL: expected diagnostic substring unsupported character variable declaration
  got direct LIRIC session MVP only supports integer, real, and logical declarations
FAIL: expected diagnostic substring unsupported module program unit
  got direct LIRIC session MVP only supports a top-level program unit
STOP 1
```

Passing after:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics
```

Full suite:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test
PASS: LIRIC session binding tests
PASS: empty program compiles and runs through direct LIRIC session
PASS: empty program emits object through direct LIRIC session
PASS: integer stop expression lowers through direct LIRIC session
PASS: integer variable lowers through direct LIRIC session
PASS: block IF lowers through direct LIRIC session
PASS: fallthrough IF merges integer values through direct LIRIC
PASS: integer print lowers through direct LIRIC session
PASS: real literal print lowers through direct LIRIC session
PASS: character literal print lowers through direct LIRIC session
PASS: logical literal print lowers through direct LIRIC session
PASS: logical variables lower through direct LIRIC session
PASS: real variables and arithmetic lower through direct LIRIC
PASS: integer function calls lower through direct LIRIC session
PASS: integer subroutine reference args lower through direct LIRIC session
PASS: integer intrinsics lower through direct LIRIC session
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```
