### PR TITLE
fix: diagnose unsupported derived types (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -1,6 +1,8 @@
 module session_program_lowering
     use, intrinsic :: iso_c_binding, only: c_double, c_int, c_int32_t, &
                                                                               c_int64_t
+    use ast_nodes_core, only: component_access_node
+    use ast_nodes_data, only: derived_type_node
     use fortfront, only: assignment_node, ast_arena_t, binary_op_node, &
                          call_or_subscript_node, declaration_node, do_loop_node, &
                          cycle_node, exit_node, function_def_node, &
@@ -331,6 +333,12 @@ contains
                                            'direct LIRIC session does not '// &
                                            'support multi-way branches', &
                                            error_msg)
+        type is (derived_type_node)
+            call unsupported_feature_error('derived type definition', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support derived types or '// &
+                                           'component layout', error_msg)
         class default
             node_type = 'unknown'
             if (allocated(arena%entries(node_index)%node_type)) then
@@ -760,6 +768,11 @@ contains
                                                       error_msg)) return
         type is (call_or_subscript_node)
             call lower_i32_call(arena, node, context, value, error_msg)
+        type is (component_access_node)
+            call unsupported_feature_error('derived type component expression', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support component access', error_msg)
         class default
             error_msg = 'direct LIRIC session MVP only supports integer expressions'
         end select
@@ -930,6 +943,13 @@ contains
             end if
             name = node%name
             call set_empty(error_msg)
+        type is (component_access_node)
+            call unsupported_feature_error('derived type component assignment target', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support assigning to components', &
+                                           error_msg)
+            call set_empty(name)
         class default
             error_msg = 'expected identifier assignment target'
             call set_empty(name)

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -19,6 +19,10 @@ program test_session_unsupported_diagnostics
     if (.not. test_exit_diagnostic()) all_passed = .false.
     if (.not. test_cycle_diagnostic()) all_passed = .false.
     if (.not. test_select_case_diagnostic()) all_passed = .false.
+    if (.not. test_derived_type_diagnostic()) all_passed = .false.
+    if (.not. test_component_assignment_target_diagnostic()) &
+        all_passed = .false.
+    if (.not. test_component_expression_diagnostic()) all_passed = .false.
     if (.not. test_unsupported_intrinsic_diagnostic()) all_passed = .false.
     if (.not. test_external_function_call_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
@@ -30,6 +34,11 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_exit_diagnostic()) all_passed = .false.
     if (.not. test_cli_cycle_diagnostic()) all_passed = .false.
     if (.not. test_cli_select_case_diagnostic()) all_passed = .false.
+    if (.not. test_cli_derived_type_diagnostic()) all_passed = .false.
+    if (.not. test_cli_component_assignment_target_diagnostic()) &
+        all_passed = .false.
+    if (.not. test_cli_component_expression_diagnostic()) &
+        all_passed = .false.
     if (.not. test_cli_unsupported_intrinsic_diagnostic()) all_passed = .false.
     if (.not. test_cli_external_function_call_diagnostic()) all_passed = .false.
 
@@ -159,6 +168,48 @@ contains
                                     source, 'unsupported select case statement', &
                                     '/tmp/ffc_session_select_case_test')
     end function test_select_case_diagnostic
+
+    logical function test_derived_type_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  type :: point'//new_line('a')// &
+                                       '    integer :: x'//new_line('a')// &
+                                       '  end type point'//new_line('a')// &
+                                       'end program main'
+
+        test_derived_type_diagnostic = expect_error_contains( &
+                                       source, &
+                                       'unsupported derived type definition', &
+                                       '/tmp/ffc_session_derived_type_test')
+    end function test_derived_type_diagnostic
+
+    logical function test_component_assignment_target_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported derived type component '// &
+                                       'assignment target'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  p%x = 1'//new_line('a')// &
+                                       'end program main'
+
+        test_component_assignment_target_diagnostic = expect_error_contains( &
+                                                      source, expected, &
+                                             '/tmp/ffc_session_component_target_test')
+    end function test_component_assignment_target_diagnostic
+
+    logical function test_component_expression_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported derived type component '// &
+                                       'expression'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  print *, p%x'//new_line('a')// &
+                                       'end program main'
+
+        test_component_expression_diagnostic = expect_error_contains( &
+                                               source, expected, &
+                                               '/tmp/ffc_session_component_expr_test')
+    end function test_component_expression_diagnostic
 
     logical function test_unsupported_intrinsic_diagnostic()
         character(len=*), parameter :: source = &
