### PR TITLE
fix: support scalar character variables (refs #51)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,10 @@ calls, LIRIC bindings, object emission, and executable emission.
 - Literal-bound counted `do` loops expanded through direct LIRIC scalar
   operations.
 - Minimal `print *, expr` for integer expressions, real literals, character
-  literals, and logical literals through direct-session external `printf`
-  calls.
+  literals, character variables, and logical literals through direct-session
+  external `printf` calls.
+- Scalar `character(len=N)` declarations, assignment from character literals,
+  and printed character variables.
 - Real declarations, assignments, arithmetic expressions, and printed real
   variables.
 - Logical declarations, assignments, `if (flag)` conditions, and printed
@@ -90,6 +92,7 @@ LIBRARY_PATH=/home/ert/code/liric/build fpm test test_counted_do_compiler
 LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_scalar_print_compiler
 LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_real_literal_print_compiler
 LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_character_literal_print_compiler
+LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_character_variable_compiler
 LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_logical_literal_print_compiler
 LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_logical_variable_compiler
 LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_real_variable_compiler

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ is not part of the default fpm build.
 - The direct LIRIC session lowerer can compile counted `do` loops with
   runtime-computed integer bounds through LIRIC blocks and PHI backedges.
 - The direct LIRIC session lowerer can compile minimal integer
-  `print *, expr`, real literal `print`, character literal `print`, and
-  logical literal `print` through external `printf` calls.
+  `print *, expr`, real literal `print`, character literal `print`,
+  character variable `print`, and logical literal `print` through external
+  `printf` calls.
 - The direct LIRIC session lowerer can compile scalar `real` declarations,
   assignments, arithmetic, and printing of real variables.
 - The direct LIRIC session lowerer can compile scalar `logical` declarations,
@@ -91,6 +92,7 @@ The current MVP support claim is:
 - counted `do` loops with integer bounds and literal integer step
 - scalar `real` literals in `print`
 - simple `character` literals in `print`
+- scalar `character(len=N)` variables assigned from literals and printed
 - scalar `logical` literals in `print`
 - real variables/arithmetic
 - block `if`
@@ -100,8 +102,8 @@ The current MVP support claim is:
 - object/executable emission through LIRIC
 
 Arrays, allocatables, modules, derived types, full I/O, generics,
-cross-module inference, non-integer procedure ABIs, and scalar character
-variables are unsupported today. See the issue map in
+cross-module inference, and non-integer procedure ABIs are unsupported today.
+See the issue map in
 [docs/SUPPORT_CONTRACT.md](docs/SUPPORT_CONTRACT.md).
 
 ## Build

--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -26,11 +26,12 @@ issue is closed with ABI documentation and executable tests.
 - `logical` values currently use the MVP `i32` representation: zero is false,
   nonzero is true. Printed logicals therefore use the same integer `printf`
   path and currently print `0` or `1`.
+- Scalar `character(len=N)` variables keep an `i8*` pointer to the current
+  literal-backed storage plus the declared length `N` in the lowering symbol.
+  The first character slice supports assignment from character literals.
 - The current lowerer keeps ordinary scalar symbols as SSA-like current values.
 - Procedure reference arguments use LIRIC `alloca`/`load`/`store` slots at the
   call boundary.
-- Scalar character variables are unsupported; #51 owns their value-plus-length
-  ABI.
 - Scalar `abs`, `min`, and `max` intrinsics are supported for integer and real
   values. Integer-to-real `real()` conversion is supported. They lower inline
   through LIRIC scalar operations, comparisons, branches, casts, and PHI values.
@@ -59,9 +60,14 @@ issue is closed with ABI documentation and executable tests.
 - The current format globals are:
   - integer/logical: `%d\n`
   - real: `%f\n`
-  - character literal: `%s\n`
-- Character literal print materializes a global null-terminated byte array and
-  passes a pointer to `printf`.
+  - character: `%s\n`
+- Character literal print and scalar character variable print pass a pointer to
+  a null-terminated global byte array to `printf`. Character variables retain
+  their declared length in the lowering metadata, but the current C `printf`
+  shim does not consume that length. #55 owns the Fortran-aware I/O runtime.
+- Character concatenation, substring access, deferred length, nonliteral
+  character assignment, character procedure arguments, and character
+  control-flow merges are unsupported in this slice.
 - Object output may contain unresolved references such as `printf`; final
   linking is responsible for resolving the C runtime.
 - The current `printf` path is the only supported I/O surface. #55 owns the
@@ -71,7 +77,6 @@ issue is closed with ABI documentation and executable tests.
 
 - #50: non-integer pass-by-reference arguments and richer procedure
   signatures.
-- #51: character value plus length passing.
 - #52: fixed-size one-dimensional array lowering.
 - #53: array descriptors, allocatables, and pointer representation.
 - #54: module and external symbol mangling.

--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -26,9 +26,10 @@ issue is closed with ABI documentation and executable tests.
 - `logical` values currently use the MVP `i32` representation: zero is false,
   nonzero is true. Printed logicals therefore use the same integer `printf`
   path and currently print `0` or `1`.
-- Scalar `character(len=N)` variables keep an `i8*` pointer to the current
-  literal-backed storage plus the declared length `N` in the lowering symbol.
-  The first character slice supports assignment from character literals.
+- Scalar `character(len=N)` variables keep an `i8*` pointer to literal-backed
+  storage plus the declared length `N` in the lowering symbol. Assignment from
+  character literals stores exactly `N` characters by truncating long literals
+  and blank-padding short literals.
 - The current lowerer keeps ordinary scalar symbols as SSA-like current values.
 - Procedure reference arguments use LIRIC `alloca`/`load`/`store` slots at the
   call boundary.
@@ -61,10 +62,11 @@ issue is closed with ABI documentation and executable tests.
   - integer/logical: `%d\n`
   - real: `%f\n`
   - character: `%s\n`
-- Character literal print and scalar character variable print pass a pointer to
-  a null-terminated global byte array to `printf`. Character variables retain
-  their declared length in the lowering metadata, but the current C `printf`
-  shim does not consume that length. #55 owns the Fortran-aware I/O runtime.
+- Character literal print passes a pointer to a null-terminated global byte
+  array to `printf`. Scalar character variable print passes a pointer to a
+  global byte array containing the fixed-length value followed by a null
+  terminator. The current C `printf` shim consumes the terminator, not an
+  explicit length argument. #55 owns the Fortran-aware I/O runtime.
 - Character concatenation, substring access, deferred length, nonliteral
   character assignment, character procedure arguments, and character
   control-flow merges are unsupported in this slice.

--- a/docs/SUPPORT_CONTRACT.md
+++ b/docs/SUPPORT_CONTRACT.md
@@ -33,14 +33,13 @@ The current implementation is a single-file, direct-session scalar subset.
 | `do` | Counted `do` loops with integer bounds and literal integer step. |
 | Procedures | Contained integer functions and subroutines with integer parameters only. Integer procedure actual arguments use pointer parameters with copy-back for variable actuals. |
 | Intrinsics | Scalar `abs`, `min`, and `max` for integer and real values, plus integer-to-real `real()` conversion. These lower inline with LIRIC scalar operations, comparisons, branches, and PHI operations. |
-| `print` | Minimal scalar `print *, expr` through the current `printf` shim for integer expressions, real values, character literals, logical literals, real variables, and logical variables. |
+| `print` | Minimal scalar `print *, expr` through the current `printf` shim for integer expressions, real values, character literals, character variables, logical literals, real variables, and logical variables. |
 
 ## Unsupported Work
 
 | Issue | Missing feature | Required result before support is claimed |
 | --- | --- | --- |
 | #50 | Non-integer scalar procedure ABI | Real, logical, and character scalar function/subroutine arguments and results have ABI tests and executable tests. |
-| #51 | Scalar character variables and ABI | Character variables have a documented value-plus-length representation and executable behavior. |
 | #52 | Fixed-size one-dimensional arrays | Declaration, indexing, assignment, and printing tests pass for explicit-shape rank-one arrays. |
 | #53 | Allocatable arrays | Descriptor layout, allocation, deallocation, bounds, and element access are documented and tested. |
 | #54 | Modules and separate compilation | Module symbols, external procedure symbols, name mangling, and link behavior are deterministic and tested. |

--- a/fpm.toml
+++ b/fpm.toml
@@ -78,6 +78,11 @@ source-dir = "test_mvp"
 main = "test_session_character_literal_print_compiler.f90"
 
 [[test]]
+name = "test_session_character_variable_compiler"
+source-dir = "test_mvp"
+main = "test_session_character_variable_compiler.f90"
+
+[[test]]
 name = "test_session_logical_literal_print_compiler"
 source-dir = "test_mvp"
 main = "test_session_logical_literal_print_compiler.f90"

--- a/src_mvp/liric_session_io_bindings.f90
+++ b/src_mvp/liric_session_io_bindings.f90
@@ -28,7 +28,9 @@ module liric_session_io_bindings
     public :: emit_liric_print_f64
     public :: emit_liric_print_i32
     public :: emit_liric_print_string
+    public :: emit_liric_print_string_operand
     public :: liric_f64_immediate
+    public :: materialize_liric_string
     public :: prepare_liric_print_runtime
 
     interface
@@ -221,13 +223,29 @@ contains
         character(len=*), intent(in) :: string_global_name
         character(len=*), intent(in) :: text
         character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: string_ptr
+
+        emit_liric_print_string = .false.
+        call materialize_liric_string(session, string_global_name, text, &
+                                      string_ptr, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        emit_liric_print_string = emit_liric_print_string_operand( &
+                                  session, format_global_id, string_ptr, error_msg)
+    end function emit_liric_print_string
+
+    logical function emit_liric_print_string_operand(session, format_global_id, &
+                                                     string_ptr, error_msg)
+        type(liric_session_t), intent(inout) :: session
+        integer(c_int32_t), intent(in) :: format_global_id
+        type(lr_operand_desc_t), intent(in) :: string_ptr
+        character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t) :: callee
         type(lr_operand_desc_t) :: format_ptr
-        type(lr_operand_desc_t) :: string_ptr
         type(lr_error_t) :: error
         integer(c_int32_t) :: unused_vreg
 
-        emit_liric_print_string = .false.
+        emit_liric_print_string_operand = .false.
         if (.not. require_open_session(session, error_msg)) return
 
         call make_printf_operand(session, callee, error_msg)
@@ -237,17 +255,25 @@ contains
                                         error_msg)
         if (len_trim(error_msg) > 0) return
 
