### PR TITLE
fix: diagnose terminating do loop body (refs #57)

### DIFF
--- a/src_mvp/session_program_lowering_loops.inc
+++ b/src_mvp/session_program_lowering_loops.inc
@@ -106,8 +106,11 @@
             return
         end if
         if (body_terminated) then
-            error_msg = 'direct LIRIC session DO does not support '// &
-                        'terminating loop bodies'
+            call unsupported_feature_error('terminating do loop body', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support stop or return inside '// &
+                                           'counted do loops', error_msg)
             return
         end if
         if (.not. emit_liric_br(context%session, latch_block, error_msg)) return

--- a/test_mvp/test_session_unsupported_diagnostics.f90
+++ b/test_mvp/test_session_unsupported_diagnostics.f90
@@ -23,6 +23,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_select_case_diagnostic()) all_passed = .false.
     if (.not. test_do_step_diagnostic()) all_passed = .false.
     if (.not. test_do_zero_step_diagnostic()) all_passed = .false.
+    if (.not. test_do_terminating_body_diagnostic()) all_passed = .false.
     if (.not. test_do_while_diagnostic()) all_passed = .false.
     if (.not. test_derived_type_diagnostic()) all_passed = .false.
     if (.not. test_component_assignment_target_diagnostic()) &
@@ -55,6 +56,7 @@ program test_session_unsupported_diagnostics
     if (.not. test_cli_select_case_diagnostic()) all_passed = .false.
     if (.not. test_cli_do_step_diagnostic()) all_passed = .false.
     if (.not. test_cli_do_zero_step_diagnostic()) all_passed = .false.
+    if (.not. test_cli_do_terminating_body_diagnostic()) all_passed = .false.
     if (.not. test_cli_do_while_diagnostic()) all_passed = .false.
     if (.not. test_cli_derived_type_diagnostic()) all_passed = .false.
     if (.not. test_cli_component_assignment_target_diagnostic()) &
@@ -256,6 +258,20 @@ contains
                                        source, 'nonzero literal step', &
                                        '/tmp/ffc_session_do_zero_step_test')
     end function test_do_zero_step_diagnostic
+
+    logical function test_do_terminating_body_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: i'//new_line('a')// &
+                                       '  do i = 1, 3'//new_line('a')// &
+                                       '    stop 1'//new_line('a')// &
+                                       '  end do'//new_line('a')// &
+                                       'end program main'
+
+        test_do_terminating_body_diagnostic = expect_error_contains( &
+            source, 'unsupported terminating do loop body', &
+            '/tmp/ffc_session_do_terminating_body_test')
+    end function test_do_terminating_body_diagnostic
 
     logical function test_do_while_diagnostic()
         character(len=*), parameter :: source = &
@@ -624,6 +640,20 @@ contains
                                            source, 'nonzero literal step', &
                                            '/tmp/ffc_cli_do_zero_step_test')
     end function test_cli_do_zero_step_diagnostic
+
+    logical function test_cli_do_terminating_body_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: i'//new_line('a')// &
+                                       '  do i = 1, 3'//new_line('a')// &
+                                       '    stop 1'//new_line('a')// &
+                                       '  end do'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_do_terminating_body_diagnostic = expect_cli_error_contains( &
+            source, 'unsupported terminating do loop body', &
+            '/tmp/ffc_cli_do_terminating_body_test')
+    end function test_cli_do_terminating_body_diagnostic
 
     logical function test_cli_do_while_diagnostic()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
## Requirements

- REQ-001 Unsupported counted `do` loops with a terminating body must report a targeted unsupported-feature diagnostic, not an internal lowering string.
- REQ-002 The diagnostic must include line/column in both direct lowering and CLI paths.
- REQ-003 Existing unsupported-diagnostic coverage must keep passing.

This is partial progress on diagnostics coverage (ref #57).

## Verification
### Test fails on main
```text
$ LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
FAIL: expected diagnostic substring unsupported terminating do loop body
  got direct LIRIC session DO does not support terminating loop bodies
FAIL: expected CLI diagnostic substring unsupported terminating do loop body
  got STOP 1
direct LIRIC session DO does not support terminating loop bodies
```

### Test passes after fix
```text
$ fpm clean --skip && LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_unsupported_diagnostics
PASS: unsupported direct-session features emit diagnostics
```

```text
$ LIBRARY_PATH=/home/ert/code/liric/build fpm test
PASS: LIRIC session binding tests
PASS: empty program compiles and runs through direct LIRIC session
PASS: empty program emits object through direct LIRIC session
PASS: integer stop expression lowers through direct LIRIC session
PASS: integer variable lowers through direct LIRIC session
PASS: block IF lowers through direct LIRIC session
PASS: fallthrough IF merges scalar values through direct LIRIC
PASS: integer print lowers through direct LIRIC session
PASS: real literal print lowers through direct LIRIC session
PASS: character literal print lowers through direct LIRIC session
PASS: character variables lower through direct LIRIC session
PASS: logical literal print lowers through direct LIRIC session
PASS: logical variables lower through direct LIRIC session
PASS: real variables and arithmetic lower through direct LIRIC
PASS: integer function calls lower through direct LIRIC session
PASS: integer subroutine reference args lower through direct LIRIC session
PASS: non-integer contained procedures lower through direct LIRIC
PASS: scalar intrinsics lower through direct LIRIC session
PASS: unsupported direct-session features emit diagnostics
PASS: runtime counted DO loop lowers through direct LIRIC session
```
