### PR TITLE
fix: intrinsic diagnostics include locations (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering_intrinsics.inc
+++ b/src_mvp/session_program_lowering_intrinsics.inc
@@ -283,8 +283,14 @@
         character(len=:), allocatable, intent(out) :: error_msg
 
         if (allocated(node%name)) then
-            error_msg = 'unsupported scalar intrinsic: '//trim(node%name)
+            call unsupported_feature_error('scalar intrinsic: '//trim(node%name), &
+                                           node%line, node%column, &
+                                           'direct LIRIC session supports only '// &
+                                           'abs, min, max, and real', error_msg)
         else
-            error_msg = 'unsupported scalar intrinsic'
+            call unsupported_feature_error('scalar intrinsic', node%line, &
+                                           node%column, &
+                                           'direct LIRIC session supports only '// &
+                                           'abs, min, max, and real', error_msg)
         end if
     end subroutine unsupported_intrinsic_error

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -15,11 +15,13 @@ program test_session_unsupported_diagnostics
     if (.not. test_module_diagnostic()) all_passed = .false.
     if (.not. test_exit_diagnostic()) all_passed = .false.
     if (.not. test_cycle_diagnostic()) all_passed = .false.
+    if (.not. test_unsupported_intrinsic_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_declaration_diagnostic()) all_passed = .false.
     if (.not. test_cli_module_diagnostic()) all_passed = .false.
     if (.not. test_cli_exit_diagnostic()) all_passed = .false.
     if (.not. test_cli_cycle_diagnostic()) all_passed = .false.
+    if (.not. test_cli_unsupported_intrinsic_diagnostic()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: unsupported direct-session features emit diagnostics'
@@ -86,6 +88,17 @@ contains
             '/tmp/ffc_session_cycle_diagnostic_test')
     end function test_cycle_diagnostic
 
+    logical function test_unsupported_intrinsic_diagnostic()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  print *, sqrt(4)'//new_line('a')// &
+            'end program main'
+
+        test_unsupported_intrinsic_diagnostic = expect_error_contains( &
+            source, 'unsupported scalar intrinsic: sqrt', &
+            '/tmp/ffc_session_intrinsic_diagnostic_test')
+    end function test_unsupported_intrinsic_diagnostic
+
     logical function test_cli_array_declaration_diagnostic()
         character(len=*), parameter :: source = &
             'program main'//new_line('a')// &
@@ -145,6 +158,17 @@ contains
             source, 'unsupported cycle statement', &
             '/tmp/ffc_cli_cycle_diagnostic_test')
     end function test_cli_cycle_diagnostic
+
+    logical function test_cli_unsupported_intrinsic_diagnostic()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  print *, sqrt(4)'//new_line('a')// &
+            'end program main'
+
+        test_cli_unsupported_intrinsic_diagnostic = expect_cli_error_contains( &
+            source, 'unsupported scalar intrinsic: sqrt', &
+            '/tmp/ffc_cli_intrinsic_diagnostic_test')
+    end function test_cli_unsupported_intrinsic_diagnostic
 
     logical function expect_error_contains(source, expected, exe_path)
         character(len=*), intent(in) :: source


### PR DESCRIPTION
## Requirements

REQ-001 Unsupported scalar intrinsics must keep a targeted user-facing diagnostic. (ref #57)
REQ-002 When the FortFront node has source data, the diagnostic must include line and column. (ref #57)
REQ-003 CLI lowering failures must exit nonzero and print the same concise diagnostic. (ref #57)
REQ-004 Add behavior tests for direct lowering and CLI paths. (ref #57)

## Verification

Failing before implementation:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
FAIL: expected line/column diagnostic, got unsupported scalar intrinsic: sqrt
FAIL: expected CLI line/column diagnostic, got STOP 1
unsupported scalar intrinsic: sqrt
<ERROR> Execution for object " test_session_unsupported_diagnostics " returned exit code  1
```

Passing after implementation:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics
```

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test
PASS: LIRIC session binding tests
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```