### PR TITLE
fix: read/write diagnostics (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -8,8 +8,10 @@ module session_program_lowering
                          cycle_node, exit_node, function_def_node, &
                          identifier_node, if_node, literal_node, &
                          parameter_declaration_node, &
-                         print_statement_node, program_node, module_node, &
+                         print_statement_node, program_node, read_statement_node, &
+                         module_node, &
                          select_case_node, stop_node, subroutine_def_node, &
+                         write_statement_node, &
                          get_subroutine_call_arg_indices, &
                          get_subroutine_call_name, is_subroutine_call_statement
     use liric_session_bindings, only: liric_session_t, liric_session_create, &
@@ -305,6 +307,17 @@ contains
             call lower_assignment(arena, node, context, error_msg)
         type is (print_statement_node)
             call lower_print(arena, node, context, error_msg)
+        type is (read_statement_node)
+            call unsupported_feature_error('read statement', node%line, &
+                                           node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support input runtime calls', &
+                                           error_msg)
+        type is (write_statement_node)
+            call unsupported_feature_error('write statement', node%line, &
+                                           node%column, &
+                                           'direct LIRIC session only supports '// &
+                                           'minimal print output', error_msg)
         type is (stop_node)
             call lower_stop(arena, node, context, value, error_msg)
             if (len_trim(error_msg) == 0) then
@@ -972,29 +985,6 @@ contains
     end function find_symbol
 
     include 'session_program_lowering_text.inc'
-
-    subroutine set_empty(value)
-        character(len=:), allocatable, intent(out) :: value
-
-        allocate (character(len=0) :: value)
-    end subroutine set_empty
-
-    subroutine unsupported_feature_error(feature, line, column, limitation, &
-                                         error_msg)
-        character(len=*), intent(in) :: feature
-        integer, intent(in) :: line
-        integer, intent(in) :: column
-        character(len=*), intent(in) :: limitation
-        character(len=:), allocatable, intent(out) :: error_msg
-        character(len=64) :: location
-
-        if (line > 0 .and. column > 0) then
-            write (location, '(" at line ",I0,", column ",I0)') line, column
-            error_msg = 'unsupported '//trim(feature)//trim(location)//': '// &
-                        trim(limitation)
-        else
-            error_msg = 'unsupported '//trim(feature)//': '//trim(limitation)
-        end if
-    end subroutine unsupported_feature_error
+    include 'session_program_lowering_diagnostics.inc'
 
 end module session_program_lowering

--- a/src_mvp/session_program_lowering_diagnostics.inc
+++ b/src_mvp/session_program_lowering_diagnostics.inc
@@ -1,0 +1,23 @@
+    subroutine set_empty(value)
+        character(len=:), allocatable, intent(out) :: value
+
+        allocate (character(len=0) :: value)
+    end subroutine set_empty
+
+    subroutine unsupported_feature_error(feature, line, column, limitation, &
+                                         error_msg)
+        character(len=*), intent(in) :: feature
+        integer, intent(in) :: line
+        integer, intent(in) :: column
+        character(len=*), intent(in) :: limitation
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=64) :: location
+
+        if (line > 0 .and. column > 0) then
+            write (location, '(" at line ",I0,", column ",I0)') line, column
+            error_msg = 'unsupported '//trim(feature)//trim(location)//': '// &
+                        trim(limitation)
+        else
+            error_msg = 'unsupported '//trim(feature)//': '//trim(limitation)
+        end if
+    end subroutine unsupported_feature_error

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -32,6 +32,8 @@ program test_session_unsupported_diagnostics
     if (.not. test_external_logical_function_call_diagnostic()) &
         all_passed = .false.
     if (.not. test_real_exponent_operator_diagnostic()) all_passed = .false.
+    if (.not. test_read_statement_diagnostic()) all_passed = .false.
+    if (.not. test_write_statement_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_assignment_target_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_expression_diagnostic()) all_passed = .false.
@@ -57,6 +59,8 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_external_logical_function_call_diagnostic()) &
         all_passed = .false.
     if (.not. test_cli_real_exponent_operator_diagnostic()) all_passed = .false.
+    if (.not. test_cli_read_statement_diagnostic()) all_passed = .false.
+    if (.not. test_cli_write_statement_diagnostic()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: unsupported direct-session features emit diagnostics'
@@ -329,6 +333,31 @@ contains
             '/tmp/ffc_session_real_exponent_operator_test')
     end function test_real_exponent_operator_diagnostic
 
