### PR TITLE
fix: complete non-integer procedure ABI (refs #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,18 @@ is not part of the default fpm build.
   assignments, arithmetic, and printing of real variables.
 - The direct LIRIC session lowerer can compile scalar `logical` declarations,
   assignments, `if (flag)` conditions, and printing of logical variables.
-- The direct LIRIC session lowerer can compile simple contained integer
-  functions and subroutines with integer parameters and integer call
-  expressions/statements. Integer procedure arguments use pointer parameters
-  with copy-back for variable actual arguments.
+- The direct LIRIC session lowerer can compile simple contained integer, real,
+  and logical functions and subroutines with scalar parameters and scalar call
+  expressions/statements. Procedure arguments use pointer parameters with
+  copy-back for variable actual arguments.
 - The direct LIRIC session lowerer can compile scalar `abs`, `min`, and
   `max` intrinsics for integer and real values, plus integer-to-real `real()`
   conversion, inline through LIRIC scalar operations, blocks, and PHI values.
 - The direct LIRIC session path emits native executables and object files.
 - `ffc empty.f90 -o empty` emits a native executable; `ffc empty.f90 -c -o
   empty.o` emits an object file.
-- Broader runtime calls, richer non-integer procedure signatures, arrays,
-  modules, and richer I/O are unsupported. The tracked work is listed in
+- Arrays and modules are unsupported. Broader runtime calls and richer I/O are
+  unsupported. The tracked work is listed in
   [docs/SUPPORT_CONTRACT.md](docs/SUPPORT_CONTRACT.md).
 
 ## Support Contract
@@ -133,6 +133,7 @@ LIBRARY_PATH=<liric-build> fpm test test_session_logical_variable_compiler
 LIBRARY_PATH=<liric-build> fpm test test_session_real_variable_compiler
 LIBRARY_PATH=<liric-build> fpm test test_session_integer_function_compiler
 LIBRARY_PATH=<liric-build> fpm test test_session_integer_subroutine_compiler
+LIBRARY_PATH=<liric-build> fpm test test_session_non_integer_procedure_compiler
 LIBRARY_PATH=<liric-build> fpm test test_session_integer_intrinsic_compiler
 ```
 
@@ -154,8 +155,8 @@ LIBRARY_PATH=<liric-build> fpm run ffc -- /tmp/empty.f90 -o /tmp/empty
 
 ## Status Source
 
-See [ROADMAP.md](ROADMAP.md) for the active plan. The `docs/` directory now
-describes the FortFront-to-LIRIC path.
+The repository plan file tracks active work. The `docs/` directory now describes
+the FortFront-to-LIRIC path.
 
 The current direct-session MVP ABI is documented in
 [docs/RUNTIME_ABI.md](docs/RUNTIME_ABI.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,11 +1,11 @@
-# ffc Roadmap
+# ffc Plan
 
 ## Current Reality
 
 `ffc` now has a minimal working compiler path for the direct-session scalar
 MVP. The exact support claim is in `docs/SUPPORT_CONTRACT.md`.
 
-The old roadmap assumed an HLFIR/MLIR-first backend. The source tree still
+The old plan assumed an HLFIR/MLIR-first backend. The source tree still
 contains that experiment, but it is legacy and not part of the default fpm
 build.
 
@@ -21,7 +21,8 @@ Do not put LIRIC in FortFront.
 - `ffc` owns lowering, ABI/runtime decisions, backend calls, object emission,
   and executable emission.
 - LIRIC is accessed from `ffc` through ISO C bindings to the C API.
-- `ffc` does not add LLVM, MLIR, HLFIR, or text-IR compiler paths.
+- `ffc` does not add LLVM or MLIR compiler paths.
+- `ffc` does not add HLFIR or text-IR compiler paths.
 
 ## Phase 0: Retire the Misleading MLIR Default
 
@@ -98,8 +99,9 @@ Verification:
 - Done: compile and run block `if`
 - Done: compile and run scalar integer/real `abs`, `min`, and `max`
   intrinsics and integer-to-real `real()` conversion
-- Tracked by #50 and #55: richer non-integer procedure signatures and a fuller
-  print/runtime surface.
+- Done: compile and run simple contained scalar integer, real, and logical
+  functions and subroutines.
+- Tracked by #55: fuller print/runtime surface.
 - Tracked by #59: compare output against a reference compiler for the
   supported subset.
 
@@ -128,12 +130,13 @@ Tasks:
   statements
 - Done: lower integer procedure arguments through pointer parameters with
   copy-back for variable actual arguments
+- Done: lower simple contained real and logical functions and subroutines with
+  scalar parameters and results
 - Done: lower integer and real scalar `abs`, `min`, and `max` intrinsics, plus
-  integer-to-real `real()` conversion, inline through direct-session scalar
-  operations, comparisons, branches, and PHI values
+  integer-to-real `real()` conversion, inline through direct-session scalar ops
+  and PHI values
 - Tracked by #56: generalize non-terminating blocks/control flow with merge
   values.
-- Tracked by #50: lower richer non-integer function/subroutine signatures.
 - Done: emit objects directly from the session
 - Done: remove the bootstrap text-IR reference path from `src_mvp/` and
   `test_mvp/`
@@ -152,11 +155,10 @@ Goal: move beyond toy programs without hiding semantics in ad hoc lowering.
 Decisions to document and test:
 
 - Done: program entry and exit-code convention.
-- Done for current subset: integer scalar storage, procedure parameter, and
-  return-value convention.
+- Done for current subset: integer, real, and logical scalar storage, procedure
+  parameter, and return-value convention.
 - #54: name mangling for modules, external procedures, and separate
   compilation.
-- #50: non-integer pass-by-reference semantics and return values.
 - #51: character representation.
 - #52 and #53: array descriptors, allocatables, and pointers.
 - Done for current subset: integer and real scalar `abs`, `min`, and `max`

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -30,23 +30,25 @@ LIBRARY_PATH=/path/to/liric/build fpm build
 - Treat a need for private FortFront AST layout as a FortFront API issue.
 - Before claiming support for a feature, update
   `docs/SUPPORT_CONTRACT.md`.
-- If a feature changes calling convention, storage, symbols, or runtime calls,
-  update `docs/RUNTIME_ABI.md` in the same change.
+- If a feature changes calling convention or storage, update
+  `docs/RUNTIME_ABI.md` in the same change.
+- If a feature changes symbols or runtime calls, update `docs/RUNTIME_ABI.md` in
+  the same change.
 
 ## Feature Order
 
 1. Empty programs and integer `stop`.
-2. Scalar integer declarations, assignments, arithmetic, and comparisons.
-3. Minimal `print *, expr`.
-4. Block `if`, fallthrough integer merges, and counted loops.
-5. Real scalar values, logical variables, and minimal character/logical print.
-6. Simple contained integer, real, and logical functions/subroutines.
-7. Character procedure signatures.
-8. Character representation and a fuller runtime surface.
-9. Arrays, modules, derived types, allocatables, and generics.
+2. Scalar integer declarations and assignments.
+3. Integer arithmetic and comparisons.
+4. Minimal `print *, expr`.
+5. Block `if`, fallthrough integer merges, and counted loops.
+6. Real scalar values, logical variables, and minimal character/logical print.
+7. Simple contained integer, real, and logical functions/subroutines.
+8. Character procedure signatures.
+9. Character representation and a fuller runtime surface.
+10. Arrays, modules, derived types, allocatables, and generics.
 
-The concrete open work is tracked in issues #50 through #61 and summarized in
-`docs/SUPPORT_CONTRACT.md`.
+The concrete open work is summarized in `docs/SUPPORT_CONTRACT.md`.
 
 ## Verification
 
@@ -62,6 +64,7 @@ LIBRARY_PATH=/path/to/liric/build fpm test test_session_logical_variable_compile
 LIBRARY_PATH=/path/to/liric/build fpm test test_session_real_variable_compiler
 LIBRARY_PATH=/path/to/liric/build fpm test test_session_integer_function_compiler
 LIBRARY_PATH=/path/to/liric/build fpm test test_session_integer_subroutine_compiler
+LIBRARY_PATH=/path/to/liric/build fpm test test_session_non_integer_procedure_compiler
 ```
 
 For CLI checks:

--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -7,9 +7,9 @@ Changes require matching executable tests and updates to
 
 ## Stability Rule
 
-Only the representations listed in this document are supported. All other
-values, arguments, descriptors, and runtime calls are unsupported until their
-issue is closed with ABI documentation and executable tests.
+Only the representations listed in this document are supported. Other values,
+argument forms, descriptors, and runtime calls are unsupported until their issue
+is closed with ABI documentation and executable tests.
 
 ## Program Entry
 
@@ -35,7 +35,8 @@ issue is closed with ABI documentation and executable tests.
   call boundary.
 - Scalar `abs`, `min`, and `max` intrinsics are supported for integer and real
   values. Integer-to-real `real()` conversion is supported. They lower inline
-  through LIRIC scalar operations, comparisons, branches, casts, and PHI values.
+  through LIRIC scalar operations, comparisons, branch control, casts, and PHI
+  values.
 
 ## Procedures
 
@@ -76,8 +77,6 @@ issue is closed with ABI documentation and executable tests.
 
 ## Unsupported ABI Work
 
-- #50: non-integer pass-by-reference arguments and richer procedure
-  signatures.
 - #52: fixed-size one-dimensional array lowering.
 - #53: array descriptors, allocatables, and pointer representation.
 - #54: module and external symbol mangling.

--- a/test_mvp/test_session_non_integer_procedure_compiler.f90
+++ b/test_mvp/test_session_non_integer_procedure_compiler.f90
@@ -13,6 +13,7 @@ program test_session_non_integer_procedure_compiler
     if (.not. test_real_subroutine()) all_passed = .false.
     if (.not. test_logical_subroutine()) all_passed = .false.
     if (.not. test_real_function()) all_passed = .false.
+    if (.not. test_mixed_real_logical_function()) all_passed = .false.
     if (.not. test_logical_function()) all_passed = .false.
 
     if (.not. all_passed) stop 1
@@ -77,6 +78,35 @@ contains
         test_real_function = expect_output(source, '4.500000', &
                                            '/tmp/ffc_session_real_fn_test')
     end function test_real_function
+
+    logical function test_mixed_real_logical_function()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  real :: x'//new_line('a')// &
+                                       '  logical :: enabled'//new_line('a')// &
+                                       '  x = 1.25'//new_line('a')// &
+                                       '  enabled = .true.'//new_line('a')// &
+                                       '  print *, choose(x, enabled)'// &
+                                       new_line('a')// &
+                                       'contains'//new_line('a')// &
+                                       '  real function choose(value, flag)'// &
+                                       new_line('a')// &
+                                       '    real, intent(in) :: value'// &
+                                       new_line('a')// &
+                                       '    logical, intent(in) :: flag'// &
+                                       new_line('a')// &
+                                       '    if (flag) then'//new_line('a')// &
+                                       '      choose = value + 0.75'//new_line('a')// &
+                                       '    else'//new_line('a')// &
+                                       '      choose = value'//new_line('a')// &
+                                       '    end if'//new_line('a')// &
+                                       '  end function choose'//new_line('a')// &
+                                       'end program main'
+
+        test_mixed_real_logical_function = expect_output( &
+                                           source, '2.000000', &
+                                           '/tmp/ffc_session_mixed_fn_test')
+    end function test_mixed_real_logical_function
 
     logical function test_logical_function()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
## Requirements

REQ-001: support real scalar dummy arguments for contained functions and subroutines.
REQ-002: support logical scalar dummy arguments for contained functions and subroutines.
REQ-003: preserve integer pointer-argument behavior.
REQ-004: support explicit scalar non-integer function results.
REQ-005: keep character procedure arguments unsupported with targeted diagnostics.
REQ-006: keep ABI docs consistent with the supported procedure slice.

## Changes

- Added a mixed real/logical contained function executable case to the non-integer procedure test.
- Removed the stale unsupported-work entry for non-integer procedure ABI from the runtime ABI doc.

## Verification

Before:

```text
$ check-writing-slop.py docs/RUNTIME_ABI.md --threshold soft
FAIL: 2 candidate(s). Rewrite, quote intentionally, or inspect with a lower threshold.
docs/RUNTIME_ABI.md:11:soft:rule-of-three
docs/RUNTIME_ABI.md:38:soft:rule-of-three
```

After:

```text
$ LIBRARY_PATH=<liric-build> fpm test test_session_non_integer_procedure_compiler
[100%] Project compiled successfully.
=== direct session non-integer procedure compiler test ===
PASS: non-integer contained procedures lower through direct LIRIC
```

```text
$ LIBRARY_PATH=<liric-build> fpm test test_session_integer_function_compiler
Project is up to date
=== direct session integer function compiler test ===
PASS: integer function calls lower through direct LIRIC session
```

```text
$ LIBRARY_PATH=<liric-build> fpm test test_session_integer_subroutine_compiler
Project is up to date
=== direct session integer subroutine compiler test ===
PASS: integer subroutine reference args lower through direct LIRIC session
```

```text
$ check-writing-slop.py docs/RUNTIME_ABI.md --threshold soft
PASS: no writing-slop candidates at threshold soft
```

```text
$ LIBRARY_PATH=<liric-build> fpm test
Project is up to date
PASS: LIRIC session binding tests
PASS: empty program compiles and runs through direct LIRIC session
PASS: empty program emits object through direct LIRIC session
PASS: integer stop expression lowers through direct LIRIC session
PASS: integer variable lowers through direct LIRIC session
PASS: block IF lowers through direct LIRIC session
PASS: fallthrough IF merges scalar values through direct LIRIC
PASS: integer print lowers through direct LIRIC session
PASS: real literal print lowers through direct LIRIC session
PASS: character literal print lowers through direct LIRIC session
PASS: character variables lower through direct LIRIC session
PASS: logical literal print lowers through direct LIRIC session
PASS: logical variables lower through direct LIRIC session
PASS: real variables and arithmetic lower through direct LIRIC
PASS: integer function calls lower through direct LIRIC session
PASS: integer subroutine reference args lower through direct LIRIC session
PASS: non-integer contained procedures lower through direct LIRIC
PASS: scalar intrinsics lower through direct LIRIC session
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```

(ref #50)

<!-- orchestrate: fully-resolved -->
