### PR TITLE
fix: diagnose unsupported do steps (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering_loops.inc
+++ b/src_mvp/session_program_lowering_loops.inc
@@ -221,7 +221,11 @@
                                 error_msg)
         if (len_trim(error_msg) > 0) return
         if (step_value == 0_c_int64_t) then
-            error_msg = 'direct LIRIC session DO does not support zero step'
+            call unsupported_feature_error('do loop step', &
+                                           arena%get_node_line(step_expr_index), &
+                                           arena%get_node_column(step_expr_index), &
+                                           'direct LIRIC session requires a '// &
+                                           'nonzero literal step', error_msg)
         end if
     end subroutine parse_do_step
 
@@ -242,6 +246,10 @@
         type is (literal_node)
             call parse_i32_literal(node%value, value, error_msg)
         class default
-            error_msg = 'direct LIRIC session DO only supports literal steps'
+            call unsupported_feature_error('do loop '//trim(name), &
+                                           arena%get_node_line(node_index), &
+                                           arena%get_node_column(node_index), &
+                                           'direct LIRIC session only '// &
+                                           'supports literal steps', error_msg)
         end select
     end subroutine parse_i32_constant

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -19,6 +19,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_exit_diagnostic()) all_passed = .false.
     if (.not. test_cycle_diagnostic()) all_passed = .false.
     if (.not. test_select_case_diagnostic()) all_passed = .false.
+    if (.not. test_do_step_diagnostic()) all_passed = .false.
     if (.not. test_derived_type_diagnostic()) all_passed = .false.
     if (.not. test_component_assignment_target_diagnostic()) &
         all_passed = .false.
@@ -34,6 +35,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_exit_diagnostic()) all_passed = .false.
     if (.not. test_cli_cycle_diagnostic()) all_passed = .false.
     if (.not. test_cli_select_case_diagnostic()) all_passed = .false.
+    if (.not. test_cli_do_step_diagnostic()) all_passed = .false.
     if (.not. test_cli_derived_type_diagnostic()) all_passed = .false.
     if (.not. test_cli_component_assignment_target_diagnostic()) &
         all_passed = .false.
@@ -168,6 +170,21 @@ contains
                                     source, 'unsupported select case statement', &
                                     '/tmp/ffc_session_select_case_test')
     end function test_select_case_diagnostic
+
+    logical function test_do_step_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: i, step'//new_line('a')// &
+                                       '  step = 1'//new_line('a')// &
+                                       '  do i = 1, 3, step'//new_line('a')// &
+                                       '    print *, i'//new_line('a')// &
+                                       '  end do'//new_line('a')// &
+                                       'end program main'
+
+        test_do_step_diagnostic = expect_error_contains( &
+                                  source, 'unsupported do loop step', &
+                                  '/tmp/ffc_session_do_step_test')
+    end function test_do_step_diagnostic
 
     logical function test_derived_type_diagnostic()
         character(len=*), parameter :: source = &
@@ -355,6 +372,21 @@ contains
                                     source, 'unsupported select case statement', &
                                     '/tmp/ffc_cli_select_case_test')
     end function test_cli_select_case_diagnostic
+
+    logical function test_cli_do_step_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: i, step'//new_line('a')// &
+                                       '  step = 1'//new_line('a')// &
+                                       '  do i = 1, 3, step'//new_line('a')// &
+                                       '    print *, i'//new_line('a')// &
+                                       '  end do'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_do_step_diagnostic = expect_cli_error_contains( &
+                                      source, 'unsupported do loop step', &
+                                      '/tmp/ffc_cli_do_step_test')
+    end function test_cli_do_step_diagnostic
 
     logical function test_cli_derived_type_diagnostic()
         character(len=*), parameter :: source = &

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -20,6 +20,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_cycle_diagnostic()) all_passed = .false.
     if (.not. test_select_case_diagnostic()) all_passed = .false.
     if (.not. test_do_step_diagnostic()) all_passed = .false.
+    if (.not. test_do_zero_step_diagnostic()) all_passed = .false.
     if (.not. test_derived_type_diagnostic()) all_passed = .false.
     if (.not. test_component_assignment_target_diagnostic()) &
         all_passed = .false.
@@ -36,6 +37,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_cycle_diagnostic()) all_passed = .false.
     if (.not. test_cli_select_case_diagnostic()) all_passed = .false.
     if (.not. test_cli_do_step_diagnostic()) all_passed = .false.
+    if (.not. test_cli_do_zero_step_diagnostic()) all_passed = .false.
     if (.not. test_cli_derived_type_diagnostic()) all_passed = .false.
     if (.not. test_cli_component_assignment_target_diagnostic()) &
         all_passed = .false.
@@ -185,6 +187,20 @@ contains
                                   source, 'unsupported do loop step', &
                                   '/tmp/ffc_session_do_step_test')
     end function test_do_step_diagnostic
+
+    logical function test_do_zero_step_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: i'//new_line('a')// &
+                                       '  do i = 1, 3, 0'//new_line('a')// &
+                                       '    print *, i'//new_line('a')// &
+                                       '  end do'//new_line('a')// &
+                                       'end program main'
+
+        test_do_zero_step_diagnostic = expect_error_contains( &
+                                       source, 'nonzero literal step', &
+                                       '/tmp/ffc_session_do_zero_step_test')
+    end function test_do_zero_step_diagnostic
 
     logical function test_derived_type_diagnostic()
         character(len=*), parameter :: source = &
@@ -387,6 +403,20 @@ contains
                                       source, 'unsupported do loop step', &
                                       '/tmp/ffc_cli_do_step_test')
     end function test_cli_do_step_diagnostic
+
+    logical function test_cli_do_zero_step_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: i'//new_line('a')// &
+                                       '  do i = 1, 3, 0'//new_line('a')// &
+                                       '    print *, i'//new_line('a')// &
+                                       '  end do'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_do_zero_step_diagnostic = expect_cli_error_contains( &
+                                           source, 'nonzero literal step', &
+                                           '/tmp/ffc_cli_do_zero_step_test')
+    end function test_cli_do_zero_step_diagnostic
 
     logical function test_cli_derived_type_diagnostic()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
## Requirements

- REQ-001: Unsupported lowering diagnostics name the feature and current limitation.
- REQ-002: Diagnostics include line/column when FortFront exposes them.
- REQ-003: Negative tests cover unsupported cases through both the direct lowerer and CLI.
- REQ-004: CLI returns nonzero and prints a concise diagnostic for unsupported input.

## Change

- Added targeted unsupported `do` loop step diagnostics for nonliteral and zero steps.
- Added direct lowerer and CLI negative coverage for nonliteral `do` loop steps.

## Verification

- Failing before, with the new test applied to previous commit `abe3a02`: `LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics`
  - Failed with `FAIL: expected diagnostic substring unsupported do loop step`.
  - Old diagnostic was `direct LIRIC session DO only supports literal steps`.
- Passing after: `fpm clean --all && LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics`
  - Passed with `PASS: unsupported direct-session features emit diagnostics`.
- Passing after: `LIBRARY_PATH=/home/ert/code/liric/build fpm test`
  - Passed all configured fpm tests.

(ref #57)
