### PR TITLE
fix: return statement diagnostic (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering.f90
+++ b/src_mvp/session_program_lowering.f90
@@ -10,8 +10,8 @@ module session_program_lowering
                          parameter_declaration_node, &
                          print_statement_node, program_node, read_statement_node, &
                          module_node, &
-                         select_case_node, stop_node, subroutine_def_node, &
-                         write_statement_node, &
+                         return_node, select_case_node, stop_node, &
+                         subroutine_def_node, write_statement_node, &
                          allocate_statement_node, deallocate_statement_node, &
                          get_subroutine_call_arg_indices, &
                          get_subroutine_call_name, is_subroutine_call_statement
@@ -330,6 +330,12 @@ contains
                                            node%column, &
                                            'direct LIRIC session does not '// &
                                            'support dynamic allocation', &
+                                           error_msg)
+        type is (return_node)
+            call unsupported_feature_error('return statement', node%line, &
+                                           node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support early procedure returns', &
                                            error_msg)
         type is (stop_node)
             call lower_stop(arena, node, context, value, error_msg)

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -39,6 +39,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_write_statement_diagnostic()) all_passed = .false.
     if (.not. test_allocate_statement_diagnostic()) all_passed = .false.
     if (.not. test_deallocate_statement_diagnostic()) all_passed = .false.
+    if (.not. test_return_statement_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_assignment_target_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_expression_diagnostic()) all_passed = .false.
@@ -73,6 +74,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_write_statement_diagnostic()) all_passed = .false.
     if (.not. test_cli_allocate_statement_diagnostic()) all_passed = .false.
     if (.not. test_cli_deallocate_statement_diagnostic()) all_passed = .false.
+    if (.not. test_cli_return_statement_diagnostic()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: unsupported direct-session features emit diagnostics'
@@ -435,6 +437,18 @@ contains
                                                '/tmp/ffc_session_deallocate_test')
     end function test_deallocate_statement_diagnostic
 
+    logical function test_return_statement_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  return'//new_line('a')// &
+                                       'end program main'
+
+        test_return_statement_diagnostic = expect_error_contains( &
+                                           source, &
+                                           'unsupported return statement', &
+                                           '/tmp/ffc_session_return_test')
+    end function test_return_statement_diagnostic
+
     logical function test_cli_array_declaration_diagnostic()
         character(len=*), parameter :: source = &
                                        'program main'//new_line('a')// &
@@ -791,6 +805,18 @@ contains
                                                    'unsupported deallocate statement', &
                                                    '/tmp/ffc_cli_deallocate_test')
     end function test_cli_deallocate_statement_diagnostic
+
+    logical function test_cli_return_statement_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  return'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_return_statement_diagnostic = expect_cli_error_contains( &
+                                               source, &
+                                               'unsupported return statement', &
+                                               '/tmp/ffc_cli_return_test')
+    end function test_cli_return_statement_diagnostic
 
     logical function expect_error_contains(source, expected, exe_path)
         character(len=*), intent(in) :: source


### PR DESCRIPTION
## Requirements

REQ-001: Unsupported statements should use targeted user-facing diagnostics, not raw internal node names.
REQ-002: Diagnostics should include line and column when FortFront provides them.
REQ-003: The CLI should exit nonzero and print the same concise diagnostic.
REQ-004: Add behavior coverage for the lowering API and CLI path.

This is partial progress on diagnostics (ref #57).

## Verification

### Test fails on main

With the new regression test added before the lowerer change:

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
[100%] Project compiled successfully.
 === direct session unsupported diagnostic test ===
 FAIL: expected diagnostic substring unsupported return statement
   got direct LIRIC session MVP does not support statement node: return_node
 FAIL: expected CLI diagnostic substring unsupported return statement
   got STOP 1
direct LIRIC session MVP does not support statement node: return_node

STOP 1
<ERROR> Execution for object " test_session_unsupported_diagnostics " returned exit code  1
```

### Test passes after fix

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
[100%] Project compiled successfully.
 === direct session unsupported diagnostic test ===
 PASS: unsupported direct-session features emit diagnostics
```

```text
LIBRARY_PATH=/home/ert/code/liric/build fpm test
Project is up to date
 === LIRIC session binding tests ===
 PASS: LIRIC session binding tests
 === direct session empty program compiler test ===
 PASS: empty program compiles and runs through direct LIRIC session
 === direct session empty program object compiler test ===
 PASS: empty program emits object through direct LIRIC session
 === direct session stop code compiler test ===
 PASS: integer stop expression lowers through direct LIRIC session
 === direct session integer variable compiler test ===
 PASS: integer variable lowers through direct LIRIC session
 === direct session block if compiler test ===
 PASS: block IF lowers through direct LIRIC session
 === direct session if merge compiler test ===
 PASS: fallthrough IF merges scalar values through direct LIRIC
 === direct session scalar print compiler test ===
 PASS: integer print lowers through direct LIRIC session
 === direct session real literal print compiler test ===
 PASS: real literal print lowers through direct LIRIC session
 === direct session character literal print compiler test ===
 PASS: character literal print lowers through direct LIRIC session
 === direct session character variable compiler test ===
 PASS: character variables lower through direct LIRIC session
 === direct session logical literal print compiler test ===
 PASS: logical literal print lowers through direct LIRIC session
 === direct session logical variable compiler test ===
 PASS: logical variables lower through direct LIRIC session
 === direct session real variable compiler test ===
 PASS: real variables and arithmetic lower through direct LIRIC
 === direct session integer function compiler test ===
 PASS: integer function calls lower through direct LIRIC session
 === direct session integer subroutine compiler test ===
 PASS: integer subroutine reference args lower through direct LIRIC session
 === direct session non-integer procedure compiler test ===
 PASS: non-integer contained procedures lower through direct LIRIC
 === direct session scalar intrinsic compiler test ===
 PASS: scalar intrinsics lower through direct LIRIC session
 === direct session unsupported diagnostic test ===
 PASS: unsupported direct-session features emit diagnostics
 === counted do compiler test ===
 PASS: runtime counted DO loop lowers through direct LIRIC session
```

```text
$HOME/code/prompts/scripts/check-writing-slop.py src_mvp/session_program_lowering.f90 test_mvp/test_session_unsupported_diagnostics.f90
PASS: no writing-slop candidates at threshold medium
```