@@ -304,6 +355,48 @@ contains
                                     source, 'unsupported select case statement', &
                                     '/tmp/ffc_cli_select_case_test')
     end function test_cli_select_case_diagnostic
+
+    logical function test_cli_derived_type_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  type :: point'//new_line('a')// &
+                                       '    integer :: x'//new_line('a')// &
+                                       '  end type point'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_derived_type_diagnostic = expect_cli_error_contains( &
+                                           source, &
+                                           'unsupported derived type definition', &
+                                           '/tmp/ffc_cli_derived_type_test')
+    end function test_cli_derived_type_diagnostic
+
+    logical function test_cli_component_assignment_target_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported derived type component '// &
+                                       'assignment target'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  p%x = 1'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_component_assignment_target_diagnostic = &
+            expect_cli_error_contains(source, expected, &
+                                      '/tmp/ffc_cli_component_target_test')
+    end function test_cli_component_assignment_target_diagnostic
+
+    logical function test_cli_component_expression_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported derived type component '// &
+                                       'expression'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  print *, p%x'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_component_expression_diagnostic = expect_cli_error_contains( &
+                                                   source, expected, &
+                                                   '/tmp/ffc_cli_component_expr_test')
+    end function test_cli_component_expression_diagnostic
 
     logical function test_cli_unsupported_intrinsic_diagnostic()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
## Requirements

- REQ-001: Emit targeted unsupported-feature diagnostics for unsupported direct-session features (ref #57).
- REQ-002: Include line/column information when FortFront exposes it (ref #57).
- REQ-003: Cover negative behavior through direct lowering and CLI diagnostics (ref #57).
- REQ-004: Keep CLI failures nonzero with concise diagnostic text (ref #57).

## Changes

- Add explicit diagnostics for derived type definitions.
- Add explicit diagnostics for derived type component assignment targets and expressions.
- Add direct-lowering and CLI negative tests for those cases.

## Verification

Failing before, with only the new diagnostic tests applied to `origin/main`:

```text
$ cd /home/ert/code/lazy-fortran/ffc-before-issue57 && LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
FAIL: expected diagnostic substring unsupported derived type definition
  got direct LIRIC session MVP does not support statement node: derived_type
FAIL: expected diagnostic substring unsupported derived type component assignment target
  got expected identifier assignment target
FAIL: expected diagnostic substring unsupported derived type component expression
  got direct LIRIC session MVP only supports integer expressions
FAIL: expected CLI diagnostic substring unsupported derived type definition
  got STOP 1
direct LIRIC session MVP does not support statement node: derived_type
FAIL: expected CLI diagnostic substring unsupported derived type component assignment target
  got STOP 1
expected identifier assignment target
FAIL: expected CLI diagnostic substring unsupported derived type component expression
  got STOP 1
direct LIRIC session MVP only supports integer expressions
STOP 1
<ERROR> Execution for object " test_session_unsupported_diagnostics " returned exit code  1
```

Passing after:

```text
$ LIBRARY_PATH=/home/ert/code/liric/build fpm test
[100%] Project compiled successfully.
PASS: LIRIC session binding tests
PASS: empty program compiles and runs through direct LIRIC session
PASS: empty program emits object through direct LIRIC session
PASS: integer stop expression lowers through direct LIRIC session
PASS: integer variable lowers through direct LIRIC session
PASS: block IF lowers through direct LIRIC session
PASS: fallthrough IF merges scalar values through direct LIRIC
PASS: integer print lowers through direct LIRIC session
PASS: real literal print lowers through direct LIRIC session
PASS: character literal print lowers through direct LIRIC session
PASS: character variables lower through direct LIRIC session
PASS: logical literal print lowers through direct LIRIC session
PASS: logical variables lower through direct LIRIC session
PASS: real variables and arithmetic lower through direct LIRIC
PASS: integer function calls lower through direct LIRIC session
PASS: integer subroutine reference args lower through direct LIRIC session
PASS: non-integer contained procedures lower through direct LIRIC
PASS: scalar intrinsics lower through direct LIRIC session
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```
