### PR TITLE
fix: select case diagnostic (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -6,8 +6,9 @@ module session_program_lowering
                          cycle_node, exit_node, function_def_node, &
                          identifier_node, if_node, literal_node, &
                          parameter_declaration_node, &
-                         print_statement_node, program_node, module_node, stop_node, &
-                         subroutine_def_node, get_subroutine_call_arg_indices, &
+                         print_statement_node, program_node, module_node, &
+                         select_case_node, stop_node, subroutine_def_node, &
+                         get_subroutine_call_arg_indices, &
                          get_subroutine_call_name, is_subroutine_call_statement
     use liric_session_bindings, only: liric_session_t, liric_session_create, &
                                       lr_operand_desc_t, LR_OP_ADD, LR_OP_SUB
@@ -324,6 +325,12 @@ contains
             call lower_if(arena, node, context, value, error_msg)
         type is (do_loop_node)
             call lower_do_loop(arena, node, context, value, error_msg)
+        type is (select_case_node)
+            call unsupported_feature_error('select case statement', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support multi-way branches', &
+                                           error_msg)
         class default
             node_type = 'unknown'
             if (allocated(arena%entries(node_index)%node_type)) then

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -16,6 +16,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_character_parameter_diagnostic()) all_passed = .false.
     if (.not. test_exit_diagnostic()) all_passed = .false.
     if (.not. test_cycle_diagnostic()) all_passed = .false.
+    if (.not. test_select_case_diagnostic()) all_passed = .false.
     if (.not. test_unsupported_intrinsic_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_expression_diagnostic()) all_passed = .false.
@@ -23,6 +24,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_character_parameter_diagnostic()) all_passed = .false.
     if (.not. test_cli_exit_diagnostic()) all_passed = .false.
     if (.not. test_cli_cycle_diagnostic()) all_passed = .false.
+    if (.not. test_cli_select_case_diagnostic()) all_passed = .false.
     if (.not. test_cli_unsupported_intrinsic_diagnostic()) all_passed = .false.
 
     if (.not. all_passed) stop 1
@@ -111,6 +113,22 @@ contains
                                 source, 'unsupported cycle statement', &
                                 '/tmp/ffc_session_cycle_diagnostic_test')
     end function test_cycle_diagnostic
+
+    logical function test_select_case_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: x'//new_line('a')// &
+                                       '  x = 1'//new_line('a')// &
+                                       '  select case (x)'//new_line('a')// &
+                                       '  case (1)'//new_line('a')// &
+                                       '    print *, 1'//new_line('a')// &
+                                       '  end select'//new_line('a')// &
+                                       'end program main'
+
+        test_select_case_diagnostic = expect_error_contains( &
+                                    source, 'unsupported select case statement', &
+                                    '/tmp/ffc_session_select_case_test')
+    end function test_select_case_diagnostic
 
     logical function test_unsupported_intrinsic_diagnostic()
         character(len=*), parameter :: source = &
@@ -204,6 +222,22 @@ contains
                                     source, 'unsupported cycle statement', &
                                     '/tmp/ffc_cli_cycle_diagnostic_test')
     end function test_cli_cycle_diagnostic
+
+    logical function test_cli_select_case_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: x'//new_line('a')// &
+                                       '  x = 1'//new_line('a')// &
+                                       '  select case (x)'//new_line('a')// &
+                                       '  case (1)'//new_line('a')// &
+                                       '    print *, 1'//new_line('a')// &
+                                       '  end select'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_select_case_diagnostic = expect_cli_error_contains( &
+                                    source, 'unsupported select case statement', &
+                                    '/tmp/ffc_cli_select_case_test')
+    end function test_cli_select_case_diagnostic
 
     logical function test_cli_unsupported_intrinsic_diagnostic()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
## Requirements

- REQ-001: Unsupported features must use targeted feature names instead of raw AST node names.
- REQ-002: Diagnostics should include line and column when FortFront exposes them.
- REQ-003: CLI errors must exit nonzero and print the same concise diagnostic.
- REQ-004: Negative tests must cover the behavior.

(ref #57)

## Changes

- Add API and CLI negative coverage for unsupported `select case`.
- Report `unsupported select case statement` through the location-aware diagnostic helper.

## Verification

Failing before:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
FAIL: expected diagnostic substring unsupported select case statement
  got direct LIRIC session MVP does not support statement node: select_case
FAIL: expected CLI diagnostic substring unsupported select case statement
  got STOP 1
direct LIRIC session MVP does not support statement node: select_case
```

Passing after:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics

LIBRARY_PATH=/home/ert/code/liric/build fpm test
PASS: counted do compiler test
```
