### PR TITLE
fix: simple derived types (refs #60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ is not part of the default fpm build.
   reads, `print`, `stop`, and counted-loop subscripts are supported. Runtime
   bounds checks are not emitted; out-of-bounds subscripts have backend-level
   behavior until #53 defines array descriptors and checks.
+- The direct LIRIC session lowerer can compile simple derived type definitions
+  with scalar integer components, scalar variables of those types, component
+  assignment, component reads, `print`, and `stop`. Constructors, inheritance,
+  type parameters, type-bound procedures, nested derived types, derived type
+  arrays, whole-derived assignment, and non-integer components are unsupported.
 - The direct LIRIC session path emits native executables and object files.
 - `ffc empty.f90 -o empty` emits a native executable; `ffc empty.f90 -c -o
   empty.o` emits an object file.
@@ -107,11 +112,12 @@ The current MVP support claim is:
 - integer and real scalar `abs`, `min`, and `max` intrinsics
 - integer-to-real `real()` conversion
 - fixed-size one-dimensional integer arrays with compile-time integer bounds
+- simple derived types with scalar integer components and component access
 - object/executable emission through LIRIC
 
 Allocatable arrays, multidimensional arrays, non-integer arrays, modules,
-derived types, full I/O, generics, cross-module inference, and character
-procedure arguments are unsupported today. See the issue map in
+full I/O, generics, cross-module inference, and character procedure arguments
+are unsupported today. See the issue map in
 [docs/SUPPORT_CONTRACT.md](docs/SUPPORT_CONTRACT.md).
 
 ## Build

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -46,7 +46,7 @@ LIBRARY_PATH=/path/to/liric/build fpm build
 7. Simple contained integer, real, and logical functions/subroutines.
 8. Character procedure signatures.
 9. Character representation and a fuller runtime surface.
-10. Arrays, modules, derived types, allocatables, and generics.
+10. Arrays, simple derived types, modules, allocatables, and generics.
 
 The concrete open work is summarized in `docs/SUPPORT_CONTRACT.md`.
 

--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -38,6 +38,19 @@ is closed with ABI documentation and executable tests.
   through LIRIC scalar operations, comparisons, branch control, casts, and PHI
   values.
 
+## Derived Types
+
+- The MVP derived-type layout supports only scalar integer components.
+- Each scalar derived-type variable is stored as one LIRIC array alloca with
+  `component_count` `i32` elements.
+- Component order is source declaration order. Offset zero is the first
+  declared component, offset one is the second component, and so on.
+- Component assignment and reads use the same explicit storage operations as
+  fixed-size arrays: alloca, aggregate GEP, `i32` store, and `i32` load.
+- Constructors, inheritance, type parameters, type-bound procedures, nested
+  derived types, derived type arrays, whole-derived assignment, and non-integer
+  components have no ABI representation in this slice.
+
 ## Procedures
 
 - The supported procedure slice is contained integer, real, and logical
@@ -77,7 +90,6 @@ is closed with ABI documentation and executable tests.
 
 ## Unsupported ABI Work
 
-- #52: fixed-size one-dimensional array lowering.
 - #53: array descriptors, allocatables, and pointer representation.
 - #54: module and external symbol mangling.
 - #55: runtime I/O beyond the current scalar `printf` shim.

--- a/docs/SUPPORT_CONTRACT.md
+++ b/docs/SUPPORT_CONTRACT.md
@@ -35,6 +35,7 @@ The current implementation is a single-file, direct-session subset.
 | Intrinsics | Scalar `abs`, `min`, and `max` for integer and real values, plus integer-to-real `real()` conversion. These lower inline with LIRIC scalar operations and control-flow PHI values. |
 | `print` | Minimal scalar `print *, expr` through the current `printf` shim for integer expressions, real values, character literals, character variables, logical literals, real variables, and logical variables. |
 | Arrays | Fixed-size one-dimensional integer arrays with compile-time integer bounds. Scalar integer parameters and explicit lower:upper bounds are supported. Element assignment, element reads, `print`, `stop`, and counted-loop subscripts are supported. Runtime bounds checks are not emitted; out-of-bounds subscripts have backend-level behavior until #53 defines array descriptors and checks. |
+| Derived types | Simple program-scope derived type definitions with scalar integer components. Scalar variables of those types are supported. Component assignment, component reads, `print`, and `stop` are supported. Constructors, inheritance, type parameters, type-bound procedures, nested derived types, derived type arrays, whole-derived assignment, and non-integer components are unsupported. |
 
 ## Unsupported Work
 
@@ -47,7 +48,6 @@ The current implementation is a single-file, direct-session subset.
 | #57 | Source locations and diagnostics | Unsupported features fail with targeted diagnostics containing source locations. |
 | #58 | FortFront compiler query boundary | `ffc` no longer depends on FortFront arena internals for lowering decisions. |
 | #59 | Standard and Infer-mode conformance tests | Supported constructs have reference behavior tests against the intended standard and Infer-mode semantics. |
-| #60 | Derived types and component access | Simple derived type declarations, scalar components, assignment, and access are lowered and tested. |
 
 Unsupported features must fail during parsing, semantic analysis, or lowering
 with a diagnostic. Silent partial lowering is a bug.

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -57,10 +57,13 @@ module session_program_lowering
 
     integer, parameter :: MAX_SYMBOLS = 64
     integer, parameter :: MAX_PROCEDURES = 32
+    integer, parameter :: MAX_DERIVED_TYPES = 32
+    integer, parameter :: MAX_DERIVED_COMPONENTS = 32
     integer, parameter :: VALUE_I32 = 1
     integer, parameter :: VALUE_F64 = 2
     integer, parameter :: VALUE_LOGICAL = 3
     integer, parameter :: VALUE_CHARACTER = 4
+    integer, parameter :: VALUE_DERIVED = 5
     integer, parameter :: I32_INTRINSIC_NONE = 0
     integer, parameter :: I32_INTRINSIC_ABS = 1
     integer, parameter :: I32_INTRINSIC_MIN = 2
@@ -91,6 +94,8 @@ module session_program_lowering
         integer :: character_length = 0
         logical :: has_character_value = .false.
         logical :: is_array = .false.
+        logical :: is_derived = .false.
+        integer :: derived_type_index = 0
         integer :: array_size = 0
         integer :: array_lower_bound = 1
         type(lr_operand_desc_t) :: element_address
@@ -98,11 +103,19 @@ module session_program_lowering
         integer(c_int64_t) :: i32_constant = 0_c_int64_t
     end type symbol_t
 
+    type :: derived_type_info_t
+        character(len=64) :: name = ''
+        integer :: component_count = 0
+        character(len=64) :: component_names(MAX_DERIVED_COMPONENTS) = ''
+    end type derived_type_info_t
+
     type :: lowering_context_t
         type(liric_session_t) :: session
         type(ast_arena_t) :: arena
         type(symbol_t) :: symbols(MAX_SYMBOLS)
         integer :: symbol_count = 0
+        type(derived_type_info_t) :: derived_types(MAX_DERIVED_TYPES)
+        integer :: derived_type_count = 0
         integer(c_int32_t) :: current_block_id = 0_c_int32_t
         integer(c_int32_t) :: i32_print_format_id = -1_c_int32_t
         integer(c_int32_t) :: f64_print_format_id = -1_c_int32_t
@@ -169,6 +182,13 @@ contains
                                               context%f64_print_format_id, &
                                               context%str_print_format_id, &
                                               error_msg)) then
