### PR TITLE
feat: support integer mod intrinsic

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ is not part of the default fpm build.
   expressions/statements. Procedure arguments use pointer parameters with
   copy-back for variable actual arguments.
 - The direct LIRIC session lowerer can compile scalar `abs`, `min`, and
-  `max` intrinsics for integer and real values, plus integer-to-real `real()`
-  conversion, inline through LIRIC scalar operations, blocks, and PHI values.
+  `max` intrinsics for integer and real values, integer `mod`, plus
+  integer-to-real `real()` conversion, inline through LIRIC scalar operations,
+  blocks, and PHI values.
 - The direct LIRIC session lowerer can compile fixed-size one-dimensional
   integer arrays with compile-time integer bounds, including scalar integer
   parameters and explicit lower:upper bounds. Element assignment, element
@@ -109,7 +110,8 @@ The current MVP support claim is:
 - real variables/arithmetic
 - block `if`
 - simple contained integer, real, and logical functions and subroutines
-- integer and real scalar `abs`, `min`, and `max` intrinsics
+- integer and real scalar `abs`, `min`, and `max` intrinsics, plus integer
+  `mod`
 - integer-to-real `real()` conversion
 - fixed-size one-dimensional integer arrays with compile-time integer bounds
 - simple derived types with scalar integer components and component access

--- a/src/liric_session_bindings.f90
+++ b/src/liric_session_bindings.f90
@@ -20,6 +20,7 @@ module liric_session_bindings
     integer(c_int), parameter, public :: LR_OP_SUB = 6_c_int
     integer(c_int), parameter, public :: LR_OP_MUL = 7_c_int
     integer(c_int), parameter, public :: LR_OP_SDIV = 8_c_int
+    integer(c_int), parameter, public :: LR_OP_SREM = 9_c_int
     integer(c_int), parameter, public :: LR_OP_ALLOCA = 26_c_int
     integer(c_int), parameter, public :: LR_OP_LOAD = 27_c_int
     integer(c_int), parameter, public :: LR_OP_STORE = 28_c_int

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -18,7 +18,8 @@ module session_program_lowering
                          get_subroutine_call_arg_indices, &
                          get_subroutine_call_name, is_subroutine_call_statement
     use liric_session_bindings, only: liric_session_t, liric_session_create, &
-                                      lr_operand_desc_t, LR_OP_ADD, LR_OP_SUB
+                                      lr_operand_desc_t, LR_OP_ADD, LR_OP_SREM, &
+                                      LR_OP_SUB
     use liric_session_control_bindings, only: create_liric_block, &
                                               emit_liric_br, &
                                               emit_liric_condbr, &
@@ -68,15 +69,17 @@ module session_program_lowering
     integer, parameter :: I32_INTRINSIC_ABS = 1
     integer, parameter :: I32_INTRINSIC_MIN = 2
     integer, parameter :: I32_INTRINSIC_MAX = 3
+    integer, parameter :: I32_INTRINSIC_MOD = 4
     integer, parameter :: F64_INTRINSIC_NONE = 0
     integer, parameter :: F64_INTRINSIC_ABS = 1
     integer, parameter :: F64_INTRINSIC_MIN = 2
     integer, parameter :: F64_INTRINSIC_MAX = 3
     integer, parameter :: F64_INTRINSIC_REAL = 4
-    character(len=8), parameter :: I32_INTRINSIC_NAMES(3) = &
-                                   [character(len=8) :: 'abs', 'min', 'max']
-    integer, parameter :: I32_INTRINSIC_IDS(3) = &
-                          [I32_INTRINSIC_ABS, I32_INTRINSIC_MIN, I32_INTRINSIC_MAX]
+    character(len=8), parameter :: I32_INTRINSIC_NAMES(4) = &
+                                   [character(len=8) :: 'abs', 'min', 'max', 'mod']
+    integer, parameter :: I32_INTRINSIC_IDS(4) = &
+                          [I32_INTRINSIC_ABS, I32_INTRINSIC_MIN, I32_INTRINSIC_MAX, &
+                           I32_INTRINSIC_MOD]
     character(len=8), parameter :: F64_INTRINSIC_NAMES(4) = &
                                    [character(len=8) :: 'abs', 'min', 'max', 'real']
     integer, parameter :: F64_INTRINSIC_IDS(4) = &

--- a/src/session_program_lowering_intrinsics.inc
+++ b/src/session_program_lowering_intrinsics.inc
@@ -16,6 +16,8 @@
         case (I32_INTRINSIC_MAX)
             call lower_i32_minmax_intrinsic(arena, node, LR_CMP_SGE, context, &
                                             value, error_msg)
+        case (I32_INTRINSIC_MOD)
+            call lower_i32_mod_intrinsic(arena, node, context, value, error_msg)
         case default
             call unsupported_intrinsic_error(node, error_msg)
         end select
@@ -96,6 +98,28 @@
                                         arg, negative, error_msg)) return
         call select_value(context, condition, arg, negative, value, error_msg)
     end subroutine lower_f64_abs_intrinsic
