### PR TITLE
fix: support fixed-size arrays (refs #52)

### DIFF
--- a/src/session_program_lowering_arrays.inc
+++ b/src/session_program_lowering_arrays.inc
@@ -61,7 +61,10 @@
         end select
 
         if (extent <= 0_c_int64_t) then
-            error_msg = 'array bounds produce a non-positive extent'
+            call unsupported_feature_error('array declaration', node%line, &
+                                           node%column, &
+                                           'array bounds produce a '// &
+                                           'non-positive extent', error_msg)
             return
         end if
         array_lower_bound = int(lower_value)

--- a/test/test_session_array_unsupported_diagnostics.f90
+++ b/test/test_session_array_unsupported_diagnostics.f90
@@ -11,6 +11,8 @@ program test_session_array_unsupported_diagnostics
 
     all_passed = .true.
     if (.not. test_array_declaration_diagnostic()) all_passed = .false.
+    if (.not. test_array_zero_extent_diagnostic()) all_passed = .false.
+    if (.not. test_array_reversed_extent_diagnostic()) all_passed = .false.
     if (.not. test_noninteger_array_declaration_diagnostic()) &
         all_passed = .false.
     if (.not. test_array_assignment_target_diagnostic()) all_passed = .false.
@@ -23,6 +25,8 @@ program test_session_array_unsupported_diagnostics
         all_passed = .false.
     if (.not. test_whole_array_argument_diagnostic()) all_passed = .false.
     if (.not. test_cli_array_declaration_diagnostic()) all_passed = .false.
+    if (.not. test_cli_array_zero_extent_diagnostic()) all_passed = .false.
+    if (.not. test_cli_array_reversed_extent_diagnostic()) all_passed = .false.
     if (.not. test_cli_noninteger_array_declaration_diagnostic()) &
         all_passed = .false.
     if (.not. test_cli_array_assignment_target_diagnostic()) all_passed = .false.
@@ -51,6 +55,28 @@ contains
                                             source, 'unsupported array declaration', &
                                             '/tmp/ffc_session_array_diagnostic_test')
     end function test_array_declaration_diagnostic
+
+    logical function test_array_zero_extent_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: values(0)'//new_line('a')// &
+                                       'end program main'
+
+        test_array_zero_extent_diagnostic = expect_error_contains( &
+                                            source, 'non-positive extent', &
+                                            '/tmp/ffc_session_array_zero_test')
+    end function test_array_zero_extent_diagnostic
+
+    logical function test_array_reversed_extent_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: values(2:1)'//new_line('a')// &
+                                       'end program main'
+
+        test_array_reversed_extent_diagnostic = expect_error_contains( &
+                                                source, 'non-positive extent', &
+                                                '/tmp/ffc_session_array_reversed_test')
+    end function test_array_reversed_extent_diagnostic
 
     logical function test_noninteger_array_declaration_diagnostic()
         character(len=*), parameter :: source = &
@@ -178,6 +204,28 @@ contains
                                               source, 'unsupported array declaration', &
                                                 '/tmp/ffc_cli_array_diagnostic_test')
     end function test_cli_array_declaration_diagnostic
+
+    logical function test_cli_array_zero_extent_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: values(0)'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_array_zero_extent_diagnostic = expect_cli_error_contains( &
+                                                source, 'non-positive extent', &
+                                                '/tmp/ffc_cli_array_zero_test')
+    end function test_cli_array_zero_extent_diagnostic
+
+    logical function test_cli_array_reversed_extent_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: values(2:1)'//new_line('a')// &
+                                       'end program main'
+
+        test_cli_array_reversed_extent_diagnostic = expect_cli_error_contains( &
+                                                    source, 'non-positive extent', &
+                                                    '/tmp/ffc_cli_array_reversed_test')
+    end function test_cli_array_reversed_extent_diagnostic
 
     logical function test_cli_noninteger_array_declaration_diagnostic()
         character(len=*), parameter :: source = &

