### PR TITLE
fix: cover character variable length ABI (refs #51)

### DIFF
--- a/test_mvp/test_session_character_variable_compiler.f90
+++ b/test_mvp/test_session_character_variable_compiler.f90
@@ -5,81 +5,137 @@ program test_session_character_variable_compiler
     use session_program_lowering, only: lower_program_to_liric_exe
     implicit none
 
-    type(compiler_frontend_options_t) :: options
-    type(compiler_frontend_result_t) :: frontend_result
-    character(len=:), allocatable :: error_msg
-    character(len=6) :: output_text
-    character(len=64) :: output_line
-    character(len=*), parameter :: exe_path = '/tmp/ffc_session_char_var_test'
-    character(len=*), parameter :: out_path = &
-                                   '/tmp/ffc_session_char_var_test.out'
-    integer :: exit_stat
-    integer :: file_size
-    integer :: io_stat
-    integer :: unit
-    character(len=*), parameter :: source = &
-                                   'program main'//new_line('a')// &
-                                   '  character(len=5) :: s'//new_line('a')// &
-                                   '  s = "hello"'//new_line('a')// &
-                                   '  print *, s'//new_line('a')// &
-                                   'end program main'
+    logical :: all_passed
 
     print *, '=== direct session character variable compiler test ==='
 
-    options = compiler_frontend_options_t()
-    options%run_semantics = .true.
-    options%input_mode = INPUT_MODE_STANDARD
+    all_passed = .true.
+    if (.not. test_exact_length_character_print()) all_passed = .false.
+    if (.not. test_short_character_assignment_pads()) all_passed = .false.
+    if (.not. test_long_character_assignment_truncates()) all_passed = .false.
 
-    call compile_frontend_from_string(source, frontend_result, options)
-    if (.not. frontend_result%success()) then
-        print *, 'FAIL: FortFront rejected source: ', &
-            trim(frontend_result%diagnostic_text)
-        stop 1
-    end if
-
-    call execute_command_line('rm -f '//exe_path//' '//out_path)
-    call lower_program_to_liric_exe(frontend_result%arena, &
-                                    frontend_result%root_index, exe_path, &
-                                    error_msg)
-    if (len_trim(error_msg) > 0) then
-        print *, 'FAIL: direct LIRIC lowering failed: ', trim(error_msg)
-        stop 1
-    end if
-
-    call execute_command_line(exe_path//' > '//out_path, exitstat=exit_stat)
-    if (exit_stat /= 0) then
-        print *, 'FAIL: executable exit status ', exit_stat
-        call execute_command_line('rm -f '//exe_path//' '//out_path)
-        stop 1
-    end if
-
-    open (newunit=unit, file=out_path, status='old', action='read', &
-          iostat=io_stat)
-    if (io_stat /= 0) then
-        print *, 'FAIL: could not open captured output'
-        call execute_command_line('rm -f '//exe_path//' '//out_path)
-        stop 1
-    end if
-    read (unit, '(A)', iostat=io_stat) output_line
-    close (unit)
-
-    inquire (file=out_path, size=file_size)
-    open (newunit=unit, file=out_path, status='old', access='stream', &
-          form='unformatted', action='read', iostat=io_stat)
-    if (io_stat /= 0) then
-        print *, 'FAIL: could not open captured output as stream'
-        call execute_command_line('rm -f '//exe_path//' '//out_path)
-        stop 1
-    end if
-    read (unit, iostat=io_stat) output_text
-    close (unit)
-    call execute_command_line('rm -f '//exe_path//' '//out_path)
-
-    if (io_stat /= 0 .or. file_size /= 6 .or. &
-        output_text /= 'hello'//new_line('a')) then
-        print *, 'FAIL: expected fixed-length output hello, got ', output_line
-        stop 1
-    end if
-
+    if (.not. all_passed) stop 1
     print *, 'PASS: character variables lower through direct LIRIC session'
+
+contains
+
+    logical function test_exact_length_character_print()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  character(len=5) :: s'//new_line('a')// &
+                                       '  s = "hello"'//new_line('a')// &
+                                       '  print *, s'//new_line('a')// &
+                                       'end program main'
+
+        test_exact_length_character_print = expect_output( &
+                                            source, 'hello'//new_line('a'), &
+                                            '/tmp/ffc_session_char_exact_test')
+    end function test_exact_length_character_print
+
+    logical function test_short_character_assignment_pads()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  character(len=5) :: s'//new_line('a')// &
+                                       '  s = "hi"'//new_line('a')// &
+                                       '  print *, s'//new_line('a')// &
+                                       'end program main'
+
+        test_short_character_assignment_pads = expect_output( &
+                                               source, 'hi   '//new_line('a'), &
+                                               '/tmp/ffc_session_char_pad_test')
+    end function test_short_character_assignment_pads
+
+    logical function test_long_character_assignment_truncates()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  character(len=3) :: s'//new_line('a')// &
+                                       '  s = "hello"'//new_line('a')// &
+                                       '  print *, s'//new_line('a')// &
+                                       'end program main'
+
+        test_long_character_assignment_truncates = expect_output( &
+                                                   source, 'hel'//new_line('a'), &
+                                                   '/tmp/ffc_session_char_trunc_test')
+    end function test_long_character_assignment_truncates
+
+    logical function expect_output(source, expected, stem)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        character(len=*), intent(in) :: stem
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: exe_path
+        character(len=:), allocatable :: output_text
+        character(len=:), allocatable :: out_path
+        integer :: exit_stat
+        integer :: file_size
+        integer :: io_stat
+        integer :: unit
+
+        expect_output = .false.
+        exe_path = stem
+        out_path = stem//'.out'
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+        call compile_and_lower(source, exe_path, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: direct LIRIC lowering failed: ', trim(error_msg)
+            return
+        end if
+
+        call execute_command_line(exe_path//' > '//out_path, exitstat=exit_stat)
+        if (exit_stat /= 0) then
+            print *, 'FAIL: executable exit status ', exit_stat
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+
+        inquire (file=out_path, size=file_size)
+        if (file_size /= len(expected)) then
+            print *, 'FAIL: expected output size ', len(expected), &
+                ', got ', file_size
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+
+        allocate (character(len=file_size) :: output_text)
+        open (newunit=unit, file=out_path, status='old', access='stream', &
+              form='unformatted', action='read', iostat=io_stat)
+        if (io_stat /= 0) then
+            print *, 'FAIL: could not open captured output as stream'
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+        read (unit, iostat=io_stat) output_text
+        close (unit)
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+
+        if (io_stat /= 0 .or. output_text /= expected) then
+            print *, 'FAIL: unexpected character output bytes'
+            return
+        end if
+
+        expect_output = .true.
+    end function expect_output
+
+    subroutine compile_and_lower(source, exe_path, error_msg)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: exe_path
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: frontend_result
+
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+
+        call compile_frontend_from_string(source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            error_msg = 'FortFront rejected source: '// &
+                        trim(frontend_result%diagnostic_text)
+            return
+        end if
+
+        call lower_program_to_liric_exe(frontend_result%arena, &
+                                        frontend_result%root_index, exe_path, &
+                                        error_msg)
+    end subroutine compile_and_lower
 end program test_session_character_variable_compiler


### PR DESCRIPTION
## Requirements

(ref #51)

REQ-001: represent scalar `character(len=N)` values with pointer plus declared-length metadata in direct-session lowering.
REQ-002: support assignment from character literals to scalar character variables.
REQ-003: support `print *, character_variable`.
REQ-004: document the MVP character ABI and current limitations.
REQ-005: keep character dummy arguments out of this slice and report them as unsupported.

## Changes

- Expanded the character variable executable test from one exact-length case to exact-length, blank-padded, and truncated literal assignment cases.
- The tests assert captured output bytes, so the declared-length ABI behavior is covered directly.

## Verification

Focused:

```text
$ LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_character_variable_compiler
[100%] Project compiled successfully.
 === direct session character variable compiler test ===
 PASS: character variables lower through direct LIRIC session
```

Full:

```text
$ LIBRARY_PATH=/home/ert/code/liric/build fpm test
Project is up to date
 === LIRIC session binding tests ===
 PASS: LIRIC session binding tests
 === direct session empty program compiler test ===
 PASS: empty program compiles and runs through direct LIRIC session
 === direct session empty program object compiler test ===
 PASS: empty program emits object through direct LIRIC session
 === direct session stop code compiler test ===
 PASS: integer stop expression lowers through direct LIRIC session
 === direct session integer variable compiler test ===
 PASS: integer variable lowers through direct LIRIC session
 === direct session block if compiler test ===
 PASS: block IF lowers through direct LIRIC session
 === direct session if merge compiler test ===
 PASS: fallthrough IF merges scalar values through direct LIRIC
 === direct session scalar print compiler test ===
 PASS: integer print lowers through direct LIRIC session
 === direct session real literal print compiler test ===
 PASS: real literal print lowers through direct LIRIC session
 === direct session character literal print compiler test ===
 PASS: character literal print lowers through direct LIRIC session
 === direct session character variable compiler test ===
 PASS: character variables lower through direct LIRIC session
 === direct session logical literal print compiler test ===
 PASS: logical literal print lowers through direct LIRIC session
 === direct session logical variable compiler test ===
 PASS: logical variables lower through direct LIRIC session
 === direct session real variable compiler test ===
 PASS: real variables and arithmetic lower through direct LIRIC
 === direct session integer function compiler test ===
 PASS: integer function calls lower through direct LIRIC session
 === direct session integer subroutine compiler test ===
 PASS: integer subroutine reference args lower through direct LIRIC session
 === direct session non-integer procedure compiler test ===
 PASS: non-integer contained procedures lower through direct LIRIC
 === direct session scalar intrinsic compiler test ===
 PASS: scalar intrinsics lower through direct LIRIC session
 === direct session unsupported diagnostic test ===
 PASS: unsupported direct-session features emit diagnostics
 === counted do compiler test ===
 PASS: runtime counted DO loop lowers through direct LIRIC session
```

<!-- orchestrate: fully-resolved -->
