### PR TITLE
fix: unassigned character print diagnostic (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering_values.inc
+++ b/src_mvp/session_program_lowering_values.inc
@@ -59,8 +59,11 @@
                 end if
                 if (context%symbols(symbol_index)%value_kind == VALUE_CHARACTER) then
                     if (.not. context%symbols(symbol_index)%has_character_value) then
-                        error_msg = 'character variable was not assigned: '// &
-                                    trim(node%name)
+                        call unsupported_feature_error( &
+                            'character variable print', node%line, node%column, &
+                            'direct LIRIC session requires character variables '// &
+                            'to be assigned from a literal before printing', &
+                            error_msg)
                         return
                     end if
                     if (.not. emit_liric_print_string_operand( &

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -14,6 +14,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_array_assignment_target_diagnostic()) all_passed = .false.
     if (.not. test_array_expression_diagnostic()) all_passed = .false.
     if (.not. test_character_expression_diagnostic()) all_passed = .false.
+    if (.not. test_unassigned_character_print_diagnostic()) all_passed = .false.
     if (.not. test_module_diagnostic()) all_passed = .false.
     if (.not. test_character_parameter_diagnostic()) all_passed = .false.
     if (.not. test_unsupported_scalar_type_diagnostic()) all_passed = .false.
@@ -39,6 +40,8 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_array_assignment_target_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_expression_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_expression_diagnostic()) all_passed = .false.
+    if (.not. test_cli_unassigned_character_print_diagnostic()) &
+        all_passed = .false.
     if (.not. test_cli_module_diagnostic()) all_passed = .false.
     if (.not. test_cli_character_parameter_diagnostic()) all_passed = .false.
     if (.not. test_cli_unsupported_scalar_type_diagnostic()) &
@@ -115,6 +118,20 @@ contains
                                            source, 'unsupported character assignment', &
                                            '/tmp/ffc_session_character_diagnostic_test')
     end function test_character_expression_diagnostic
+
+    logical function test_unassigned_character_print_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported character variable print'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  character(len=5) :: name'//new_line('a')// &
+                                       '  print *, name'//new_line('a')// &
+                                       'end program main'
+
+        test_unassigned_character_print_diagnostic = &
+            expect_error_contains(source, expected, &
+                                  '/tmp/ffc_session_unassigned_character_test')
+    end function test_unassigned_character_print_diagnostic
 
     logical function test_module_diagnostic()
         character(len=*), parameter :: source = &
@@ -421,6 +438,20 @@ contains
                                            source, 'unsupported character assignment', &
                                                '/tmp/ffc_cli_character_diagnostic_test')
     end function test_cli_character_expression_diagnostic
+
+    logical function test_cli_unassigned_character_print_diagnostic()
+        character(len=*), parameter :: expected = &
+                                       'unsupported character variable print'
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  character(len=5) :: name'//new_line('a')// &
+                                       '  print *, name'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_unassigned_character_print_diagnostic = &
+            expect_cli_error_contains(source, expected, &
+                                      '/tmp/ffc_cli_unassigned_character_test')
+    end function test_cli_unassigned_character_print_diagnostic
 
     logical function test_cli_module_diagnostic()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
## Requirements

- REQ-001 (ref #57): unsupported or invalid programs should produce targeted diagnostics instead of internal lowering errors.
- REQ-002 (ref #57): diagnostics should include line and column when FortFront exposes the source location.
- REQ-003 (ref #57): CLI failures must exit nonzero and print the same concise diagnostic shape.
- REQ-004 (ref #57): add negative tests for changed behavior.

## Changes

- Report unassigned scalar character variable prints through `unsupported_feature_error`, using the identifier line and column.
- Add direct lowering and CLI negative tests for `character(len=5) :: name; print *, name`.

## Verification

Failing before:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
FAIL: expected diagnostic substring unsupported character variable print
  got character variable was not assigned: name
FAIL: expected CLI diagnostic substring unsupported character variable print
  got STOP 1
character variable was not assigned: name
```

Passing after:

```text
fpm clean --all && LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics
```

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```

```text
$HOME/code/prompts/scripts/check-writing-slop.py src_mvp/session_program_lowering_values.inc test_mvp/test_session_unsupported_diagnostics.f90
PASS: no writing-slop candidates at threshold medium
```