+    logical function test_read_statement_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: x'//new_line('a')// &
+                                       '  read *, x'//new_line('a')// &
+                                       'end program main'
+
+        test_read_statement_diagnostic = expect_error_contains( &
+                                         source, 'unsupported read statement', &
+                                         '/tmp/ffc_session_read_statement_test')
+    end function test_read_statement_diagnostic
+
+    logical function test_write_statement_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: x'//new_line('a')// &
+                                       '  x = 1'//new_line('a')// &
+                                       '  write (*,*) x'//new_line('a')// &
+                                       'end program main'
+
+        test_write_statement_diagnostic = expect_error_contains( &
+                                          source, 'unsupported write statement', &
+                                          '/tmp/ffc_session_write_statement_test')
+    end function test_write_statement_diagnostic
+
     logical function test_cli_array_declaration_diagnostic()
         character(len=*), parameter :: source = &
                                        'program main'//new_line('a')// &
@@ -594,6 +623,31 @@ contains
             source, 'unsupported real operator', &
             '/tmp/ffc_cli_real_exponent_operator_test')
     end function test_cli_real_exponent_operator_diagnostic
+
+    logical function test_cli_read_statement_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: x'//new_line('a')// &
+                                       '  read *, x'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_read_statement_diagnostic = expect_cli_error_contains( &
+                                             source, 'unsupported read statement', &
+                                             '/tmp/ffc_cli_read_statement_test')
+    end function test_cli_read_statement_diagnostic
+
+    logical function test_cli_write_statement_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: x'//new_line('a')// &
+                                       '  x = 1'//new_line('a')// &
+                                       '  write (*,*) x'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_write_statement_diagnostic = expect_cli_error_contains( &
+                                              source, 'unsupported write statement', &
+                                              '/tmp/ffc_cli_write_statement_test')
+    end function test_cli_write_statement_diagnostic
 
     logical function expect_error_contains(source, expected, exe_path)
         character(len=*), intent(in) :: source


### PR DESCRIPTION
Partial progress for (ref #57).

## Requirements

REQ-001: Unsupported `read` statements must fail with a targeted diagnostic instead of the generic AST node fallback.
REQ-002: Unsupported `write` statements must fail with a targeted diagnostic instead of the generic AST node fallback.
REQ-003: Diagnostics must include source line and column when FortFront provides them.
REQ-004: Negative tests must cover both direct lowering and CLI nonzero behavior.

## Verification

Failing before:

```text
$ build/gfortran_*/app/ffc /tmp/ffc_issue57_read_before.f90 -o /tmp/ffc_issue57_read_before.exe
read status=1
STOP 1
direct LIRIC session MVP does not support statement node: read_statement

$ build/gfortran_*/app/ffc /tmp/ffc_issue57_write_before.f90 -o /tmp/ffc_issue57_write_before.exe
write status=1
STOP 1
direct LIRIC session MVP does not support statement node: write_statement
```

Passing after:

```text
$ LIBRARY_PATH=/home/ert/code/liric/build fpm build
[100%] Project compiled successfully.

$ LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics

$ LIBRARY_PATH=/home/ert/code/liric/build fpm test
PASS: LIRIC session binding tests
PASS: empty program compiles and runs through direct LIRIC session
PASS: empty program emits object through direct LIRIC session
PASS: integer stop expression lowers through direct LIRIC session
PASS: integer variable lowers through direct LIRIC session
PASS: block IF lowers through direct LIRIC session
PASS: fallthrough IF merges scalar values through direct LIRIC
PASS: integer print lowers through direct LIRIC session
PASS: real literal print lowers through direct LIRIC session
PASS: character literal print lowers through direct LIRIC session
PASS: character variables lower through direct LIRIC session
PASS: logical literal print lowers through direct LIRIC session
PASS: logical variables lower through direct LIRIC session
PASS: real variables and arithmetic lower through direct LIRIC
PASS: integer function calls lower through direct LIRIC session
PASS: integer subroutine reference args lower through direct LIRIC session
PASS: non-integer contained procedures lower through direct LIRIC
PASS: scalar intrinsics lower through direct LIRIC session
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session

$ build/gfortran_*/app/ffc /tmp/ffc_issue57_read_after.f90 -o /tmp/ffc_issue57_read_after.exe
read status=1
STOP 1
unsupported read statement at line 3, column 3: direct LIRIC session does not support input runtime calls

$ build/gfortran_*/app/ffc /tmp/ffc_issue57_write_after.f90 -o /tmp/ffc_issue57_write_after.exe
write status=1
STOP 1
unsupported write statement at line 4, column 3: direct LIRIC session only supports minimal print output
```
