### PR TITLE
fix: diagnose unsupported scalar types (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -380,9 +380,7 @@ contains
         type(declaration_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: i
-
-        integer :: value_kind
+        integer :: i, value_kind
 
         if (node%is_array) then
             call unsupported_feature_error('array declaration', &
@@ -439,8 +437,7 @@ contains
         type(parameter_declaration_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: symbol_index
-        integer :: value_kind
+        integer :: symbol_index, value_kind
 
         if (.not. allocated(node%name)) then
             error_msg = 'parameter declaration did not expose a name'
@@ -454,7 +451,8 @@ contains
             return
         end if
         if (allocated(node%type_name)) then
-            call type_name_value_kind(node%type_name, value_kind, error_msg)
+            call type_name_value_kind(node%type_name, node%line, node%column, &
+                                      value_kind, error_msg)
             if (len_trim(error_msg) > 0) return
             if (value_kind == VALUE_CHARACTER) then
                 call unsupported_feature_error( &
@@ -485,11 +483,11 @@ contains
         call set_empty(error_msg)
     end subroutine lower_parameter_declaration
 
-    subroutine type_name_value_kind(type_name, value_kind, error_msg)
+    subroutine type_name_value_kind(type_name, line, column, value_kind, error_msg)
         character(len=*), intent(in) :: type_name
+        integer, intent(in) :: line, column
         integer, intent(out) :: value_kind
         character(len=:), allocatable, intent(out) :: error_msg
-
         value_kind = VALUE_I32
         call set_empty(error_msg)
         if (is_character_type_name(type_name)) then
@@ -504,8 +502,10 @@ contains
         case ('logical')
             value_kind = VALUE_LOGICAL
         case default
-            error_msg = 'direct LIRIC session MVP only supports integer, real, '// &
-                        'and logical scalar types'
+            call unsupported_feature_error('scalar type', line, column, &
+                                           'direct LIRIC session only supports '// &
+                                           'integer, real, logical, and character '// &
+                                           'scalars', error_msg)
         end select
     end subroutine type_name_value_kind
 
@@ -517,7 +517,8 @@ contains
         value_kind = VALUE_I32
         call set_empty(error_msg)
         if (.not. allocated(node%type_name)) return
-        call type_name_value_kind(node%type_name, value_kind, error_msg)
+        call type_name_value_kind(node%type_name, node%line, node%column, &
+                                  value_kind, error_msg)
     end subroutine declaration_value_kind
 
     subroutine define_symbol(context, name, value_kind, error_msg)

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -16,6 +16,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_module_diagnostic()) all_passed = .false.
     if (.not. test_character_parameter_diagnostic()) all_passed = .false.
+    if (.not. test_unsupported_scalar_type_diagnostic()) all_passed = .false.
     if (.not. test_exit_diagnostic()) all_passed = .false.
     if (.not. test_cycle_diagnostic()) all_passed = .false.
     if (.not. test_select_case_diagnostic()) all_passed = .false.
@@ -36,6 +37,8 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_character_expression_diagnostic()) all_passed = .false.
     if (.not. test_cli_module_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_parameter_diagnostic()) all_passed = .false.
+    if (.not. test_cli_unsupported_scalar_type_diagnostic()) &
+        all_passed = .false.
     if (.not. test_cli_exit_diagnostic()) all_passed = .false.
     if (.not. test_cli_cycle_diagnostic()) all_passed = .false.
     if (.not. test_cli_select_case_diagnostic()) all_passed = .false.
@@ -135,6 +138,17 @@ contains
                                               source, expected, &
                                               '/tmp/ffc_session_char_param_test')
     end function test_character_parameter_diagnostic
+
+    logical function test_unsupported_scalar_type_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  complex :: z'//new_line('a')// &
+                                       'end program main'
+
+        test_unsupported_scalar_type_diagnostic = expect_error_contains( &
+                                                  source, 'unsupported scalar type', &
+                                                  '/tmp/ffc_session_scalar_type_test')
+    end function test_unsupported_scalar_type_diagnostic
 
     logical function test_exit_diagnostic()
         character(len=*), parameter :: source = &
@@ -378,6 +392,17 @@ contains
                                                   source, expected, &
                                                   '/tmp/ffc_cli_char_param_test')
     end function test_cli_character_parameter_diagnostic
+
+    logical function test_cli_unsupported_scalar_type_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  complex :: z'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_unsupported_scalar_type_diagnostic = expect_cli_error_contains( &
+                                                    source, 'unsupported scalar type', &
+                                                      '/tmp/ffc_cli_scalar_type_test')
+    end function test_cli_unsupported_scalar_type_diagnostic
 
     logical function test_cli_exit_diagnostic()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
## Requirements

REQ-001: Unsupported scalar type declarations report a targeted `unsupported scalar type` diagnostic (ref #57).
REQ-002: Diagnostics include FortFront line and column when available.
REQ-003: CLI failures exit nonzero and print the concise diagnostic.
REQ-004: Negative tests cover direct lowering and CLI behavior.

## Changes

- Routes unsupported scalar declaration type names through the location-aware unsupported-feature diagnostic helper.
- Adds direct-lowering and CLI negative coverage for `complex :: z`.

## Verification

Failing before:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
FAIL: expected diagnostic substring unsupported scalar type
  got direct LIRIC session MVP only supports integer, real, and logical scalar types
FAIL: expected CLI diagnostic substring unsupported scalar type
  got STOP 1
direct LIRIC session MVP only supports integer, real, and logical scalar types
```

Passing after:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics
```

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test
Project compiled successfully.
PASS: unsupported direct-session features emit diagnostics
PASS: counted do compiler test
```