-        call make_string_literal_operand(session, string_global_name, text, &
-                                         string_ptr, error_msg)
-        if (len_trim(error_msg) > 0) return
-
         unused_vreg = emit_call_ptr(session%handle, callee, format_ptr, &
                                     string_ptr, error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
         call set_empty(error_msg)
-        emit_liric_print_string = .true.
-    end function emit_liric_print_string
+        emit_liric_print_string_operand = .true.
+    end function emit_liric_print_string_operand
+
+    subroutine materialize_liric_string(session, string_global_name, text, &
+                                        operand, error_msg)
+        type(liric_session_t), intent(inout) :: session
+        character(len=*), intent(in) :: string_global_name
+        character(len=*), intent(in) :: text
+        type(lr_operand_desc_t), intent(out) :: operand
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call make_string_literal_operand(session, string_global_name, text, &
+                                         operand, error_msg)
+    end subroutine materialize_liric_string
 
     subroutine make_printf_operand(session, operand, error_msg)
         type(liric_session_t), intent(inout) :: session

--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -28,9 +28,11 @@ module session_program_lowering
                                          emit_liric_i32_to_f64, &
                                          emit_liric_print_f64, &
                                          emit_liric_print_i32, &
+                                         emit_liric_print_string_operand, &
                                          emit_liric_print_string, &
                                          liric_f64_immediate, &
                                          LR_OP_FSUB, &
+                                         materialize_liric_string, &
                                          prepare_liric_print_runtime
     use session_lowering_ops, only: integer_compare_predicate, &
                                     integer_opcode, parse_i32_literal
@@ -45,6 +47,7 @@ module session_program_lowering
     integer, parameter :: VALUE_I32 = 1
     integer, parameter :: VALUE_F64 = 2
     integer, parameter :: VALUE_LOGICAL = 3
+    integer, parameter :: VALUE_CHARACTER = 4
     integer, parameter :: I32_INTRINSIC_NONE = 0
     integer, parameter :: I32_INTRINSIC_ABS = 1
     integer, parameter :: I32_INTRINSIC_MIN = 2
@@ -72,6 +75,8 @@ module session_program_lowering
         logical :: is_parameter = .false.
         logical :: is_reference = .false.
         logical :: has_address = .false.
+        integer :: character_length = 0
+        logical :: has_character_value = .false.
     end type symbol_t
 
     type :: lowering_context_t
@@ -370,16 +375,35 @@ contains
         if (len_trim(error_msg) > 0) return
         if (node%is_multi_declaration .and. allocated(node%var_names)) then
             do i = 1, size(node%var_names)
-                call define_symbol(context, node%var_names(i), value_kind, &
-                                   error_msg)
+                call define_declared_symbol(context, node, node%var_names(i), &
+                                            value_kind, error_msg)
                 if (len_trim(error_msg) > 0) return
             end do
         else if (allocated(node%var_name)) then
-            call define_symbol(context, node%var_name, value_kind, error_msg)
+            call define_declared_symbol(context, node, node%var_name, &
+                                        value_kind, error_msg)
         else
             error_msg = 'scalar declaration did not expose a variable name'
         end if
     end subroutine lower_declaration
+
+    subroutine define_declared_symbol(context, node, name, value_kind, error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        type(declaration_node), intent(in) :: node
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: value_kind
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: character_length
+
+        if (value_kind == VALUE_CHARACTER) then
+            call declaration_character_length(node, character_length, error_msg)
+            if (len_trim(error_msg) > 0) return
+            call define_character_symbol(context, name, character_length, &
+                                         error_msg)
+        else
+            call define_symbol(context, name, value_kind, error_msg)
+        end if
+    end subroutine define_declared_symbol
 
     subroutine lower_parameter_declaration(node, context, error_msg)
         type(parameter_declaration_node), intent(in) :: node
@@ -438,11 +462,7 @@ contains
         call set_empty(error_msg)
         if (.not. allocated(node%type_name)) return
         if (is_character_type_name(node%type_name)) then
-            call unsupported_feature_error('character variable declaration', &
-                                           node%line, node%column, &
-                                           'scalar character variables are not '// &
-                                           'supported by direct LIRIC session', &
-                                           error_msg)
+            value_kind = VALUE_CHARACTER
             return
         end if
         select case (trim(node%type_name))
@@ -457,6 +477,23 @@ contains
                         'and logical declarations'
         end select
     end subroutine declaration_value_kind
+
+    subroutine declaration_character_length(node, character_length, error_msg)
+        type(declaration_node), intent(in) :: node
+        integer, intent(out) :: character_length
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: parse_error
+
+        character_length = 1
+        call set_empty(error_msg)
+        if (.not. allocated(node%type_name)) return
+        call parse_character_length(node%type_name, character_length, parse_error)
+        if (len_trim(parse_error) > 0) then
+            call unsupported_feature_error('character length declaration', &
+                                           node%line, node%column, &
+                                           trim(parse_error), error_msg)
+        end if
+    end subroutine declaration_character_length
 
     subroutine define_symbol(context, name, value_kind, error_msg)
         type(lowering_context_t), intent(inout) :: context
@@ -483,6 +520,8 @@ contains
             call define_f64_symbol(context, name, error_msg)
         else if (value_kind == VALUE_LOGICAL) then
             call define_logical_symbol(context, name, error_msg)
+        else if (value_kind == VALUE_CHARACTER) then
+            call define_character_symbol(context, name, 1, error_msg)
         else
             error_msg = 'unknown scalar value kind for direct LIRIC session'
         end if
@@ -558,6 +597,36 @@ contains
         call set_empty(error_msg)
     end subroutine define_logical_symbol
 
+    subroutine define_character_symbol(context, name, character_length, &
+                                       error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: character_length
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: index
+
+        if (find_symbol(context, name) > 0) then
+            error_msg = 'duplicate character declaration: '//trim(name)
+            return
+        end if
+        if (context%symbol_count >= MAX_SYMBOLS) then
+            error_msg = 'too many scalar symbols for direct LIRIC session MVP'
+            return
+        end if
+        if (character_length <= 0) then
+            error_msg = 'character declaration requires positive length'
+            return
+        end if
+
+        index = context%symbol_count + 1
+        context%symbols(index)%name = trim(name)
+        context%symbols(index)%value_kind = VALUE_CHARACTER
+        context%symbols(index)%character_length = character_length
+        context%symbols(index)%has_character_value = .false.
+        context%symbol_count = index
+        call set_empty(error_msg)
+    end subroutine define_character_symbol
+
     subroutine lower_assignment(arena, node, context, error_msg)
         type(ast_arena_t), intent(in) :: arena
         type(assignment_node), intent(in) :: node
@@ -582,6 +651,10 @@ contains
         else if (context%symbols(symbol_index)%value_kind == VALUE_LOGICAL) then
             call lower_logical_expression(arena, node%value_index, context, &
                                           value, error_msg)
+        else if (context%symbols(symbol_index)%value_kind == VALUE_CHARACTER) then
+            call lower_character_assignment(arena, node, context, symbol_index, &
+                                            error_msg)
+            return
         else
             call lower_i32_expression(arena, node%value_index, context, value, &
                                       error_msg)
@@ -601,6 +674,59 @@ contains
         end if
         call set_empty(error_msg)
     end subroutine lower_assignment
+
+    subroutine lower_character_assignment(arena, node, context, symbol_index, &
+                                          error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(assignment_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: literal_text
+        character(len=64) :: string_name
+
+        if (.not. arena%has_node_at(node%value_index)) then
+            error_msg = 'character assignment value does not reference an AST node'
+            return
+        end if
+
+        select type (value_node => arena%entries(node%value_index)%node)
+        type is (literal_node)
+            if (.not. is_character_literal(value_node)) then
+                call unsupported_feature_error('character assignment', &
+                                               node%line, node%column, &
+                                               'only character literal '// &
+                                               'assignment is supported', &
+                                               error_msg)
+                return
+            end if
+            call strip_literal_quotes(value_node%value, literal_text)
+        class default
+            call unsupported_feature_error('character assignment', &
+                                           node%line, node%column, &
+                                           'only character literal assignment '// &
+                                           'is supported', error_msg)
+            return
+        end select
+
+        if (len(literal_text) > &
+            context%symbols(symbol_index)%character_length) then
+            literal_text = literal_text(1: &
+                                        context%symbols(symbol_index)%character_length)
+        end if
+
+        context%string_literal_count = context%string_literal_count + 1
+        write (string_name, '(A,I0)') '.ffc.char.', &
+            context%string_literal_count
+        call materialize_liric_string(context%session, trim(string_name), &
+                                      literal_text, &
+                                      context%symbols(symbol_index)%value, &
+                                      error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        context%symbols(symbol_index)%has_character_value = .true.
+        call set_empty(error_msg)
+    end subroutine lower_character_assignment
 
     subroutine lower_stop(arena, node, context, value, error_msg)
         type(ast_arena_t), intent(in) :: arena
@@ -971,6 +1097,48 @@ contains
         is_character_type_name = lowered == 'character' .or. &
                                  index(lowered, 'character(') == 1
     end function is_character_type_name
+
+    subroutine parse_character_length(type_name, character_length, error_msg)
+        character(len=*), intent(in) :: type_name
+        integer, intent(out) :: character_length
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: lowered
+        character(len=:), allocatable :: length_text
+        integer :: close_pos
+        integer :: io_stat
+        integer :: len_pos
+        integer :: start_pos
+
+        character_length = 1
+        lowered = lowercase_text(type_name)
+        if (trim(lowered) == 'character') then
+            call set_empty(error_msg)
+            return
+        end if
+
+        len_pos = index(lowered, 'len=')
+        if (len_pos <= 0) then
+            error_msg = 'only character(len=N) declarations are supported'
+            return
+        end if
+
+        start_pos = len_pos + len('len=')
+        close_pos = index(lowered(start_pos:), ')')
+        if (close_pos <= 0) then
+            error_msg = 'character length declaration is missing ")"'
+            return
+        end if
+
+        close_pos = start_pos + close_pos - 2
+        length_text = adjustl(lowered(start_pos:close_pos))
+        read (length_text, *, iostat=io_stat) character_length
+        if (io_stat /= 0 .or. character_length <= 0) then
+            error_msg = 'character length must be a positive integer literal'
+            return
+        end if
+
+        call set_empty(error_msg)
+    end subroutine parse_character_length
 
     subroutine set_empty(value)
         character(len=:), allocatable, intent(out) :: value

--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -478,23 +478,6 @@ contains
         end select
     end subroutine declaration_value_kind
 
-    subroutine declaration_character_length(node, character_length, error_msg)
-        type(declaration_node), intent(in) :: node
-        integer, intent(out) :: character_length
-        character(len=:), allocatable, intent(out) :: error_msg
-        character(len=:), allocatable :: parse_error
-
-        character_length = 1
-        call set_empty(error_msg)
-        if (.not. allocated(node%type_name)) return
-        call parse_character_length(node%type_name, character_length, parse_error)
-        if (len_trim(parse_error) > 0) then
-            call unsupported_feature_error('character length declaration', &
-                                           node%line, node%column, &
-                                           trim(parse_error), error_msg)
-        end if
-    end subroutine declaration_character_length
-
     subroutine define_symbol(context, name, value_kind, error_msg)
         type(lowering_context_t), intent(inout) :: context
         character(len=*), intent(in) :: name
@@ -597,36 +580,6 @@ contains
         call set_empty(error_msg)
     end subroutine define_logical_symbol
 
-    subroutine define_character_symbol(context, name, character_length, &
-                                       error_msg)
-        type(lowering_context_t), intent(inout) :: context
-        character(len=*), intent(in) :: name
-        integer, intent(in) :: character_length
-        character(len=:), allocatable, intent(out) :: error_msg
-        integer :: index
-
-        if (find_symbol(context, name) > 0) then
-            error_msg = 'duplicate character declaration: '//trim(name)
-            return
-        end if
-        if (context%symbol_count >= MAX_SYMBOLS) then
-            error_msg = 'too many scalar symbols for direct LIRIC session MVP'
-            return
-        end if
-        if (character_length <= 0) then
-            error_msg = 'character declaration requires positive length'
-            return
-        end if
-
-        index = context%symbol_count + 1
-        context%symbols(index)%name = trim(name)
-        context%symbols(index)%value_kind = VALUE_CHARACTER
-        context%symbols(index)%character_length = character_length
-        context%symbols(index)%has_character_value = .false.
-        context%symbol_count = index
-        call set_empty(error_msg)
-    end subroutine define_character_symbol
-
     subroutine lower_assignment(arena, node, context, error_msg)
         type(ast_arena_t), intent(in) :: arena
         type(assignment_node), intent(in) :: node
@@ -675,58 +628,7 @@ contains
         call set_empty(error_msg)
     end subroutine lower_assignment
 
-    subroutine lower_character_assignment(arena, node, context, symbol_index, &
-                                          error_msg)
-        type(ast_arena_t), intent(in) :: arena
-        type(assignment_node), intent(in) :: node
-        type(lowering_context_t), intent(inout) :: context
-        integer, intent(in) :: symbol_index
-        character(len=:), allocatable, intent(out) :: error_msg
-        character(len=:), allocatable :: literal_text
-        character(len=64) :: string_name
-
-        if (.not. arena%has_node_at(node%value_index)) then
-            error_msg = 'character assignment value does not reference an AST node'
-            return
-        end if
-
-        select type (value_node => arena%entries(node%value_index)%node)
-        type is (literal_node)
-            if (.not. is_character_literal(value_node)) then
-                call unsupported_feature_error('character assignment', &
-                                               node%line, node%column, &
-                                               'only character literal '// &
-                                               'assignment is supported', &
-                                               error_msg)
-                return
-            end if
-            call strip_literal_quotes(value_node%value, literal_text)
-        class default
-            call unsupported_feature_error('character assignment', &
-                                           node%line, node%column, &
-                                           'only character literal assignment '// &
-                                           'is supported', error_msg)
-            return
-        end select
-
-        if (len(literal_text) > &
-            context%symbols(symbol_index)%character_length) then
-            literal_text = literal_text(1: &
-                                        context%symbols(symbol_index)%character_length)
-        end if
-
-        context%string_literal_count = context%string_literal_count + 1
-        write (string_name, '(A,I0)') '.ffc.char.', &
-            context%string_literal_count
-        call materialize_liric_string(context%session, trim(string_name), &
-                                      literal_text, &
-                                      context%symbols(symbol_index)%value, &
-                                      error_msg)
-        if (len_trim(error_msg) > 0) return
-
-        context%symbols(symbol_index)%has_character_value = .true.
-        call set_empty(error_msg)
-    end subroutine lower_character_assignment
+    include 'session_program_lowering_character.inc'
 
     subroutine lower_stop(arena, node, context, value, error_msg)
         type(ast_arena_t), intent(in) :: arena
@@ -1066,79 +968,7 @@ contains
         end do
     end function find_symbol
 
-    logical function same_name(lhs, rhs)
-        character(len=*), intent(in) :: lhs
-        character(len=*), intent(in) :: rhs
-
-        same_name = lowercase_text(lhs) == lowercase_text(rhs)
-    end function same_name
-
-    function lowercase_text(text) result(lowered)
-        character(len=*), intent(in) :: text
-        character(len=len_trim(text)) :: lowered
-        integer :: code
-        integer :: i
-
-        do i = 1, len(lowered)
-            code = iachar(text(i:i))
-            if (code >= iachar('A') .and. code <= iachar('Z')) then
-                lowered(i:i) = achar(code + 32)
-            else
-                lowered(i:i) = text(i:i)
-            end if
-        end do
-    end function lowercase_text
-
-    logical function is_character_type_name(name)
-        character(len=*), intent(in) :: name
-        character(len=:), allocatable :: lowered
-
-        lowered = lowercase_text(name)
-        is_character_type_name = lowered == 'character' .or. &
-                                 index(lowered, 'character(') == 1
-    end function is_character_type_name
-
-    subroutine parse_character_length(type_name, character_length, error_msg)
-        character(len=*), intent(in) :: type_name
-        integer, intent(out) :: character_length
-        character(len=:), allocatable, intent(out) :: error_msg
-        character(len=:), allocatable :: lowered
-        character(len=:), allocatable :: length_text
-        integer :: close_pos
-        integer :: io_stat
-        integer :: len_pos
-        integer :: start_pos
-
-        character_length = 1
-        lowered = lowercase_text(type_name)
-        if (trim(lowered) == 'character') then
-            call set_empty(error_msg)
-            return
-        end if
-
-        len_pos = index(lowered, 'len=')
-        if (len_pos <= 0) then
-            error_msg = 'only character(len=N) declarations are supported'
-            return
-        end if
-
-        start_pos = len_pos + len('len=')
-        close_pos = index(lowered(start_pos:), ')')
-        if (close_pos <= 0) then
-            error_msg = 'character length declaration is missing ")"'
-            return
-        end if
-
-        close_pos = start_pos + close_pos - 2
-        length_text = adjustl(lowered(start_pos:close_pos))
-        read (length_text, *, iostat=io_stat) character_length
-        if (io_stat /= 0 .or. character_length <= 0) then
-            error_msg = 'character length must be a positive integer literal'
-            return
-        end if
-
-        call set_empty(error_msg)
-    end subroutine parse_character_length
+    include 'session_program_lowering_text.inc'
 
     subroutine set_empty(value)
         character(len=:), allocatable, intent(out) :: value

--- a/src_mvp/session_program_lowering_character.inc
+++ b/src_mvp/session_program_lowering_character.inc
@@ -1,0 +1,157 @@
+    subroutine declaration_character_length(node, character_length, error_msg)
+        type(declaration_node), intent(in) :: node
+        integer, intent(out) :: character_length
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: parse_error
+
+        character_length = 1
+        call set_empty(error_msg)
+        if (.not. allocated(node%type_name)) return
+        call parse_character_length(node%type_name, character_length, parse_error)
+        if (len_trim(parse_error) > 0) then
+            call unsupported_feature_error('character length declaration', &
+                                           node%line, node%column, &
+                                           trim(parse_error), error_msg)
+        end if
+    end subroutine declaration_character_length
+
+    subroutine define_character_symbol(context, name, character_length, &
+                                       error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: character_length
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: index
+
+        if (find_symbol(context, name) > 0) then
+            error_msg = 'duplicate character declaration: '//trim(name)
+            return
+        end if
+        if (context%symbol_count >= MAX_SYMBOLS) then
+            error_msg = 'too many scalar symbols for direct LIRIC session MVP'
+            return
+        end if
+        if (character_length <= 0) then
+            error_msg = 'character declaration requires positive length'
+            return
+        end if
+
+        index = context%symbol_count + 1
+        context%symbols(index)%name = trim(name)
+        context%symbols(index)%value_kind = VALUE_CHARACTER
+        context%symbols(index)%character_length = character_length
+        context%symbols(index)%has_character_value = .false.
+        context%symbol_count = index
+        call set_empty(error_msg)
+    end subroutine define_character_symbol
+
+    subroutine lower_character_assignment(arena, node, context, symbol_index, &
+                                          error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(assignment_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: literal_text
+        character(len=64) :: string_name
+
+        if (.not. arena%has_node_at(node%value_index)) then
+            error_msg = 'character assignment value does not reference an AST node'
+            return
+        end if
+
+        select type (value_node => arena%entries(node%value_index)%node)
+        type is (literal_node)
+            if (.not. is_character_literal(value_node)) then
+                call unsupported_feature_error('character assignment', &
+                                               node%line, node%column, &
+                                               'only character literal '// &
+                                               'assignment is supported', &
+                                               error_msg)
+                return
+            end if
+            call strip_literal_quotes(value_node%value, literal_text)
+        class default
+            call unsupported_feature_error('character assignment', &
+                                           node%line, node%column, &
+                                           'only character literal assignment '// &
+                                           'is supported', error_msg)
+            return
+        end select
+
+        call normalize_character_literal( &
+            literal_text, context%symbols(symbol_index)%character_length)
+
+        context%string_literal_count = context%string_literal_count + 1
+        write (string_name, '(A,I0)') '.ffc.char.', &
+            context%string_literal_count
+        call materialize_liric_string(context%session, trim(string_name), &
+                                      literal_text, &
+                                      context%symbols(symbol_index)%value, &
+                                      error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        context%symbols(symbol_index)%has_character_value = .true.
+        call set_empty(error_msg)
+    end subroutine lower_character_assignment
+
+    subroutine normalize_character_literal(literal_text, character_length)
+        character(len=:), allocatable, intent(inout) :: literal_text
+        integer, intent(in) :: character_length
+        character(len=:), allocatable :: fixed_text
+
+        allocate (character(len=character_length) :: fixed_text)
+        fixed_text(:) = literal_text
+        call move_alloc(fixed_text, literal_text)
+    end subroutine normalize_character_literal
+
+    logical function is_character_type_name(name)
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: lowered
+
+        lowered = lowercase_text(name)
+        is_character_type_name = lowered == 'character' .or. &
+                                 index(lowered, 'character(') == 1
+    end function is_character_type_name
+
+    subroutine parse_character_length(type_name, character_length, error_msg)
+        character(len=*), intent(in) :: type_name
+        integer, intent(out) :: character_length
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: lowered
+        character(len=:), allocatable :: length_text
+        integer :: close_pos
+        integer :: io_stat
+        integer :: len_pos
+        integer :: start_pos
+
+        character_length = 1
+        lowered = lowercase_text(type_name)
+        if (trim(lowered) == 'character') then
+            call set_empty(error_msg)
+            return
+        end if
+
+        len_pos = index(lowered, 'len=')
+        if (len_pos <= 0) then
+            error_msg = 'only character(len=N) declarations are supported'
+            return
+        end if
+
+        start_pos = len_pos + len('len=')
+        close_pos = index(lowered(start_pos:), ')')
+        if (close_pos <= 0) then
+            error_msg = 'character length declaration is missing ")"'
+            return
+        end if
+
+        close_pos = start_pos + close_pos - 2
+        length_text = adjustl(lowered(start_pos:close_pos))
+        read (length_text, *, iostat=io_stat) character_length
+        if (io_stat /= 0 .or. character_length <= 0) then
+            error_msg = 'character length must be a positive integer literal'
+            return
+        end if
+
+        call set_empty(error_msg)
+    end subroutine parse_character_length

--- a/src_mvp/session_program_lowering_control.inc
+++ b/src_mvp/session_program_lowering_control.inc
@@ -165,6 +165,9 @@
                                      else_result%predecessor_block_id, &
                                      context%symbols(index)%value, &
                                      error_msg)) return
+        case (VALUE_CHARACTER)
+            error_msg = 'direct LIRIC session IF cannot merge character values'
+            return
         case default
             error_msg = 'direct LIRIC session IF cannot merge unknown symbol kind'
             return

--- a/src_mvp/session_program_lowering_text.inc
+++ b/src_mvp/session_program_lowering_text.inc
@@ -1,0 +1,22 @@
+    logical function same_name(lhs, rhs)
+        character(len=*), intent(in) :: lhs
+        character(len=*), intent(in) :: rhs
+
+        same_name = lowercase_text(lhs) == lowercase_text(rhs)
+    end function same_name
+
+    function lowercase_text(text) result(lowered)
+        character(len=*), intent(in) :: text
+        character(len=len_trim(text)) :: lowered
+        integer :: code
+        integer :: i
+
+        do i = 1, len(lowered)
+            code = iachar(text(i:i))
+            if (code >= iachar('A') .and. code <= iachar('Z')) then
+                lowered(i:i) = achar(code + 32)
+            else
+                lowered(i:i) = text(i:i)
+            end if
+        end do
+    end function lowercase_text

--- a/src_mvp/session_program_lowering_values.inc
+++ b/src_mvp/session_program_lowering_values.inc
@@ -57,6 +57,17 @@
                                                    value, error_msg)) return
                     return
                 end if
+                if (context%symbols(symbol_index)%value_kind == VALUE_CHARACTER) then
+                    if (.not. context%symbols(symbol_index)%has_character_value) then
+                        error_msg = 'character variable was not assigned: '// &
+                                    trim(node%name)
+                        return
+                    end if
+                    if (.not. emit_liric_print_string_operand( &
+                        context%session, context%str_print_format_id, &
+                        context%symbols(symbol_index)%value, error_msg)) return
+                    return
+                end if
             end if
         type is (binary_op_node)
             if (is_f64_expression(arena, node_index, context)) then

--- a/test_mvp/test_session_character_variable_compiler.f90
+++ b/test_mvp/test_session_character_variable_compiler.f90
@@ -1,0 +1,71 @@
+program test_session_character_variable_compiler
+    use fortfront, only: compiler_frontend_options_t, &
+                         compiler_frontend_result_t, &
+                         compile_frontend_from_string, INPUT_MODE_STANDARD
+    use session_program_lowering, only: lower_program_to_liric_exe
+    implicit none
+
+    type(compiler_frontend_options_t) :: options
+    type(compiler_frontend_result_t) :: frontend_result
+    character(len=:), allocatable :: error_msg
+    character(len=64) :: output_line
+    character(len=*), parameter :: exe_path = '/tmp/ffc_session_char_var_test'
+    character(len=*), parameter :: out_path = &
+                                   '/tmp/ffc_session_char_var_test.out'
+    integer :: exit_stat
+    integer :: io_stat
+    integer :: unit
+    character(len=*), parameter :: source = &
+                                   'program main'//new_line('a')// &
+                                   '  character(len=5) :: s'//new_line('a')// &
+                                   '  s = "hello"'//new_line('a')// &
+                                   '  print *, s'//new_line('a')// &
+                                   'end program main'
+
+    print *, '=== direct session character variable compiler test ==='
+
+    options = compiler_frontend_options_t()
+    options%run_semantics = .true.
+    options%input_mode = INPUT_MODE_STANDARD
+
+    call compile_frontend_from_string(source, frontend_result, options)
+    if (.not. frontend_result%success()) then
+        print *, 'FAIL: FortFront rejected source: ', &
+            trim(frontend_result%diagnostic_text)
+        stop 1
+    end if
+
+    call execute_command_line('rm -f '//exe_path//' '//out_path)
+    call lower_program_to_liric_exe(frontend_result%arena, &
+                                    frontend_result%root_index, exe_path, &
+                                    error_msg)
+    if (len_trim(error_msg) > 0) then
+        print *, 'FAIL: direct LIRIC lowering failed: ', trim(error_msg)
+        stop 1
+    end if
+
+    call execute_command_line(exe_path//' > '//out_path, exitstat=exit_stat)
+    if (exit_stat /= 0) then
+        print *, 'FAIL: executable exit status ', exit_stat
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+        stop 1
+    end if
+
+    open (newunit=unit, file=out_path, status='old', action='read', &
+          iostat=io_stat)
+    if (io_stat /= 0) then
+        print *, 'FAIL: could not open captured output'
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+        stop 1
+    end if
+    read (unit, '(A)', iostat=io_stat) output_line
+    close (unit)
+    call execute_command_line('rm -f '//exe_path//' '//out_path)
+
+    if (io_stat /= 0 .or. trim(adjustl(output_line)) /= 'hello') then
+        print *, 'FAIL: expected output hello, got ', trim(output_line)
+        stop 1
+    end if
+
+    print *, 'PASS: character variables lower through direct LIRIC session'
+end program test_session_character_variable_compiler

--- a/test_mvp/test_session_character_variable_compiler.f90
+++ b/test_mvp/test_session_character_variable_compiler.f90
@@ -8,17 +8,19 @@ program test_session_character_variable_compiler
     type(compiler_frontend_options_t) :: options
     type(compiler_frontend_result_t) :: frontend_result
     character(len=:), allocatable :: error_msg
+    character(len=6) :: output_text
     character(len=64) :: output_line
     character(len=*), parameter :: exe_path = '/tmp/ffc_session_char_var_test'
     character(len=*), parameter :: out_path = &
                                    '/tmp/ffc_session_char_var_test.out'
     integer :: exit_stat
+    integer :: file_size
     integer :: io_stat
     integer :: unit
     character(len=*), parameter :: source = &
                                    'program main'//new_line('a')// &
                                    '  character(len=5) :: s'//new_line('a')// &
-                                   '  s = "hello"'//new_line('a')// &
+                                   '  s = "hi"'//new_line('a')// &
                                    '  print *, s'//new_line('a')// &
                                    'end program main'
 
@@ -60,10 +62,22 @@ program test_session_character_variable_compiler
     end if
     read (unit, '(A)', iostat=io_stat) output_line
     close (unit)
+
+    inquire (file=out_path, size=file_size)
+    open (newunit=unit, file=out_path, status='old', access='stream', &
+          form='unformatted', action='read', iostat=io_stat)
+    if (io_stat /= 0) then
+        print *, 'FAIL: could not open captured output as stream'
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+        stop 1
+    end if
+    read (unit, iostat=io_stat) output_text
+    close (unit)
     call execute_command_line('rm -f '//exe_path//' '//out_path)
 
-    if (io_stat /= 0 .or. trim(adjustl(output_line)) /= 'hello') then
-        print *, 'FAIL: expected output hello, got ', trim(output_line)
+    if (io_stat /= 0 .or. file_size /= 6 .or. &
+        output_text /= 'hi   '//new_line('a')) then
+        print *, 'FAIL: expected fixed-length output hi, got ', output_line
         stop 1
     end if
 

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -11,13 +11,13 @@ program test_session_unsupported_diagnostics
 
     all_passed = .true.
     if (.not. test_array_declaration_diagnostic()) all_passed = .false.
-    if (.not. test_character_declaration_diagnostic()) all_passed = .false.
+    if (.not. test_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_module_diagnostic()) all_passed = .false.
     if (.not. test_exit_diagnostic()) all_passed = .false.
     if (.not. test_cycle_diagnostic()) all_passed = .false.
     if (.not. test_unsupported_intrinsic_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
-    if (.not. test_cli_character_declaration_diagnostic()) all_passed = .false.
+    if (.not. test_cli_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_cli_module_diagnostic()) all_passed = .false.
     if (.not. test_cli_exit_diagnostic()) all_passed = .false.
     if (.not. test_cli_cycle_diagnostic()) all_passed = .false.
@@ -30,144 +30,146 @@ contains
 
     logical function test_array_declaration_diagnostic()
         character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  integer :: values(3)'//new_line('a')// &
-            'end program main'
+                                       'program main'//new_line('a')// &
+                                       '  integer :: values(3)'//new_line('a')// &
+                                       'end program main'
 
         test_array_declaration_diagnostic = expect_error_contains( &
-            source, 'unsupported array declaration', &
-            '/tmp/ffc_session_array_diagnostic_test')
+                                            source, 'unsupported array declaration', &
+                                            '/tmp/ffc_session_array_diagnostic_test')
     end function test_array_declaration_diagnostic
 
-    logical function test_character_declaration_diagnostic()
+    logical function test_character_expression_diagnostic()
         character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  character(len=5) :: name'//new_line('a')// &
-            'end program main'
+                                       'program main'//new_line('a')// &
+                                       '  character(len=5) :: name'//new_line('a')// &
+                                       '  name = "he" // "llo"'//new_line('a')// &
+                                       'end program main'
 
-        test_character_declaration_diagnostic = expect_error_contains( &
-            source, 'unsupported character variable declaration', &
-            '/tmp/ffc_session_character_diagnostic_test')
-    end function test_character_declaration_diagnostic
+        test_character_expression_diagnostic = expect_error_contains( &
+                                           source, 'unsupported character assignment', &
+                                           '/tmp/ffc_session_character_diagnostic_test')
+    end function test_character_expression_diagnostic
 
     logical function test_module_diagnostic()
         character(len=*), parameter :: source = &
-            'module m'//new_line('a')// &
-            'end module m'
+                                       'module m'//new_line('a')// &
+                                       'end module m'
 
         test_module_diagnostic = expect_error_contains( &
-            source, 'unsupported module program unit', &
-            '/tmp/ffc_session_module_diagnostic_test')
+                                 source, 'unsupported module program unit', &
+                                 '/tmp/ffc_session_module_diagnostic_test')
     end function test_module_diagnostic
 
     logical function test_exit_diagnostic()
         character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  integer :: i'//new_line('a')// &
-            '  do i = 1, 3'//new_line('a')// &
-            '    exit'//new_line('a')// &
-            '  end do'//new_line('a')// &
-            'end program main'
+                                       'program main'//new_line('a')// &
+                                       '  integer :: i'//new_line('a')// &
+                                       '  do i = 1, 3'//new_line('a')// &
+                                       '    exit'//new_line('a')// &
+                                       '  end do'//new_line('a')// &
+                                       'end program main'
 
         test_exit_diagnostic = expect_error_contains( &
-            source, 'unsupported exit statement', &
-            '/tmp/ffc_session_exit_diagnostic_test')
+                               source, 'unsupported exit statement', &
+                               '/tmp/ffc_session_exit_diagnostic_test')
     end function test_exit_diagnostic
 
     logical function test_cycle_diagnostic()
         character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  integer :: i'//new_line('a')// &
-            '  do i = 1, 3'//new_line('a')// &
-            '    cycle'//new_line('a')// &
-            '  end do'//new_line('a')// &
-            'end program main'
+                                       'program main'//new_line('a')// &
+                                       '  integer :: i'//new_line('a')// &
+                                       '  do i = 1, 3'//new_line('a')// &
+                                       '    cycle'//new_line('a')// &
+                                       '  end do'//new_line('a')// &
+                                       'end program main'
 
         test_cycle_diagnostic = expect_error_contains( &
-            source, 'unsupported cycle statement', &
-            '/tmp/ffc_session_cycle_diagnostic_test')
+                                source, 'unsupported cycle statement', &
+                                '/tmp/ffc_session_cycle_diagnostic_test')
     end function test_cycle_diagnostic
 
     logical function test_unsupported_intrinsic_diagnostic()
         character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  print *, sqrt(4)'//new_line('a')// &
-            'end program main'
+                                       'program main'//new_line('a')// &
+                                       '  print *, sqrt(4)'//new_line('a')// &
+                                       'end program main'
 
         test_unsupported_intrinsic_diagnostic = expect_error_contains( &
-            source, 'unsupported scalar intrinsic: sqrt', &
-            '/tmp/ffc_session_intrinsic_diagnostic_test')
+                                         source, 'unsupported scalar intrinsic: sqrt', &
+                                           '/tmp/ffc_session_intrinsic_diagnostic_test')
     end function test_unsupported_intrinsic_diagnostic
 
     logical function test_cli_array_declaration_diagnostic()
         character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  integer :: values(3)'//new_line('a')// &
-            'end program main'
+                                       'program main'//new_line('a')// &
+                                       '  integer :: values(3)'//new_line('a')// &
+                                       'end program main'
 
         test_cli_array_declaration_diagnostic = expect_cli_error_contains( &
-            source, 'unsupported array declaration', &
-            '/tmp/ffc_cli_array_diagnostic_test')
+                                              source, 'unsupported array declaration', &
+                                                '/tmp/ffc_cli_array_diagnostic_test')
     end function test_cli_array_declaration_diagnostic
 
-    logical function test_cli_character_declaration_diagnostic()
+    logical function test_cli_character_expression_diagnostic()
         character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  character(len=5) :: name'//new_line('a')// &
-            'end program main'
+                                       'program main'//new_line('a')// &
+                                       '  character(len=5) :: name'//new_line('a')// &
+                                       '  name = "he" // "llo"'//new_line('a')// &
+                                       'end program main'
 
-        test_cli_character_declaration_diagnostic = expect_cli_error_contains( &
-            source, 'unsupported character variable declaration', &
-            '/tmp/ffc_cli_character_diagnostic_test')
-    end function test_cli_character_declaration_diagnostic
+        test_cli_character_expression_diagnostic = expect_cli_error_contains( &
+                                           source, 'unsupported character assignment', &
+                                               '/tmp/ffc_cli_character_diagnostic_test')
+    end function test_cli_character_expression_diagnostic
 
     logical function test_cli_module_diagnostic()
         character(len=*), parameter :: source = &
-            'module m'//new_line('a')// &
-            'end module m'
+                                       'module m'//new_line('a')// &
+                                       'end module m'
 
         test_cli_module_diagnostic = expect_cli_error_contains( &
-            source, 'unsupported module program unit', &
-            '/tmp/ffc_cli_module_diagnostic_test')
+                                     source, 'unsupported module program unit', &
+                                     '/tmp/ffc_cli_module_diagnostic_test')
     end function test_cli_module_diagnostic
 
     logical function test_cli_exit_diagnostic()
         character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  integer :: i'//new_line('a')// &
-            '  do i = 1, 3'//new_line('a')// &
-            '    exit'//new_line('a')// &
-            '  end do'//new_line('a')// &
-            'end program main'
+                                       'program main'//new_line('a')// &
+                                       '  integer :: i'//new_line('a')// &
+                                       '  do i = 1, 3'//new_line('a')// &
+                                       '    exit'//new_line('a')// &
+                                       '  end do'//new_line('a')// &
+                                       'end program main'
 
         test_cli_exit_diagnostic = expect_cli_error_contains( &
-            source, 'unsupported exit statement', &
-            '/tmp/ffc_cli_exit_diagnostic_test')
+                                   source, 'unsupported exit statement', &
+                                   '/tmp/ffc_cli_exit_diagnostic_test')
     end function test_cli_exit_diagnostic
 
     logical function test_cli_cycle_diagnostic()
         character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  integer :: i'//new_line('a')// &
-            '  do i = 1, 3'//new_line('a')// &
-            '    cycle'//new_line('a')// &
-            '  end do'//new_line('a')// &
-            'end program main'
+                                       'program main'//new_line('a')// &
+                                       '  integer :: i'//new_line('a')// &
+                                       '  do i = 1, 3'//new_line('a')// &
+                                       '    cycle'//new_line('a')// &
+                                       '  end do'//new_line('a')// &
+                                       'end program main'
 
         test_cli_cycle_diagnostic = expect_cli_error_contains( &
-            source, 'unsupported cycle statement', &
-            '/tmp/ffc_cli_cycle_diagnostic_test')
+                                    source, 'unsupported cycle statement', &
+                                    '/tmp/ffc_cli_cycle_diagnostic_test')
     end function test_cli_cycle_diagnostic
 
     logical function test_cli_unsupported_intrinsic_diagnostic()
         character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  print *, sqrt(4)'//new_line('a')// &
-            'end program main'
+                                       'program main'//new_line('a')// &
+                                       '  print *, sqrt(4)'//new_line('a')// &
+                                       'end program main'
 
         test_cli_unsupported_intrinsic_diagnostic = expect_cli_error_contains( &
-            source, 'unsupported scalar intrinsic: sqrt', &
-            '/tmp/ffc_cli_intrinsic_diagnostic_test')
+                                         source, 'unsupported scalar intrinsic: sqrt', &
+                                               '/tmp/ffc_cli_intrinsic_diagnostic_test')
     end function test_cli_unsupported_intrinsic_diagnostic
 
     logical function expect_error_contains(source, expected, exe_path)


### PR DESCRIPTION
## Requirements

REQ-001: Represent scalar character variables with pointer plus length metadata in the direct-session lowering ABI (ref #51).
REQ-002: Support fixed-length scalar character declarations for the MVP (ref #51).
REQ-003: Support assigning a character literal to a scalar character variable (ref #51).
REQ-004: Support `print *, character_variable` (ref #51).
REQ-005: Keep unsupported character features on targeted diagnostics (ref #51).
REQ-006: Add behavior tests and document the ABI (ref #51).

## Verification

Failing before:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_character_variable_compiler
FAIL: direct LIRIC lowering failed: unsupported character variable declaration at line 1, column 1: scalar character variables are not supported by direct LIRIC session
STOP 1
```

Passing after:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_character_variable_compiler
PASS: character variables lower through direct LIRIC session
```

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics
```

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test
PASS: LIRIC session binding tests
PASS: empty program compiles and runs through direct LIRIC session
PASS: empty program emits object through direct LIRIC session
PASS: integer stop expression lowers through direct LIRIC session
PASS: integer variable lowers through direct LIRIC session
PASS: block IF lowers through direct LIRIC session
PASS: fallthrough IF merges scalar values through direct LIRIC
PASS: integer print lowers through direct LIRIC session
PASS: real literal print lowers through direct LIRIC session
PASS: character literal print lowers through direct LIRIC session
PASS: character variables lower through direct LIRIC session
PASS: logical literal print lowers through direct LIRIC session
PASS: logical variables lower through direct LIRIC session
PASS: real variables and arithmetic lower through direct LIRIC
PASS: integer function calls lower through direct LIRIC session
PASS: integer subroutine reference args lower through direct LIRIC session
PASS: scalar intrinsics lower through direct LIRIC session
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```

```text
git diff --check
(no output)
```

<!-- orchestrate: fully-resolved -->