--- a/test/test_session_fixed_size_array_compiler.f90
+++ b/test/test_session_fixed_size_array_compiler.f90
@@ -76,7 +76,8 @@ contains
                                        '  values(-1) = 4'//new_line('a')// &
                                        '  values(0) = 5'//new_line('a')// &
                                        '  values(1) = 6'//new_line('a')// &
-                                       '  print *, values(-1) + values(0) + values(1)'// &
+                                       '  print *, values(-1) + values(0) '// &
+                                       '+ values(1)'// &
                                        new_line('a')// &
                                        'end program main'
 

--- a/test/test_session_fixed_size_array_compiler.f90
+++ b/test/test_session_fixed_size_array_compiler.f90
@@ -13,6 +13,7 @@ program test_session_fixed_size_array_compiler
     if (.not. test_simple_array()) all_passed = .false.
     if (.not. test_array_parameter_bound()) all_passed = .false.
     if (.not. test_array_explicit_bounds()) all_passed = .false.
+    if (.not. test_array_negative_lower_bound()) all_passed = .false.
     if (.not. test_array_with_loop()) all_passed = .false.
     if (.not. test_array_variable_subscript()) all_passed = .false.
     if (.not. test_array_element_argument()) all_passed = .false.
@@ -67,6 +68,22 @@ contains
                                      source, '9', &
                                      '/tmp/ffc_session_array_explicit_bounds_test')
     end function test_array_explicit_bounds
+
+    logical function test_array_negative_lower_bound()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: values(-1:1)'//new_line('a')// &
+                                       '  values(-1) = 4'//new_line('a')// &
+                                       '  values(0) = 5'//new_line('a')// &
+                                       '  values(1) = 6'//new_line('a')// &
+                                       '  print *, values(-1) + values(0) + values(1)'// &
+                                       new_line('a')// &
+                                       'end program main'
+
+        test_array_negative_lower_bound = expect_output( &
+                                          source, '15', &
+                                          '/tmp/ffc_session_array_neg_lower_test')
+    end function test_array_negative_lower_bound
 
     logical function test_array_with_loop()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