+
+    subroutine lower_i32_mod_intrinsic(arena, node, context, value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: lhs
+        type(lr_operand_desc_t) :: rhs
+
+        if (.not. require_intrinsic_arg_count(node, 2, 2, error_msg)) return
+
+        call lower_i32_expression(arena, node%arg_indices(1), context, lhs, &
+                                  error_msg)
+        if (len_trim(error_msg) > 0) return
+        call lower_i32_expression(arena, node%arg_indices(2), context, rhs, &
+                                  error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        if (.not. context%session%emit_i32_binary(LR_OP_SREM, lhs, rhs, value, &
+                                                  error_msg)) return
+    end subroutine lower_i32_mod_intrinsic
 
     subroutine lower_i32_minmax_intrinsic(arena, node, predicate, context, &
                                           value, error_msg)
@@ -286,11 +310,11 @@
             call unsupported_feature_error('scalar intrinsic: '//trim(node%name), &
                                            node%line, node%column, &
                                            'direct LIRIC session supports only '// &
-                                           'abs, min, max, and real', error_msg)
+                                           'abs, min, max, mod, and real', error_msg)
         else
             call unsupported_feature_error('scalar intrinsic', node%line, &
                                            node%column, &
                                            'direct LIRIC session supports only '// &
-                                           'abs, min, max, and real', error_msg)
+                                           'abs, min, max, mod, and real', error_msg)
         end if
     end subroutine unsupported_intrinsic_error

--- a/test/test_session_integer_intrinsic_compiler.f90
+++ b/test/test_session_integer_intrinsic_compiler.f90
@@ -11,6 +11,7 @@ program test_session_integer_intrinsic_compiler
 
     all_passed = .true.
     if (.not. test_integer_intrinsic_values()) all_passed = .false.
+    if (.not. test_integer_mod_intrinsic()) all_passed = .false.
     if (.not. test_real_intrinsic_values()) all_passed = .false.
     if (.not. test_real_conversion_intrinsic()) all_passed = .false.
     if (.not. test_unsupported_intrinsic_diagnostic()) all_passed = .false.
@@ -35,6 +36,22 @@ contains
         test_integer_intrinsic_values = compile_and_expect_exit( &
                                    source, '/tmp/ffc_session_integer_intrinsic_test', 7)
     end function test_integer_intrinsic_values
+
+    logical function test_integer_mod_intrinsic()
+        character(len=*), parameter :: source = &
+                                       'program main'//new_line('a')// &
+                                       '  integer :: a'//new_line('a')// &
+                                       '  integer :: b'//new_line('a')// &
+                                       '  a = 17'//new_line('a')// &
+                                       '  b = 5'//new_line('a')// &
+                                       '  stop mod(a, b) + mod(-7, 3)'// &
+                                       new_line('a')// &
+                                       'end program main'
+
+        test_integer_mod_intrinsic = compile_and_expect_exit( &
+                                     source, &
+                                     '/tmp/ffc_session_integer_mod_test', 1)
+    end function test_integer_mod_intrinsic
 
     logical function test_real_intrinsic_values()
         character(len=*), parameter :: source = &
@@ -69,7 +86,7 @@ contains
     logical function test_unsupported_intrinsic_diagnostic()
         character(len=*), parameter :: source = &
                                        'program main'//new_line('a')// &
-                                       '  stop mod(5, 2)'//new_line('a')// &
+                                       '  stop int(5.5)'//new_line('a')// &
                                        'end program main'
         character(len=:), allocatable :: error_msg
 
@@ -80,7 +97,7 @@ contains
         call execute_command_line( &
             'rm -f /tmp/ffc_session_unsupported_intrinsic_test')
 
-        if (index(error_msg, 'unsupported scalar intrinsic: mod') <= 0) then
+        if (index(error_msg, 'unsupported scalar intrinsic: int') <= 0) then
             print *, 'FAIL: expected unsupported intrinsic diagnostic, got ', &
                 trim(error_msg)
             return


### PR DESCRIPTION
## Summary
- Bind LIRIC `LR_OP_SREM` and add an `I32_INTRINSIC_MOD` lowering path so `mod(a, b)` for integer arguments compiles to a single signed-remainder instruction. Result follows Fortran semantics (sign of dividend), matching SREM.
- Update the unsupported-intrinsic diagnostic message and the negative test (now uses `int(5.5)` since `mod` is supported).
- Cover positive `mod` behavior in `test_session_integer_intrinsic_compiler` with both a variable case (`mod(17, 5)`) and a negative-dividend case (`mod(-7, 3) == -1`).
- Update README's supported-intrinsics list.

## Verification
Before:
```
$ ffc mod.f90 -o mod
unsupported scalar intrinsic: mod at line 3, column 16: direct LIRIC session supports only abs, min, max, and real
```

After:
```
$ LIBRARY_PATH=/home/ert/code/liric/build fpm run -- /tmp/mod1.f90 -o /tmp/mod1 && /tmp/mod1
1
$ cat <<EOS > /tmp/m.f90
program main
  print *, mod(-7, 3)
end program
EOS
$ fpm run -- /tmp/m.f90 -o /tmp/m && /tmp/m
-1
```

Test suite:
```
$ LIBRARY_PATH=/home/ert/code/liric/build fpm test
... all suites PASS, including:
 === direct session scalar intrinsic compiler test ===
 PASS: scalar intrinsics lower through direct LIRIC session
```