### PR TITLE
fix: scalar IF merges (refs #56)

### DIFF
--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -3,8 +3,9 @@ module session_program_lowering
                                                                               c_int64_t
     use fortfront, only: assignment_node, ast_arena_t, binary_op_node, &
                          call_or_subscript_node, declaration_node, do_loop_node, &
-                         function_def_node, identifier_node, if_node, &
-                         literal_node, parameter_declaration_node, &
+                         cycle_node, exit_node, function_def_node, &
+                         identifier_node, if_node, literal_node, &
+                         parameter_declaration_node, &
                          print_statement_node, program_node, module_node, stop_node, &
                          subroutine_def_node, get_subroutine_call_arg_indices, &
                          get_subroutine_call_name, is_subroutine_call_statement
@@ -297,6 +298,17 @@ contains
                                                                error_msg)) return
                 context%current_block_terminated = .true.
             end if
+        type is (exit_node)
+            call unsupported_feature_error('exit statement', node%line, &
+                                           node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support early loop exits', error_msg)
+        type is (cycle_node)
+            call unsupported_feature_error('cycle statement', node%line, &
+                                           node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support early loop backedges', &
+                                           error_msg)
         type is (if_node)
             call lower_if(arena, node, context, value, error_msg)
         type is (do_loop_node)

--- a/src_mvp/session_program_lowering_control.inc
+++ b/src_mvp/session_program_lowering_control.inc
@@ -121,8 +121,7 @@
                 return
             end if
 
-            context%symbols(i)%name = then_result%symbols(i)%name
-            context%symbols(i)%value_kind = then_result%symbols(i)%value_kind
+            context%symbols(i) = then_result%symbols(i)
             if (then_result%symbols(i)%value_kind /= &
                 else_result%symbols(i)%value_kind) then
                 error_msg = 'direct LIRIC session IF branch symbol types diverged'
@@ -131,22 +130,48 @@
             if (same_operand(then_result%symbols(i)%value, &
                              else_result%symbols(i)%value)) then
                 context%symbols(i)%value = then_result%symbols(i)%value
-            else if (then_result%symbols(i)%value_kind /= VALUE_I32) then
-                error_msg = 'direct LIRIC session IF only merges integer symbols'
-                return
-            else if (.not. emit_liric_i32_phi(context%session, &
-                                              then_result%symbols(i)%value, &
-                                              then_result%predecessor_block_id, &
-                                              else_result%symbols(i)%value, &
-                                              else_result%predecessor_block_id, &
-                                              context%symbols(i)%value, &
-                                              error_msg)) then
-                return
+            else
+                call merge_symbol_value(context, then_result, else_result, i, &
+                                        error_msg)
+                if (len_trim(error_msg) > 0) return
             end if
         end do
 
         call set_empty(error_msg)
     end subroutine merge_branch_symbols
+
+    subroutine merge_symbol_value(context, then_result, else_result, index, &
+                                  error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        type(branch_result_t), intent(in) :: then_result
+        type(branch_result_t), intent(in) :: else_result
+        integer, intent(in) :: index
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        select case (then_result%symbols(index)%value_kind)
+        case (VALUE_I32, VALUE_LOGICAL)
+            if (.not. emit_liric_i32_phi(context%session, &
+                                         then_result%symbols(index)%value, &
+                                         then_result%predecessor_block_id, &
+                                         else_result%symbols(index)%value, &
+                                         else_result%predecessor_block_id, &
+                                         context%symbols(index)%value, &
+                                         error_msg)) return
+        case (VALUE_F64)
+            if (.not. emit_liric_phi(context%session, &
+                                     then_result%symbols(index)%value, &
+                                     then_result%predecessor_block_id, &
+                                     else_result%symbols(index)%value, &
+                                     else_result%predecessor_block_id, &
+                                     context%symbols(index)%value, &
+                                     error_msg)) return
+        case default
+            error_msg = 'direct LIRIC session IF cannot merge unknown symbol kind'
+            return
+        end select
+
+        call set_empty(error_msg)
+    end subroutine merge_symbol_value
 
     logical function same_operand(lhs, rhs)
         type(lr_operand_desc_t), intent(in) :: lhs

--- a/src_mvp/session_program_lowering_loops.inc
+++ b/src_mvp/session_program_lowering_loops.inc
@@ -17,6 +17,7 @@
         integer(c_int32_t) :: entry_block
         integer(c_int32_t) :: header_block
         integer(c_int32_t) :: body_block
+        integer(c_int32_t) :: latch_block
         integer(c_int32_t) :: exit_block
         integer(c_int32_t) :: reserved_vreg
         integer :: loop_symbol_index
@@ -54,8 +55,8 @@
         context%symbols(loop_symbol_index)%value = start_value
         entry_block = context%current_block_id
         initial_symbol_count = context%symbol_count
-        call collect_i32_carried_symbols(context, carried_indices, &
-                                         carried_count)
+        call collect_i32_like_carried_symbols(context, carried_indices, &
+                                              carried_count)
         do i = 1, carried_count
             entry_values(carried_indices(i)) = &
                 context%symbols(carried_indices(i))%value
@@ -67,6 +68,7 @@
 
         header_block = create_liric_block(context%session)
         body_block = create_liric_block(context%session)
+        latch_block = create_liric_block(context%session)
         exit_block = create_liric_block(context%session)
         if (.not. emit_liric_br(context%session, header_block, error_msg)) return
 
@@ -78,7 +80,7 @@
                                          entry_values(carried_indices(i)), &
                                          entry_block, &
                                          backedge_values(carried_indices(i)), &
-                                         body_block, &
+                                         latch_block, &
                                          header_values(carried_indices(i)), &
                                          error_msg)) return
             context%symbols(carried_indices(i))%value = &
