### PR TITLE
fix: diagnose non-integer external calls (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering_values.inc
+++ b/src_mvp/session_program_lowering_values.inc
@@ -200,8 +200,11 @@
             return
         end if
         if (.not. is_contained_logical_function(context, node%name)) then
-            error_msg = 'direct LIRIC session MVP does not support logical '// &
-                        'function calls'
+            call unsupported_feature_error('scalar logical function call', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session only '// &
+                                           'supports contained logical '// &
+                                           'functions', error_msg)
             return
         end if
 
@@ -315,8 +318,12 @@
         if (node%is_intrinsic) then
             call unsupported_intrinsic_error(node, error_msg)
         else
-            error_msg = 'direct LIRIC session MVP does not support real '// &
-                        'function calls'
+            call unsupported_feature_error('scalar real function call', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session only '// &
+                                           'supports contained real '// &
+                                           'functions and supported '// &
+                                           'intrinsics', error_msg)
         end if
     end subroutine lower_f64_call
 

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -27,6 +27,9 @@ program test_session_unsupported_diagnostics
     if (.not. test_component_expression_diagnostic()) all_passed = .false.
     if (.not. test_unsupported_intrinsic_diagnostic()) all_passed = .false.
     if (.not. test_external_function_call_diagnostic()) all_passed = .false.
+    if (.not. test_external_real_function_call_diagnostic()) all_passed = .false.
+    if (.not. test_external_logical_function_call_diagnostic()) &
+        all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_assignment_target_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_expression_diagnostic()) all_passed = .false.
@@ -45,6 +48,10 @@ program test_session_unsupported_diagnostics
         all_passed = .false.
     if (.not. test_cli_unsupported_intrinsic_diagnostic()) all_passed = .false.
     if (.not. test_cli_external_function_call_diagnostic()) all_passed = .false.
+    if (.not. test_cli_external_real_function_call_diagnostic()) &
+        all_passed = .false.
+    if (.not. test_cli_external_logical_function_call_diagnostic()) &
+        all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: unsupported direct-session features emit diagnostics'
@@ -267,6 +274,33 @@ contains
                                      '/tmp/ffc_session_external_call_test')
     end function test_external_function_call_diagnostic
 
+    logical function test_external_real_function_call_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  real :: x'//new_line('a')// &
+                                       '  x = external_real(1.0)'//new_line('a')// &
+                                       'end program main'
+
+        test_external_real_function_call_diagnostic = &
+            expect_error_contains(source, &
+                                  'unsupported scalar real function call', &
+                                  '/tmp/ffc_session_external_real_call_test')
+    end function test_external_real_function_call_diagnostic
+
+    logical function test_external_logical_function_call_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  logical :: flag'//new_line('a')// &
+                                       '  flag = external_flag(.true.)'// &
+                                       new_line('a')// &
+                                       'end program main'
+
+        test_external_logical_function_call_diagnostic = &
+            expect_error_contains(source, &
+                                  'unsupported scalar logical function call', &
+                                  '/tmp/ffc_session_external_logical_call_test')
+    end function test_external_logical_function_call_diagnostic
+
     logical function test_cli_array_declaration_diagnostic()
         character(len=*), parameter :: source = &
                                        'program main'//new_line('a')// &
@@ -482,6 +516,33 @@ contains
                                      source, 'unsupported scalar function call', &
                                      '/tmp/ffc_cli_external_call_test')
     end function test_cli_external_function_call_diagnostic
+
+    logical function test_cli_external_real_function_call_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  real :: x'//new_line('a')// &
+                                       '  x = external_real(1.0)'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_external_real_function_call_diagnostic = &
+            expect_cli_error_contains(source, &
+                                      'unsupported scalar real function call', &
+                                      '/tmp/ffc_cli_external_real_call_test')
+    end function test_cli_external_real_function_call_diagnostic
+
+    logical function test_cli_external_logical_function_call_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  logical :: flag'//new_line('a')// &
+                                       '  flag = external_flag(.true.)'// &
+                                       new_line('a')// &
+                                       'end program main'
+
+        test_cli_external_logical_function_call_diagnostic = &
+            expect_cli_error_contains(source, &
+                                      'unsupported scalar logical function call', &
+                                      '/tmp/ffc_cli_external_logical_call_test')
+    end function test_cli_external_logical_function_call_diagnostic
 
     logical function expect_error_contains(source, expected, exe_path)
         character(len=*), intent(in) :: source


### PR DESCRIPTION
## Requirements

- REQ-001: Unsupported lowering diagnostics name the feature and current limitation.
- REQ-002: Diagnostics include line/column when FortFront exposes them.
- REQ-003: Negative tests cover unsupported cases through both the direct lowerer and CLI.
- REQ-004: CLI returns nonzero and prints a concise diagnostic for unsupported input.

## Change

- Route unsupported external real and logical scalar function calls through `unsupported_feature_error`.
- Add direct lowerer and CLI negative coverage for both value kinds.

## Verification

- Failing before, after adding the new test cases: `LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics`
  - Failed with `FAIL: expected diagnostic substring unsupported scalar real function call`.
  - Failed with `FAIL: expected diagnostic substring unsupported scalar logical function call`.
  - Old diagnostics were `direct LIRIC session MVP does not support real function calls` and `direct LIRIC session MVP does not support logical function calls`.
- Passing after, from a clean build: `rm -rf build && LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics`
  - Passed with `PASS: unsupported direct-session features emit diagnostics`.
- Passing after: `LIBRARY_PATH=/home/ert/code/liric/build fpm test`
  - Passed all configured fpm tests.

(ref #57)
