### PR TITLE
fix: reject external scalar calls (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -795,6 +795,12 @@ contains
                 call unsupported_intrinsic_error(node, error_msg)
                 return
             end if
+            call unsupported_feature_error('scalar function call', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session only supports '// &
+                                           'contained scalar functions and '// &
+                                           'supported intrinsics', error_msg)
+            return
         end if
 
         if (allocated(node%arg_indices)) then

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -18,6 +18,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_cycle_diagnostic()) all_passed = .false.
     if (.not. test_select_case_diagnostic()) all_passed = .false.
     if (.not. test_unsupported_intrinsic_diagnostic()) all_passed = .false.
+    if (.not. test_external_function_call_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_cli_module_diagnostic()) all_passed = .false.
@@ -26,6 +27,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_cycle_diagnostic()) all_passed = .false.
     if (.not. test_cli_select_case_diagnostic()) all_passed = .false.
     if (.not. test_cli_unsupported_intrinsic_diagnostic()) all_passed = .false.
+    if (.not. test_cli_external_function_call_diagnostic()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: unsupported direct-session features emit diagnostics'
@@ -141,6 +143,18 @@ contains
                                            '/tmp/ffc_session_intrinsic_diagnostic_test')
     end function test_unsupported_intrinsic_diagnostic
 
+    logical function test_external_function_call_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: x'//new_line('a')// &
+                                       '  x = external_value(1)'//new_line('a')// &
+                                       'end program main'
+
+        test_external_function_call_diagnostic = expect_error_contains( &
+                                     source, 'unsupported scalar function call', &
+                                     '/tmp/ffc_session_external_call_test')
+    end function test_external_function_call_diagnostic
+
     logical function test_cli_array_declaration_diagnostic()
         character(len=*), parameter :: source = &
                                        'program main'//new_line('a')// &
@@ -249,6 +263,18 @@ contains
                                          source, 'unsupported scalar intrinsic: sqrt', &
                                                '/tmp/ffc_cli_intrinsic_diagnostic_test')
     end function test_cli_unsupported_intrinsic_diagnostic
+
+    logical function test_cli_external_function_call_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: x'//new_line('a')// &
+                                       '  x = external_value(1)'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_external_function_call_diagnostic = expect_cli_error_contains( &
+                                     source, 'unsupported scalar function call', &
+                                     '/tmp/ffc_cli_external_call_test')
+    end function test_cli_external_function_call_diagnostic
 
     logical function expect_error_contains(source, expected, exe_path)
         character(len=*), intent(in) :: source


### PR DESCRIPTION
## Requirements

- REQ-001 (ref #57): Unsupported lowering features must produce targeted user-facing diagnostics.
- REQ-002 (ref #57): Diagnostics should include line/column when FortFront exposes them.
- REQ-003 (ref #57): CLI must exit nonzero for unsupported programs and print the diagnostic.
- REQ-004 (ref #57): Add behavior tests for unsupported external scalar function calls.

## Changes

- Reject non-contained, non-intrinsic integer scalar calls during lowering.
- Cover the direct lowering and CLI paths for an unsupported external scalar function call.

## Verification

Failing before implementation, after adding the behavior test:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
FAIL: unsupported source lowered without error
FAIL: unsupported source CLI exited successfully
STOP 1
<ERROR> Execution for object " test_session_unsupported_diagnostics " returned exit code  1
```

Passing after implementation:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics
```

Full suite:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test
PASS: LIRIC session binding tests
PASS: empty program compiles and runs through direct LIRIC session
PASS: empty program emits object through direct LIRIC session
PASS: integer stop expression lowers through direct LIRIC session
PASS: integer variable lowers through direct LIRIC session
PASS: block IF lowers through direct LIRIC session
PASS: fallthrough IF merges scalar values through direct LIRIC
PASS: integer print lowers through direct LIRIC session
PASS: real literal print lowers through direct LIRIC session
PASS: character literal print lowers through direct LIRIC session
PASS: character variables lower through direct LIRIC session
PASS: logical literal print lowers through direct LIRIC session
PASS: logical variables lower through direct LIRIC session
PASS: real variables and arithmetic lower through direct LIRIC
PASS: integer function calls lower through direct LIRIC session
PASS: integer subroutine reference args lower through direct LIRIC session
PASS: non-integer contained procedures lower through direct LIRIC
PASS: scalar intrinsics lower through direct LIRIC session
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```
