### PR TITLE
fix: diagnose array assignment targets (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -909,7 +909,16 @@ contains
             name = node%name
             call set_empty(error_msg)
         type is (call_or_subscript_node)
-            if (node%is_array_access .or. allocated(node%arg_indices)) then
+            if (node%is_array_access) then
+                call unsupported_feature_error('array assignment target', &
+                                               node%line, node%column, &
+                                               'direct LIRIC session does not '// &
+                                               'support assigning to array '// &
+                                               'elements', error_msg)
+                call set_empty(name)
+                return
+            end if
+            if (allocated(node%arg_indices)) then
                 error_msg = 'expected scalar assignment target'
                 call set_empty(name)
                 return

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -11,6 +11,7 @@ program test_session_unsupported_diagnostics
 
     all_passed = .true.
     if (.not. test_array_declaration_diagnostic()) all_passed = .false.
+    if (.not. test_array_assignment_target_diagnostic()) all_passed = .false.
     if (.not. test_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_module_diagnostic()) all_passed = .false.
     if (.not. test_character_parameter_diagnostic()) all_passed = .false.
@@ -20,6 +21,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_unsupported_intrinsic_diagnostic()) all_passed = .false.
     if (.not. test_external_function_call_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
+    if (.not. test_cli_array_assignment_target_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_cli_module_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_parameter_diagnostic()) all_passed = .false.
@@ -44,6 +46,19 @@ contains
                                             source, 'unsupported array declaration', &
                                             '/tmp/ffc_session_array_diagnostic_test')
     end function test_array_declaration_diagnostic
+
+    logical function test_array_assignment_target_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported array assignment target'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  values(1) = 1'//new_line('a')// &
+                                       'end program main'
+
+        test_array_assignment_target_diagnostic = &
+            expect_error_contains(source, expected, &
+                                  '/tmp/ffc_session_array_target_test')
+    end function test_array_assignment_target_diagnostic
 
     logical function test_character_expression_diagnostic()
         character(len=*), parameter :: source = &
@@ -165,6 +180,19 @@ contains
                                               source, 'unsupported array declaration', &
                                                 '/tmp/ffc_cli_array_diagnostic_test')
     end function test_cli_array_declaration_diagnostic
+
+    logical function test_cli_array_assignment_target_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported array assignment target'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  values(1) = 1'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_array_assignment_target_diagnostic = &
+            expect_cli_error_contains(source, expected, &
+                                      '/tmp/ffc_cli_array_target_test')
+    end function test_cli_array_assignment_target_diagnostic
 
     logical function test_cli_character_expression_diagnostic()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
## Requirements

REQ-001 (ref #57): Unsupported array assignment targets must produce a targeted unsupported-feature diagnostic instead of generic scalar-target text.
REQ-002 (ref #57): The diagnostic must include line and column when FortFront exposes node location data.
REQ-003 (ref #57): Direct lowering and CLI coverage must assert the array assignment target error path.

## Verification

### Test fails on main
`LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics`

Output before the lowerer change with the new regression test:
```text
FAIL: expected diagnostic substring unsupported array assignment target
  got expected scalar assignment target
FAIL: expected CLI diagnostic substring unsupported array assignment target
  got STOP 1
expected scalar assignment target
```

### Test passes after fix
`LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics`

```text
PASS: unsupported direct-session features emit diagnostics
```

`LIBRARY_PATH=/home/ert/code/liric/build fpm test`

```text
PASS: LIRIC session binding tests
PASS: empty program compiles and runs through direct LIRIC session
PASS: empty program emits object through direct LIRIC session
PASS: integer stop expression lowers through direct LIRIC session
PASS: integer variable lowers through direct LIRIC session
PASS: block IF lowers through direct LIRIC session
PASS: fallthrough IF merges scalar values through direct LIRIC
PASS: integer print lowers through direct LIRIC session
PASS: real literal print lowers through direct LIRIC session
PASS: character literal print lowers through direct LIRIC session
PASS: character variables lower through direct LIRIC session
PASS: logical literal print lowers through direct LIRIC session
PASS: logical variables lower through direct LIRIC session
PASS: real variables and arithmetic lower through direct LIRIC
PASS: integer function calls lower through direct LIRIC session
PASS: integer subroutine reference args lower through direct LIRIC session
PASS: non-integer contained procedures lower through direct LIRIC
PASS: scalar intrinsics lower through direct LIRIC session
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```