### PR TITLE
fix: unsupported parameter diagnostics (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -393,6 +393,17 @@ contains
         character(len=*), intent(in) :: name
         integer, intent(in) :: value_kind
         character(len=:), allocatable, intent(out) :: error_msg
+        integer :: existing_index
+
+        existing_index = find_symbol(context, name)
+        if (existing_index > 0) then
+            if (context%symbols(existing_index)%is_parameter .and. &
+                value_kind /= VALUE_I32 .and. value_kind /= VALUE_CHARACTER) then
+                call unsupported_scalar_parameter_declaration( &
+                    value_kind, node%line, node%column, error_msg)
+                return
+            end if
+        end if
 
         if (value_kind == VALUE_CHARACTER) then
             call define_declared_character_symbol(context, node, name, error_msg)
@@ -400,6 +411,28 @@ contains
             call define_symbol(context, name, value_kind, error_msg)
         end if
     end subroutine define_declared_symbol
+
+    subroutine unsupported_scalar_parameter_declaration(value_kind, line, column, &
+                                                        error_msg)
+        integer, intent(in) :: value_kind
+        integer, intent(in) :: line
+        integer, intent(in) :: column
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (value_kind == VALUE_F64) then
+            call unsupported_feature_error( &
+                'real parameter declaration', line, column, &
+                'real scalar parameters are not supported by direct LIRIC '// &
+                'session', error_msg)
+        else if (value_kind == VALUE_LOGICAL) then
+            call unsupported_feature_error( &
+                'logical parameter declaration', line, column, &
+                'logical scalar parameters are not supported by direct LIRIC '// &
+                'session', error_msg)
+        else
+            error_msg = 'unsupported parameter declaration value kind'
+        end if
+    end subroutine unsupported_scalar_parameter_declaration
 
     subroutine lower_parameter_declaration(node, context, error_msg)
         type(parameter_declaration_node), intent(in) :: node

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -14,6 +14,8 @@ program test_session_unsupported_diagnostics
     if (.not. test_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_module_diagnostic()) all_passed = .false.
     if (.not. test_character_parameter_diagnostic()) all_passed = .false.
+    if (.not. test_real_parameter_diagnostic()) all_passed = .false.
+    if (.not. test_logical_parameter_diagnostic()) all_passed = .false.
     if (.not. test_exit_diagnostic()) all_passed = .false.
     if (.not. test_cycle_diagnostic()) all_passed = .false.
     if (.not. test_unsupported_intrinsic_diagnostic()) all_passed = .false.
@@ -21,6 +23,8 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_cli_module_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_parameter_diagnostic()) all_passed = .false.
+    if (.not. test_cli_real_parameter_diagnostic()) all_passed = .false.
+    if (.not. test_cli_logical_parameter_diagnostic()) all_passed = .false.
     if (.not. test_cli_exit_diagnostic()) all_passed = .false.
     if (.not. test_cli_cycle_diagnostic()) all_passed = .false.
     if (.not. test_cli_unsupported_intrinsic_diagnostic()) all_passed = .false.
@@ -83,6 +87,49 @@ contains
                                               source, expected, &
                                               '/tmp/ffc_session_char_param_test')
     end function test_character_parameter_diagnostic
+
+    logical function test_real_parameter_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported real parameter declaration'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  real :: x'//new_line('a')// &
+                                       '  x = 1.0'//new_line('a')// &
+                                       '  call scale(x)'//new_line('a')// &
+                                       'contains'//new_line('a')// &
+                                       '  subroutine scale(value)'//new_line('a')// &
+                                       '    real, intent(inout) :: value'// &
+                                       new_line('a')// &
+                                       '    value = value + 1.0'//new_line('a')// &
+                                       '  end subroutine scale'//new_line('a')// &
+                                       'end program main'
+
+        test_real_parameter_diagnostic = expect_error_contains( &
+                                         source, expected, &
+                                         '/tmp/ffc_session_real_param_test')
+    end function test_real_parameter_diagnostic
+
+    logical function test_logical_parameter_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported logical parameter '// &
+                                       'declaration'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  logical :: flag'//new_line('a')// &
+                                       '  flag = .false.'//new_line('a')// &
+                                       '  call enable(flag)'//new_line('a')// &
+                                       'contains'//new_line('a')// &
+                                       '  subroutine enable(value)'//new_line('a')// &
+                                       '    logical, intent(inout) :: value'// &
+                                       new_line('a')// &
+                                       '    value = .true.'//new_line('a')// &
+                                       '  end subroutine enable'//new_line('a')// &
+                                       'end program main'
+
+        test_logical_parameter_diagnostic = expect_error_contains( &
+                                            source, expected, &
+                                            '/tmp/ffc_session_logical_param_test')
+    end function test_logical_parameter_diagnostic
 
     logical function test_exit_diagnostic()
         character(len=*), parameter :: source = &