+            call context%session%destroy()
+            return
+        end if
+
+        call collect_derived_type_definitions(arena, root_index, context, &
+                                              error_msg)
+        if (len_trim(error_msg) > 0) then
             call context%session%destroy()
             return
         end if
@@ -383,11 +403,7 @@ contains
                                            'support multi-way branches', &
                                            error_msg)
         type is (derived_type_node)
-            call unsupported_feature_error('derived type definition', &
-                                           node%line, node%column, &
-                                           'direct LIRIC session does not '// &
-                                           'support derived types or '// &
-                                           'component layout', error_msg)
+            call lower_derived_type_definition(node, context, error_msg)
         class default
             node_type = 'unknown'
             if (allocated(arena%entries(node_index)%node_type)) then
@@ -428,6 +444,7 @@ contains
 
     include 'session_program_lowering_control.inc'
     include 'session_program_lowering_loops.inc'
+    include 'session_program_lowering_derived_types.inc'
 
     subroutine lower_statement_list(arena, node_indices, context, value, &
                                     terminated, error_msg)
@@ -459,18 +476,20 @@ contains
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: array_lower_bound
         integer :: array_size
+        integer :: derived_type_index
         integer :: i
         integer :: value_kind
 
-        call declaration_value_kind(node, value_kind, error_msg)
-        if (len_trim(error_msg) > 0) return
-
-        if (node%is_parameter) then
-            call lower_constant_declaration(node, context, value_kind, error_msg)
+        derived_type_index = declaration_derived_type_index(context, node)
+        if (derived_type_index > 0) then
+            call lower_derived_type_declaration(node, context, derived_type_index, &
+                                                error_msg)
             return
         end if
 
         if (node%is_array) then
+            call declaration_value_kind(node, value_kind, error_msg)
+            if (len_trim(error_msg) > 0) return
             if (value_kind /= VALUE_I32) then
                 call unsupported_feature_error('array declaration', node%line, &
                                                node%column, &
@@ -495,6 +514,14 @@ contains
             else
                 error_msg = 'array declaration did not expose a variable name'
             end if
+            return
+        end if
+
+        call declaration_value_kind(node, value_kind, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        if (node%is_parameter) then
+            call lower_constant_declaration(node, context, value_kind, error_msg)
             return
         end if
 
@@ -736,6 +763,10 @@ contains
                                                     value, error_msg)
                 return
             end if
+        type is (component_access_node)
+            call lower_derived_component_assignment(arena, node, target, context, &
+                                                    value, error_msg)
+            return
         end select
 
         call identifier_name(arena, node%target_index, name, error_msg)
@@ -759,6 +790,12 @@ contains
                                                'whole-array assignment is not '// &
                                                'supported', error_msg)
             end select
+            return
+        end if
+        if (context%symbols(symbol_index)%is_derived) then
+            call lower_derived_whole_assignment_diagnostic(arena, node, &
+                                                           context, symbol_index, &
+                                                           error_msg)
             return
         end if
 

--- a/src/session_program_lowering_arguments.inc
+++ b/src/session_program_lowering_arguments.inc
@@ -155,6 +155,8 @@
                     value_kind = VALUE_LOGICAL
                 end if
             end if
+        type is (component_access_node)
+            value_kind = VALUE_I32
         end select
     end function expression_value_kind
 

