### PR TITLE
fix: scalar character ABI coverage (refs #51)

### DIFF
--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -393,25 +393,9 @@ contains
         character(len=*), intent(in) :: name
         integer, intent(in) :: value_kind
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: character_length
-        integer :: existing_index
 
         if (value_kind == VALUE_CHARACTER) then
-            existing_index = find_symbol(context, name)
-            if (existing_index > 0) then
-                if (context%symbols(existing_index)%is_parameter) then
-                    call unsupported_feature_error( &
-                        'character parameter declaration', &
-                        node%line, node%column, &
-                        'scalar character parameters are not supported '// &
-                        'by direct LIRIC session', error_msg)
-                    return
-                end if
-            end if
-            call declaration_character_length(node, character_length, error_msg)
-            if (len_trim(error_msg) > 0) return
-            call define_character_symbol(context, name, character_length, &
-                                         error_msg)
+            call define_declared_character_symbol(context, node, name, error_msg)
         else
             call define_symbol(context, name, value_kind, error_msg)
         end if

--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -394,8 +394,20 @@ contains
         integer, intent(in) :: value_kind
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: character_length
+        integer :: existing_index
 
         if (value_kind == VALUE_CHARACTER) then
+            existing_index = find_symbol(context, name)
+            if (existing_index > 0) then
+                if (context%symbols(existing_index)%is_parameter) then
+                    call unsupported_feature_error( &
+                        'character parameter declaration', &
+                        node%line, node%column, &
+                        'scalar character parameters are not supported '// &
+                        'by direct LIRIC session', error_msg)
+                    return
+                end if
+            end if
             call declaration_character_length(node, character_length, error_msg)
             if (len_trim(error_msg) > 0) return
             call define_character_symbol(context, name, character_length, &

--- a/src_mvp/session_program_lowering_character.inc
+++ b/src_mvp/session_program_lowering_character.inc
@@ -1,3 +1,26 @@
+    subroutine define_declared_character_symbol(context, node, name, error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        type(declaration_node), intent(in) :: node
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: character_length
+        integer :: existing_index
+
+        existing_index = find_symbol(context, name)
+        if (existing_index > 0) then
+            if (context%symbols(existing_index)%is_parameter) then
+                call unsupported_feature_error( &
+                    'character parameter declaration', node%line, node%column, &
+                    'scalar character parameters are not supported '// &
+                    'by direct LIRIC session', error_msg)
+                return
+            end if
+        end if
+        call declaration_character_length(node, character_length, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call define_character_symbol(context, name, character_length, error_msg)
+    end subroutine define_declared_character_symbol
+
     subroutine declaration_character_length(node, character_length, error_msg)
         type(declaration_node), intent(in) :: node
         integer, intent(out) :: character_length

--- a/test_mvp/test_session_character_variable_compiler.f90
+++ b/test_mvp/test_session_character_variable_compiler.f90
@@ -20,7 +20,7 @@ program test_session_character_variable_compiler
     character(len=*), parameter :: source = &
                                    'program main'//new_line('a')// &
                                    '  character(len=5) :: s'//new_line('a')// &
-                                   '  s = "hi"'//new_line('a')// &
+                                   '  s = "hello"'//new_line('a')// &
                                    '  print *, s'//new_line('a')// &
                                    'end program main'
 
@@ -76,8 +76,8 @@ program test_session_character_variable_compiler
     call execute_command_line('rm -f '//exe_path//' '//out_path)
 
     if (io_stat /= 0 .or. file_size /= 6 .or. &
-        output_text /= 'hi   '//new_line('a')) then
-        print *, 'FAIL: expected fixed-length output hi, got ', output_line
+        output_text /= 'hello'//new_line('a')) then
+        print *, 'FAIL: expected fixed-length output hello, got ', output_line
         stop 1
     end if
 

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -13,12 +13,14 @@ program test_session_unsupported_diagnostics
     if (.not. test_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_module_diagnostic()) all_passed = .false.
+    if (.not. test_character_parameter_diagnostic()) all_passed = .false.
     if (.not. test_exit_diagnostic()) all_passed = .false.
     if (.not. test_cycle_diagnostic()) all_passed = .false.
     if (.not. test_unsupported_intrinsic_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_cli_module_diagnostic()) all_passed = .false.
+    if (.not. test_cli_character_parameter_diagnostic()) all_passed = .false.
     if (.not. test_cli_exit_diagnostic()) all_passed = .false.
     if (.not. test_cli_cycle_diagnostic()) all_passed = .false.
     if (.not. test_cli_unsupported_intrinsic_diagnostic()) all_passed = .false.
@@ -60,6 +62,27 @@ contains
                                  source, 'unsupported module program unit', &
                                  '/tmp/ffc_session_module_diagnostic_test')
     end function test_module_diagnostic
+
+    logical function test_character_parameter_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported character parameter '// &
+                                       'declaration'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  call show("hi")'//new_line('a')// &
+                                       'contains'//new_line('a')// &
+                                       '  subroutine show(s)'//new_line('a')// &
+                                       '    character(len=2), intent(in) :: '// &
+                                       's'// &
+                                       new_line('a')// &
+                                       '    print *, s'//new_line('a')// &
+                                       '  end subroutine show'//new_line('a')// &
+                                       'end program main'
+
+        test_character_parameter_diagnostic = expect_error_contains( &
+                                              source, expected, &
+                                              '/tmp/ffc_session_char_param_test')
+    end function test_character_parameter_diagnostic
 
     logical function test_exit_diagnostic()
         character(len=*), parameter :: source = &
@@ -132,6 +155,27 @@ contains
                                      source, 'unsupported module program unit', &
                                      '/tmp/ffc_cli_module_diagnostic_test')
     end function test_cli_module_diagnostic
+
+    logical function test_cli_character_parameter_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported character parameter '// &
+                                       'declaration'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  call show("hi")'//new_line('a')// &
+                                       'contains'//new_line('a')// &
+                                       '  subroutine show(s)'//new_line('a')// &
+                                       '    character(len=2), intent(in) :: '// &
+                                       's'// &
+                                       new_line('a')// &
+                                       '    print *, s'//new_line('a')// &
+                                       '  end subroutine show'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_character_parameter_diagnostic = expect_cli_error_contains( &
+                                                  source, expected, &
+                                                  '/tmp/ffc_cli_char_param_test')
+    end function test_cli_character_parameter_diagnostic
 
     logical function test_cli_exit_diagnostic()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
## Requirements

- REQ-001: Represent scalar `character(len=N)` variables with pointer plus length metadata in the lowering layer.
- REQ-002: Support character literal assignment to scalar character variables.
- REQ-003: Support `print *, character_variable`.
- REQ-004: Define the MVP character ABI and document current limitations.
- REQ-005: Unsupported character features produce clear diagnostics.

## Changes

- Tightens the character-variable executable test to cover `character(len=5) :: s; s = "hello"; print *, s` directly.
- Adds lowering and CLI diagnostic coverage for unsupported scalar character dummy arguments.
- Reports character dummy declarations as an unsupported feature instead of a duplicate declaration.

## Verification

Failing before implementation:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
FAIL: expected diagnostic substring unsupported character parameter declaration
  got duplicate character declaration: s
FAIL: expected CLI diagnostic substring unsupported character parameter declaration
  got STOP 1
duplicate character declaration: s
```

Passing after implementation:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_character_variable_compiler
PASS: character variables lower through direct LIRIC session
```

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics
```

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test
PASS: LIRIC session binding tests
PASS: empty program compiles and runs through direct LIRIC session
PASS: empty program emits object through direct LIRIC session
PASS: integer stop expression lowers through direct LIRIC session
PASS: integer variable lowers through direct LIRIC session
PASS: block IF lowers through direct LIRIC session
PASS: fallthrough IF merges scalar values through direct LIRIC
PASS: integer print lowers through direct LIRIC session
PASS: real literal print lowers through direct LIRIC session
PASS: character literal print lowers through direct LIRIC session
PASS: character variables lower through direct LIRIC session
PASS: logical literal print lowers through direct LIRIC session
PASS: logical variables lower through direct LIRIC session
PASS: real variables and arithmetic lower through direct LIRIC
PASS: integer function calls lower through direct LIRIC session
PASS: integer subroutine reference args lower through direct LIRIC session
PASS: scalar intrinsics lower through direct LIRIC session
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```

(ref #51)

<!-- orchestrate: fully-resolved -->
