### PR TITLE
fix: lower real scalar intrinsics (refs #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ is not part of the default fpm build.
   functions and subroutines with integer parameters and integer call
   expressions/statements. Integer procedure arguments use pointer parameters
   with copy-back for variable actual arguments.
-- The direct LIRIC session lowerer can compile integer scalar `abs`, `min`,
-  and `max` intrinsics inline through LIRIC integer operations, blocks, and
-  PHI values.
+- The direct LIRIC session lowerer can compile scalar `abs`, `min`, and
+  `max` intrinsics for integer and real values, plus integer-to-real `real()`
+  conversion, inline through LIRIC scalar operations, blocks, and PHI values.
 - The direct LIRIC session path emits native executables and object files.
 - `ffc empty.f90 -o empty` emits a native executable; `ffc empty.f90 -c -o
   empty.o` emits an object file.
@@ -95,7 +95,8 @@ The current MVP support claim is:
 - real variables/arithmetic
 - block `if`
 - simple contained integer functions and subroutines with integer parameters
-- integer scalar `abs`, `min`, and `max` intrinsics
+- integer and real scalar `abs`, `min`, and `max` intrinsics
+- integer-to-real `real()` conversion
 - object/executable emission through LIRIC
 
 Arrays, allocatables, modules, derived types, full I/O, generics,
@@ -130,6 +131,7 @@ LIBRARY_PATH=<liric-build> fpm test test_session_logical_variable_compiler
 LIBRARY_PATH=<liric-build> fpm test test_session_real_variable_compiler
 LIBRARY_PATH=<liric-build> fpm test test_session_integer_function_compiler
 LIBRARY_PATH=<liric-build> fpm test test_session_integer_subroutine_compiler
+LIBRARY_PATH=<liric-build> fpm test test_session_integer_intrinsic_compiler
 ```
 
 Compile the smallest supported program:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,7 +80,8 @@ Current supported language subset:
 - `if`
 - counted `do`
 - simple function/subroutine calls
-- integer scalar `abs`, `min`, and `max` intrinsics
+- scalar `abs`, `min`, and `max` intrinsics for integer and real values, plus
+  integer-to-real `real()` conversion
 - minimal `print` runtime call
 
 Verification:
@@ -95,6 +96,8 @@ Verification:
 - Done: compile and run `print *, .true.`
 - Done: compile and run real variables/arithmetic
 - Done: compile and run block `if`
+- Done: compile and run scalar integer/real `abs`, `min`, and `max`
+  intrinsics and integer-to-real `real()` conversion
 - Tracked by #50 and #55: richer non-integer procedure signatures and a fuller
   print/runtime surface.
 - Tracked by #59: compare output against a reference compiler for the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -125,8 +125,9 @@ Tasks:
   statements
 - Done: lower integer procedure arguments through pointer parameters with
   copy-back for variable actual arguments
-- Done: lower integer scalar `abs`, `min`, and `max` intrinsics inline through
-  direct-session comparisons, branches, and PHI values
+- Done: lower integer and real scalar `abs`, `min`, and `max` intrinsics, plus
+  integer-to-real `real()` conversion, inline through direct-session scalar
+  operations, comparisons, branches, and PHI values
 - Tracked by #56: generalize non-terminating blocks/control flow with merge
   values.
 - Tracked by #50: lower richer non-integer function/subroutine signatures.
@@ -155,7 +156,8 @@ Decisions to document and test:
 - #50: non-integer pass-by-reference semantics and return values.
 - #51: character representation.
 - #52 and #53: array descriptors, allocatables, and pointers.
-- Done for current subset: integer scalar `abs`, `min`, and `max` intrinsics.
+- Done for current subset: integer and real scalar `abs`, `min`, and `max`
+  intrinsics, plus integer-to-real `real()` conversion.
 - #55: I/O runtime surface.
 
 Verification:

--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -31,8 +31,9 @@ issue is closed with ABI documentation and executable tests.
   call boundary.
 - Scalar character variables are unsupported; #51 owns their value-plus-length
   ABI.
-- Scalar intrinsic functions are unsupported; #61 owns the first supported
-  intrinsic set.
+- Scalar `abs`, `min`, and `max` intrinsics are supported for integer and real
+  values. Integer-to-real `real()` conversion is supported. They lower inline
+  through LIRIC scalar operations, comparisons, branches, casts, and PHI values.
 
 ## Procedures
 

--- a/docs/SUPPORT_CONTRACT.md
+++ b/docs/SUPPORT_CONTRACT.md
@@ -32,7 +32,7 @@ The current implementation is a single-file, direct-session scalar subset.
 | `if` | Integer comparison `if` blocks with terminating branches or branches that assign mergeable integer values; scalar logical `if (flag)` conditions. |
 | `do` | Counted `do` loops with integer bounds and literal integer step. |
 | Procedures | Contained integer functions and subroutines with integer parameters only. Integer procedure actual arguments use pointer parameters with copy-back for variable actuals. |
-| Intrinsics | Integer scalar `abs`, `min`, and `max`, lowered inline with LIRIC integer comparison, branch, and PHI operations. |
+| Intrinsics | Scalar `abs`, `min`, and `max` for integer and real values, plus integer-to-real `real()` conversion. These lower inline with LIRIC scalar operations, comparisons, branches, and PHI operations. |
 | `print` | Minimal scalar `print *, expr` through the current `printf` shim for integer expressions, real values, character literals, logical literals, real variables, and logical variables. |
 
 ## Unsupported Work

--- a/src_mvp/liric_session_control_bindings.f90
+++ b/src_mvp/liric_session_control_bindings.f90
@@ -16,18 +16,23 @@ module liric_session_control_bindings
     integer(c_int), parameter, public :: LR_CMP_SGE = 3_c_int
     integer(c_int), parameter, public :: LR_CMP_SLT = 4_c_int
     integer(c_int), parameter, public :: LR_CMP_SLE = 5_c_int
+    integer(c_int), parameter, public :: LR_FCMP_OGE = 3_c_int
+    integer(c_int), parameter, public :: LR_FCMP_OLE = 5_c_int
 
     integer(c_int), parameter :: LR_OP_BR = 2_c_int
     integer(c_int), parameter :: LR_OP_CONDBR = 3_c_int
     integer(c_int), parameter :: LR_OP_ICMP = 24_c_int
+    integer(c_int), parameter :: LR_OP_FCMP = 25_c_int
     integer(c_int), parameter :: LR_OP_PHI = 31_c_int
     logical(c_bool), parameter :: c_false = .false.
 
     public :: create_liric_block
     public :: set_liric_block
     public :: emit_liric_br
+    public :: emit_liric_f64_fcmp
     public :: emit_liric_i32_icmp
     public :: emit_liric_condbr
+    public :: emit_liric_phi
     public :: emit_liric_i32_phi
 
     interface
@@ -128,6 +133,28 @@ contains
         emit_liric_i32_icmp = .true.
     end function emit_liric_i32_icmp
 
+    logical function emit_liric_f64_fcmp(session, pred, lhs, rhs, result, &
+                                         error_msg)
+        type(liric_session_t), intent(inout) :: session
+        integer(c_int), intent(in) :: pred
+        type(lr_operand_desc_t), intent(in) :: lhs
+        type(lr_operand_desc_t), intent(in) :: rhs
+        type(lr_operand_desc_t), intent(out) :: result
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: vreg
+
+        emit_liric_f64_fcmp = .false.
+        if (.not. require_open_session(session, error_msg)) return
+
+        vreg = emit_fcmp(session%handle, pred, lhs, rhs, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        result = i1_vreg(session, vreg)
+        call set_empty(error_msg)
+        emit_liric_f64_fcmp = .true.
+    end function emit_liric_f64_fcmp
+
     logical function emit_liric_condbr(session, condition, true_block, &
                                        false_block, error_msg)
         type(liric_session_t), intent(inout) :: session
@@ -150,8 +177,8 @@ contains
         emit_liric_condbr = .true.
     end function emit_liric_condbr
 
-    logical function emit_liric_i32_phi(session, lhs, lhs_block, rhs, rhs_block, &
-                                        result, error_msg)
+    logical function emit_liric_phi(session, lhs, lhs_block, rhs, rhs_block, &
+                                    result, error_msg)
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: lhs
         integer(c_int32_t), intent(in) :: lhs_block
@@ -162,15 +189,32 @@ contains
         type(lr_error_t) :: error
         integer(c_int32_t) :: vreg
 
-        emit_liric_i32_phi = .false.
+        emit_liric_phi = .false.
         if (.not. require_open_session(session, error_msg)) return
 
         vreg = emit_phi_inst(session%handle, lhs, block_operand(lhs_block), rhs, &
                              block_operand(rhs_block), error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
-        result = session%i32_vreg(vreg)
+        result = vreg_like(vreg, lhs)
         call set_empty(error_msg)
+        emit_liric_phi = .true.
+    end function emit_liric_phi
+
+    logical function emit_liric_i32_phi(session, lhs, lhs_block, rhs, rhs_block, &
+                                        result, error_msg)
+        type(liric_session_t), intent(inout) :: session
+        type(lr_operand_desc_t), intent(in) :: lhs
+        integer(c_int32_t), intent(in) :: lhs_block
+        type(lr_operand_desc_t), intent(in) :: rhs
+        integer(c_int32_t), intent(in) :: rhs_block
+        type(lr_operand_desc_t), intent(out) :: result
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        emit_liric_i32_phi = emit_liric_phi(session, lhs, lhs_block, rhs, &
+                                            rhs_block, result, error_msg)
+        if (.not. emit_liric_i32_phi) return
+        result = session%i32_vreg(int(result%payload, c_int32_t))
         emit_liric_i32_phi = .true.
     end function emit_liric_i32_phi
 
@@ -184,6 +228,17 @@ contains
         operand%typ = lr_type_i1_s(session%handle)
         operand%global_offset = 0_c_int64_t
     end function i1_vreg
+
+    function vreg_like(vreg, source) result(operand)
+        integer(c_int32_t), intent(in) :: vreg
+        type(lr_operand_desc_t), intent(in) :: source
+        type(lr_operand_desc_t) :: operand
+
+        operand%kind = LR_OP_KIND_VREG
+        operand%payload = int(vreg, c_int64_t)
+        operand%typ = source%typ
+        operand%global_offset = 0_c_int64_t
+    end function vreg_like
 
     function block_operand(block_id) result(operand)
         integer(c_int32_t), intent(in) :: block_id
@@ -235,6 +290,28 @@ contains
         call clear_liric_error(error)
         vreg = lr_session_emit(handle, inst, error)
     end function emit_icmp
+
+    function emit_fcmp(handle, pred, lhs, rhs, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        integer(c_int), intent(in) :: pred
+        type(lr_operand_desc_t), intent(in) :: lhs
+        type(lr_operand_desc_t), intent(in) :: rhs
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_operand_desc_t), target :: operands(2)
+        type(lr_inst_desc_t) :: inst
+
+        operands = [lhs, rhs]
+
+        call clear_inst(inst)
+        inst%op = LR_OP_FCMP
+        inst%operands = c_loc(operands)
+        inst%num_operands = 2_c_int32_t
+        inst%fcmp_pred = pred
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_fcmp
 
     function emit_condbr_inst(handle, condition, true_target, false_target, &
                               error) result(vreg)

--- a/src_mvp/liric_session_io_bindings.f90
+++ b/src_mvp/liric_session_io_bindings.f90
@@ -1,7 +1,7 @@
 module liric_session_io_bindings
     use, intrinsic :: iso_c_binding, only: c_associated, c_bool, c_char
     use, intrinsic :: iso_c_binding, only: c_double, c_int, c_int32_t, &
-                                           c_int64_t
+                                                                              c_int64_t
     use, intrinsic :: iso_c_binding, only: c_loc, c_null_char, c_null_ptr
     use, intrinsic :: iso_c_binding, only: c_ptr, c_size_t
     use liric_session_bindings, only: liric_session_error_message, &
@@ -13,8 +13,9 @@ module liric_session_io_bindings
 
     integer(c_int), parameter :: LR_OP_CALL = 30_c_int
     integer(c_int), parameter :: LR_OP_BITCAST = 36_c_int
+    integer(c_int), parameter :: LR_OP_SITOFP = 39_c_int
     integer(c_int), parameter :: LR_OP_FADD = 18_c_int
-    integer(c_int), parameter :: LR_OP_FSUB = 19_c_int
+    integer(c_int), parameter, public :: LR_OP_FSUB = 19_c_int
     integer(c_int), parameter :: LR_OP_FMUL = 20_c_int
     integer(c_int), parameter :: LR_OP_FDIV = 21_c_int
     integer(c_int), parameter :: LR_OP_KIND_IMM_F64 = 2_c_int
@@ -23,6 +24,7 @@ module liric_session_io_bindings
     logical(c_bool), parameter :: c_true = .true.
 
     public :: emit_liric_f64_binary
+    public :: emit_liric_i32_to_f64
     public :: emit_liric_print_f64
     public :: emit_liric_print_i32
     public :: emit_liric_print_string
@@ -572,6 +574,28 @@ contains
         emit_liric_f64_binary = .true.
     end function emit_liric_f64_binary
 
+    logical function emit_liric_i32_to_f64(session, source, result, error_msg)
+        type(liric_session_t), intent(inout) :: session
+        type(lr_operand_desc_t), intent(in) :: source
+        type(lr_operand_desc_t), intent(out) :: result
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: vreg
+
+        emit_liric_i32_to_f64 = .false.
+        if (.not. require_open_session(session, error_msg)) return
+
+        vreg = emit_cast_f64(session%handle, LR_OP_SITOFP, source, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        result%kind = LR_OP_KIND_VREG
+        result%payload = int(vreg, c_int64_t)
+        result%typ = lr_type_f64_s(session%handle)
+        result%global_offset = 0_c_int64_t
+        call set_empty(error_msg)
+        emit_liric_i32_to_f64 = .true.
+    end function emit_liric_i32_to_f64
+
     function emit_binary_f64(handle, opcode, lhs, rhs, error) result(vreg)
         type(c_ptr), intent(in) :: handle
         integer(c_int), intent(in) :: opcode
@@ -601,6 +625,35 @@ contains
         call clear_liric_error(error)
         vreg = lr_session_emit(handle, inst, error)
     end function emit_binary_f64
+
+    function emit_cast_f64(handle, opcode, source, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        integer(c_int), intent(in) :: opcode
+        type(lr_operand_desc_t), intent(in) :: source
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_operand_desc_t), target :: operands(1)
+        type(lr_inst_desc_t) :: inst
+
+        operands(1) = source
+
+        inst%op = opcode
+        inst%typ = lr_type_f64_s(handle)
+        inst%dest = 0_c_int32_t
+        inst%operands = c_loc(operands)
+        inst%num_operands = 1_c_int32_t
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_false
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 0_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_cast_f64
 
     function emit_bitcast_ptr(handle, source, error) result(vreg)
         type(c_ptr), intent(in) :: handle

--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -1,6 +1,6 @@
 module session_program_lowering
     use, intrinsic :: iso_c_binding, only: c_double, c_int, c_int32_t, &
-                                           c_int64_t
+                                                                              c_int64_t
     use fortfront, only: assignment_node, ast_arena_t, binary_op_node, &
                          call_or_subscript_node, declaration_node, do_loop_node, &
                          function_def_node, identifier_node, if_node, &
@@ -13,17 +13,23 @@ module session_program_lowering
     use liric_session_control_bindings, only: create_liric_block, &
                                               emit_liric_br, &
                                               emit_liric_condbr, &
+                                              emit_liric_f64_fcmp, &
                                               emit_liric_i32_icmp, &
                                               emit_liric_i32_phi, &
+                                              emit_liric_phi, &
+                                              LR_FCMP_OGE, &
+                                              LR_FCMP_OLE, &
                                               LR_CMP_SGE, &
                                               LR_CMP_SLE, &
                                               LR_CMP_NE, &
                                               set_liric_block
     use liric_session_io_bindings, only: emit_liric_f64_binary, &
+                                         emit_liric_i32_to_f64, &
                                          emit_liric_print_f64, &
                                          emit_liric_print_i32, &
                                          emit_liric_print_string, &
                                          liric_f64_immediate, &
+                                         LR_OP_FSUB, &
                                          prepare_liric_print_runtime
     use session_lowering_ops, only: integer_compare_predicate, &
                                     integer_opcode, parse_i32_literal
@@ -42,10 +48,20 @@ module session_program_lowering
     integer, parameter :: I32_INTRINSIC_ABS = 1
     integer, parameter :: I32_INTRINSIC_MIN = 2
     integer, parameter :: I32_INTRINSIC_MAX = 3
+    integer, parameter :: F64_INTRINSIC_NONE = 0
+    integer, parameter :: F64_INTRINSIC_ABS = 1
+    integer, parameter :: F64_INTRINSIC_MIN = 2
+    integer, parameter :: F64_INTRINSIC_MAX = 3
+    integer, parameter :: F64_INTRINSIC_REAL = 4
     character(len=8), parameter :: I32_INTRINSIC_NAMES(3) = &
-        [character(len=8) :: 'abs', 'min', 'max']
+                                   [character(len=8) :: 'abs', 'min', 'max']
     integer, parameter :: I32_INTRINSIC_IDS(3) = &
-        [I32_INTRINSIC_ABS, I32_INTRINSIC_MIN, I32_INTRINSIC_MAX]
+                          [I32_INTRINSIC_ABS, I32_INTRINSIC_MIN, I32_INTRINSIC_MAX]
+    character(len=8), parameter :: F64_INTRINSIC_NAMES(4) = &
+                                   [character(len=8) :: 'abs', 'min', 'max', 'real']
+    integer, parameter :: F64_INTRINSIC_IDS(4) = &
+                          [F64_INTRINSIC_ABS, F64_INTRINSIC_MIN, F64_INTRINSIC_MAX, &
+                           F64_INTRINSIC_REAL]
 
     type :: symbol_t
         character(len=64) :: name = ''

--- a/src_mvp/session_program_lowering_intrinsics.inc
+++ b/src_mvp/session_program_lowering_intrinsics.inc
@@ -21,6 +21,32 @@
         end select
     end subroutine lower_i32_intrinsic_call
 
+    subroutine lower_f64_intrinsic_call(arena, node, intrinsic_id, context, &
+                                        value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        integer, intent(in) :: intrinsic_id
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        select case (intrinsic_id)
+        case (F64_INTRINSIC_ABS)
+            call lower_f64_abs_intrinsic(arena, node, context, value, error_msg)
+        case (F64_INTRINSIC_MIN)
+            call lower_f64_minmax_intrinsic(arena, node, LR_FCMP_OLE, &
+                                            context, value, error_msg)
+        case (F64_INTRINSIC_MAX)
+            call lower_f64_minmax_intrinsic(arena, node, LR_FCMP_OGE, &
+                                            context, value, error_msg)
+        case (F64_INTRINSIC_REAL)
+            call lower_f64_real_intrinsic(arena, node, context, value, &
+                                          error_msg)
+        case default
+            call unsupported_intrinsic_error(node, error_msg)
+        end select
+    end subroutine lower_f64_intrinsic_call
+
     subroutine lower_i32_abs_intrinsic(arena, node, context, value, error_msg)
         type(ast_arena_t), intent(in) :: arena
         type(call_or_subscript_node), intent(in) :: node
@@ -43,9 +69,33 @@
                                       condition, error_msg)) return
         if (.not. context%session%emit_i32_binary(LR_OP_SUB, zero, arg, &
                                                   negative, error_msg)) return
-        call select_i32_value(context, condition, arg, negative, value, &
-                              error_msg)
+        call select_value(context, condition, arg, negative, value, error_msg)
     end subroutine lower_i32_abs_intrinsic
+
+    subroutine lower_f64_abs_intrinsic(arena, node, context, value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: arg
+        type(lr_operand_desc_t) :: condition
+        type(lr_operand_desc_t) :: negative
+        type(lr_operand_desc_t) :: zero
+
+        if (.not. require_intrinsic_arg_count(node, 1, 1, error_msg)) return
+
+        call lower_f64_intrinsic_arg(arena, node%arg_indices(1), context, arg, &
+                                     error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        zero = liric_f64_immediate(context%session, 0.0_c_double)
+        if (.not. emit_liric_f64_fcmp(context%session, LR_FCMP_OGE, arg, zero, &
+                                      condition, error_msg)) return
+        if (.not. emit_liric_f64_binary(context%session, LR_OP_FSUB, zero, &
+                                        arg, negative, error_msg)) return
+        call select_value(context, condition, arg, negative, value, error_msg)
+    end subroutine lower_f64_abs_intrinsic
 
     subroutine lower_i32_minmax_intrinsic(arena, node, predicate, context, &
                                           value, error_msg)
@@ -73,15 +123,83 @@
             if (len_trim(error_msg) > 0) return
             if (.not. emit_liric_i32_icmp(context%session, predicate, value, &
                                           candidate, condition, error_msg)) return
-            call select_i32_value(context, condition, value, candidate, &
-                                  selected, error_msg)
+            call select_value(context, condition, value, candidate, selected, &
+                              error_msg)
             if (len_trim(error_msg) > 0) return
             value = selected
         end do
     end subroutine lower_i32_minmax_intrinsic
 
-    subroutine select_i32_value(context, condition, true_value, false_value, &
-                                value, error_msg)
+    subroutine lower_f64_minmax_intrinsic(arena, node, predicate, context, &
+                                          value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        integer(c_int), intent(in) :: predicate
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: candidate
+        type(lr_operand_desc_t) :: condition
+        type(lr_operand_desc_t) :: selected
+        integer :: i
+
+        if (.not. require_intrinsic_arg_count(node, 2, MAX_SYMBOLS, &
+                                              error_msg)) return
+
+        call lower_f64_intrinsic_arg(arena, node%arg_indices(1), context, &
+                                     value, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        do i = 2, size(node%arg_indices)
+            call lower_f64_intrinsic_arg(arena, node%arg_indices(i), context, &
+                                         candidate, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (.not. emit_liric_f64_fcmp(context%session, predicate, value, &
+                                          candidate, condition, error_msg)) return
+            call select_value(context, condition, value, candidate, selected, &
+                              error_msg)
+            if (len_trim(error_msg) > 0) return
+            value = selected
+        end do
+    end subroutine lower_f64_minmax_intrinsic
+
+    subroutine lower_f64_real_intrinsic(arena, node, context, value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (.not. require_intrinsic_arg_count(node, 1, 1, error_msg)) return
+
+        call lower_f64_intrinsic_arg(arena, node%arg_indices(1), context, value, &
+                                     error_msg)
+    end subroutine lower_f64_real_intrinsic
+
+    subroutine lower_f64_intrinsic_arg(arena, node_index, context, value, &
+                                       error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: integer_value
+
+        if (is_f64_expression(arena, node_index, context)) then
+            call lower_f64_expression(arena, node_index, context, value, &
+                                      error_msg)
+            return
+        end if
+
+        call lower_i32_expression(arena, node_index, context, integer_value, &
+                                  error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_liric_i32_to_f64(context%session, integer_value, value, &
+                                        error_msg)) return
+    end subroutine lower_f64_intrinsic_arg
+
+    subroutine select_value(context, condition, true_value, false_value, value, &
+                            error_msg)
         type(lowering_context_t), intent(inout) :: context
         type(lr_operand_desc_t), intent(in) :: condition
         type(lr_operand_desc_t), intent(in) :: true_value
@@ -108,10 +226,10 @@
         if (.not. set_liric_block(context%session, merge_block, error_msg)) return
         context%current_block_id = merge_block
         context%current_block_terminated = .false.
-        if (.not. emit_liric_i32_phi(context%session, true_value, true_block, &
-                                     false_value, false_block, value, &
-                                     error_msg)) return
-    end subroutine select_i32_value
+        if (.not. emit_liric_phi(context%session, true_value, true_block, &
+                                 false_value, false_block, value, &
+                                 error_msg)) return
+    end subroutine select_value
 
     logical function require_intrinsic_arg_count(node, min_count, max_count, &
                                                  error_msg)
@@ -146,6 +264,19 @@
             end if
         end do
     end function i32_intrinsic_id
+
+    integer function f64_intrinsic_id(name) result(intrinsic_id)
+        character(len=*), intent(in) :: name
+        integer :: i
+
+        intrinsic_id = F64_INTRINSIC_NONE
+        do i = 1, size(F64_INTRINSIC_NAMES)
+            if (same_name(name, F64_INTRINSIC_NAMES(i))) then
+                intrinsic_id = F64_INTRINSIC_IDS(i)
+                return
+            end if
+        end do
+    end function f64_intrinsic_id
 
     subroutine unsupported_intrinsic_error(node, error_msg)
         type(call_or_subscript_node), intent(in) :: node

--- a/src_mvp/session_program_lowering_values.inc
+++ b/src_mvp/session_program_lowering_values.inc
@@ -68,6 +68,16 @@
                                                value, error_msg)) return
                 return
             end if
+        type is (call_or_subscript_node)
+            if (is_f64_expression(arena, node_index, context)) then
+                call lower_f64_expression(arena, node_index, context, value, &
+                                          error_msg)
+                if (len_trim(error_msg) > 0) return
+                if (.not. emit_liric_print_f64(context%session, &
+                                               context%f64_print_format_id, &
+                                               value, error_msg)) return
+                return
+            end if
         type is (literal_node)
             if (is_character_literal(node)) then
                 call strip_literal_quotes(node%value, character_value)
@@ -196,16 +206,42 @@
             if (.not. emit_liric_f64_binary(context%session, opcode, lhs, rhs, &
                                             value, error_msg)) return
         type is (call_or_subscript_node)
-            if (node%is_intrinsic) then
-                call unsupported_intrinsic_error(node, error_msg)
-            else
-                error_msg = 'direct LIRIC session MVP does not support real '// &
-                            'function calls'
-            end if
+            call lower_f64_call(arena, node, context, value, error_msg)
         class default
             error_msg = 'direct LIRIC session MVP only supports real expressions'
         end select
     end subroutine lower_f64_expression
+
+    subroutine lower_f64_call(arena, node, context, value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: intrinsic_id
+
+        if (node%is_array_access) then
+            error_msg = 'direct LIRIC session MVP does not support array access'
+            return
+        end if
+        if (.not. allocated(node%name)) then
+            error_msg = 'direct LIRIC session real function call requires a name'
+            return
+        end if
+
+        intrinsic_id = f64_intrinsic_id(node%name)
+        if (intrinsic_id /= F64_INTRINSIC_NONE) then
+            call lower_f64_intrinsic_call(arena, node, intrinsic_id, context, &
+                                          value, error_msg)
+            return
+        end if
+        if (node%is_intrinsic) then
+            call unsupported_intrinsic_error(node, error_msg)
+        else
+            error_msg = 'direct LIRIC session MVP does not support real '// &
+                        'function calls'
+        end if
+    end subroutine lower_f64_call
 
     recursive logical function is_f64_expression(arena, node_index, context) &
         result(is_f64)
@@ -228,8 +264,37 @@
         type is (binary_op_node)
             is_f64 = is_f64_expression(arena, node%left_index, context) .or. &
                      is_f64_expression(arena, node%right_index, context)
+        type is (call_or_subscript_node)
+            is_f64 = is_f64_intrinsic_expression(arena, node, context)
         end select
     end function is_f64_expression
+
+    logical function is_f64_intrinsic_expression(arena, node, context) &
+        result(is_f64)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        type(lowering_context_t), intent(in) :: context
+        integer :: i
+        integer :: intrinsic_id
+
+        is_f64 = .false.
+        if (.not. allocated(node%name)) return
+
+        intrinsic_id = f64_intrinsic_id(node%name)
+        if (intrinsic_id == F64_INTRINSIC_REAL) then
+            is_f64 = .true.
+            return
+        end if
+        if (intrinsic_id == F64_INTRINSIC_NONE) return
+        if (.not. allocated(node%arg_indices)) return
+
+        do i = 1, size(node%arg_indices)
+            if (is_f64_expression(arena, node%arg_indices(i), context)) then
+                is_f64 = .true.
+                return
+            end if
+        end do
+    end function is_f64_intrinsic_expression
 
     subroutine real_opcode(source_op, opcode, error_msg)
         character(len=*), intent(in) :: source_op

--- a/test_mvp/test_session_integer_intrinsic_compiler.f90
+++ b/test_mvp/test_session_integer_intrinsic_compiler.f90
@@ -7,15 +7,18 @@ program test_session_integer_intrinsic_compiler
 
     logical :: all_passed
 
-    print *, '=== direct session integer intrinsic compiler test ==='
+    print *, '=== direct session scalar intrinsic compiler test ==='
 
     all_passed = .true.
     if (.not. test_integer_intrinsic_values()) all_passed = .false.
+    if (.not. test_real_intrinsic_values()) all_passed = .false.
+    if (.not. test_real_conversion_intrinsic()) all_passed = .false.
     if (.not. test_unsupported_intrinsic_diagnostic()) all_passed = .false.
+    if (.not. test_unsupported_real_intrinsic_diagnostic()) all_passed = .false.
     if (.not. test_user_function_shadowing()) all_passed = .false.
 
     if (.not. all_passed) stop 1
-    print *, 'PASS: integer intrinsics lower through direct LIRIC session'
+    print *, 'PASS: scalar intrinsics lower through direct LIRIC session'
 
 contains
 
@@ -32,6 +35,36 @@ contains
         test_integer_intrinsic_values = compile_and_expect_exit( &
                                    source, '/tmp/ffc_session_integer_intrinsic_test', 7)
     end function test_integer_intrinsic_values
+
+    logical function test_real_intrinsic_values()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  real :: x'//new_line('a')// &
+                                       '  x = abs(0.0 - 2.5) '// &
+                                       '+ min(3.5, 1.25, 2.0) '// &
+                                       '+ max(0.5, 4.25)'//new_line('a')// &
+                                       '  print *, x'//new_line('a')// &
+                                       'end program main'
+
+        test_real_intrinsic_values = compile_and_expect_output( &
+                                     source, '/tmp/ffc_session_real_intrinsic_test', &
+                                     '8.000000')
+    end function test_real_intrinsic_values
+
+    logical function test_real_conversion_intrinsic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: i'//new_line('a')// &
+                                       '  real :: x'//new_line('a')// &
+                                       '  i = 4'//new_line('a')// &
+                                       '  x = real(i) + 1.5'//new_line('a')// &
+                                       '  print *, x'//new_line('a')// &
+                                       'end program main'
+
+        test_real_conversion_intrinsic = compile_and_expect_output( &
+                                      source, '/tmp/ffc_session_real_conversion_test', &
+                                         '5.500000')
+    end function test_real_conversion_intrinsic
 
     logical function test_unsupported_intrinsic_diagnostic()
         character(len=*), parameter :: source = &
@@ -55,6 +88,30 @@ contains
 
         test_unsupported_intrinsic_diagnostic = .true.
     end function test_unsupported_intrinsic_diagnostic
+
+    logical function test_unsupported_real_intrinsic_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  real :: x'//new_line('a')// &
+                                       '  x = sqrt(4.0)'//new_line('a')// &
+                                       'end program main'
+        character(len=:), allocatable :: error_msg
+
+        test_unsupported_real_intrinsic_diagnostic = .false.
+        call compile_and_lower(source, &
+                               '/tmp/ffc_session_unsupported_real_intrinsic_test', &
+                               error_msg)
+        call execute_command_line( &
+            'rm -f /tmp/ffc_session_unsupported_real_intrinsic_test')
+
+        if (index(error_msg, 'unsupported scalar intrinsic: sqrt') <= 0) then
+            print *, 'FAIL: expected unsupported real intrinsic diagnostic, got ', &
+                trim(error_msg)
+            return
+        end if
+
+        test_unsupported_real_intrinsic_diagnostic = .true.
+    end function test_unsupported_real_intrinsic_diagnostic
 
     logical function test_user_function_shadowing()
         character(len=*), parameter :: source = &
@@ -102,6 +159,53 @@ contains
 
         compile_and_expect_exit = .true.
     end function compile_and_expect_exit
+
+    logical function compile_and_expect_output(source, exe_path, expected_output)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: exe_path
+        character(len=*), intent(in) :: expected_output
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: out_path
+        character(len=64) :: output_line
+        integer :: cmd_stat
+        integer :: exit_stat
+        integer :: io_stat
+        integer :: unit
+
+        compile_and_expect_output = .false.
+        out_path = exe_path//'.out'
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+        call compile_and_lower(source, exe_path, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: direct LIRIC lowering failed: ', trim(error_msg)
+            return
+        end if
+
+        call execute_command_line(exe_path//' > '//out_path, exitstat=exit_stat, &
+                                  cmdstat=cmd_stat)
+        if (cmd_stat /= 0 .or. exit_stat /= 0) then
+            print *, 'FAIL: emitted executable did not run cleanly'
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+
+        open (newunit=unit, file=out_path, status='old', action='read', &
+              iostat=io_stat)
+        if (io_stat == 0) read (unit, '(A)', iostat=io_stat) output_line
+        if (io_stat == 0) close (unit)
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+        if (io_stat /= 0) then
+            print *, 'FAIL: could not read captured output'
+            return
+        end if
+        if (trim(adjustl(output_line)) /= expected_output) then
+            print *, 'FAIL: expected output ', expected_output, &
+                ', got ', trim(output_line)
+            return
+        end if
+
+        compile_and_expect_output = .true.
+    end function compile_and_expect_output
 
     subroutine compile_and_lower(source, exe_path, error_msg)
         character(len=*), intent(in) :: source


### PR DESCRIPTION
## Requirements

REQ-001: Support an explicit scalar intrinsic set for integer and real values: abs, min, max, and integer-to-real real() conversion.
REQ-002: Lower supported intrinsics inline through LIRIC scalar operations, comparisons, branches, casts, and PHI values.
REQ-003: Keep unsupported intrinsics diagnostic-only instead of treating unknown calls as supported intrinsics.
REQ-004: Preserve user-defined procedure call behavior for existing contained integer procedures.
REQ-005: Document the supported intrinsic set.

## Verification

Before implementation:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_integer_intrinsic_compiler
FAIL: direct LIRIC lowering failed: unsupported scalar intrinsic: abs
FAIL: direct LIRIC lowering failed: unsupported scalar intrinsic: real
STOP 1
```

After implementation:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test
[100%] Project compiled successfully.
PASS: scalar intrinsics lower through direct LIRIC session
PASS: counted DO loop lowers through direct LIRIC session
```

(ref #61)

<!-- orchestrate: fully-resolved -->