### PR TITLE
fix: diagnose unsupported real exponent operator (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering_values.inc
+++ b/src_mvp/session_program_lowering_values.inc
@@ -273,7 +273,8 @@
             call lower_f64_expression(arena, node%right_index, context, rhs, &
                                       error_msg)
             if (len_trim(error_msg) > 0) return
-            call real_opcode(node%operator, opcode, error_msg)
+            call real_opcode(node%operator, node%line, node%column, opcode, &
+                             error_msg)
             if (len_trim(error_msg) > 0) return
             if (.not. emit_liric_f64_binary(context%session, opcode, lhs, rhs, &
                                             value, error_msg)) return
@@ -407,8 +408,10 @@
         end do
     end function is_f64_intrinsic_expression
 
-    subroutine real_opcode(source_op, opcode, error_msg)
+    subroutine real_opcode(source_op, line, column, opcode, error_msg)
         character(len=*), intent(in) :: source_op
+        integer, intent(in) :: line
+        integer, intent(in) :: column
         integer, intent(out) :: opcode
         character(len=:), allocatable, intent(out) :: error_msg
 
@@ -423,8 +426,10 @@
         case ('/')
             opcode = 21
         case default
-            error_msg = 'direct LIRIC session MVP does not support real operator: '// &
-                        trim(source_op)
+            call unsupported_feature_error('real operator', line, column, &
+                                           'direct LIRIC session supports '// &
+                                           '+, -, *, and / for real expressions', &
+                                           error_msg)
         end select
     end subroutine real_opcode
 

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -31,6 +31,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_external_real_function_call_diagnostic()) all_passed = .false.
     if (.not. test_external_logical_function_call_diagnostic()) &
         all_passed = .false.
+    if (.not. test_real_exponent_operator_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_assignment_target_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_expression_diagnostic()) all_passed = .false.
@@ -55,6 +56,7 @@ program test_session_unsupported_diagnostics
         all_passed = .false.
     if (.not. test_cli_external_logical_function_call_diagnostic()) &
         all_passed = .false.
+    if (.not. test_cli_real_exponent_operator_diagnostic()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: unsupported direct-session features emit diagnostics'
@@ -315,6 +317,18 @@ contains
                                   '/tmp/ffc_session_external_logical_call_test')
     end function test_external_logical_function_call_diagnostic
 
+    logical function test_real_exponent_operator_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  real :: x'//new_line('a')// &
+                                       '  x = 2.0 ** 3.0'//new_line('a')// &
+                                       'end program main'
+
+        test_real_exponent_operator_diagnostic = expect_error_contains( &
+            source, 'unsupported real operator', &
+            '/tmp/ffc_session_real_exponent_operator_test')
+    end function test_real_exponent_operator_diagnostic
+
     logical function test_cli_array_declaration_diagnostic()
         character(len=*), parameter :: source = &
                                        'program main'//new_line('a')// &
@@ -568,6 +582,18 @@ contains
                                       'unsupported scalar logical function call', &
                                       '/tmp/ffc_cli_external_logical_call_test')
     end function test_cli_external_logical_function_call_diagnostic
+
+    logical function test_cli_real_exponent_operator_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  real :: x'//new_line('a')// &
+                                       '  x = 2.0 ** 3.0'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_real_exponent_operator_diagnostic = expect_cli_error_contains( &
+            source, 'unsupported real operator', &
+            '/tmp/ffc_cli_real_exponent_operator_test')
+    end function test_cli_real_exponent_operator_diagnostic
 
     logical function expect_error_contains(source, expected, exe_path)
         character(len=*), intent(in) :: source


### PR DESCRIPTION
## Requirements

- REQ-001 Add a targeted diagnostic for unsupported real exponentiation in direct-session lowering (ref #57).
- REQ-002 Include line and column when FortFront provides them.
- REQ-003 Cover both lowering API and CLI behavior with negative tests.
- REQ-004 Keep existing unsupported diagnostics passing.

## Verification

Failing before implementation:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
FAIL: expected diagnostic substring unsupported real operator
  got direct LIRIC session MVP does not support real operator: **
FAIL: expected CLI diagnostic substring unsupported real operator
  got STOP 1
direct LIRIC session MVP does not support real operator: **
<ERROR> Execution for object " test_session_unsupported_diagnostics " returned exit code  1
```

Passing focused test after implementation:

```text
fpm clean --skip && LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics
```

Passing full test after implementation:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test
PASS: LIRIC session binding tests
PASS: empty program compiles and runs through direct LIRIC session
PASS: non-integer contained procedures lower through direct LIRIC
PASS: scalar intrinsics lower through direct LIRIC session
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```

Writing check:

```text
$HOME/code/prompts/scripts/check-writing-slop.py src_mvp/session_program_lowering_values.inc test_mvp/test_session_unsupported_diagnostics.f90
PASS: no writing-slop candidates at threshold medium
```