(ref #52)

## Requirements

- REQ-001: satisfied. Fixed-size one-dimensional integer arrays with compile-time bounds lower through the direct LIRIC session path. This was already satisfied by prior branch work now present on `origin/main`.
- REQ-002: satisfied. Integer array declarations, element assignment, element load, `print`, and `stop` use are covered. Existing tests cover the main behavior; this PR adds negative explicit lower-bound coverage.
- REQ-003: satisfied. Literal integer subscripts and scalar integer variable subscripts work, including counted-loop indices. This was already satisfied by prior branch work now present on `origin/main`.
- REQ-004: satisfied. Bounds behavior is documented: runtime bounds checks are deferred to #53 and out-of-bounds access has backend-level behavior. This was already satisfied in `README.md`, `ROADMAP.md`, and `docs/SUPPORT_CONTRACT.md`.
- REQ-005: satisfied. The symbol model distinguishes array storage from scalar values. This was already satisfied by the array symbol fields in the lowerer.
- REQ-006: satisfied. Arrays lower to LIRIC stack storage and element GEPs, not independent scalar symbols. This was already satisfied by the LIRIC array helper path.
- REQ-007: satisfied. The FortFront API gap is recorded in `docs/SUPPORT_CONTRACT.md` and tracked by #58.
- REQ-008: satisfied. Unsupported ranks and unsupported array features produce targeted diagnostics. This PR adds line/column diagnostics for zero and reversed extents.
- REQ-009: satisfied. Focused executable tests cover supported behavior and diagnostics. This PR adds zero, reversed, and negative-bound adversarial cases.

## File Set

Edited in this PR:

- `src/session_program_lowering_arrays.inc`: changes non-positive array extents from a raw error string to a targeted `array declaration` diagnostic with line and column data.
- `test/test_session_fixed_size_array_compiler.f90`: adds a negative explicit lower-bound executable fixture.
- `test/test_session_array_unsupported_diagnostics.f90`: adds API and CLI diagnostics for implicit zero extent and reversed explicit bounds.

Issue-scope files left alone because prior branch work already satisfies them:

- `README.md`: already documents fixed-size integer arrays and deferred runtime bounds checks.
- `ROADMAP.md`: already records the completed fixed-size array slice and deferred descriptor work.
- `docs/SUPPORT_CONTRACT.md`: already lists supported rank-one integer arrays and the FortFront query gap.
- `docs/RUNTIME_ABI.md`: already keeps array descriptors and allocatables deferred to #53; this PR adds no runtime ABI call.
- `src/liric_session_arrays.inc`: already implements integer array alloca and element-address helpers.
- `src/liric_session_bindings.f90`: already exposes the LIRIC array type API and array helper methods.
- `src/session_program_lowering.f90`: already carries array symbol metadata and routes array declarations, assignments, and expressions.
- `src/session_program_lowering_arguments.inc`: already handles scalar array elements as procedure actuals and rejects whole-array arguments.
- `src/session_program_lowering_declarations.inc`: already preserves compile-time integer parameter values for array bounds.
- `src/session_program_lowering_functions.inc`: already carries the arena into internal procedure lowering contexts.
- `src/session_program_lowering_integer.inc`: already lowers integer array element reads and rejects whole-array expressions.
- `src/session_program_lowering_loops.inc`: already excludes array storage from scalar loop merge values.
- `test/test_session_unsupported_diagnostics.f90`: already moved array cases out of the generic unsupported-feature test.

Issue-scope files left alone because #52 does not require changes there:

- `app/ffc.f90`: CLI already reports lowerer diagnostics.
- `src/session_lowering_ops.f90`: existing integer literal and operator helpers cover bound and subscript expressions.
- `src/session_program_lowering_control.inc`: array support needs no new branch primitive.
- `src/session_program_lowering_character.inc`: first array slice is integer-only.
- `src/session_program_lowering_intrinsics.inc`: array intrinsics remain unsupported.
- `src/session_program_lowering_text.inc`: text lowering is unrelated.
- `src/session_program_lowering_values.inc`: real, logical, and character arrays remain unsupported.
- `src/liric_session_control_bindings.f90`: existing control-flow bindings are sufficient.
- `src/liric_session_io_bindings.f90`: existing scalar `printf` shim prints loaded integer elements.
- `src/liric_session_procedure_bindings.f90`: scalar pointer parameter ABI already accepts array element addresses.
- `docs/API_REFERENCE.md`, `docs/C_API_USAGE.md`, `docs/DEVELOPER_GUIDE.md`, `docs/MIGRATION_GUIDE.md`: no public CLI/API surface changed beyond the support contract.
- `legacy_mlir/`: retired backend path; project docs say to ignore it unless porting a specific piece.

Follow-up issues split out:

- None for #52. Allocatable arrays and runtime bounds checks remain tracked by #53. FortFront resolved-shape query replacement remains tracked by #58.

## Verification

RED before the diagnostic fix:

```bash
LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_array_unsupported_diagnostics
```

Excerpt:

```text
=== direct session array unsupported diagnostic test ===
FAIL: expected line/column diagnostic, got array bounds produce a non-positive extent
FAIL: expected CLI line/column diagnostic, got STOP 1
array bounds produce a non-positive extent
<ERROR> Execution for object " test_session_array_unsupported_diagnostics " returned exit code  1
```

Passing after the merge with `origin/main`:

```bash
LIBRARY_PATH=/home/ert/code/liric/build fpm build && LIBRARY_PATH=/home/ert/code/liric/build fpm test
```

Excerpt:

```text
Project is up to date
=== direct session fixed-size array compiler test ===
PASS: fixed-size arrays lower through direct LIRIC
=== direct session array unsupported diagnostic test ===
PASS: unsupported direct-session array features emit diagnostics
=== direct session scalar print compiler test ===
PASS: integer print lowers through direct LIRIC session
```

Prose check:

```bash
$HOME/code/prompts/scripts/check-writing-slop.py --threshold soft README.md ROADMAP.md docs/SUPPORT_CONTRACT.md docs/RUNTIME_ABI.md
```

Output:

```text
PASS: no writing-slop candidates at threshold soft
```

CI:

```text
FortFC CI / test: SUCCESS
```

<!-- orchestrate: fully-resolved -->