--- a/src/session_program_lowering_derived_types.inc
+++ b/src/session_program_lowering_derived_types.inc
@@ -1,0 +1,565 @@
+    subroutine collect_derived_type_definitions(arena, root_index, context, &
+                                                error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: root_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        context%derived_types = derived_type_info_t()
+        context%derived_type_count = 0
+        call set_empty(error_msg)
+
+        select type (program => arena%entries(root_index)%node)
+        type is (program_node)
+            if (.not. allocated(program%body_indices)) return
+            do i = 1, size(program%body_indices)
+                select type (node => arena%entries(program%body_indices(i))%node)
+                type is (derived_type_node)
+                    call lower_derived_type_definition(node, context, error_msg)
+                    if (len_trim(error_msg) > 0) return
+                end select
+            end do
+        end select
+    end subroutine collect_derived_type_definitions
+
+    subroutine lower_derived_type_definition(node, context, error_msg)
+        type(derived_type_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: type_index
+
+        if (.not. allocated(node%name)) then
+            error_msg = 'derived type definition did not expose a name'
+            return
+        end if
+
+        type_index = find_derived_type(context, node%name)
+        if (type_index > 0) then
+            call set_empty(error_msg)
+            return
+        end if
+
+        if (allocated(node%extends_parent)) then
+            call unsupported_feature_error('derived type inheritance', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session only supports '// &
+                                           'plain derived types', error_msg)
+            return
+        end if
+        if (node%has_parameters .or. allocated(node%param_indices)) then
+            call unsupported_feature_error('derived type parameters', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session only supports '// &
+                                           'non-parameterized derived types', &
+                                           error_msg)
+            return
+        end if
+        if (node%has_contains .or. allocated(node%binding_indices)) then
+            call unsupported_feature_error('type-bound procedure', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support type-bound procedures', &
+                                           error_msg)
+            return
+        end if
+        if (.not. allocated(node%component_indices)) then
+            call unsupported_feature_error('derived type definition', &
+                                           node%line, node%column, &
+                                           'derived types need at least one '// &
+                                           'integer component', error_msg)
+            return
+        end if
+
+        if (context%derived_type_count >= MAX_DERIVED_TYPES) then
+            error_msg = 'too many derived types for direct LIRIC session MVP'
+            return
+        end if
+
+        type_index = context%derived_type_count + 1
+        context%derived_types(type_index)%name = trim(node%name)
+        call collect_derived_components(node, context, type_index, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        context%derived_type_count = type_index
+        call set_empty(error_msg)
+    end subroutine lower_derived_type_definition
+
+    subroutine collect_derived_components(node, context, type_index, error_msg)
+        type(derived_type_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: type_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        context%derived_types(type_index)%component_count = 0
+        do i = 1, size(node%component_indices)
+            call collect_component_declaration( &
+                node%component_indices(i), node, context, type_index, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+        if (context%derived_types(type_index)%component_count <= 0) then
+            call unsupported_feature_error('derived type definition', &
+                                           node%line, node%column, &
+                                           'derived types need at least one '// &
+                                           'integer component', error_msg)
+            return
+        end if
+        call set_empty(error_msg)
+    end subroutine collect_derived_components
+
+    subroutine collect_component_declaration(component_index, parent, context, &
+                                             type_index, error_msg)
+        integer, intent(in) :: component_index
+        type(derived_type_node), intent(in) :: parent
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: type_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        if (.not. context%arena%has_node_at(component_index)) then
+            error_msg = 'derived type component index does not reference an AST node'
+            return
+        end if
+
+        select type (component => context%arena%entries(component_index)%node)
+        type is (declaration_node)
+            call validate_component_declaration(component, parent, context, &
+                                                error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (component%is_multi_declaration .and. &
+                allocated(component%var_names)) then
+                do i = 1, size(component%var_names)
+                    call add_derived_component(context, type_index, &
+                                               component%var_names(i), &
+                                               component%line, component%column, &
+                                               error_msg)
+                    if (len_trim(error_msg) > 0) return
+                end do
+            else if (allocated(component%var_name)) then
+                call add_derived_component(context, type_index, component%var_name, &
+                                           component%line, component%column, &
+                                           error_msg)
+            else
+                error_msg = 'derived type component declaration did not expose a name'
+                return
+            end if
+        class default
+            call unsupported_feature_error('derived type component', &
+                                           parent%line, parent%column, &
+                                           'direct LIRIC session only supports '// &
+                                           'integer component declarations', &
+                                           error_msg)
+            return
+        end select
+        call set_empty(error_msg)
+    end subroutine collect_component_declaration
+
+    subroutine validate_component_declaration(component, parent, context, &
+                                              error_msg)
+        type(declaration_node), intent(in) :: component
+        type(derived_type_node), intent(in) :: parent
+        type(lowering_context_t), intent(in) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: nested_index
+
+        if (component%is_array) then
+            call unsupported_feature_error('derived type component', &
+                                           component%line, component%column, &
+                                           'direct LIRIC session only supports '// &
+                                           'scalar integer components', error_msg)
+            return
+        end if
+        if (component%has_initializer) then
+            call unsupported_feature_error('derived type component initializer', &
+                                           component%line, component%column, &
+                                           'component default initialization is '// &
+                                           'not supported', error_msg)
+            return
+        end if
+        if (.not. allocated(component%type_name)) then
+            call set_empty(error_msg)
+            return
+        end if
+
+        nested_index = declaration_derived_type_index(context, component)
+        if (nested_index > 0 .or. is_derived_type_spec(component%type_name)) then
+            call unsupported_feature_error('nested derived type component', &
+                                           component%line, component%column, &
+                                           'direct LIRIC session only supports '// &
+                                           'scalar integer components', error_msg)
+            return
+        end if
+        if (trim(lowercase_text(component%type_name)) /= 'integer') then
+            call unsupported_feature_error('derived type component', &
+                                           component%line, component%column, &
+                                           'direct LIRIC session only supports '// &
+                                           'scalar integer components', error_msg)
+            return
+        end if
+        call set_empty(error_msg)
+    end subroutine validate_component_declaration
+
+    subroutine add_derived_component(context, type_index, name, line, column, &
+                                     error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: type_index
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: line, column
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: component_index
+
+        if (find_derived_component(context, type_index, name) > 0) then
+            error_msg = 'duplicate derived type component: '//trim(name)
+            return
+        end if
+        if (context%derived_types(type_index)%component_count >= &
+            MAX_DERIVED_COMPONENTS) then
+            error_msg = 'too many derived type components for direct LIRIC session MVP'
+            return
+        end if
+
+        component_index = context%derived_types(type_index)%component_count + 1
+        context%derived_types(type_index)%component_names(component_index) = &
+            trim(name)
+        context%derived_types(type_index)%component_count = component_index
+        call set_empty(error_msg)
+    end subroutine add_derived_component
+
+    subroutine lower_derived_type_declaration(node, context, derived_type_index, &
+                                              error_msg)
+        type(declaration_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: derived_type_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        if (node%is_parameter) then
+            call unsupported_feature_error('derived type parameter declaration', &
+                                           node%line, node%column, &
+                                           'derived type parameters are not '// &
+                                           'supported by direct LIRIC session', &
+                                           error_msg)
+            return
+        end if
+        if (node%is_array) then
+            call unsupported_feature_error('derived type array declaration', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session only supports '// &
+                                           'scalar derived type variables', &
+                                           error_msg)
+            return
+        end if
+        if (node%has_initializer) then
+            call unsupported_feature_error('derived type constructor', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support derived type constructors', &
+                                           error_msg)
+            return
+        end if
+
+        if (node%is_multi_declaration .and. allocated(node%var_names)) then
+            do i = 1, size(node%var_names)
+                call define_derived_symbol(context, node, node%var_names(i), &
+                                           derived_type_index, error_msg)
+                if (len_trim(error_msg) > 0) return
+            end do
+        else if (allocated(node%var_name)) then
+            call define_derived_symbol(context, node, node%var_name, &
+                                       derived_type_index, error_msg)
+        else
+            error_msg = 'derived type declaration did not expose a variable name'
+        end if
+    end subroutine lower_derived_type_declaration
+
+    subroutine define_derived_symbol(context, node, name, derived_type_index, &
+                                     error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        type(declaration_node), intent(in) :: node
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: derived_type_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: component_count
+        integer :: index
+
+        if (find_symbol(context, name) > 0) then
+            error_msg = 'duplicate derived type declaration: '//trim(name)
+            return
+        end if
+        if (context%symbol_count >= MAX_SYMBOLS) then
+            error_msg = 'too many symbols for direct LIRIC session MVP'
+            return
+        end if
+
+        component_count = context%derived_types(derived_type_index)%component_count
+        index = context%symbol_count + 1
+        context%symbols(index)%name = trim(name)
+        context%symbols(index)%value_kind = VALUE_DERIVED
+        context%symbols(index)%is_derived = .true.
+        context%symbols(index)%derived_type_index = derived_type_index
+        context%symbols(index)%array_size = component_count
+
+        if (.not. context%session%emit_i32_array_alloca( &
+            component_count, context%symbols(index)%element_address, &
+            error_msg)) then
+            error_msg = 'derived_alloca['//trim(name)//']: '//error_msg
+            return
+        end if
+
+        context%symbol_count = index
+        call set_empty(error_msg)
+    end subroutine define_derived_symbol
+
+    subroutine lower_derived_component_assignment(arena, node, target, context, &
+                                                  value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(assignment_node), intent(in) :: node
+        type(component_access_node), intent(in) :: target
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: component_address
+
+        call lower_i32_expression(arena, node%value_index, context, value, &
+                                  error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        call lower_derived_component_address(arena, target, context, &
+                                             component_address, error_msg, &
+                                             'derived type component assignment target')
+        if (len_trim(error_msg) > 0) return
+
+        if (.not. context%session%emit_i32_store(value, component_address, &
+                                                 error_msg)) then
+            error_msg = 'component_store: '//error_msg
+            return
+        end if
+        call set_empty(error_msg)
+    end subroutine lower_derived_component_assignment
+
+    subroutine lower_derived_component_load(arena, node, context, value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(component_access_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: component_address
+
+        call lower_derived_component_address(arena, node, context, &
+                                             component_address, error_msg, &
+                                             'derived type component expression')
+        if (len_trim(error_msg) > 0) return
+
+        if (.not. context%session%emit_i32_load(component_address, value, &
+                                                error_msg)) then
+            error_msg = 'component_load: '//error_msg
+            return
+        end if
+        call set_empty(error_msg)
+    end subroutine lower_derived_component_load
+
+    subroutine lower_derived_component_address(arena, node, context, &
+                                               component_address, error_msg, &
+                                               feature)
+        type(ast_arena_t), intent(in) :: arena
+        type(component_access_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: component_address
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=*), intent(in) :: feature
+        character(len=:), allocatable :: base_name
+        integer :: component_index
+        integer :: symbol_index
+        integer :: type_index
+        type(lr_operand_desc_t) :: offset
+
+        call component_base_name(arena, node%base_expr_index, base_name, error_msg)
+        if (len_trim(error_msg) > 0) then
+            call unsupported_feature_error(feature, node%line, node%column, &
+                                           trim(error_msg), error_msg)
+            return
+        end if
+
+        symbol_index = find_symbol(context, base_name)
+        if (symbol_index <= 0) then
+            call unsupported_feature_error(feature, node%line, node%column, &
+                                           'component base was not declared: '// &
+                                           trim(base_name), error_msg)
+            return
+        end if
+        if (.not. context%symbols(symbol_index)%is_derived) then
+            call unsupported_feature_error(feature, node%line, node%column, &
+                                           'component base is not a derived type: '// &
+                                           trim(base_name), error_msg)
+            return
+        end if
+
+        type_index = context%symbols(symbol_index)%derived_type_index
+        component_index = find_derived_component(context, type_index, &
+                                                 node%component_name)
+        if (component_index <= 0) then
+            call unsupported_feature_error(feature, node%line, node%column, &
+                                           'component is not declared for type '// &
+                                           trim(context%derived_types(type_index)%name)// &
+                                           ': '//trim(node%component_name), &
+                                           error_msg)
+            return
+        end if
+
+        offset = context%session%i32_immediate(int(component_index - 1, c_int64_t))
+        if (.not. context%session%emit_i32_array_element_addr( &
+            context%derived_types(type_index)%component_count, &
+            context%symbols(symbol_index)%element_address, offset, &
+            component_address, error_msg)) then
+            error_msg = 'component_gep: '//error_msg
+            return
+        end if
+        call set_empty(error_msg)
+    end subroutine lower_derived_component_address
+
+    subroutine component_base_name(arena, node_index, name, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable, intent(out) :: name
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (.not. arena%has_node_at(node_index)) then
+            error_msg = 'component base index does not reference an AST node'
+            call set_empty(name)
+            return
+        end if
+
+        select type (base => arena%entries(node_index)%node)
+        type is (identifier_node)
+            name = base%name
+            call set_empty(error_msg)
+        class default
+            error_msg = 'nested component access is not supported'
+            call set_empty(name)
+        end select
+    end subroutine component_base_name
+
+    subroutine lower_derived_whole_assignment_diagnostic(arena, node, context, &
+                                                         symbol_index, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(assignment_node), intent(in) :: node
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: symbol_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: type_index
+
+        type_index = context%symbols(symbol_index)%derived_type_index
+        if (is_derived_constructor_call(arena, node%value_index, context, &
+                                        type_index)) then
+            call unsupported_feature_error('derived type constructor', &
+                                           node%line, node%column, &
+                                           'direct LIRIC session does not '// &
+                                           'support derived type constructors', &
+                                           error_msg)
+            return
+        end if
+        call unsupported_feature_error('derived type assignment', &
+                                       node%line, node%column, &
+                                       'direct LIRIC session only supports '// &
+                                       'component assignment', error_msg)
+    end subroutine lower_derived_whole_assignment_diagnostic
+
+    logical function is_derived_constructor_call(arena, node_index, context, &
+                                                 type_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: type_index
+
+        is_derived_constructor_call = .false.
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+        type is (call_or_subscript_node)
+            if (allocated(node%name)) then
+                is_derived_constructor_call = &
+                    same_name(node%name, context%derived_types(type_index)%name)
+            end if
+        end select
+    end function is_derived_constructor_call
+
+    integer function declaration_derived_type_index(context, node) result(type_index)
+        type(lowering_context_t), intent(in) :: context
+        type(declaration_node), intent(in) :: node
+        character(len=:), allocatable :: type_name
+
+        type_index = 0
+        if (.not. allocated(node%type_name)) return
+        call extracted_derived_type_name(node%type_name, type_name)
+        if (len_trim(type_name) == 0) return
+        type_index = find_derived_type(context, type_name)
+    end function declaration_derived_type_index
+
+    subroutine extracted_derived_type_name(type_spec, type_name)
+        character(len=*), intent(in) :: type_spec
+        character(len=:), allocatable, intent(out) :: type_name
+        character(len=:), allocatable :: lowered
+        integer :: close_pos
+        integer :: open_pos
+
+        lowered = trim(lowercase_text(type_spec))
+        if (len_trim(lowered) >= 5) then
+            if (lowered(1:5) == 'type(') then
+                open_pos = index(lowered, '(')
+                close_pos = index(lowered, ')', back=.true.)
+                if (close_pos > open_pos + 1) then
+                    type_name = lowered(open_pos + 1:close_pos - 1)
+                else
+                    type_name = ''
+                end if
+                return
+            end if
+        end if
+
+        if (lowered /= 'integer' .and. lowered /= 'real' .and. &
+            lowered /= 'logical' .and. .not. is_character_type_name(lowered)) then
+            type_name = lowered
+        else
+            type_name = ''
+        end if
+    end subroutine extracted_derived_type_name
+
+    logical function is_derived_type_spec(type_spec)
+        character(len=*), intent(in) :: type_spec
+        character(len=:), allocatable :: type_name
+
+        call extracted_derived_type_name(type_spec, type_name)
+        is_derived_type_spec = len_trim(type_name) > 0
+    end function is_derived_type_spec
+
+    integer function find_derived_type(context, name) result(type_index)
+        type(lowering_context_t), intent(in) :: context
+        character(len=*), intent(in) :: name
+        integer :: i
+
+        type_index = 0
+        do i = 1, context%derived_type_count
+            if (same_name(context%derived_types(i)%name, name)) then
+                type_index = i
+                return
+            end if
+        end do
+    end function find_derived_type
+
+    integer function find_derived_component(context, type_index, name) &
+        result(component_index)
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: type_index
+        character(len=*), intent(in) :: name
+        integer :: i
+
+        component_index = 0
+        if (type_index <= 0 .or. type_index > context%derived_type_count) return
+        do i = 1, context%derived_types(type_index)%component_count
+            if (same_name(context%derived_types(type_index)%component_names(i), &
+                          name)) then
+                component_index = i
+                return
+            end if
+        end do
+    end function find_derived_component

--- a/src/session_program_lowering_functions.inc
+++ b/src/session_program_lowering_functions.inc
@@ -88,6 +88,14 @@
         destination%function_count = source%function_count
     end subroutine copy_internal_function_names
 
+    subroutine copy_derived_type_table(source, destination)
+        type(lowering_context_t), intent(in) :: source
+        type(lowering_context_t), intent(inout) :: destination
+
+        destination%derived_types = source%derived_types
+        destination%derived_type_count = source%derived_type_count
+    end subroutine copy_derived_type_table
+
     logical function is_contained_i32_function(context, name)
         type(lowering_context_t), intent(in) :: context
         character(len=*), intent(in) :: name
@@ -196,6 +204,7 @@
         context%string_literal_count = parent_context%string_literal_count
         context%arena = arena
         call copy_internal_function_names(parent_context, context)
+        call copy_derived_type_table(parent_context, context)
         context%in_internal_function = .true.
 
         param_count = 0
@@ -259,6 +268,7 @@
         context%string_literal_count = parent_context%string_literal_count
         context%arena = arena
         call copy_internal_function_names(parent_context, context)
+        call copy_derived_type_table(parent_context, context)
         context%in_internal_function = .true.
 
         param_count = 0

--- a/src/session_program_lowering_integer.inc
+++ b/src/session_program_lowering_integer.inc
@@ -74,10 +74,7 @@
               call lower_i32_call(arena, node, context, value, error_msg)
           end if
       type is (component_access_node)
-          call unsupported_feature_error('derived type component expression', &
-                                         node%line, node%column, &
-                                         'direct LIRIC session does not '// &
-                                         'support component access', error_msg)
+          call lower_derived_component_load(arena, node, context, value, error_msg)
       type is (array_slice_node)
           call unsupported_array_subscript(arena, node_index, &
                                            'ranges and slices', error_msg)

--- a/test/test_session_derived_type_compiler.f90
+++ b/test/test_session_derived_type_compiler.f90
@@ -1,0 +1,297 @@
+program test_session_derived_type_compiler
+    use fortfront, only: compiler_frontend_options_t, &
+                         compiler_frontend_result_t, &
+                         compile_frontend_from_string, INPUT_MODE_STANDARD
+    use session_program_lowering, only: lower_program_to_liric_exe
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session derived type compiler test ==='
+
+    all_passed = .true.
+    if (.not. test_component_slots()) all_passed = .false.
+    if (.not. test_two_variables_do_not_alias()) all_passed = .false.
+    if (.not. test_component_stop_code()) all_passed = .false.
+    if (.not. test_real_component_diagnostic()) all_passed = .false.
+    if (.not. test_nested_component_diagnostic()) all_passed = .false.
+    if (.not. test_constructor_diagnostic()) all_passed = .false.
+    if (.not. test_inheritance_diagnostic()) all_passed = .false.
+    if (.not. test_type_bound_diagnostic()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: derived types lower through direct LIRIC'
+
+contains
+
+    logical function test_component_slots()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  type :: cell_t'//new_line('a')// &
+                                       '    integer :: lo'//new_line('a')// &
+                                       '    integer :: mid'//new_line('a')// &
+                                       '    integer :: hi'//new_line('a')// &
+                                       '  end type cell_t'//new_line('a')// &
+                                       '  type(cell_t) :: node'//new_line('a')// &
+                                       '  node%lo = 4'//new_line('a')// &
+                                       '  node%mid = 6'//new_line('a')// &
+                                       '  node%hi = node%lo + node%mid'//new_line('a')// &
+                                       '  print *, node%lo + node%mid + node%hi'// &
+                                       new_line('a')// &
+                                       'end program main'
+
+        test_component_slots = expect_output(source, '20', &
+                                             '/tmp/ffc_session_derived_slots_test')
+    end function test_component_slots
+
+    logical function test_two_variables_do_not_alias()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  type :: pair_t'//new_line('a')// &
+                                       '    integer :: left'//new_line('a')// &
+                                       '    integer :: right'//new_line('a')// &
+                                       '  end type pair_t'//new_line('a')// &
+                                       '  type(pair_t) :: first'//new_line('a')// &
+                                       '  type(pair_t) :: second'//new_line('a')// &
+                                       '  first%left = 3'//new_line('a')// &
+                                       '  first%right = 8'//new_line('a')// &
+                                       '  second%left = 11'//new_line('a')// &
+                                       '  second%right = 13'//new_line('a')// &
+                                       '  print *, first%left + second%right'// &
+                                       new_line('a')// &
+                                       'end program main'
+
+        test_two_variables_do_not_alias = expect_output( &
+                                          source, '16', &
+                                          '/tmp/ffc_session_derived_alias_test')
+    end function test_two_variables_do_not_alias
+
+    logical function test_component_stop_code()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  type :: status_t'//new_line('a')// &
+                                       '    integer :: code'//new_line('a')// &
+                                       '  end type status_t'//new_line('a')// &
+                                       '  type(status_t) :: result'//new_line('a')// &
+                                       '  result%code = 7'//new_line('a')// &
+                                       '  stop result%code'//new_line('a')// &
+                                       'end program main'
+
+        test_component_stop_code = expect_exit_status( &
+                                   source, 7, &
+                                   '/tmp/ffc_session_derived_stop_test')
+    end function test_component_stop_code
+
+    logical function test_real_component_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  type :: sample_t'//new_line('a')// &
+                                       '    real :: value'//new_line('a')// &
+                                       '  end type sample_t'//new_line('a')// &
+                                       'end program main'
+
+        test_real_component_diagnostic = expect_error_contains( &
+                                         source, 'unsupported derived type component', &
+                                         '/tmp/ffc_session_derived_real_test')
+    end function test_real_component_diagnostic
+
+    logical function test_nested_component_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  type :: inner_t'//new_line('a')// &
+                                       '    integer :: value'//new_line('a')// &
+                                       '  end type inner_t'//new_line('a')// &
+                                       '  type :: outer_t'//new_line('a')// &
+                                       '    type(inner_t) :: inner'//new_line('a')// &
+                                       '  end type outer_t'//new_line('a')// &
+                                       'end program main'
+
+        test_nested_component_diagnostic = expect_error_contains( &
+                                           source, 'unsupported nested derived type', &
+                                           '/tmp/ffc_session_derived_nested_test')
+    end function test_nested_component_diagnostic
+
+    logical function test_constructor_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  type :: item_t'//new_line('a')// &
+                                       '    integer :: count'//new_line('a')// &
+                                       '  end type item_t'//new_line('a')// &
+                                       '  type(item_t) :: item'//new_line('a')// &
+                                       '  item = item_t(4)'//new_line('a')// &
+                                       'end program main'
+
+        test_constructor_diagnostic = expect_error_contains( &
+                                      source, 'unsupported derived type constructor', &
+                                      '/tmp/ffc_session_derived_constructor_test')
+    end function test_constructor_diagnostic
+
+    logical function test_inheritance_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  type :: base_t'//new_line('a')// &
+                                       '    integer :: code'//new_line('a')// &
+                                       '  end type base_t'//new_line('a')// &
+                                       '  type, extends(base_t) :: child_t'// &
+                                       new_line('a')// &
+                                       '    integer :: extra'//new_line('a')// &
+                                       '  end type child_t'//new_line('a')// &
+                                       'end program main'
+
+        test_inheritance_diagnostic = expect_error_contains( &
+                                      source, 'unsupported derived type inheritance', &
+                                      '/tmp/ffc_session_derived_extends_test')
+    end function test_inheritance_diagnostic
+
+    logical function test_type_bound_diagnostic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  type :: bound_t'//new_line('a')// &
+                                       '    integer :: code'//new_line('a')// &
+                                       '  contains'//new_line('a')// &
+                                       '    procedure :: show'//new_line('a')// &
+                                       '  end type bound_t'//new_line('a')// &
+                                       'contains'//new_line('a')// &
+                                       '  subroutine show(self)'//new_line('a')// &
+                                       '    type(bound_t) :: self'//new_line('a')// &
+                                       '  end subroutine show'//new_line('a')// &
+                                       'end program main'
+
+        test_type_bound_diagnostic = expect_error_contains( &
+                                     source, 'unsupported type-bound procedure', &
+                                     '/tmp/ffc_session_derived_bound_test')
+    end function test_type_bound_diagnostic
+
+    logical function expect_exit_status(source, expected, stem)
+        character(len=*), intent(in) :: source
+        integer, intent(in) :: expected
+        character(len=*), intent(in) :: stem
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: exe_path
+        integer :: cmd_stat
+        integer :: exit_stat
+
+        expect_exit_status = .false.
+        exe_path = stem
+        call execute_command_line('rm -f '//exe_path)
+        call compile_and_lower(source, exe_path, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: direct LIRIC lowering failed: ', trim(error_msg)
+            return
+        end if
+
+        call execute_command_line(exe_path, exitstat=exit_stat, cmdstat=cmd_stat)
+        call execute_command_line('rm -f '//exe_path)
+        if (cmd_stat /= 0) then
+            print *, 'FAIL: executable did not run'
+            return
+        end if
+        if (exit_stat /= expected) then
+            print *, 'FAIL: expected exit status ', expected, ', got ', exit_stat
+            return
+        end if
+
+        expect_exit_status = .true.
+    end function expect_exit_status
+
+    logical function expect_output(source, expected, stem)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        character(len=*), intent(in) :: stem
+        character(len=64) :: output_line
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: exe_path
+        character(len=:), allocatable :: out_path
+        integer :: exit_stat
+        integer :: io_stat
+        integer :: unit
+
+        expect_output = .false.
+        exe_path = stem
+        out_path = stem//'.out'
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+        call compile_and_lower(source, exe_path, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: direct LIRIC lowering failed: ', trim(error_msg)
+            return
+        end if
+
+        call execute_command_line(exe_path//' > '//out_path, exitstat=exit_stat)
+        if (exit_stat /= 0) then
+            print *, 'FAIL: executable exit status ', exit_stat
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+
+        open (newunit=unit, file=out_path, status='old', action='read', &
+              iostat=io_stat)
+        if (io_stat /= 0) then
+            print *, 'FAIL: could not open captured output'
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+        read (unit, '(A)', iostat=io_stat) output_line
+        close (unit)
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+
+        if (io_stat /= 0 .or. trim(adjustl(output_line)) /= expected) then
+            print *, 'FAIL: expected output ', expected, ', got ', &
+                trim(output_line)
+            return
+        end if
+
+        expect_output = .true.
+    end function expect_output
+
+    logical function expect_error_contains(source, expected, exe_path)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        character(len=*), intent(in) :: exe_path
+        character(len=:), allocatable :: error_msg
+
+        expect_error_contains = .false.
+        call compile_and_lower(source, exe_path, error_msg)
+        call execute_command_line('rm -f '//exe_path)
+
+        if (len_trim(error_msg) == 0) then
+            print *, 'FAIL: unsupported source lowered without error'
+            return
+        end if
+        if (index(error_msg, expected) <= 0) then
+            print *, 'FAIL: expected diagnostic substring ', expected
+            print *, '  got ', trim(error_msg)
+            return
+        end if
+        if (index(error_msg, 'line ') <= 0 .or. &
+            index(error_msg, 'column ') <= 0) then
+            print *, 'FAIL: expected line/column diagnostic, got ', &
+                trim(error_msg)
+            return
+        end if
+
+        expect_error_contains = .true.
+    end function expect_error_contains
+
+    subroutine compile_and_lower(source, exe_path, error_msg)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: exe_path
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: frontend_result
+
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+
+        call compile_frontend_from_string(source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            error_msg = 'FortFront rejected source: '// &
+                        trim(frontend_result%diagnostic_text)
+            return
+        end if
+
+        call lower_program_to_liric_exe(frontend_result%arena, &
+                                        frontend_result%root_index, exe_path, &
+                                        error_msg)
+    end subroutine compile_and_lower
+end program test_session_derived_type_compiler

--- a/test/test_session_derived_type_compiler.f90
+++ b/test/test_session_derived_type_compiler.f90
@@ -35,7 +35,7 @@ contains
                                        '  type(cell_t) :: node'//new_line('a')// &
                                        '  node%lo = 4'//new_line('a')// &
                                        '  node%mid = 6'//new_line('a')// &
-                                       '  node%hi = node%lo + node%mid'//new_line('a')// &
+                                     '  node%hi = node%lo + node%mid'//new_line('a')// &
                                        '  print *, node%lo + node%mid + node%hi'// &
                                        new_line('a')// &
                                        'end program main'

--- a/test/test_session_unsupported_diagnostics.f90
+++ b/test/test_session_unsupported_diagnostics.f90
@@ -251,13 +251,13 @@ contains
         character(len=*), parameter :: source = &
                                        'program main'//new_line('a')// &
                                        '  type :: point'//new_line('a')// &
-                                       '    integer :: x'//new_line('a')// &
+                                       '    real :: x'//new_line('a')// &
                                        '  end type point'//new_line('a')// &
                                        'end program main'
 
         test_derived_type_diagnostic = expect_error_contains( &
                                        source, &
-                                       'unsupported derived type definition', &
+                                       'unsupported derived type component', &
                                        '/tmp/ffc_session_derived_type_test')
     end function test_derived_type_diagnostic
 
@@ -598,13 +598,13 @@ contains
         character(len=*), parameter :: source = &
                                        'program main'//new_line('a')// &
                                        '  type :: point'//new_line('a')// &
-                                       '    integer :: x'//new_line('a')// &
+                                       '    real :: x'//new_line('a')// &
                                        '  end type point'//new_line('a')// &
                                        'end program main'
 
         test_cli_derived_type_diagnostic = expect_cli_error_contains( &
                                            source, &
-                                           'unsupported derived type definition', &
+                                           'unsupported derived type component', &
                                            '/tmp/ffc_cli_derived_type_test')
     end function test_cli_derived_type_diagnostic
 


### PR DESCRIPTION
## Requirements

Already satisfied before this branch's implementation commits: none.

- REQ-001: satisfied. Simple program-scope derived type definitions with scalar integer fields are collected and validated.
- REQ-002: satisfied. Scalar variables declared with `type(name)` allocate component storage.
- REQ-003: satisfied. Component assignment and component reads lower through explicit storage operations and work in `print` and `stop`.
- REQ-004: satisfied. Unsupported derived-type features emit targeted diagnostics: non-integer components, nested derived types, constructors, inheritance, type parameters, type-bound procedures, derived-type arrays, and whole-derived assignment.
- REQ-005: satisfied. Layout and unsupported ABI cases are documented in `docs/RUNTIME_ABI.md`, `docs/SUPPORT_CONTRACT.md`, and `README.md`.
- REQ-006: satisfied. Commit `43d8055` adds the spec-derived red tests first. Commit `7a70679` implements the feature and docs.

## File Set

Edited:

- `src/session_program_lowering.f90`: added derived type metadata, definition collection, declaration dispatch, assignment dispatch, and the new include.
- `src/session_program_lowering_derived_types.inc`: added derived type validation, scalar variable storage, component addressing, component load/store, and diagnostics.
- `src/session_program_lowering_integer.inc`: lowers integer component expressions.
- `src/session_program_lowering_arguments.inc`: treats component expressions as integer values for argument handling.
- `src/session_program_lowering_functions.inc`: copies the derived type table into contained procedure contexts.
- `test/test_session_derived_type_compiler.f90`: covers multi-slot layout, two variables, `stop`, and unsupported derived-type clauses.
- `test/test_session_unsupported_diagnostics.f90`: changes the old simple-derived unsupported test to a non-integer-component diagnostic.
- `docs/RUNTIME_ABI.md`: documents the `[N x i32]` component layout and unsupported ABI cases.
- `docs/SUPPORT_CONTRACT.md`: moves simple derived types into supported behavior and removes #60 from unsupported work.
- `README.md`: updates current status and MVP scope.
- `docs/DEVELOPER_GUIDE.md`: updates the feature-order wording.

Left alone:

- `src/liric_session_bindings.f90` and `src/liric_session_arrays.inc`: existing array alloca, GEP, load, and store bindings cover this layout.
- `src/liric_session_control_bindings.f90`, `src/liric_session_io_bindings.f90`, and `src/liric_session_procedure_bindings.f90`: no new control, I/O, or procedure ABI calls were needed.
- `src/session_program_lowering_arrays.inc`: component storage reuses its LIRIC array helpers without changing array behavior.
- `src/session_program_lowering_character.inc`, `src/session_program_lowering_control.inc`, `src/session_program_lowering_declarations.inc`, `src/session_program_lowering_diagnostics.inc`, `src/session_program_lowering_intrinsics.inc`, `src/session_program_lowering_loops.inc`, `src/session_program_lowering_text.inc`, `src/session_program_lowering_values.inc`, and `src/session_lowering_ops.f90`: no derived-type-specific behavior belongs there.
- `app/ffc.f90`: CLI error forwarding already reports lowering diagnostics.
- `docs/API_REFERENCE.md`, `docs/C_API_USAGE.md`, and `docs/MIGRATION_GUIDE.md`: no public LIRIC C API or migration path changed.
- Other tests in `test/`: unchanged; full `fpm test` covers them.

Follow-up issues: none.

## Verification

Red step:

```text
$ LIBRARY_PATH=/home/ert/code/liric/build fpm test test_session_derived_type_compiler
[100%] Project compiled successfully.
 === direct session derived type compiler test ===
 FAIL: direct LIRIC lowering failed: unsupported derived type definition at line 1, column 1: direct LIRIC session does not support derived types or component layout
 FAIL: expected diagnostic substring unsupported derived type component
   got unsupported derived type definition at line 1, column 1: direct LIRIC session does not support derived types or component layout
STOP 1
```

Passing checks:

```text
$ LIBRARY_PATH=/home/ert/code/liric/build fpm build
Project is up to date

$ LIBRARY_PATH=/home/ert/code/liric/build fpm test
Project is up to date
 === direct session derived type compiler test ===
 PASS: derived types lower through direct LIRIC
 === direct session fixed-size array compiler test ===
 PASS: fixed-size arrays lower through direct LIRIC
 === direct session scalar print compiler test ===
 PASS: integer print lowers through direct LIRIC session
 === direct session character variable compiler test ===
 PASS: character variables lower through direct LIRIC session

$ $HOME/code/prompts/scripts/check-writing-slop.py README.md docs/DEVELOPER_GUIDE.md docs/RUNTIME_ABI.md docs/SUPPORT_CONTRACT.md
PASS: no writing-slop candidates at threshold medium
```

(ref #60)

<!-- orchestrate: fully-resolved -->
