### PR TITLE
fix: support non-integer procedure ABI (refs #50)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,8 @@ calls, LIRIC bindings, object emission, and executable emission.
   variables.
 - Logical declarations, assignments, `if (flag)` conditions, and printed
   logical variables.
-- Simple contained integer functions and subroutines with integer parameters,
-  assignment to the function result name, and integer call
+- Simple contained integer, real, and logical functions and subroutines with
+  scalar parameters, assignment to the function result name, and scalar call
   expressions/statements.
 
 ## Immediate Work

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ The current MVP support claim is:
 - scalar `logical` literals in `print`
 - real variables/arithmetic
 - block `if`
-- simple contained integer functions and subroutines with integer parameters
+- simple contained integer, real, and logical functions and subroutines
 - integer and real scalar `abs`, `min`, and `max` intrinsics
 - integer-to-real `real()` conversion
 - object/executable emission through LIRIC
 
 Arrays, allocatables, modules, derived types, full I/O, generics,
-cross-module inference, and non-integer procedure ABIs are unsupported today.
+cross-module inference, and character procedure arguments are unsupported today.
 See the issue map in
 [docs/SUPPORT_CONTRACT.md](docs/SUPPORT_CONTRACT.md).
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -40,8 +40,8 @@ LIBRARY_PATH=/path/to/liric/build fpm build
 3. Minimal `print *, expr`.
 4. Block `if`, fallthrough integer merges, and counted loops.
 5. Real scalar values, logical variables, and minimal character/logical print.
-6. Simple contained integer functions/subroutines and explicit ABI tests.
-7. Richer non-integer procedure signatures.
+6. Simple contained integer, real, and logical functions/subroutines.
+7. Character procedure signatures.
 8. Character representation and a fuller runtime surface.
 9. Arrays, modules, derived types, allocatables, and generics.
 

--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -39,19 +39,18 @@ issue is closed with ABI documentation and executable tests.
 
 ## Procedures
 
-- The supported procedure slice is contained integer functions and subroutines
-  with integer parameters.
+- The supported procedure slice is contained integer, real, and logical
+  functions and subroutines with scalar parameters.
 - Procedure parameters are currently lowered as LIRIC pointer parameters for
-  integer arguments. Callers pass a reference slot; variable actual arguments
-  are copied back after the call, and parameter assignment stores through the
-  pointer.
+  integer, real, and logical arguments. Callers pass a reference slot; variable
+  actual arguments are copied back after the call, and parameter assignment
+  stores through the pointer.
 - Function results are represented by assignment to the function result name.
 - Subroutines return LIRIC `void`; explicit `CALL` statements emit `void` calls.
 - Names are emitted as source names for the current single-file subset. A
   deterministic mangling scheme is still required before broader procedure and
   module support.
-- Non-integer procedure parameters and results are unsupported; #50 owns that
-  ABI.
+- Character procedure parameters and results are unsupported.
 - External procedures, modules, and separate compilation are unsupported; #54
   owns symbol mangling and link behavior.
 

--- a/docs/SUPPORT_CONTRACT.md
+++ b/docs/SUPPORT_CONTRACT.md
@@ -31,7 +31,7 @@ The current implementation is a single-file, direct-session scalar subset.
 | Termination | Falling off `program main` returns zero. `stop <integer expression>` returns the integer expression as process status. |
 | `if` | Integer comparison `if` blocks with terminating branches or branches that assign mergeable integer values; scalar logical `if (flag)` conditions. |
 | `do` | Counted `do` loops with integer bounds and literal integer step. |
-| Procedures | Contained integer functions and subroutines with integer parameters only. Integer procedure actual arguments use pointer parameters with copy-back for variable actuals. |
+| Procedures | Contained integer, real, and logical functions and subroutines. Scalar procedure actual arguments use pointer parameters with copy-back for variable actuals. |
 | Intrinsics | Scalar `abs`, `min`, and `max` for integer and real values, plus integer-to-real `real()` conversion. These lower inline with LIRIC scalar operations, comparisons, branches, and PHI operations. |
 | `print` | Minimal scalar `print *, expr` through the current `printf` shim for integer expressions, real values, character literals, character variables, logical literals, real variables, and logical variables. |
 
@@ -39,7 +39,6 @@ The current implementation is a single-file, direct-session scalar subset.
 
 | Issue | Missing feature | Required result before support is claimed |
 | --- | --- | --- |
-| #50 | Non-integer scalar procedure ABI | Real, logical, and character scalar function/subroutine arguments and results have ABI tests and executable tests. |
 | #52 | Fixed-size one-dimensional arrays | Declaration, indexing, assignment, and printing tests pass for explicit-shape rank-one arrays. |
 | #53 | Allocatable arrays | Descriptor layout, allocation, deallocation, bounds, and element access are documented and tested. |
 | #54 | Modules and separate compilation | Module symbols, external procedure symbols, name mangling, and link behavior are deterministic and tested. |

--- a/fpm.toml
+++ b/fpm.toml
@@ -108,6 +108,11 @@ source-dir = "test_mvp"
 main = "test_session_integer_subroutine_compiler.f90"
 
 [[test]]
+name = "test_session_non_integer_procedure_compiler"
+source-dir = "test_mvp"
+main = "test_session_non_integer_procedure_compiler.f90"
+
+[[test]]
 name = "test_session_integer_intrinsic_compiler"
 source-dir = "test_mvp"
 main = "test_session_integer_intrinsic_compiler.f90"

--- a/src_mvp/liric_session_procedure_bindings.f90
+++ b/src_mvp/liric_session_procedure_bindings.f90
@@ -1,0 +1,418 @@
+module liric_session_procedure_bindings
+    use, intrinsic :: iso_c_binding, only: c_associated, c_bool, c_char
+    use, intrinsic :: iso_c_binding, only: c_int, c_int32_t, c_int64_t
+    use, intrinsic :: iso_c_binding, only: c_loc, c_null_char, c_null_ptr, c_ptr
+    use liric_session_bindings, only: liric_session_error_message, &
+                                      liric_session_t, lr_error_t, &
+                                      lr_inst_desc_t, lr_operand_desc_t, LR_OK, &
+                                      LR_OP_KIND_GLOBAL, LR_OP_KIND_VREG
+    implicit none
+    private
+
+    integer(c_int), parameter :: LR_OP_CALL = 30_c_int
+    integer(c_int), parameter :: LR_OP_ALLOCA = 26_c_int
+    integer(c_int), parameter :: LR_OP_LOAD = 27_c_int
+    integer(c_int), parameter :: LR_OP_STORE = 28_c_int
+    logical(c_bool), parameter :: c_false = .false.
+
+    public :: begin_liric_f64_function
+    public :: emit_liric_f64_alloca
+    public :: emit_liric_f64_call
+    public :: emit_liric_f64_load
+    public :: emit_liric_f64_store
+
+    interface
+        function lr_type_f64_s(handle) result(typ) bind(c)
+            import :: c_ptr
+            type(c_ptr), value :: handle
+            type(c_ptr) :: typ
+        end function lr_type_f64_s
+
+        function lr_type_ptr_s(handle) result(typ) bind(c)
+            import :: c_ptr
+            type(c_ptr), value :: handle
+            type(c_ptr) :: typ
+        end function lr_type_ptr_s
+
+        function lr_session_func_begin(handle, name, ret, params, n, &
+                                       vararg, err) result(status) bind(c)
+            import :: c_bool, c_char, c_int, c_int32_t, c_ptr, lr_error_t
+            type(c_ptr), value :: handle
+            character(kind=c_char), intent(in) :: name(*)
+            type(c_ptr), value :: ret
+            type(c_ptr), value :: params
+            integer(c_int32_t), value :: n
+            logical(c_bool), value :: vararg
+            type(lr_error_t), intent(inout) :: err
+            integer(c_int) :: status
+        end function lr_session_func_begin
+
+        function lr_session_block(handle) result(block_id) bind(c)
+            import :: c_int32_t, c_ptr
+            type(c_ptr), value :: handle
+            integer(c_int32_t) :: block_id
+        end function lr_session_block
+
+        function lr_session_set_block(handle, block_id, err) result(status) &
+            bind(c)
+            import :: c_int, c_int32_t, c_ptr, lr_error_t
+            type(c_ptr), value :: handle
+            integer(c_int32_t), value :: block_id
+            type(lr_error_t), intent(inout) :: err
+            integer(c_int) :: status
+        end function lr_session_set_block
+
+        function lr_session_intern(handle, name) result(symbol_id) bind(c)
+            import :: c_char, c_int32_t, c_ptr
+            type(c_ptr), value :: handle
+            character(kind=c_char), intent(in) :: name(*)
+            integer(c_int32_t) :: symbol_id
+        end function lr_session_intern
+
+        function lr_session_emit(handle, inst, err) result(vreg) bind(c)
+            import :: c_int32_t, c_ptr, lr_error_t, lr_inst_desc_t
+            type(c_ptr), value :: handle
+            type(lr_inst_desc_t), intent(in) :: inst
+            type(lr_error_t), intent(inout) :: err
+            integer(c_int32_t) :: vreg
+        end function lr_session_emit
+    end interface
+
+contains
+
+    logical function begin_liric_f64_function(session, name, param_count, &
+                                              error_msg)
+        type(liric_session_t), intent(inout) :: session
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: param_count
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(kind=c_char), allocatable :: c_name(:)
+        type(c_ptr), allocatable, target :: params(:)
+        type(c_ptr) :: params_ptr
+        type(c_ptr) :: param_type
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: block_id
+        integer(c_int) :: status
+        integer :: i
+
+        begin_liric_f64_function = .false.
+        if (.not. require_open_session(session, error_msg)) return
+
+        param_type = lr_type_ptr_s(session%handle)
+        if (.not. c_associated(param_type)) then
+            error_msg = 'LIRIC did not return a pointer type'
+            return
+        end if
+
+        params_ptr = c_null_ptr
+        if (param_count > 0) then
+            allocate (params(param_count))
+            do i = 1, param_count
+                params(i) = param_type
+            end do
+            params_ptr = c_loc(params)
+        end if
+
+        call clear_liric_error(error)
+        call to_c_chars(trim(name), c_name)
+        status = lr_session_func_begin(session%handle, c_name, &
+                                       lr_type_f64_s(session%handle), &
+                                       params_ptr, int(param_count, c_int32_t), &
+                                       c_false, error)
+        if (.not. status_ok(status, error, error_msg)) return
+
+        block_id = lr_session_block(session%handle)
+        status = lr_session_set_block(session%handle, block_id, error)
+        if (.not. status_ok(status, error, error_msg)) return
+
+        call set_empty(error_msg)
+        begin_liric_f64_function = .true.
+    end function begin_liric_f64_function
+
+    logical function emit_liric_f64_alloca(session, address, error_msg)
+        type(liric_session_t), intent(inout) :: session
+        type(lr_operand_desc_t), intent(out) :: address
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: vreg
+
+        emit_liric_f64_alloca = .false.
+        if (.not. require_open_session(session, error_msg)) return
+
+        vreg = emit_alloca_typed(session%handle, lr_type_f64_s(session%handle), &
+                                 error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        address = ptr_vreg(session%handle, vreg)
+        call set_empty(error_msg)
+        emit_liric_f64_alloca = .true.
+    end function emit_liric_f64_alloca
+
+    logical function emit_liric_f64_load(session, address, value, error_msg)
+        type(liric_session_t), intent(inout) :: session
+        type(lr_operand_desc_t), intent(in) :: address
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: vreg
+
+        emit_liric_f64_load = .false.
+        if (.not. require_open_session(session, error_msg)) return
+
+        vreg = emit_load_typed(session%handle, lr_type_f64_s(session%handle), &
+                               address, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        value = f64_vreg(session%handle, vreg)
+        call set_empty(error_msg)
+        emit_liric_f64_load = .true.
+    end function emit_liric_f64_load
+
+    logical function emit_liric_f64_store(session, value, address, error_msg)
+        type(liric_session_t), intent(inout) :: session
+        type(lr_operand_desc_t), intent(in) :: value
+        type(lr_operand_desc_t), intent(in) :: address
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: unused_vreg
+
+        emit_liric_f64_store = .false.
+        if (.not. require_open_session(session, error_msg)) return
+
+        unused_vreg = emit_store_typed(session%handle, value, address, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        call set_empty(error_msg)
+        emit_liric_f64_store = .true.
+    end function emit_liric_f64_store
+
+    logical function emit_liric_f64_call(session, name, args, result, error_msg)
+        type(liric_session_t), intent(inout) :: session
+        character(len=*), intent(in) :: name
+        type(lr_operand_desc_t), intent(in) :: args(:)
+        type(lr_operand_desc_t), intent(out) :: result
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: vreg
+
+        emit_liric_f64_call = .false.
+        if (.not. require_open_session(session, error_msg)) return
+
+        vreg = emit_call_f64_function(session%handle, name, args, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        result = f64_vreg(session%handle, vreg)
+        call set_empty(error_msg)
+        emit_liric_f64_call = .true.
+    end function emit_liric_f64_call
+
+    function emit_alloca_typed(handle, typ, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        type(c_ptr), intent(in) :: typ
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_inst_desc_t) :: inst
+
+        inst%op = LR_OP_ALLOCA
+        inst%typ = typ
+        inst%dest = 0_c_int32_t
+        inst%operands = c_null_ptr
+        inst%num_operands = 0_c_int32_t
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_false
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 0_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_alloca_typed
+
+    function emit_load_typed(handle, typ, address, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        type(c_ptr), intent(in) :: typ
+        type(lr_operand_desc_t), intent(in) :: address
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_operand_desc_t), target :: operands(1)
+        type(lr_inst_desc_t) :: inst
+
+        operands(1) = address
+
+        inst%op = LR_OP_LOAD
+        inst%typ = typ
+        inst%dest = 0_c_int32_t
+        inst%operands = c_loc(operands)
+        inst%num_operands = 1_c_int32_t
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_false
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 0_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_load_typed
+
+    function emit_store_typed(handle, value, address, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        type(lr_operand_desc_t), intent(in) :: value
+        type(lr_operand_desc_t), intent(in) :: address
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_operand_desc_t), target :: operands(2)
+        type(lr_inst_desc_t) :: inst
+
+        operands = [value, address]
+
+        inst%op = LR_OP_STORE
+        inst%typ = c_null_ptr
+        inst%dest = 0_c_int32_t
+        inst%operands = c_loc(operands)
+        inst%num_operands = 2_c_int32_t
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_false
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 0_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_store_typed
+
+    function emit_call_f64_function(handle, name, args, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        character(len=*), intent(in) :: name
+        type(lr_operand_desc_t), intent(in) :: args(:)
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_operand_desc_t), target :: operands(9)
+        type(lr_inst_desc_t) :: inst
+        character(kind=c_char), allocatable :: c_name(:)
+        integer(c_int32_t) :: symbol_id
+        integer :: i
+
+        call to_c_chars(trim(name), c_name)
+        symbol_id = lr_session_intern(handle, c_name)
+        if (symbol_id < 0_c_int32_t .or. size(args) > 8) then
+            call clear_liric_error(error)
+            error%code = 1_c_int
+            return
+        end if
+
+        operands(1) = global_operand(handle, symbol_id)
+        do i = 1, size(args)
+            operands(i + 1) = args(i)
+        end do
+
+        inst%op = LR_OP_CALL
+        inst%typ = lr_type_f64_s(handle)
+        inst%dest = 0_c_int32_t
+        inst%operands = c_loc(operands)
+        inst%num_operands = int(size(args) + 1, c_int32_t)
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_false
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 0_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_call_f64_function
+
+    function f64_vreg(handle, vreg) result(operand)
+        type(c_ptr), intent(in) :: handle
+        integer(c_int32_t), intent(in) :: vreg
+        type(lr_operand_desc_t) :: operand
+
+        operand%kind = LR_OP_KIND_VREG
+        operand%payload = int(vreg, c_int64_t)
+        operand%typ = lr_type_f64_s(handle)
+        operand%global_offset = 0_c_int64_t
+    end function f64_vreg
+
+    function ptr_vreg(handle, vreg) result(operand)
+        type(c_ptr), intent(in) :: handle
+        integer(c_int32_t), intent(in) :: vreg
+        type(lr_operand_desc_t) :: operand
+
+        operand%kind = LR_OP_KIND_VREG
+        operand%payload = int(vreg, c_int64_t)
+        operand%typ = lr_type_ptr_s(handle)
+        operand%global_offset = 0_c_int64_t
+    end function ptr_vreg
+
+    function global_operand(handle, id) result(operand)
+        type(c_ptr), intent(in) :: handle
+        integer(c_int32_t), intent(in) :: id
+        type(lr_operand_desc_t) :: operand
+
+        operand%kind = LR_OP_KIND_GLOBAL
+        operand%payload = int(id, c_int64_t)
+        operand%typ = lr_type_ptr_s(handle)
+        operand%global_offset = 0_c_int64_t
+    end function global_operand
+
+    logical function require_open_session(session, error_msg)
+        type(liric_session_t), intent(in) :: session
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        require_open_session = c_associated(session%handle)
+        if (require_open_session) then
+            call set_empty(error_msg)
+        else
+            error_msg = 'LIRIC session handle is not open'
+        end if
+    end function require_open_session
+
+    logical function status_ok(status, error, error_msg)
+        integer(c_int), intent(in) :: status
+        type(lr_error_t), intent(in) :: error
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        status_ok = status == LR_OK
+        if (status_ok) then
+            call set_empty(error_msg)
+        else
+            error_msg = liric_session_error_message(error)
+        end if
+    end function status_ok
+
+    subroutine clear_liric_error(error)
+        type(lr_error_t), intent(out) :: error
+
+        error%code = LR_OK
+        error%msg = c_null_char
+    end subroutine clear_liric_error
+
+    subroutine to_c_chars(text, chars)
+        character(len=*), intent(in) :: text
+        character(kind=c_char), allocatable, intent(out) :: chars(:)
+        integer :: i
+
+        allocate (chars(len(text) + 1))
+        do i = 1, len(text)
+            chars(i) = text(i:i)
+        end do
+        chars(len(text) + 1) = c_null_char
+    end subroutine to_c_chars
+
+    subroutine set_empty(value)
+        character(len=:), allocatable, intent(out) :: value
+
+        allocate (character(len=0) :: value)
+    end subroutine set_empty
+
+end module liric_session_procedure_bindings

--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -34,6 +34,11 @@ module session_program_lowering
                                          LR_OP_FSUB, &
                                          materialize_liric_string, &
                                          prepare_liric_print_runtime
+    use liric_session_procedure_bindings, only: begin_liric_f64_function, &
+                                                emit_liric_f64_alloca, &
+                                                emit_liric_f64_call, &
+                                                emit_liric_f64_load, &
+                                                emit_liric_f64_store
     use session_lowering_ops, only: integer_compare_predicate, &
                                     integer_opcode, parse_i32_literal
     implicit none
@@ -88,8 +93,9 @@ module session_program_lowering
         integer(c_int32_t) :: f64_print_format_id = -1_c_int32_t
         integer(c_int32_t) :: str_print_format_id = -1_c_int32_t
         integer :: string_literal_count = 0
-        character(len=64) :: integer_function_names(MAX_PROCEDURES)
-        integer :: integer_function_count = 0
+        character(len=64) :: function_names(MAX_PROCEDURES)
+        integer :: function_value_kinds(MAX_PROCEDURES) = VALUE_I32
+        integer :: function_count = 0
         logical :: in_internal_function = .false.
         logical :: current_block_terminated = .false.
     end type lowering_context_t
@@ -398,9 +404,11 @@ contains
         existing_index = find_symbol(context, name)
         if (existing_index > 0) then
             if (context%symbols(existing_index)%is_parameter .and. &
-                value_kind /= VALUE_I32 .and. value_kind /= VALUE_CHARACTER) then
-                call unsupported_scalar_parameter_declaration( &
-                    value_kind, node%line, node%column, error_msg)
+                value_kind == VALUE_CHARACTER) then
+                call unsupported_feature_error( &
+                    'character parameter declaration', node%line, node%column, &
+                    'scalar character parameters are not supported '// &
+                    'by direct LIRIC session', error_msg)
                 return
             end if
         end if
@@ -412,33 +420,12 @@ contains
         end if
     end subroutine define_declared_symbol
 
-    subroutine unsupported_scalar_parameter_declaration(value_kind, line, column, &
-                                                        error_msg)
-        integer, intent(in) :: value_kind
-        integer, intent(in) :: line
-        integer, intent(in) :: column
-        character(len=:), allocatable, intent(out) :: error_msg
-
-        if (value_kind == VALUE_F64) then
-            call unsupported_feature_error( &
-                'real parameter declaration', line, column, &
-                'real scalar parameters are not supported by direct LIRIC '// &
-                'session', error_msg)
-        else if (value_kind == VALUE_LOGICAL) then
-            call unsupported_feature_error( &
-                'logical parameter declaration', line, column, &
-                'logical scalar parameters are not supported by direct LIRIC '// &
-                'session', error_msg)
-        else
-            error_msg = 'unsupported parameter declaration value kind'
-        end if
-    end subroutine unsupported_scalar_parameter_declaration
-
     subroutine lower_parameter_declaration(node, context, error_msg)
         type(parameter_declaration_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: symbol_index
+        integer :: value_kind
 
         if (.not. allocated(node%name)) then
             error_msg = 'parameter declaration did not expose a name'
@@ -452,19 +439,18 @@ contains
             return
         end if
         if (allocated(node%type_name)) then
-            if (trim(node%type_name) /= 'integer') then
-                if (is_character_type_name(node%type_name)) then
-                    call unsupported_feature_error( &
-                        'character parameter declaration', &
-                        node%line, node%column, &
-                        'scalar character parameters are not supported '// &
-                        'by direct LIRIC session', error_msg)
-                else
-                    error_msg = 'direct LIRIC session MVP only supports '// &
-                                'integer parameters'
-                end if
+            call type_name_value_kind(node%type_name, value_kind, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (value_kind == VALUE_CHARACTER) then
+                call unsupported_feature_error( &
+                    'character parameter declaration', &
+                    node%line, node%column, &
+                    'scalar character parameters are not supported '// &
+                    'by direct LIRIC session', error_msg)
                 return
             end if
+        else
+            value_kind = VALUE_I32
         end if
 
         symbol_index = find_symbol(context, node%name)
@@ -479,8 +465,34 @@ contains
             return
         end if
 
+        call update_parameter_symbol(context, symbol_index, value_kind, error_msg)
+        if (len_trim(error_msg) > 0) return
         call set_empty(error_msg)
     end subroutine lower_parameter_declaration
+
+    subroutine type_name_value_kind(type_name, value_kind, error_msg)
+        character(len=*), intent(in) :: type_name
+        integer, intent(out) :: value_kind
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        value_kind = VALUE_I32
+        call set_empty(error_msg)
+        if (is_character_type_name(type_name)) then
+            value_kind = VALUE_CHARACTER
+            return
+        end if
+        select case (trim(type_name))
+        case ('integer')
+            value_kind = VALUE_I32
+        case ('real')
+            value_kind = VALUE_F64
+        case ('logical')
+            value_kind = VALUE_LOGICAL
+        case default
+            error_msg = 'direct LIRIC session MVP only supports integer, real, '// &
+                        'and logical scalar types'
+        end select
+    end subroutine type_name_value_kind
 
     subroutine declaration_value_kind(node, value_kind, error_msg)
         type(declaration_node), intent(in) :: node
@@ -490,21 +502,7 @@ contains
         value_kind = VALUE_I32
         call set_empty(error_msg)
         if (.not. allocated(node%type_name)) return
-        if (is_character_type_name(node%type_name)) then
-            value_kind = VALUE_CHARACTER
-            return
-        end if
-        select case (trim(node%type_name))
-        case ('integer')
-            value_kind = VALUE_I32
-        case ('real')
-            value_kind = VALUE_F64
-        case ('logical')
-            value_kind = VALUE_LOGICAL
-        case default
-            error_msg = 'direct LIRIC session MVP only supports integer, real, '// &
-                        'and logical declarations'
-        end select
+        call type_name_value_kind(node%type_name, value_kind, error_msg)
     end subroutine declaration_value_kind
 
     subroutine define_symbol(context, name, value_kind, error_msg)
@@ -517,11 +515,8 @@ contains
         existing_index = find_symbol(context, name)
         if (existing_index > 0) then
             if (context%symbols(existing_index)%is_parameter) then
-                if (context%symbols(existing_index)%value_kind == value_kind) then
-                    call set_empty(error_msg)
-                else
-                    error_msg = 'parameter declaration type mismatch: '//trim(name)
-                end if
+                call update_parameter_symbol(context, existing_index, value_kind, &
+                                             error_msg)
                 return
             end if
         end if
@@ -538,6 +533,34 @@ contains
             error_msg = 'unknown scalar value kind for direct LIRIC session'
         end if
     end subroutine define_symbol
+
+    subroutine update_parameter_symbol(context, index, value_kind, error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: index
+        integer, intent(in) :: value_kind
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (index <= 0 .or. index > context%symbol_count) then
+            error_msg = 'parameter index is outside the symbol table'
+            return
+        end if
+        if (.not. context%symbols(index)%is_parameter) then
+            error_msg = 'symbol is not a parameter: '//trim(context%symbols(index)%name)
+            return
+        end if
+
+        context%symbols(index)%value_kind = value_kind
+        if (value_kind == VALUE_F64) then
+            context%symbols(index)%value = liric_f64_immediate(context%session, &
+                                                               0.0_c_double)
+        else if (value_kind == VALUE_LOGICAL .or. value_kind == VALUE_I32) then
+            context%symbols(index)%value = context%session%i32_immediate(0_c_int64_t)
+        else
+            error_msg = 'unsupported parameter declaration value kind'
+            return
+        end if
+        call set_empty(error_msg)
+    end subroutine update_parameter_symbol
 
     subroutine define_i32_symbol(context, name, error_msg)
         type(lowering_context_t), intent(inout) :: context
@@ -646,16 +669,13 @@ contains
         context%symbols(symbol_index)%value = value
         if (context%symbols(symbol_index)%has_address .and. &
             context%symbols(symbol_index)%is_reference) then
-            if (context%symbols(symbol_index)%value_kind /= VALUE_I32) then
-                error_msg = 'direct LIRIC session only stores integer '// &
-                            'reference arguments'
-                return
-            end if
-            if (.not. context%session%emit_i32_store( &
-                value, context%symbols(symbol_index)%address, error_msg)) return
+            call store_reference_value(context, symbol_index, value, error_msg)
+            if (len_trim(error_msg) > 0) return
         end if
         call set_empty(error_msg)
     end subroutine lower_assignment
+
+    include 'session_program_lowering_arguments.inc'
 
     include 'session_program_lowering_character.inc'
 
@@ -704,6 +724,11 @@ contains
             symbol_index = find_symbol(context, node%name)
             if (symbol_index <= 0) then
                 error_msg = 'integer identifier was not declared: '//trim(node%name)
+                return
+            end if
+            if (context%symbols(symbol_index)%value_kind /= VALUE_I32) then
+                error_msg = 'integer expression used non-integer identifier: '// &
+                            trim(node%name)
                 return
             end if
             if (context%symbols(symbol_index)%has_address .and. &
@@ -766,8 +791,9 @@ contains
         end if
 
         if (allocated(node%arg_indices)) then
-            call prepare_i32_reference_args(arena, node%arg_indices, context, &
-                                            args, copyback_indices, error_msg)
+            call prepare_reference_args(arena, node%arg_indices, context, &
+                                        VALUE_I32, args, copyback_indices, &
+                                        error_msg)
             if (len_trim(error_msg) > 0) return
         else
             allocate (args(0))
@@ -797,113 +823,13 @@ contains
                                              error_msg)
         if (len_trim(error_msg) > 0) return
 
-        call prepare_i32_reference_args(arena, arg_indices, context, args, &
-                                        copyback_indices, error_msg)
+        call prepare_reference_args(arena, arg_indices, context, VALUE_I32, &
+                                    args, copyback_indices, error_msg)
         if (len_trim(error_msg) > 0) return
 
         if (.not. context%session%emit_void_call(name, args, error_msg)) return
         call copy_back_reference_args(context, args, copyback_indices, error_msg)
     end subroutine lower_subroutine_call
-
-    subroutine prepare_i32_reference_args(arena, arg_indices, context, args, &
-                                          copyback_indices, error_msg)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: arg_indices(:)
-        type(lowering_context_t), intent(inout) :: context
-        type(lr_operand_desc_t), allocatable, intent(out) :: args(:)
-        integer, allocatable, intent(out) :: copyback_indices(:)
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: value
-        integer :: symbol_index
-        integer :: i
-
-        allocate (args(size(arg_indices)))
-        allocate (copyback_indices(size(arg_indices)))
-        copyback_indices = 0
-
-        do i = 1, size(arg_indices)
-            call argument_symbol_index(arena, arg_indices(i), context, &
-                                       symbol_index, error_msg)
-            if (len_trim(error_msg) > 0) return
-            if (symbol_index > 0) then
-                if (context%symbols(symbol_index)%is_reference) then
-                    args(i) = context%symbols(symbol_index)%address
-                    cycle
-                end if
-                value = context%symbols(symbol_index)%value
-                copyback_indices(i) = symbol_index
-            else
-                call lower_i32_expression(arena, arg_indices(i), context, &
-                                          value, error_msg)
-                if (len_trim(error_msg) > 0) return
-            end if
-            call make_i32_reference_argument(context, value, args(i), &
-                                             error_msg)
-            if (len_trim(error_msg) > 0) return
-        end do
-
-        call set_empty(error_msg)
-    end subroutine prepare_i32_reference_args
-
-    subroutine argument_symbol_index(arena, node_index, context, symbol_index, &
-                                     error_msg)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: node_index
-        type(lowering_context_t), intent(in) :: context
-        integer, intent(out) :: symbol_index
-        character(len=:), allocatable, intent(out) :: error_msg
-
-        symbol_index = 0
-        if (.not. arena%has_node_at(node_index)) then
-            error_msg = 'argument index does not reference an AST node'
-            return
-        end if
-
-        select type (node => arena%entries(node_index)%node)
-        type is (identifier_node)
-            symbol_index = find_symbol(context, node%name)
-        class default
-            symbol_index = 0
-        end select
-
-        if (symbol_index > 0) then
-            if (context%symbols(symbol_index)%value_kind /= VALUE_I32) then
-                error_msg = 'direct LIRIC session only passes integer '// &
-                            'arguments by reference'
-                return
-            end if
-        end if
-        call set_empty(error_msg)
-    end subroutine argument_symbol_index
-
-    subroutine make_i32_reference_argument(context, value, address, error_msg)
-        type(lowering_context_t), intent(inout) :: context
-        type(lr_operand_desc_t), intent(in) :: value
-        type(lr_operand_desc_t), intent(out) :: address
-        character(len=:), allocatable, intent(out) :: error_msg
-
-        if (.not. context%session%emit_i32_alloca(address, error_msg)) return
-        if (.not. context%session%emit_i32_store(value, address, error_msg)) return
-        call set_empty(error_msg)
-    end subroutine make_i32_reference_argument
-
-    subroutine copy_back_reference_args(context, args, copyback_indices, &
-                                        error_msg)
-        type(lowering_context_t), intent(inout) :: context
-        type(lr_operand_desc_t), intent(in) :: args(:)
-        integer, intent(in) :: copyback_indices(:)
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: value
-        integer :: i
-
-        do i = 1, size(copyback_indices)
-            if (copyback_indices(i) <= 0) cycle
-            if (.not. context%session%emit_i32_load(args(i), value, &
-                                                    error_msg)) return
-            context%symbols(copyback_indices(i))%value = value
-        end do
-        call set_empty(error_msg)
-    end subroutine copy_back_reference_args
 
     recursive subroutine lower_i1_condition(arena, node_index, context, &
                                             value, error_msg)

--- a/src_mvp/session_program_lowering_arguments.inc
+++ b/src_mvp/session_program_lowering_arguments.inc
@@ -1,0 +1,199 @@
+    subroutine store_reference_value(context, symbol_index, value, error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        type(lr_operand_desc_t), intent(in) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        select case (context%symbols(symbol_index)%value_kind)
+        case (VALUE_I32, VALUE_LOGICAL)
+            if (.not. context%session%emit_i32_store( &
+                value, context%symbols(symbol_index)%address, error_msg)) return
+        case (VALUE_F64)
+            if (.not. emit_liric_f64_store( &
+                context%session, value, context%symbols(symbol_index)%address, &
+                error_msg)) return
+        case default
+            error_msg = 'direct LIRIC session only stores numeric reference arguments'
+            return
+        end select
+        call set_empty(error_msg)
+    end subroutine store_reference_value
+
+    subroutine prepare_reference_args(arena, arg_indices, context, default_kind, &
+                                      args, copyback_indices, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: arg_indices(:)
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: default_kind
+        type(lr_operand_desc_t), allocatable, intent(out) :: args(:)
+        integer, allocatable, intent(out) :: copyback_indices(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: value
+        integer :: value_kind
+        integer :: symbol_index
+        integer :: i
+
+        allocate (args(size(arg_indices)))
+        allocate (copyback_indices(size(arg_indices)))
+        copyback_indices = 0
+
+        do i = 1, size(arg_indices)
+            call argument_symbol_index(arena, arg_indices(i), context, &
+                                       symbol_index, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (symbol_index > 0) then
+                if (context%symbols(symbol_index)%is_reference) then
+                    args(i) = context%symbols(symbol_index)%address
+                    cycle
+                end if
+                value = context%symbols(symbol_index)%value
+                value_kind = context%symbols(symbol_index)%value_kind
+                copyback_indices(i) = symbol_index
+            else
+                value_kind = expression_value_kind(arena, arg_indices(i), context, &
+                                                   default_kind)
+                call lower_expression_by_kind(arena, arg_indices(i), context, &
+                                              value_kind, value, error_msg)
+                if (len_trim(error_msg) > 0) return
+            end if
+            call make_reference_argument(context, value_kind, value, args(i), &
+                                         error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+
+        call set_empty(error_msg)
+    end subroutine prepare_reference_args
+
+    subroutine argument_symbol_index(arena, node_index, context, symbol_index, &
+                                     error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(out) :: symbol_index
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        symbol_index = 0
+        if (.not. arena%has_node_at(node_index)) then
+            error_msg = 'argument index does not reference an AST node'
+            return
+        end if
+
+        select type (node => arena%entries(node_index)%node)
+        type is (identifier_node)
+            symbol_index = find_symbol(context, node%name)
+        class default
+            symbol_index = 0
+        end select
+
+        if (symbol_index > 0) then
+            call set_empty(error_msg)
+            return
+        end if
+        call set_empty(error_msg)
+    end subroutine argument_symbol_index
+
+    integer function expression_value_kind(arena, node_index, context, &
+                                           default_kind) result(value_kind)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: default_kind
+        integer :: symbol_index
+
+        value_kind = default_kind
+        if (.not. arena%has_node_at(node_index)) return
+
+        select type (node => arena%entries(node_index)%node)
+        type is (identifier_node)
+            symbol_index = find_symbol(context, node%name)
+            if (symbol_index > 0) value_kind = context%symbols(symbol_index)%value_kind
+        type is (literal_node)
+            if (is_real_literal(node)) then
+                value_kind = VALUE_F64
+            else if (is_logical_literal(node)) then
+                value_kind = VALUE_LOGICAL
+            end if
+        type is (binary_op_node)
+            if (is_f64_expression(arena, node_index, context)) value_kind = VALUE_F64
+        type is (call_or_subscript_node)
+            if (allocated(node%name)) then
+                if (is_contained_f64_function(context, node%name)) then
+                    value_kind = VALUE_F64
+                else if (is_contained_logical_function(context, node%name)) then
+                    value_kind = VALUE_LOGICAL
+                end if
+            end if
+        end select
+    end function expression_value_kind
+
+    subroutine lower_expression_by_kind(arena, node_index, context, value_kind, &
+                                        value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: value_kind
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        select case (value_kind)
+        case (VALUE_F64)
+            call lower_f64_expression(arena, node_index, context, value, error_msg)
+        case (VALUE_LOGICAL)
+            call lower_logical_expression(arena, node_index, context, value, &
+                                          error_msg)
+        case default
+            call lower_i32_expression(arena, node_index, context, value, error_msg)
+        end select
+    end subroutine lower_expression_by_kind
+
+    subroutine make_reference_argument(context, value_kind, value, address, &
+                                       error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: value_kind
+        type(lr_operand_desc_t), intent(in) :: value
+        type(lr_operand_desc_t), intent(out) :: address
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        select case (value_kind)
+        case (VALUE_F64)
+            if (.not. emit_liric_f64_alloca(context%session, address, error_msg)) &
+                return
+            if (.not. emit_liric_f64_store(context%session, value, address, &
+                                           error_msg)) return
+        case (VALUE_I32, VALUE_LOGICAL)
+            if (.not. context%session%emit_i32_alloca(address, error_msg)) return
+            if (.not. context%session%emit_i32_store(value, address, error_msg)) &
+                return
+        case default
+            error_msg = 'direct LIRIC session cannot pass this scalar argument'
+            return
+        end select
+        call set_empty(error_msg)
+    end subroutine make_reference_argument
+
+    subroutine copy_back_reference_args(context, args, copyback_indices, &
+                                        error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: args(:)
+        integer, intent(in) :: copyback_indices(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: value
+        integer :: i
+
+        do i = 1, size(copyback_indices)
+            if (copyback_indices(i) <= 0) cycle
+            select case (context%symbols(copyback_indices(i))%value_kind)
+            case (VALUE_F64)
+                if (.not. emit_liric_f64_load(context%session, args(i), value, &
+                                              error_msg)) return
+            case (VALUE_I32, VALUE_LOGICAL)
+                if (.not. context%session%emit_i32_load(args(i), value, &
+                                                        error_msg)) return
+            case default
+                error_msg = 'direct LIRIC session cannot copy back this argument'
+                return
+            end select
+            context%symbols(copyback_indices(i))%value = value
+        end do
+        call set_empty(error_msg)
+    end subroutine copy_back_reference_args

--- a/src_mvp/session_program_lowering_functions.inc
+++ b/src_mvp/session_program_lowering_functions.inc
@@ -6,8 +6,9 @@
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: i
 
-        context%integer_function_count = 0
-        context%integer_function_names = ''
+        context%function_count = 0
+        context%function_names = ''
+        context%function_value_kinds = VALUE_I32
         call set_empty(error_msg)
 
         select type (program => arena%entries(root_index)%node)
@@ -29,47 +30,101 @@
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: next_index
+        integer :: value_kind
 
         if (.not. allocated(node%name)) then
             error_msg = 'direct LIRIC session function requires a name'
             return
         end if
-        if (context%integer_function_count >= MAX_PROCEDURES) then
+        if (context%function_count >= MAX_PROCEDURES) then
             error_msg = 'too many contained functions for direct LIRIC session MVP'
             return
         end if
-        if (is_contained_i32_function(context, node%name)) then
+        if (contained_function_kind(context, node%name) /= 0) then
             error_msg = 'duplicate contained function: '//trim(node%name)
             return
         end if
+        call function_value_kind(node, value_kind, error_msg)
+        if (len_trim(error_msg) > 0) return
 
-        next_index = context%integer_function_count + 1
-        context%integer_function_names(next_index) = trim(node%name)
-        context%integer_function_count = next_index
+        next_index = context%function_count + 1
+        context%function_names(next_index) = trim(node%name)
+        context%function_value_kinds(next_index) = value_kind
+        context%function_count = next_index
         call set_empty(error_msg)
     end subroutine register_internal_function_name
+
+    subroutine function_value_kind(node, value_kind, error_msg)
+        type(function_def_node), intent(in) :: node
+        integer, intent(out) :: value_kind
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        value_kind = VALUE_I32
+        call set_empty(error_msg)
+        if (.not. allocated(node%return_type)) return
+
+        select case (trim(node%return_type))
+        case ('integer')
+            value_kind = VALUE_I32
+        case ('real')
+            value_kind = VALUE_F64
+        case ('logical')
+            value_kind = VALUE_LOGICAL
+        case default
+            call unsupported_feature_error('function result type', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session supports '// &
+                                           'integer, real, and logical '// &
+                                           'contained functions', error_msg)
+        end select
+    end subroutine function_value_kind
 
     subroutine copy_internal_function_names(source, destination)
         type(lowering_context_t), intent(in) :: source
         type(lowering_context_t), intent(inout) :: destination
 
-        destination%integer_function_names = source%integer_function_names
-        destination%integer_function_count = source%integer_function_count
+        destination%function_names = source%function_names
+        destination%function_value_kinds = source%function_value_kinds
+        destination%function_count = source%function_count
     end subroutine copy_internal_function_names
 
     logical function is_contained_i32_function(context, name)
         type(lowering_context_t), intent(in) :: context
         character(len=*), intent(in) :: name
+
+        is_contained_i32_function = &
+            contained_function_kind(context, name) == VALUE_I32
+    end function is_contained_i32_function
+
+    logical function is_contained_f64_function(context, name)
+        type(lowering_context_t), intent(in) :: context
+        character(len=*), intent(in) :: name
+
+        is_contained_f64_function = &
+            contained_function_kind(context, name) == VALUE_F64
+    end function is_contained_f64_function
+
+    logical function is_contained_logical_function(context, name)
+        type(lowering_context_t), intent(in) :: context
+        character(len=*), intent(in) :: name
+
+        is_contained_logical_function = &
+            contained_function_kind(context, name) == VALUE_LOGICAL
+    end function is_contained_logical_function
+
+    integer function contained_function_kind(context, name) result(value_kind)
+        type(lowering_context_t), intent(in) :: context
+        character(len=*), intent(in) :: name
         integer :: i
 
-        is_contained_i32_function = .false.
-        do i = 1, context%integer_function_count
-            if (same_name(context%integer_function_names(i), name)) then
-                is_contained_i32_function = .true.
+        value_kind = 0
+        do i = 1, context%function_count
+            if (same_name(context%function_names(i), name)) then
+                value_kind = context%function_value_kinds(i)
                 return
             end if
         end do
-    end function is_contained_i32_function
+    end function contained_function_kind
 
     subroutine lower_internal_functions(arena, root_index, context, error_msg)
         type(ast_arena_t), intent(in) :: arena
@@ -85,7 +140,7 @@
             do i = 1, size(program%body_indices)
                 select type (node => arena%entries(program%body_indices(i))%node)
                 type is (function_def_node)
-                    call lower_i32_function(arena, node, context, error_msg)
+                    call lower_scalar_function(arena, node, context, error_msg)
                     if (len_trim(error_msg) > 0) return
                 type is (subroutine_def_node)
                     call lower_void_subroutine(arena, node, context, error_msg)
@@ -115,7 +170,7 @@
         end if
     end function is_internal_procedure_entry
 
-    subroutine lower_i32_function(arena, node, parent_context, error_msg)
+    subroutine lower_scalar_function(arena, node, parent_context, error_msg)
         type(ast_arena_t), intent(in) :: arena
         type(function_def_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: parent_context
@@ -123,18 +178,16 @@
         type(lowering_context_t) :: context
         type(lr_operand_desc_t) :: value
         integer :: param_count
+        integer :: result_index
+        integer :: value_kind
         logical :: terminated
 
         if (.not. allocated(node%name)) then
             error_msg = 'direct LIRIC session function requires a name'
             return
         end if
-        if (allocated(node%return_type)) then
-            if (trim(node%return_type) /= 'integer') then
-                error_msg = 'direct LIRIC session MVP only supports integer functions'
-                return
-            end if
-        end if
+        call function_value_kind(node, value_kind, error_msg)
+        if (len_trim(error_msg) > 0) return
 
         context%session = parent_context%session
         context%i32_print_format_id = parent_context%i32_print_format_id
@@ -146,12 +199,18 @@
 
         param_count = 0
         if (allocated(node%param_indices)) param_count = size(node%param_indices)
-        if (.not. context%session%begin_i32_function(node%name, param_count, &
-                                                     error_msg)) return
+        if (value_kind == VALUE_F64) then
+            if (.not. begin_liric_f64_function(context%session, node%name, &
+                                               param_count, error_msg)) return
+        else
+            if (.not. context%session%begin_i32_function(node%name, param_count, &
+                                                         error_msg)) return
+        end if
 
-        call define_i32_symbol(context, node%name, error_msg)
+        call define_symbol(context, node%name, value_kind, error_msg)
         if (len_trim(error_msg) > 0) return
-        call define_i32_parameters(arena, node%param_indices, context, error_msg)
+        call define_reference_parameters(arena, node%param_indices, context, &
+                                         error_msg)
         if (len_trim(error_msg) > 0) return
 
         if (allocated(node%body_indices)) then
@@ -160,7 +219,13 @@
             if (len_trim(error_msg) > 0) return
         end if
 
-        value = context%symbols(find_symbol(context, node%name))%value
+        result_index = find_symbol(context, node%name)
+        if (result_index <= 0) then
+            error_msg = 'function result symbol was not declared: '// &
+                        trim(node%name)
+            return
+        end if
+        value = context%symbols(result_index)%value
         if (.not. context%current_block_terminated) then
             if (.not. context%session%emit_ret_i32_operand(value, error_msg)) return
         end if
@@ -169,7 +234,7 @@
         parent_context%session = context%session
         parent_context%string_literal_count = context%string_literal_count
         call set_empty(error_msg)
-    end subroutine lower_i32_function
+    end subroutine lower_scalar_function
 
     subroutine lower_void_subroutine(arena, node, parent_context, error_msg)
         type(ast_arena_t), intent(in) :: arena
@@ -199,7 +264,8 @@
         if (.not. context%session%begin_void_subroutine(node%name, param_count, &
                                                         error_msg)) return
 
-        call define_i32_parameters(arena, node%param_indices, context, error_msg)
+        call define_reference_parameters(arena, node%param_indices, context, &
+                                         error_msg)
         if (len_trim(error_msg) > 0) return
 
         if (allocated(node%body_indices)) then
@@ -218,7 +284,7 @@
         call set_empty(error_msg)
     end subroutine lower_void_subroutine
 
-    subroutine define_i32_parameters(arena, param_indices, context, error_msg)
+    subroutine define_reference_parameters(arena, param_indices, context, error_msg)
         type(ast_arena_t), intent(in) :: arena
         integer, allocatable, intent(in) :: param_indices(:)
         type(lowering_context_t), intent(inout) :: context
@@ -231,10 +297,10 @@
         do i = 1, size(param_indices)
             call parameter_name(arena, param_indices(i), name, error_msg)
             if (len_trim(error_msg) > 0) return
-            call define_i32_parameter_symbol(context, name, i - 1, error_msg)
+            call define_parameter_symbol(context, name, i - 1, error_msg)
             if (len_trim(error_msg) > 0) return
         end do
-    end subroutine define_i32_parameters
+    end subroutine define_reference_parameters
 
     subroutine parameter_name(arena, node_index, name, error_msg)
         type(ast_arena_t), intent(in) :: arena
@@ -261,7 +327,7 @@
         end select
     end subroutine parameter_name
 
-    subroutine define_i32_parameter_symbol(context, name, param_index, error_msg)
+    subroutine define_parameter_symbol(context, name, param_index, error_msg)
         type(lowering_context_t), intent(inout) :: context
         character(len=*), intent(in) :: name
         integer, intent(in) :: param_index
@@ -287,4 +353,4 @@
         context%symbols(index)%is_parameter = .true.
         context%symbol_count = index
         call set_empty(error_msg)
-    end subroutine define_i32_parameter_symbol
+    end subroutine define_parameter_symbol

--- a/src_mvp/session_program_lowering_values.inc
+++ b/src_mvp/session_program_lowering_values.inc
@@ -161,13 +161,60 @@
                             trim(node%name)
                 return
             end if
-            value = context%symbols(symbol_index)%value
-            call set_empty(error_msg)
+            if (context%symbols(symbol_index)%has_address .and. &
+                context%symbols(symbol_index)%is_reference) then
+                if (.not. context%session%emit_i32_load( &
+                    context%symbols(symbol_index)%address, value, &
+                    error_msg)) return
+            else
+                value = context%symbols(symbol_index)%value
+                call set_empty(error_msg)
+            end if
+        type is (call_or_subscript_node)
+            call lower_logical_call(arena, node, context, value, error_msg)
         class default
             error_msg = 'direct LIRIC session MVP only supports logical '// &
-                        'literals and identifiers'
+                        'literals, identifiers, and contained calls'
         end select
     end subroutine lower_logical_expression
+
+    subroutine lower_logical_call(arena, node, context, value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t), allocatable :: args(:)
+        integer, allocatable :: copyback_indices(:)
+
+        if (node%is_array_access) then
+            error_msg = 'direct LIRIC session MVP does not support array access'
+            return
+        end if
+        if (.not. allocated(node%name)) then
+            error_msg = 'direct LIRIC session logical function call requires a name'
+            return
+        end if
+        if (.not. is_contained_logical_function(context, node%name)) then
+            error_msg = 'direct LIRIC session MVP does not support logical '// &
+                        'function calls'
+            return
+        end if
+
+        if (allocated(node%arg_indices)) then
+            call prepare_reference_args(arena, node%arg_indices, context, &
+                                        VALUE_LOGICAL, args, copyback_indices, &
+                                        error_msg)
+            if (len_trim(error_msg) > 0) return
+        else
+            allocate (args(0))
+            allocate (copyback_indices(0))
+        end if
+
+        if (.not. context%session%emit_i32_call(node%name, args, value, &
+                                                error_msg)) return
+        call copy_back_reference_args(context, args, copyback_indices, error_msg)
+    end subroutine lower_logical_call
 
     recursive subroutine lower_f64_expression(arena, node_index, context, &
                                               value, error_msg)
@@ -203,8 +250,15 @@
                             trim(node%name)
                 return
             end if
-            value = context%symbols(symbol_index)%value
-            call set_empty(error_msg)
+            if (context%symbols(symbol_index)%has_address .and. &
+                context%symbols(symbol_index)%is_reference) then
+                if (.not. emit_liric_f64_load( &
+                    context%session, context%symbols(symbol_index)%address, &
+                    value, error_msg)) return
+            else
+                value = context%symbols(symbol_index)%value
+                call set_empty(error_msg)
+            end if
         type is (binary_op_node)
             call lower_f64_expression(arena, node%left_index, context, lhs, &
                                       error_msg)
@@ -246,6 +300,10 @@
                                           value, error_msg)
             return
         end if
+        if (is_contained_f64_function(context, node%name)) then
+            call lower_contained_f64_call(arena, node, context, value, error_msg)
+            return
+        end if
         if (node%is_intrinsic) then
             call unsupported_intrinsic_error(node, error_msg)
         else
@@ -253,6 +311,30 @@
                         'function calls'
         end if
     end subroutine lower_f64_call
+
+    subroutine lower_contained_f64_call(arena, node, context, value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t), allocatable :: args(:)
+        integer, allocatable :: copyback_indices(:)
+
+        if (allocated(node%arg_indices)) then
+            call prepare_reference_args(arena, node%arg_indices, context, &
+                                        VALUE_F64, args, copyback_indices, &
+                                        error_msg)
+            if (len_trim(error_msg) > 0) return
+        else
+            allocate (args(0))
+            allocate (copyback_indices(0))
+        end if
+
+        if (.not. emit_liric_f64_call(context%session, node%name, args, value, &
+                                      error_msg)) return
+        call copy_back_reference_args(context, args, copyback_indices, error_msg)
+    end subroutine lower_contained_f64_call
 
     recursive logical function is_f64_expression(arena, node_index, context) &
         result(is_f64)
@@ -276,7 +358,10 @@
             is_f64 = is_f64_expression(arena, node%left_index, context) .or. &
                      is_f64_expression(arena, node%right_index, context)
         type is (call_or_subscript_node)
-            is_f64 = is_f64_intrinsic_expression(arena, node, context)
+            if (allocated(node%name)) then
+                is_f64 = is_contained_f64_function(context, node%name)
+            end if
+            is_f64 = is_f64 .or. is_f64_intrinsic_expression(arena, node, context)
         end select
     end function is_f64_expression
 

--- a/test_mvp/test_session_non_integer_procedure_compiler.f90
+++ b/test_mvp/test_session_non_integer_procedure_compiler.f90
@@ -1,0 +1,179 @@
+program test_session_non_integer_procedure_compiler
+    use fortfront, only: compiler_frontend_options_t, &
+                         compiler_frontend_result_t, &
+                         compile_frontend_from_string, INPUT_MODE_STANDARD
+    use session_program_lowering, only: lower_program_to_liric_exe
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session non-integer procedure compiler test ==='
+
+    all_passed = .true.
+    if (.not. test_real_subroutine()) all_passed = .false.
+    if (.not. test_logical_subroutine()) all_passed = .false.
+    if (.not. test_real_function()) all_passed = .false.
+    if (.not. test_logical_function()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: non-integer contained procedures lower through direct LIRIC'
+
+contains
+
+    logical function test_real_subroutine()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  real :: x'//new_line('a')// &
+                                       '  x = 1.5'//new_line('a')// &
+                                       '  call bump(x)'//new_line('a')// &
+                                       '  print *, x'//new_line('a')// &
+                                       'contains'//new_line('a')// &
+                                       '  subroutine bump(value)'//new_line('a')// &
+                                   '    real, intent(inout) :: value'//new_line('a')// &
+                                       '    value = value + 1.0'//new_line('a')// &
+                                       '  end subroutine bump'//new_line('a')// &
+                                       'end program main'
+
+        test_real_subroutine = expect_output(source, '2.500000', &
+                                             '/tmp/ffc_session_real_sub_test')
+    end function test_real_subroutine
+
+    logical function test_logical_subroutine()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  logical :: flag'//new_line('a')// &
+                                       '  flag = .false.'//new_line('a')// &
+                                       '  call enable(flag)'//new_line('a')// &
+                                       '  if (flag) then'//new_line('a')// &
+                                       '    print *, 1'//new_line('a')// &
+                                       '  else'//new_line('a')// &
+                                       '    print *, 0'//new_line('a')// &
+                                       '  end if'//new_line('a')// &
+                                       'contains'//new_line('a')// &
+                                       '  subroutine enable(value)'//new_line('a')// &
+                                '    logical, intent(inout) :: value'//new_line('a')// &
+                                       '    value = .true.'//new_line('a')// &
+                                       '  end subroutine enable'//new_line('a')// &
+                                       'end program main'
+
+        test_logical_subroutine = expect_output(source, '1', &
+                                                '/tmp/ffc_session_logical_sub_test')
+    end function test_logical_subroutine
+
+    logical function test_real_function()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  real :: x'//new_line('a')// &
+                                       '  x = add(1.5, 3.0)'//new_line('a')// &
+                                       '  print *, x'//new_line('a')// &
+                                       'contains'//new_line('a')// &
+                                       '  real function add(a, b)'//new_line('a')// &
+                                       '    real, intent(in) :: a'//new_line('a')// &
+                                       '    real, intent(in) :: b'//new_line('a')// &
+                                       '    add = a + b'//new_line('a')// &
+                                       '  end function add'//new_line('a')// &
+                                       'end program main'
+
+        test_real_function = expect_output(source, '4.500000', &
+                                           '/tmp/ffc_session_real_fn_test')
+    end function test_real_function
+
+    logical function test_logical_function()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  logical :: flag'//new_line('a')// &
+                                       '  logical :: ok'//new_line('a')// &
+                                       '  flag = .false.'//new_line('a')// &
+                                       '  ok = enabled(flag)'//new_line('a')// &
+                                       '  if (ok) then'//new_line('a')// &
+                                       '    print *, 1'//new_line('a')// &
+                                       '  else'//new_line('a')// &
+                                       '    print *, 0'//new_line('a')// &
+                                       '  end if'//new_line('a')// &
+                                       'contains'//new_line('a')// &
+                                   '  logical function enabled(flag)'//new_line('a')// &
+                                    '    logical, intent(in) :: flag'//new_line('a')// &
+                                       '    if (flag) then'//new_line('a')// &
+                                       '      enabled = .false.'//new_line('a')// &
+                                       '    else'//new_line('a')// &
+                                       '      enabled = .true.'//new_line('a')// &
+                                       '    end if'//new_line('a')// &
+                                       '  end function enabled'//new_line('a')// &
+                                       'end program main'
+
+        test_logical_function = expect_output(source, '1', &
+                                              '/tmp/ffc_session_logical_fn_test')
+    end function test_logical_function
+
+    logical function expect_output(source, expected, stem)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        character(len=*), intent(in) :: stem
+        character(len=64) :: output_line
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: exe_path
+        character(len=:), allocatable :: out_path
+        integer :: exit_stat
+        integer :: io_stat
+        integer :: unit
+
+        expect_output = .false.
+        exe_path = stem
+        out_path = stem//'.out'
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+        call compile_and_lower(source, exe_path, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: direct LIRIC lowering failed: ', trim(error_msg)
+            return
+        end if
+
+        call execute_command_line(exe_path//' > '//out_path, exitstat=exit_stat)
+        if (exit_stat /= 0) then
+            print *, 'FAIL: executable exit status ', exit_stat
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+
+        open (newunit=unit, file=out_path, status='old', action='read', &
+              iostat=io_stat)
+        if (io_stat /= 0) then
+            print *, 'FAIL: could not open captured output'
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+        read (unit, '(A)', iostat=io_stat) output_line
+        close (unit)
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+
+        if (io_stat /= 0 .or. trim(adjustl(output_line)) /= expected) then
+            print *, 'FAIL: expected output ', expected, ', got ', &
+                trim(output_line)
+            return
+        end if
+
+        expect_output = .true.
+    end function expect_output
+
+    subroutine compile_and_lower(source, exe_path, error_msg)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: exe_path
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: frontend_result
+
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+
+        call compile_frontend_from_string(source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            error_msg = 'FortFront rejected source: '// &
+                        trim(frontend_result%diagnostic_text)
+            return
+        end if
+
+        call lower_program_to_liric_exe(frontend_result%arena, &
+                                        frontend_result%root_index, exe_path, &
+                                        error_msg)
+    end subroutine compile_and_lower
+end program test_session_non_integer_procedure_compiler

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -14,8 +14,6 @@ program test_session_unsupported_diagnostics
     if (.not. test_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_module_diagnostic()) all_passed = .false.
     if (.not. test_character_parameter_diagnostic()) all_passed = .false.
-    if (.not. test_real_parameter_diagnostic()) all_passed = .false.
-    if (.not. test_logical_parameter_diagnostic()) all_passed = .false.
     if (.not. test_exit_diagnostic()) all_passed = .false.
     if (.not. test_cycle_diagnostic()) all_passed = .false.
     if (.not. test_unsupported_intrinsic_diagnostic()) all_passed = .false.
@@ -23,8 +21,6 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_cli_module_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_parameter_diagnostic()) all_passed = .false.
-    if (.not. test_cli_real_parameter_diagnostic()) all_passed = .false.
-    if (.not. test_cli_logical_parameter_diagnostic()) all_passed = .false.
     if (.not. test_cli_exit_diagnostic()) all_passed = .false.
     if (.not. test_cli_cycle_diagnostic()) all_passed = .false.
     if (.not. test_cli_unsupported_intrinsic_diagnostic()) all_passed = .false.
@@ -87,49 +83,6 @@ contains
                                               source, expected, &
                                               '/tmp/ffc_session_char_param_test')
     end function test_character_parameter_diagnostic
-
-    logical function test_real_parameter_diagnostic()
-        character(len=*), parameter :: expected = &
-                                       'unsupported real parameter declaration'
-        character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  real :: x'//new_line('a')// &
-                                       '  x = 1.0'//new_line('a')// &
-                                       '  call scale(x)'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine scale(value)'//new_line('a')// &
-                                       '    real, intent(inout) :: value'// &
-                                       new_line('a')// &
-                                       '    value = value + 1.0'//new_line('a')// &
-                                       '  end subroutine scale'//new_line('a')// &
-                                       'end program main'
-
-        test_real_parameter_diagnostic = expect_error_contains( &
-                                         source, expected, &
-                                         '/tmp/ffc_session_real_param_test')
-    end function test_real_parameter_diagnostic
-
-    logical function test_logical_parameter_diagnostic()
-        character(len=*), parameter :: expected = &
-                                       'unsupported logical parameter '// &
-                                       'declaration'
-        character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  logical :: flag'//new_line('a')// &
-                                       '  flag = .false.'//new_line('a')// &
-                                       '  call enable(flag)'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine enable(value)'//new_line('a')// &
-                                       '    logical, intent(inout) :: value'// &
-                                       new_line('a')// &
-                                       '    value = .true.'//new_line('a')// &
-                                       '  end subroutine enable'//new_line('a')// &
-                                       'end program main'
-
-        test_logical_parameter_diagnostic = expect_error_contains( &
-                                            source, expected, &
-                                            '/tmp/ffc_session_logical_param_test')
-    end function test_logical_parameter_diagnostic
 
     logical function test_exit_diagnostic()
         character(len=*), parameter :: source = &
@@ -223,49 +176,6 @@ contains
                                                   source, expected, &
                                                   '/tmp/ffc_cli_char_param_test')
     end function test_cli_character_parameter_diagnostic
-
-    logical function test_cli_real_parameter_diagnostic()
-        character(len=*), parameter :: expected = &
-                                       'unsupported real parameter declaration'
-        character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  real :: x'//new_line('a')// &
-                                       '  x = 1.0'//new_line('a')// &
-                                       '  call scale(x)'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine scale(value)'//new_line('a')// &
-                                       '    real, intent(inout) :: value'// &
-                                       new_line('a')// &
-                                       '    value = value + 1.0'//new_line('a')// &
-                                       '  end subroutine scale'//new_line('a')// &
-                                       'end program main'
-
-        test_cli_real_parameter_diagnostic = expect_cli_error_contains( &
-                                             source, expected, &
-                                             '/tmp/ffc_cli_real_param_test')
-    end function test_cli_real_parameter_diagnostic
-
-    logical function test_cli_logical_parameter_diagnostic()
-        character(len=*), parameter :: expected = &
-                                       'unsupported logical parameter '// &
-                                       'declaration'
-        character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  logical :: flag'//new_line('a')// &
-                                       '  flag = .false.'//new_line('a')// &
-                                       '  call enable(flag)'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine enable(value)'//new_line('a')// &
-                                       '    logical, intent(inout) :: value'// &
-                                       new_line('a')// &
-                                       '    value = .true.'//new_line('a')// &
-                                       '  end subroutine enable'//new_line('a')// &
-                                       'end program main'
-
-        test_cli_logical_parameter_diagnostic = expect_cli_error_contains( &
-                                                source, expected, &
-                                                '/tmp/ffc_cli_logical_param_test')
-    end function test_cli_logical_parameter_diagnostic
 
     logical function test_cli_exit_diagnostic()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
## Requirements

- REQ-001 (ref #50): support real scalar dummy arguments for contained functions and subroutines.
- REQ-002 (ref #50): support logical scalar dummy arguments for contained functions and subroutines.
- REQ-003 (ref #50): preserve existing integer pointer-argument behavior.
- REQ-004 (ref #50): support explicit scalar non-integer function result assignment, excluding character arguments.
- REQ-005 (ref #50): add focused executable tests under `test_mvp/`.

## Verification

Failing before:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_non_integer_procedure_compiler
=== direct session non-integer procedure compiler test ===
FAIL: direct LIRIC lowering failed: unsupported real parameter declaration at line 1, column 1: real scalar parameters are not supported by direct LIRIC session
FAIL: direct LIRIC lowering failed: unsupported logical parameter declaration at line 1, column 1: logical scalar parameters are not supported by direct LIRIC session
FAIL: direct LIRIC lowering failed: direct LIRIC session MVP only supports integer functions
STOP 1
```

Passing after:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_non_integer_procedure_compiler
PASS: non-integer contained procedures lower through direct LIRIC

LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_integer_function_compiler
PASS: integer function calls lower through direct LIRIC session

LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_integer_subroutine_compiler
PASS: integer subroutine reference args lower through direct LIRIC session

LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics

LIBRARY_PATH=/home/ert/code/liric/build fpm test
PASS: LIRIC session binding tests
PASS: empty program compiles and runs through direct LIRIC session
PASS: empty program emits object through direct LIRIC session
PASS: integer stop expression lowers through direct LIRIC session
PASS: integer variable lowers through direct LIRIC session
PASS: block IF lowers through direct LIRIC session
PASS: fallthrough IF merges scalar values through direct LIRIC
PASS: integer print lowers through direct LIRIC session
PASS: real literal print lowers through direct LIRIC session
PASS: character literal print lowers through direct LIRIC session
PASS: character variables lower through direct LIRIC session
PASS: logical literal print lowers through direct LIRIC session
PASS: logical variables lower through direct LIRIC session
PASS: real variables and arithmetic lower through direct LIRIC
PASS: integer function calls lower through direct LIRIC session
PASS: integer subroutine reference args lower through direct LIRIC session
PASS: non-integer contained procedures lower through direct LIRIC
PASS: scalar intrinsics lower through direct LIRIC session
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```

<!-- orchestrate: fully-resolved -->