@@ -176,6 +223,49 @@ contains
                                                   source, expected, &
                                                   '/tmp/ffc_cli_char_param_test')
     end function test_cli_character_parameter_diagnostic
+
+    logical function test_cli_real_parameter_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported real parameter declaration'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  real :: x'//new_line('a')// &
+                                       '  x = 1.0'//new_line('a')// &
+                                       '  call scale(x)'//new_line('a')// &
+                                       'contains'//new_line('a')// &
+                                       '  subroutine scale(value)'//new_line('a')// &
+                                       '    real, intent(inout) :: value'// &
+                                       new_line('a')// &
+                                       '    value = value + 1.0'//new_line('a')// &
+                                       '  end subroutine scale'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_real_parameter_diagnostic = expect_cli_error_contains( &
+                                             source, expected, &
+                                             '/tmp/ffc_cli_real_param_test')
+    end function test_cli_real_parameter_diagnostic
+
+    logical function test_cli_logical_parameter_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported logical parameter '// &
+                                       'declaration'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  logical :: flag'//new_line('a')// &
+                                       '  flag = .false.'//new_line('a')// &
+                                       '  call enable(flag)'//new_line('a')// &
+                                       'contains'//new_line('a')// &
+                                       '  subroutine enable(value)'//new_line('a')// &
+                                       '    logical, intent(inout) :: value'// &
+                                       new_line('a')// &
+                                       '    value = .true.'//new_line('a')// &
+                                       '  end subroutine enable'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_logical_parameter_diagnostic = expect_cli_error_contains( &
+                                                source, expected, &
+                                                '/tmp/ffc_cli_logical_param_test')
+    end function test_cli_logical_parameter_diagnostic
 
     logical function test_cli_exit_diagnostic()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
## Requirements

- REQ-001 Unsupported non-integer contained-procedure parameter declarations must use targeted unsupported-feature diagnostics instead of raw MVP strings (ref #57).
- REQ-002 Those diagnostics must include line and column in both direct lowering and CLI output when FortFront provides them (ref #57).
- REQ-003 Add focused negative behavior tests for real and logical dummy-argument declarations (ref #57).

## Verification

Red before lowerer change:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
FAIL: expected diagnostic substring unsupported real parameter declaration
  got parameter declaration type mismatch: value
FAIL: expected diagnostic substring unsupported logical parameter declaration
  got parameter declaration type mismatch: value
FAIL: expected CLI diagnostic substring unsupported real parameter declaration
  got STOP 1
parameter declaration type mismatch: value
FAIL: expected CLI diagnostic substring unsupported logical parameter declaration
  got STOP 1
parameter declaration type mismatch: value
STOP 1
```

Passing after change:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics
```

Full suite:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test
Project is up to date
PASS: LIRIC session binding tests
PASS: empty program compiles and runs through direct LIRIC session
PASS: empty program emits object through direct LIRIC session
PASS: integer stop expression lowers through direct LIRIC session
PASS: integer variable lowers through direct LIRIC session
PASS: block IF lowers through direct LIRIC session
PASS: fallthrough IF merges scalar values through direct LIRIC
PASS: integer print lowers through direct LIRIC session
PASS: real literal print lowers through direct LIRIC session
PASS: character literal print lowers through direct LIRIC session
PASS: character variables lower through direct LIRIC session
PASS: logical literal print lowers through direct LIRIC session
PASS: logical variables lower through direct LIRIC session
PASS: real variables and arithmetic lower through direct LIRIC
PASS: integer function calls lower through direct LIRIC session
PASS: integer subroutine reference args lower through direct LIRIC session
PASS: scalar intrinsics lower through direct LIRIC session
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```