### PR TITLE
fix: diagnose memory statements (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -12,6 +12,7 @@ module session_program_lowering
                          module_node, &
                          select_case_node, stop_node, subroutine_def_node, &
                          write_statement_node, &
+                         allocate_statement_node, deallocate_statement_node, &
                          get_subroutine_call_arg_indices, &
                          get_subroutine_call_name, is_subroutine_call_statement
     use liric_session_bindings, only: liric_session_t, liric_session_create, &
@@ -318,6 +319,18 @@ contains
                                            node%column, &
                                            'direct LIRIC session only supports '// &
                                            'minimal print output', error_msg)
+        type is (allocate_statement_node)
+            call unsupported_feature_error('allocate statement', node%line, &
+                                           node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support dynamic allocation', &
+                                           error_msg)
+        type is (deallocate_statement_node)
+            call unsupported_feature_error('deallocate statement', node%line, &
+                                           node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support dynamic allocation', &
+                                           error_msg)
         type is (stop_node)
             call lower_stop(arena, node, context, value, error_msg)
             if (len_trim(error_msg) == 0) then

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -37,6 +37,8 @@ program test_session_unsupported_diagnostics
     if (.not. test_real_exponent_operator_diagnostic()) all_passed = .false.
     if (.not. test_read_statement_diagnostic()) all_passed = .false.
     if (.not. test_write_statement_diagnostic()) all_passed = .false.
+    if (.not. test_allocate_statement_diagnostic()) all_passed = .false.
+    if (.not. test_deallocate_statement_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_assignment_target_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_expression_diagnostic()) all_passed = .false.
@@ -69,6 +71,8 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_real_exponent_operator_diagnostic()) all_passed = .false.
     if (.not. test_cli_read_statement_diagnostic()) all_passed = .false.
     if (.not. test_cli_write_statement_diagnostic()) all_passed = .false.
+    if (.not. test_cli_allocate_statement_diagnostic()) all_passed = .false.
+    if (.not. test_cli_deallocate_statement_diagnostic()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: unsupported direct-session features emit diagnostics'
@@ -407,6 +411,30 @@ contains
                                           '/tmp/ffc_session_write_statement_test')
     end function test_write_statement_diagnostic
 
+    logical function test_allocate_statement_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  allocate(values(3))'//new_line('a')// &
+                                       'end program main'
+
+        test_allocate_statement_diagnostic = expect_error_contains( &
+                                             source, &
+                                             'unsupported allocate statement', &
+                                             '/tmp/ffc_session_allocate_test')
+    end function test_allocate_statement_diagnostic
+
+    logical function test_deallocate_statement_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  deallocate(values)'//new_line('a')// &
+                                       'end program main'
+
+        test_deallocate_statement_diagnostic = expect_error_contains( &
+                                               source, &
+                                               'unsupported deallocate statement', &
+                                               '/tmp/ffc_session_deallocate_test')
+    end function test_deallocate_statement_diagnostic
+
     logical function test_cli_array_declaration_diagnostic()
         character(len=*), parameter :: source = &
                                        'program main'//new_line('a')// &
@@ -739,6 +767,30 @@ contains
                                               source, 'unsupported write statement', &
                                               '/tmp/ffc_cli_write_statement_test')
     end function test_cli_write_statement_diagnostic
+
+    logical function test_cli_allocate_statement_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  allocate(values(3))'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_allocate_statement_diagnostic = expect_cli_error_contains( &
+                                                 source, &
+                                                 'unsupported allocate statement', &
+                                                 '/tmp/ffc_cli_allocate_test')
+    end function test_cli_allocate_statement_diagnostic
+
+    logical function test_cli_deallocate_statement_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  deallocate(values)'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_deallocate_statement_diagnostic = expect_cli_error_contains( &
+                                                   source, &
+                                                   'unsupported deallocate statement', &
+                                                   '/tmp/ffc_cli_deallocate_test')
+    end function test_cli_deallocate_statement_diagnostic
 
     logical function expect_error_contains(source, expected, exe_path)
         character(len=*), intent(in) :: source


### PR DESCRIPTION
## Requirements

REQ-001: Diagnose unsupported `allocate` statements with a targeted message and source location. (ref #57)
REQ-002: Diagnose unsupported `deallocate` statements with a targeted message and source location. (ref #57)
REQ-003: Cover direct lowering and CLI failures for both statements. (ref #57)

## Verification

### Test fails on main
`LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics`

Output before the fix after adding the behavior tests:
```text
FAIL: expected diagnostic substring unsupported allocate statement
  got direct LIRIC session MVP does not support statement node: allocate_statement
FAIL: expected diagnostic substring unsupported deallocate statement
  got direct LIRIC session MVP does not support statement node: deallocate_statement
FAIL: expected CLI diagnostic substring unsupported allocate statement
  got STOP 1
direct LIRIC session MVP does not support statement node: allocate_statement
FAIL: expected CLI diagnostic substring unsupported deallocate statement
  got STOP 1
direct LIRIC session MVP does not support statement node: deallocate_statement
<ERROR> Execution for object " test_session_unsupported_diagnostics " returned exit code  1
```

### Test passes after fix
`LIBRARY_PATH=/home/ert/code/liric/build fpm build && LIBRARY_PATH=/home/ert/code/liric/build fpm test`

Output after the fix:
```text
Project is up to date
[100%] Project compiled successfully.
=== LIRIC session binding tests ===
PASS: LIRIC session binding tests
=== direct session unsupported diagnostic test ===
PASS: unsupported direct-session features emit diagnostics
=== counted do compiler test ===
PASS: runtime counted DO loop lowers through direct LIRIC session
```
