### PR TITLE
fix: diagnose unsupported do while (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -5,7 +5,7 @@ module session_program_lowering
     use ast_nodes_data, only: derived_type_node
     use fortfront, only: assignment_node, ast_arena_t, binary_op_node, &
                          call_or_subscript_node, declaration_node, do_loop_node, &
-                         cycle_node, exit_node, function_def_node, &
+                         do_while_node, cycle_node, exit_node, function_def_node, &
                          identifier_node, if_node, literal_node, &
                          parameter_declaration_node, &
                          print_statement_node, program_node, read_statement_node, &
@@ -340,6 +340,12 @@ contains
             call lower_if(arena, node, context, value, error_msg)
         type is (do_loop_node)
             call lower_do_loop(arena, node, context, value, error_msg)
+        type is (do_while_node)
+            call unsupported_feature_error('do while statement', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session only supports '// &
+                                           'literal-bound counted do loops', &
+                                           error_msg)
         type is (select_case_node)
             call unsupported_feature_error('select case statement', &
                                            node%line, node%column, &

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -22,6 +22,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_select_case_diagnostic()) all_passed = .false.
     if (.not. test_do_step_diagnostic()) all_passed = .false.
     if (.not. test_do_zero_step_diagnostic()) all_passed = .false.
+    if (.not. test_do_while_diagnostic()) all_passed = .false.
     if (.not. test_derived_type_diagnostic()) all_passed = .false.
     if (.not. test_component_assignment_target_diagnostic()) &
         all_passed = .false.
@@ -47,6 +48,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_select_case_diagnostic()) all_passed = .false.
     if (.not. test_cli_do_step_diagnostic()) all_passed = .false.
     if (.not. test_cli_do_zero_step_diagnostic()) all_passed = .false.
+    if (.not. test_cli_do_while_diagnostic()) all_passed = .false.
     if (.not. test_cli_derived_type_diagnostic()) all_passed = .false.
     if (.not. test_cli_component_assignment_target_diagnostic()) &
         all_passed = .false.
@@ -228,6 +230,21 @@ contains
                                        source, 'nonzero literal step', &
                                        '/tmp/ffc_session_do_zero_step_test')
     end function test_do_zero_step_diagnostic
+
+    logical function test_do_while_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: i'//new_line('a')// &
+                                       '  i = 1'//new_line('a')// &
+                                       '  do while (i < 3)'//new_line('a')// &
+                                       '    i = i + 1'//new_line('a')// &
+                                       '  end do'//new_line('a')// &
+                                       'end program main'
+
+        test_do_while_diagnostic = expect_error_contains( &
+                                   source, 'unsupported do while statement', &
+                                   '/tmp/ffc_session_do_while_test')
+    end function test_do_while_diagnostic
 
     logical function test_derived_type_diagnostic()
         character(len=*), parameter :: source = &
@@ -519,6 +536,21 @@ contains
                                            source, 'nonzero literal step', &
                                            '/tmp/ffc_cli_do_zero_step_test')
     end function test_cli_do_zero_step_diagnostic
+
+    logical function test_cli_do_while_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: i'//new_line('a')// &
+                                       '  i = 1'//new_line('a')// &
+                                       '  do while (i < 3)'//new_line('a')// &
+                                       '    i = i + 1'//new_line('a')// &
+                                       '  end do'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_do_while_diagnostic = expect_cli_error_contains( &
+                                       source, 'unsupported do while statement', &
+                                       '/tmp/ffc_cli_do_while_test')
+    end function test_cli_do_while_diagnostic
 
     logical function test_cli_derived_type_diagnostic()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
## Requirements

- REQ-001: Unsupported `do while` statements produce a targeted unsupported-feature diagnostic. (ref #57)
- REQ-002: The diagnostic includes line and column when FortFront exposes them.
- REQ-003: The CLI exits nonzero and prints the same concise diagnostic.
- REQ-004: Existing unsupported diagnostic coverage keeps passing.

## Verification

Before change:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
FAIL: expected diagnostic substring unsupported do while statement
  got direct LIRIC session MVP does not support statement node: do_while
FAIL: expected CLI diagnostic substring unsupported do while statement
  got STOP 1
direct LIRIC session MVP does not support statement node: do_while
<ERROR> Execution for object " test_session_unsupported_diagnostics " returned exit code  1
```

After change:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics
```

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test
PASS: LIRIC session binding tests
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```