@@ -104,23 +106,28 @@
             return
         end if
         if (body_terminated) then
-            error_msg = 'direct LIRIC session DO does not support terminating loop bodies'
+            error_msg = 'direct LIRIC session DO does not support '// &
+                        'terminating loop bodies'
             return
         end if
+        if (.not. emit_liric_br(context%session, latch_block, error_msg)) return
+
+        if (.not. set_liric_block(context%session, latch_block, error_msg)) return
+        context%current_block_id = latch_block
+        context%current_block_terminated = .false.
 
         step_operand = context%session%i32_immediate(step_value)
         reserved_vreg = int(backedge_values(loop_symbol_index)%payload, &
                             c_int32_t)
-        if (.not. context%session%emit_i32_binary_into(LR_OP_ADD, &
-                                                       header_values(loop_symbol_index), &
-                                                       step_operand, &
-                                                       reserved_vreg, &
-                                                       next_index, &
-                                                       error_msg)) return
+        if (.not. context%session%emit_i32_binary_into( &
+            LR_OP_ADD, header_values(loop_symbol_index), step_operand, &
+            reserved_vreg, next_index, error_msg)) return
         do i = 1, carried_count
             if (carried_indices(i) == loop_symbol_index) cycle
-            if (context%symbols(carried_indices(i))%value_kind /= VALUE_I32) then
-                error_msg = 'direct LIRIC session DO only carries integer symbols'
+            if (.not. is_i32_like_kind( &
+                context%symbols(carried_indices(i))%value_kind)) then
+                error_msg = 'direct LIRIC session DO only carries integer '// &
+                            'or logical symbols'
                 return
             end if
             if (.not. context%session%emit_i32_copy_to( &
@@ -142,7 +149,7 @@
         call set_empty(error_msg)
     end subroutine lower_do_loop
 
-    subroutine collect_i32_carried_symbols(context, indices, count)
+    subroutine collect_i32_like_carried_symbols(context, indices, count)
         type(lowering_context_t), intent(in) :: context
         integer, intent(out) :: indices(MAX_SYMBOLS)
         integer, intent(out) :: count
@@ -150,12 +157,19 @@
 
         count = 0
         do i = 1, context%symbol_count
-            if (context%symbols(i)%value_kind == VALUE_I32) then
+            if (is_i32_like_kind(context%symbols(i)%value_kind)) then
                 count = count + 1
                 indices(count) = i
             end if
         end do
-    end subroutine collect_i32_carried_symbols
+    end subroutine collect_i32_like_carried_symbols
+
+    logical function is_i32_like_kind(value_kind)
+        integer, intent(in) :: value_kind
+
+        is_i32_like_kind = value_kind == VALUE_I32 .or. &
+                           value_kind == VALUE_LOGICAL
+    end function is_i32_like_kind
 
     subroutine reserve_backedge_value(context, vreg, error_msg)
         type(lowering_context_t), intent(in) :: context

--- a/test_mvp/test_session_if_merge_compiler.f90
+++ b/test_mvp/test_session_if_merge_compiler.f90
@@ -13,6 +13,8 @@ program test_session_if_merge_compiler
     if (.not. test_integer_if_merge()) all_passed = .false.
     if (.not. test_real_if_merge()) all_passed = .false.
     if (.not. test_logical_if_merge()) all_passed = .false.
+    if (.not. test_nested_if_in_do_merge()) all_passed = .false.
+    if (.not. test_do_in_if_merge()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: fallthrough IF merges scalar values through direct LIRIC'
@@ -74,6 +76,63 @@ contains
                                 '/tmp/ffc_session_if_logical_merge_test', 7)
     end function test_logical_if_merge
 
+    logical function test_nested_if_in_do_merge()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       'integer :: i'//new_line('a')// &
+                                       'integer :: total'//new_line('a')// &
+                                       'logical :: found'//new_line('a')// &
+                                       'total = 0'//new_line('a')// &
+                                       'found = .false.'//new_line('a')// &
+                                       'do i = 1, 3'//new_line('a')// &
+                                       '    if (i < 3) then'//new_line('a')// &
+                                       '        total = total + i'//new_line('a')// &
+                                       '        found = .true.'//new_line('a')// &
+                                       '    else'//new_line('a')// &
+                                       '        total = total + 4'//new_line('a')// &
+                                       '        found = found'//new_line('a')// &
+                                       '    end if'//new_line('a')// &
+                                       'end do'//new_line('a')// &
+                                       'if (found) then'//new_line('a')// &
+                                       '    stop total'//new_line('a')// &
+                                       'else'//new_line('a')// &
+                                       '    stop 1'//new_line('a')// &
+                                       'end if'//new_line('a')// &
+                                       'end program main'
+
+        test_nested_if_in_do_merge = compile_and_expect_exit( &
+                                     source, &
+                                     '/tmp/ffc_session_nested_if_do_test', 7)
+    end function test_nested_if_in_do_merge
+
+    logical function test_do_in_if_merge()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       'integer :: i'//new_line('a')// &
+                                       'integer :: total'//new_line('a')// &
+                                       'logical :: flag'//new_line('a')// &
+                                       'total = 0'//new_line('a')// &
+                                       'flag = .false.'//new_line('a')// &
+                                       'if (2 < 3) then'//new_line('a')// &
+                                       '    do i = 1, 2'//new_line('a')// &
+                                       '        total = total + i'//new_line('a')// &
+                                       '        flag = .true.'//new_line('a')// &
+                                       '    end do'//new_line('a')// &
+                                       'else'//new_line('a')// &
+                                       '    total = 9'//new_line('a')// &
+                                       '    flag = .false.'//new_line('a')// &
+                                       'end if'//new_line('a')// &
+                                       'if (flag) then'//new_line('a')// &
+                                       '    stop total'//new_line('a')// &
+                                       'else'//new_line('a')// &
+                                       '    stop 8'//new_line('a')// &
+                                       'end if'//new_line('a')// &
+                                       'end program main'
+
+        test_do_in_if_merge = compile_and_expect_exit( &
+                              source, '/tmp/ffc_session_do_if_test', 3)
+    end function test_do_in_if_merge
+
     logical function compile_and_expect_exit(source, exe_path, expected_status)
         character(len=*), intent(in) :: source
         character(len=*), intent(in) :: exe_path
@@ -126,8 +185,11 @@ contains
         if (io_stat == 0) close (unit)
         call execute_command_line('rm -f '//exe_path//' '//out_path)
 
-        if (io_stat /= 0 .or. &
-            trim(adjustl(output_line)) /= expected_output) then
+        if (io_stat /= 0) then
+            print *, 'FAIL: could not read executable output'
+            return
+        end if
+        if (trim(adjustl(output_line)) /= expected_output) then
             print *, 'FAIL: expected output ', expected_output, ', got ', &
                 trim(output_line)
             return

--- a/test_mvp/test_session_if_merge_compiler.f90
+++ b/test_mvp/test_session_if_merge_compiler.f90
@@ -5,55 +5,165 @@ program test_session_if_merge_compiler
     use session_program_lowering, only: lower_program_to_liric_exe
     implicit none
 
-    type(compiler_frontend_options_t) :: options
-    type(compiler_frontend_result_t) :: frontend_result
-    character(len=:), allocatable :: error_msg
-    character(len=*), parameter :: exe_path = '/tmp/ffc_session_if_merge_test'
-    integer :: exit_stat
-    integer :: cmd_stat
-    character(len=*), parameter :: source = &
-                                   'program main'//new_line('a')// &
-                                   'integer :: x'//new_line('a')// &
-                                   'if (2 < 3) then'//new_line('a')// &
-                                   '    x = 9'//new_line('a')// &
-                                   'else'//new_line('a')// &
-                                   '    x = 4'//new_line('a')// &
-                                   'end if'//new_line('a')// &
-                                   'stop x'//new_line('a')// &
-                                   'end program main'
+    logical :: all_passed
 
     print *, '=== direct session if merge compiler test ==='
 
-    options = compiler_frontend_options_t()
-    options%run_semantics = .true.
-    options%input_mode = INPUT_MODE_STANDARD
+    all_passed = .true.
+    if (.not. test_integer_if_merge()) all_passed = .false.
+    if (.not. test_real_if_merge()) all_passed = .false.
+    if (.not. test_logical_if_merge()) all_passed = .false.
 
-    call compile_frontend_from_string(source, frontend_result, options)
-    if (.not. frontend_result%success()) then
-        print *, 'FAIL: FortFront rejected source: ', &
-            trim(frontend_result%diagnostic_text)
-        stop 1
-    end if
+    if (.not. all_passed) stop 1
+    print *, 'PASS: fallthrough IF merges scalar values through direct LIRIC'
 
-    call execute_command_line('rm -f '//exe_path)
-    call lower_program_to_liric_exe(frontend_result%arena, &
-                                    frontend_result%root_index, exe_path, &
-                                    error_msg)
-    if (len_trim(error_msg) > 0) then
-        print *, 'FAIL: direct LIRIC lowering failed: ', trim(error_msg)
-        stop 1
-    end if
+contains
 
-    call execute_command_line(exe_path, exitstat=exit_stat, cmdstat=cmd_stat)
-    call execute_command_line('rm -f '//exe_path)
-    if (cmd_stat /= 0) then
-        print *, 'FAIL: emitted executable did not run'
-        stop 1
-    end if
-    if (exit_stat /= 9) then
-        print *, 'FAIL: executable exit status ', exit_stat
-        stop 1
-    end if
+    logical function test_integer_if_merge()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       'integer :: x'//new_line('a')// &
+                                       'if (2 < 3) then'//new_line('a')// &
+                                       '    x = 9'//new_line('a')// &
+                                       'else'//new_line('a')// &
+                                       '    x = 4'//new_line('a')// &
+                                       'end if'//new_line('a')// &
+                                       'stop x'//new_line('a')// &
+                                       'end program main'
 
-    print *, 'PASS: fallthrough IF merges integer values through direct LIRIC'
+        test_integer_if_merge = compile_and_expect_exit( &
+                                source, &
+                                '/tmp/ffc_session_if_integer_merge_test', 9)
+    end function test_integer_if_merge
+
+    logical function test_real_if_merge()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       'real :: x'//new_line('a')// &
+                                       'if (2 < 3) then'//new_line('a')// &
+                                       '    x = 4.5'//new_line('a')// &
+                                       'else'//new_line('a')// &
+                                       '    x = 1.25'//new_line('a')// &
+                                       'end if'//new_line('a')// &
+                                       'print *, x'//new_line('a')// &
+                                       'end program main'
+
+        test_real_if_merge = compile_and_expect_output( &
+                             source, '/tmp/ffc_session_if_real_merge_test', &
+                             '4.500000')
+    end function test_real_if_merge
+
+    logical function test_logical_if_merge()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       'logical :: flag'//new_line('a')// &
+                                       'if (2 < 3) then'//new_line('a')// &
+                                       '    flag = .true.'//new_line('a')// &
+                                       'else'//new_line('a')// &
+                                       '    flag = .false.'//new_line('a')// &
+                                       'end if'//new_line('a')// &
+                                       'if (flag) then'//new_line('a')// &
+                                       '    stop 7'//new_line('a')// &
+                                       'else'//new_line('a')// &
+                                       '    stop 3'//new_line('a')// &
+                                       'end if'//new_line('a')// &
+                                       'end program main'
+
+        test_logical_if_merge = compile_and_expect_exit( &
+                                source, &
+                                '/tmp/ffc_session_if_logical_merge_test', 7)
+    end function test_logical_if_merge
+
+    logical function compile_and_expect_exit(source, exe_path, expected_status)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: exe_path
+        integer, intent(in) :: expected_status
+        integer :: cmd_stat
+        integer :: exit_stat
+
+        compile_and_expect_exit = .false.
+        if (.not. compile_source(source, exe_path)) return
+
+        call execute_command_line(exe_path, exitstat=exit_stat, &
+                                  cmdstat=cmd_stat)
+        call execute_command_line('rm -f '//exe_path)
+        if (cmd_stat /= 0) then
+            print *, 'FAIL: emitted executable did not run'
+            return
+        end if
+        if (exit_stat /= expected_status) then
+            print *, 'FAIL: executable exit status ', exit_stat
+            return
+        end if
+
+        compile_and_expect_exit = .true.
+    end function compile_and_expect_exit
+
+    logical function compile_and_expect_output(source, exe_path, expected_output)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: exe_path
+        character(len=*), intent(in) :: expected_output
+        character(len=:), allocatable :: out_path
+        character(len=64) :: output_line
+        integer :: exit_stat
+        integer :: io_stat
+        integer :: unit
+
+        compile_and_expect_output = .false.
+        out_path = exe_path//'.out'
+        if (.not. compile_source(source, exe_path)) return
+
+        call execute_command_line(exe_path//' > '//out_path, exitstat=exit_stat)
+        if (exit_stat /= 0) then
+            print *, 'FAIL: executable exit status ', exit_stat
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+
+        open (newunit=unit, file=out_path, status='old', action='read', &
+              iostat=io_stat)
+        if (io_stat == 0) read (unit, '(A)', iostat=io_stat) output_line
+        if (io_stat == 0) close (unit)
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+
+        if (io_stat /= 0 .or. &
+            trim(adjustl(output_line)) /= expected_output) then
+            print *, 'FAIL: expected output ', expected_output, ', got ', &
+                trim(output_line)
+            return
+        end if
+
+        compile_and_expect_output = .true.
+    end function compile_and_expect_output
+
+    logical function compile_source(source, exe_path)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: exe_path
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: frontend_result
+        character(len=:), allocatable :: error_msg
+
+        compile_source = .false.
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+
+        call compile_frontend_from_string(source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            print *, 'FAIL: FortFront rejected source: ', &
+                trim(frontend_result%diagnostic_text)
+            return
+        end if
+
+        call execute_command_line('rm -f '//exe_path)
+        call lower_program_to_liric_exe(frontend_result%arena, &
+                                        frontend_result%root_index, exe_path, &
+                                        error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: direct LIRIC lowering failed: ', trim(error_msg)
+            return
+        end if
+
+        compile_source = .true.
+    end function compile_source
 end program test_session_if_merge_compiler

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -13,9 +13,13 @@ program test_session_unsupported_diagnostics
     if (.not. test_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_character_declaration_diagnostic()) all_passed = .false.
     if (.not. test_module_diagnostic()) all_passed = .false.
+    if (.not. test_exit_diagnostic()) all_passed = .false.
+    if (.not. test_cycle_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_declaration_diagnostic()) all_passed = .false.
     if (.not. test_cli_module_diagnostic()) all_passed = .false.
+    if (.not. test_cli_exit_diagnostic()) all_passed = .false.
+    if (.not. test_cli_cycle_diagnostic()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: unsupported direct-session features emit diagnostics'
@@ -54,6 +58,34 @@ contains
             '/tmp/ffc_session_module_diagnostic_test')
     end function test_module_diagnostic
 
+    logical function test_exit_diagnostic()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  do i = 1, 3'//new_line('a')// &
+            '    exit'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            'end program main'
+
+        test_exit_diagnostic = expect_error_contains( &
+            source, 'unsupported exit statement', &
+            '/tmp/ffc_session_exit_diagnostic_test')
+    end function test_exit_diagnostic
+
+    logical function test_cycle_diagnostic()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  do i = 1, 3'//new_line('a')// &
+            '    cycle'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            'end program main'
+
+        test_cycle_diagnostic = expect_error_contains( &
+            source, 'unsupported cycle statement', &
+            '/tmp/ffc_session_cycle_diagnostic_test')
+    end function test_cycle_diagnostic
+
     logical function test_cli_array_declaration_diagnostic()
         character(len=*), parameter :: source = &
             'program main'//new_line('a')// &
@@ -85,6 +117,34 @@ contains
             source, 'unsupported module program unit', &
             '/tmp/ffc_cli_module_diagnostic_test')
     end function test_cli_module_diagnostic
+
+    logical function test_cli_exit_diagnostic()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  do i = 1, 3'//new_line('a')// &
+            '    exit'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            'end program main'
+
+        test_cli_exit_diagnostic = expect_cli_error_contains( &
+            source, 'unsupported exit statement', &
+            '/tmp/ffc_cli_exit_diagnostic_test')
+    end function test_cli_exit_diagnostic
+
+    logical function test_cli_cycle_diagnostic()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  do i = 1, 3'//new_line('a')// &
+            '    cycle'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            'end program main'
+
+        test_cli_cycle_diagnostic = expect_cli_error_contains( &
+            source, 'unsupported cycle statement', &
+            '/tmp/ffc_cli_cycle_diagnostic_test')
+    end function test_cli_cycle_diagnostic
 
     logical function expect_error_contains(source, expected, exe_path)
         character(len=*), intent(in) :: source


### PR DESCRIPTION
## Requirements

- REQ-001 (ref #56): IF branch merges handle real scalar values instead of rejecting non-integer symbols.
- REQ-002 (ref #56): IF branch merges handle logical scalar values using the existing i32 logical representation.
- REQ-003 (ref #56): Existing integer IF merge behavior remains covered.
- REQ-004 (ref #56): Focused executable tests cover integer, real, and logical IF merge behavior.

This is partial progress for scalar IF merges. Loop-carried real/logical values, broader nested IF/DO merge cases, and targeted `exit`/`cycle` diagnostics remain outside this PR.

## Verification

### Test fails on main

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_if_merge_compiler
[100%] Project compiled successfully.
 === direct session if merge compiler test ===
 FAIL: direct LIRIC lowering failed: direct LIRIC session IF only merges integer symbols
 FAIL: direct LIRIC lowering failed: direct LIRIC session IF only merges integer symbols
STOP 1
<ERROR> Execution for object " test_session_if_merge_compiler " returned exit code  1
<ERROR> *cmd_run*:stopping due to failed executions
STOP 1
```

### Test passes after fix

```text
fpm clean --skip && LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_if_merge_compiler
[100%] Project compiled successfully.
 === direct session if merge compiler test ===
 PASS: fallthrough IF merges scalar values through direct LIRIC
```

Full suite:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test
Project is up to date
 === LIRIC session binding tests ===
 PASS: LIRIC session binding tests
 === direct session empty program compiler test ===
 PASS: empty program compiles and runs through direct LIRIC session
 === direct session empty program object compiler test ===
 PASS: empty program emits object through direct LIRIC session
 === direct session stop code compiler test ===
 PASS: integer stop expression lowers through direct LIRIC session
 === direct session integer variable compiler test ===
 PASS: integer variable lowers through direct LIRIC session
 === direct session block if compiler test ===
 PASS: block IF lowers through direct LIRIC session
 === direct session if merge compiler test ===
 PASS: fallthrough IF merges scalar values through direct LIRIC
 === direct session scalar print compiler test ===
 PASS: integer print lowers through direct LIRIC session
 === direct session real literal print compiler test ===
 PASS: real literal print lowers through direct LIRIC session
 === direct session character literal print compiler test ===
 PASS: character literal print lowers through direct LIRIC session
 === direct session logical literal print compiler test ===
 PASS: logical literal print lowers through direct LIRIC session
 === direct session logical variable compiler test ===
 PASS: logical variables lower through direct LIRIC session
 === direct session real variable compiler test ===
 PASS: real variables and arithmetic lower through direct LIRIC
 === direct session integer function compiler test ===
 PASS: integer function calls lower through direct LIRIC session
 === direct session integer subroutine compiler test ===
 PASS: integer subroutine reference args lower through direct LIRIC session
 === direct session scalar intrinsic compiler test ===
 PASS: scalar intrinsics lower through direct LIRIC session
 === direct session unsupported diagnostic test ===
 PASS: unsupported direct-session features emit diagnostics
 === counted do compiler test ===
 PASS: runtime counted DO loop lowers through direct LIRIC session
```
