### PR TITLE
fix: diagnose array expressions (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -776,7 +776,11 @@ contains
         integer :: intrinsic_id
 
         if (node%is_array_access) then
-            error_msg = 'direct LIRIC session MVP does not support array access'
+            call unsupported_feature_error('array expression', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support reading array elements', &
+                                           error_msg)
             return
         end if
         if (.not. allocated(node%name)) then
@@ -795,11 +799,12 @@ contains
                 call unsupported_intrinsic_error(node, error_msg)
                 return
             end if
-            call unsupported_feature_error('scalar function call', &
-                                           node%line, node%column, &
-                                           'direct LIRIC session only supports '// &
-                                           'contained scalar functions and '// &
-                                           'supported intrinsics', error_msg)
+            call unsupported_feature_error( &
+                'scalar function call or array expression', &
+                node%line, node%column, &
+                'direct LIRIC session only supports contained scalar '// &
+                'functions, supported intrinsics, and scalar variables', &
+                error_msg)
             return
         end if
 

--- a/src_mvp/session_program_lowering_values.inc
+++ b/src_mvp/session_program_lowering_values.inc
@@ -188,7 +188,11 @@
         integer, allocatable :: copyback_indices(:)
 
         if (node%is_array_access) then
-            error_msg = 'direct LIRIC session MVP does not support array access'
+            call unsupported_feature_error('array expression', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support reading array elements', &
+                                           error_msg)
             return
         end if
         if (.not. allocated(node%name)) then
@@ -286,7 +290,11 @@
         integer :: intrinsic_id
 
         if (node%is_array_access) then
-            error_msg = 'direct LIRIC session MVP does not support array access'
+            call unsupported_feature_error('array expression', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support reading array elements', &
+                                           error_msg)
             return
         end if
         if (.not. allocated(node%name)) then

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -12,6 +12,7 @@ program test_session_unsupported_diagnostics
     all_passed = .true.
     if (.not. test_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_array_assignment_target_diagnostic()) all_passed = .false.
+    if (.not. test_array_expression_diagnostic()) all_passed = .false.
     if (.not. test_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_module_diagnostic()) all_passed = .false.
     if (.not. test_character_parameter_diagnostic()) all_passed = .false.
@@ -22,6 +23,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_external_function_call_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_assignment_target_diagnostic()) all_passed = .false.
+    if (.not. test_cli_array_expression_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_cli_module_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_parameter_diagnostic()) all_passed = .false.
@@ -59,6 +61,17 @@ contains
             expect_error_contains(source, expected, &
                                   '/tmp/ffc_session_array_target_test')
     end function test_array_assignment_target_diagnostic
+
+    logical function test_array_expression_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  print *, values(1)'//new_line('a')// &
+                                       'end program main'
+
+        test_array_expression_diagnostic = expect_error_contains( &
+                                           source, 'array expression', &
+                                           '/tmp/ffc_session_array_expr_test')
+    end function test_array_expression_diagnostic
 
     logical function test_character_expression_diagnostic()
         character(len=*), parameter :: source = &
@@ -193,6 +206,17 @@ contains
             expect_cli_error_contains(source, expected, &
                                       '/tmp/ffc_cli_array_target_test')
     end function test_cli_array_assignment_target_diagnostic
+
+    logical function test_cli_array_expression_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  print *, values(1)'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_array_expression_diagnostic = expect_cli_error_contains( &
+                                               source, 'array expression', &
+                                               '/tmp/ffc_cli_array_expr_test')
+    end function test_cli_array_expression_diagnostic
 
     logical function test_cli_character_expression_diagnostic()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
## Requirements

REQ-001: Unsupported lowering errors should use user-facing feature names and limitation text.
REQ-002: Diagnostics should include line and column when FortFront exposes them.
REQ-003: Negative tests should assert diagnostic substrings and nonzero CLI exit.
REQ-004: Advance unsupported array expression diagnostics for issue (ref #57). This is partial progress; source-location coverage for other unsupported paths remains outside this PR.

## Changes

- Report classified array reads as `array expression` diagnostics with line/column and a direct-session limitation.
- Report unresolved `name(...)` expression lowering as `scalar function call or array expression`, preserving the scalar-call diagnostic while covering FortFront's ambiguous call/subscript form.
- Add lowerer and CLI negative coverage for `print *, values(1)`.

## Verification

Failing before final fix:

```text
$ LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
FAIL: expected diagnostic substring unsupported array expression
  got unsupported scalar function call at line 2, column 20: direct LIRIC session only supports contained scalar functions and supported intrinsics
FAIL: expected CLI diagnostic substring unsupported array expression
  got STOP 1
unsupported scalar function call at line 2, column 20: direct LIRIC session only supports contained scalar functions and supported intrinsics
<ERROR> Execution for object " test_session_unsupported_diagnostics " returned exit code  1
```

Passing after:

```text
$ LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics
```

```text
$ LIBRARY_PATH=/home/ert/code/liric/build fpm test
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```
