### PR TITLE
fix: support deferred char self-aliasing concat (refs #197)

### DIFF
--- a/src/liric_session_arrays.inc
+++ b/src/liric_session_arrays.inc
@@ -211,3 +211,27 @@
         call clear_liric_error(error)
         vreg = lr_session_emit(handle, inst, error)
     end function emit_alloca_i32
+
+    function emit_alloca_i64(handle, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_inst_desc_t) :: inst
+
+        inst%op = LR_OP_ALLOCA
+        inst%typ = lr_type_i64_s(handle)
+        inst%dest = 0_c_int32_t
+        inst%operands = c_null_ptr
+        inst%num_operands = 0_c_int32_t
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_false
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 0_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_alloca_i64

--- a/src/liric_session_bindings.f90
+++ b/src/liric_session_bindings.f90
@@ -78,6 +78,7 @@ module liric_session_bindings
         procedure :: emit_i32_binary_into
         procedure :: emit_i32_copy_to
         procedure :: emit_i32_alloca
+        procedure :: emit_i64_alloca
         procedure :: emit_i32_array_alloca
         procedure :: emit_i32_array_element_addr
         procedure :: emit_i32_load
@@ -92,9 +93,17 @@ module liric_session_bindings
         procedure :: finish_and_emit_exe
         procedure :: i32_param
         procedure :: i32_immediate
+        procedure :: i64_immediate
         procedure :: i32_vreg
         procedure :: ptr_param
         procedure :: ptr_vreg
+        procedure :: i64_vreg
+        procedure :: emit_i64_load
+        procedure :: emit_i64_store
+        procedure :: emit_i64_binary
+        procedure :: emit_alloca_bytes
+        procedure :: emit_ptr_store
+        procedure :: emit_memcpy
         procedure :: reserve_i32_vreg
     end type liric_session_t
 
@@ -588,6 +597,17 @@ contains
         operand%global_offset = 0_c_int64_t
     end function ptr_vreg
 
+    function i64_vreg(this, vreg) result(operand)
+        class(liric_session_t), intent(in) :: this
+        integer(c_int32_t), intent(in) :: vreg
+        type(lr_operand_desc_t) :: operand
+
+        operand%kind = LR_OP_KIND_VREG
+        operand%payload = int(vreg, c_int64_t)
+        operand%typ = lr_type_i64_s(this%handle)
+        operand%global_offset = 0_c_int64_t
+    end function i64_vreg
+
     logical function emit_i32_binary(this, opcode, lhs, rhs, result, error_msg)
         class(liric_session_t), intent(inout) :: this
         integer(c_int), intent(in) :: opcode
@@ -669,6 +689,154 @@ contains
         call set_empty(error_msg)
         emit_i32_alloca = .true.
     end function emit_i32_alloca
+
+    logical function emit_i64_alloca(this, address, error_msg)
+        class(liric_session_t), intent(inout) :: this
+        type(lr_operand_desc_t), intent(out) :: address
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: vreg
+
+        emit_i64_alloca = .false.
+        if (.not. require_open_session(this, error_msg)) return
+
+        vreg = emit_alloca_i64(this%handle, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        address = this%ptr_vreg(vreg)
+        call set_empty(error_msg)
+        emit_i64_alloca = .true.
+    end function emit_i64_alloca
+
+    function i64_immediate(this, value) result(operand)
+        class(liric_session_t), intent(in) :: this
+        integer(c_int64_t), intent(in) :: value
+        type(lr_operand_desc_t) :: operand
+
+        operand%kind = LR_OP_KIND_IMM_I64
+        operand%payload = value
+        operand%typ = lr_type_i64_s(this%handle)
+        operand%global_offset = 0_c_int64_t
+    end function i64_immediate
+
+    logical function emit_i64_load(this, address, value, error_msg)
+        class(liric_session_t), intent(inout) :: this
+        type(lr_operand_desc_t), intent(in) :: address
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: vreg
+
+        emit_i64_load = .false.
+        if (.not. require_open_session(this, error_msg)) return
+
+        vreg = emit_load_i64(this%handle, address, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        value = this%i64_vreg(vreg)
+        call set_empty(error_msg)
+        emit_i64_load = .true.
+    end function emit_i64_load
+
+    logical function emit_i64_store(this, value, address, error_msg)
+        class(liric_session_t), intent(inout) :: this
+        type(lr_operand_desc_t), intent(in) :: value
+        type(lr_operand_desc_t), intent(in) :: address
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: unused_vreg
+
+        emit_i64_store = .false.
+        if (.not. require_open_session(this, error_msg)) return
+
+        unused_vreg = emit_store_i64(this%handle, value, address, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        call set_empty(error_msg)
+        emit_i64_store = .true.
+    end function emit_i64_store
+
+    logical function emit_i64_binary(this, opcode, lhs, rhs, result, error_msg)
+        class(liric_session_t), intent(inout) :: this
+        integer(c_int), intent(in) :: opcode
+        type(lr_operand_desc_t), intent(in) :: lhs
+        type(lr_operand_desc_t), intent(in) :: rhs
+        type(lr_operand_desc_t), intent(out) :: result
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: vreg
+
+        emit_i64_binary = .false.
+        if (.not. require_open_session(this, error_msg)) return
+
+        vreg = emit_binary_i64(this%handle, opcode, lhs, rhs, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        result = this%i64_vreg(vreg)
+        call set_empty(error_msg)
+        emit_i64_binary = .true.
+    end function emit_i64_binary
+
+    logical function emit_alloca_bytes(this, size, result, error_msg)
+        class(liric_session_t), intent(inout) :: this
+        type(lr_operand_desc_t), intent(in) :: size
+        type(lr_operand_desc_t), intent(out) :: result
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: vreg
+
+        emit_alloca_bytes = .false.
+        if (.not. require_open_session(this, error_msg)) return
+
+        vreg = emit_alloca_i64_bytes(this%handle, size, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        result = this%ptr_vreg(vreg)
+        call set_empty(error_msg)
+        emit_alloca_bytes = .true.
+    end function emit_alloca_bytes
+
+    logical function emit_ptr_store(this, value, address, error_msg)
+        class(liric_session_t), intent(inout) :: this
+        type(lr_operand_desc_t), intent(in) :: value
+        type(lr_operand_desc_t), intent(in) :: address
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: unused_vreg
+
+        emit_ptr_store = .false.
+        if (.not. require_open_session(this, error_msg)) return
+
+        unused_vreg = emit_store_ptr(this%handle, value, address, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        call set_empty(error_msg)
+        emit_ptr_store = .true.
+    end function emit_ptr_store
+
+    logical function emit_memcpy(this, dest, src, n_bytes, error_msg)
+        class(liric_session_t), intent(inout) :: this
+        type(lr_operand_desc_t), intent(in) :: dest
+        type(lr_operand_desc_t), intent(in) :: src
+        type(lr_operand_desc_t), intent(in) :: n_bytes
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        type(lr_operand_desc_t) :: args(3)
+        integer(c_int32_t) :: unused_vreg
+
+        emit_memcpy = .false.
+        if (.not. require_open_session(this, error_msg)) return
+
+        args(1) = dest
+        args(2) = src
+        args(3) = n_bytes
+
+        unused_vreg = emit_call_void(this%handle, 'memcpy', args, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        call set_empty(error_msg)
+        emit_memcpy = .true.
+    end function emit_memcpy
 
     include 'liric_session_arrays.inc'
 
@@ -889,6 +1057,150 @@ contains
         call clear_liric_error(error)
         vreg = lr_session_emit(handle, inst, error)
     end function emit_call_void
+
+    function emit_load_i64(handle, address, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        type(lr_operand_desc_t), intent(in) :: address
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_operand_desc_t), target :: operands(1)
+        type(lr_inst_desc_t) :: inst
+
+        operands(1) = address
+
+        inst%op = LR_OP_LOAD
+        inst%typ = lr_type_i64_s(handle)
+        inst%dest = 0_c_int32_t
+        inst%operands = c_loc(operands)
+        inst%num_operands = 1_c_int32_t
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_false
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 0_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_load_i64
+
+    function emit_store_i64(handle, value, address, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        type(lr_operand_desc_t), intent(in) :: value
+        type(lr_operand_desc_t), intent(in) :: address
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_operand_desc_t), target :: operands(2)
+        type(lr_inst_desc_t) :: inst
+
+        operands = [value, address]
+
+        inst%op = LR_OP_STORE
+        inst%typ = c_null_ptr
+        inst%dest = 0_c_int32_t
+        inst%operands = c_loc(operands)
+        inst%num_operands = 2_c_int32_t
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_false
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 0_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_store_i64
+
+    function emit_binary_i64(handle, opcode, lhs, rhs, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        integer(c_int), intent(in) :: opcode
+        type(lr_operand_desc_t), intent(in) :: lhs
+        type(lr_operand_desc_t), intent(in) :: rhs
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_operand_desc_t), target :: operands(2)
+        type(lr_inst_desc_t) :: inst
+
+        operands = [lhs, rhs]
+
+        inst%op = opcode
+        inst%typ = lr_type_i64_s(handle)
+        inst%dest = 0_c_int32_t
+        inst%operands = c_loc(operands)
+        inst%num_operands = 2_c_int32_t
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_false
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 0_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_binary_i64
+
+    function emit_alloca_i64_bytes(handle, size, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        type(lr_operand_desc_t), intent(in) :: size
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_operand_desc_t), target :: operands(1)
+        type(lr_inst_desc_t) :: inst
+
+        operands(1) = size
+
+        inst%op = LR_OP_ALLOCA
+        inst%typ = lr_type_ptr_s(handle)
+        inst%dest = 0_c_int32_t
+        inst%operands = c_loc(operands)
+        inst%num_operands = 1_c_int32_t
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_false
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 0_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_alloca_i64_bytes
+
+    function emit_store_ptr(handle, value, address, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        type(lr_operand_desc_t), intent(in) :: value
+        type(lr_operand_desc_t), intent(in) :: address
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_operand_desc_t), target :: operands(2)
+        type(lr_inst_desc_t) :: inst
+
+        operands = [value, address]
+
+        inst%op = LR_OP_STORE
+        inst%typ = c_null_ptr
+        inst%dest = 0_c_int32_t
+        inst%operands = c_loc(operands)
+        inst%num_operands = 2_c_int32_t
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_false
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 0_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_store_ptr
 
     function global_operand(handle, symbol_id) result(operand)
         type(c_ptr), intent(in) :: handle

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -896,6 +896,8 @@ contains
 
     include 'session_program_lowering_character.inc'
 
+    include 'session_program_lowering_deferred_char.inc'
+
     subroutine lower_stop(arena, node, context, value, error_msg)
         type(ast_arena_t), intent(in) :: arena
         type(stop_node), intent(in) :: node

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -114,6 +114,9 @@ use liric_session_io_bindings, only: emit_liric_f64_binary, &
         type(lr_operand_desc_t) :: element_address
         logical :: has_i32_constant = .false.
         integer(c_int64_t) :: i32_constant = 0_c_int64_t
+        logical :: is_deferred_character = .false.
+        type(lr_operand_desc_t) :: deferred_data
+        type(lr_operand_desc_t) :: deferred_length
     end type symbol_t
 
     type :: derived_type_info_t

--- a/src/session_program_lowering_character.inc
+++ b/src/session_program_lowering_character.inc
@@ -26,10 +26,18 @@
         integer, intent(out) :: character_length
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: parse_error
+        character(len=:), allocatable :: lowered
 
-        character_length = 1
+        character_length = -1
         call set_empty(error_msg)
-        if (.not. allocated(node%type_name)) return
+        if (.not. allocated(node%type_name)) then
+            return
+        end if
+        lowered = lowercase_text(node%type_name)
+        if (trim(lowered) == 'character') then
+            ! Deferred character: no len=N specified
+            return
+        end if
         call parse_character_length(node%type_name, character_length, parse_error)
         if (len_trim(parse_error) > 0) then
             call unsupported_feature_error('character length declaration', &
@@ -55,7 +63,7 @@
             return
         end if
         if (character_length <= 0) then
-            error_msg = 'character declaration requires positive length'
+            call define_deferred_character_symbol(context, name, error_msg)
             return
         end if
 
@@ -77,10 +85,23 @@
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: literal_text
         character(len=64) :: string_name
+        type(binary_op_node) :: binop
 
         if (.not. arena%has_node_at(node%value_index)) then
             error_msg = 'character assignment value does not reference an AST node'
             return
+        end if
+
+        ! Check for deferred character with binary // operator
+        if (context%symbols(symbol_index)%is_deferred_character) then
+            select type (value_node => arena%entries(node%value_index)%node)
+            type is (binary_op_node)
+                if (trim(value_node%operator) == '//') then
+                    call lower_deferred_concat_assignment(arena, node, &
+                        context, symbol_index, error_msg)
+                    return
+                end if
+            end select
         end if
 
         select type (value_node => arena%entries(node%value_index)%node)
@@ -203,8 +224,8 @@
         context%symbols(index)%has_character_value = .false.
 
         ! Allocate stack space for descriptor: data_addr + len_addr
-        if (.not. context%session%emit_i32_alloca(data_addr, error_msg)) return
-        if (.not. context%session%emit_i32_alloca(len_addr, error_msg)) return
+        if (.not. context%session%emit_i64_alloca(data_addr, error_msg)) return
+        if (.not. context%session%emit_i64_alloca(len_addr, error_msg)) return
 
         context%symbols(index)%deferred_data = data_addr
         context%symbols(index)%deferred_length = len_addr

--- a/src/session_program_lowering_character.inc
+++ b/src/session_program_lowering_character.inc
@@ -203,10 +203,8 @@
         context%symbols(index)%has_character_value = .false.
 
         ! Allocate stack space for descriptor: data_addr + len_addr
-        call context%session%emit_i32_alloca(data_addr, error_msg)
-        if (len_trim(error_msg) > 0) return
-        call context%session%emit_i32_alloca(len_addr, error_msg)
-        if (len_trim(error_msg) > 0) return
+        if (.not. context%session%emit_i32_alloca(data_addr, error_msg)) return
+        if (.not. context%session%emit_i32_alloca(len_addr, error_msg)) return
 
         context%symbols(index)%deferred_data = data_addr
         context%symbols(index)%deferred_length = len_addr

--- a/src/session_program_lowering_character.inc
+++ b/src/session_program_lowering_character.inc
@@ -178,3 +178,38 @@
 
         call set_empty(error_msg)
     end subroutine parse_character_length
+
+    subroutine define_deferred_character_symbol(context, name, error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: index
+        type(lr_operand_desc_t) :: data_addr
+        type(lr_operand_desc_t) :: len_addr
+
+        if (find_symbol(context, name) > 0) then
+            error_msg = 'duplicate character declaration: '//trim(name)
+            return
+        end if
+        if (context%symbol_count >= MAX_SYMBOLS) then
+            error_msg = 'too many scalar symbols for direct LIRIC session MVP'
+            return
+        end if
+
+        index = context%symbol_count + 1
+        context%symbols(index)%name = trim(name)
+        context%symbols(index)%value_kind = VALUE_CHARACTER
+        context%symbols(index)%is_deferred_character = .true.
+        context%symbols(index)%has_character_value = .false.
+
+        ! Allocate stack space for descriptor: data_addr + len_addr
+        call context%session%emit_i32_alloca(data_addr, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call context%session%emit_i32_alloca(len_addr, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        context%symbols(index)%deferred_data = data_addr
+        context%symbols(index)%deferred_length = len_addr
+        context%symbol_count = index
+        call set_empty(error_msg)
+    end subroutine define_deferred_character_symbol

--- a/src/session_program_lowering_deferred_char.inc
+++ b/src/session_program_lowering_deferred_char.inc
@@ -1,0 +1,232 @@
+integer function resolve_concat_operand(arena, node_index, context, &
+                                           out_name, is_literal, error_msg) &
+      result(symbol_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(in) :: context
+        character(len=:), allocatable, intent(out) :: out_name
+        logical, intent(out) :: is_literal
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: name
+        integer :: idx
+
+        symbol_index = 0
+        is_literal = .false.
+        out_name = ''
+        call set_empty(error_msg)
+
+        if (.not. arena%has_node_at(node_index)) then
+            error_msg = 'concat operand index does not reference an AST node'
+            return
+        end if
+
+        select type (node => arena%entries(node_index)%node)
+        type is (identifier_node)
+            name = node%name
+            idx = find_symbol(context, trim(name))
+            if (idx > 0) then
+                symbol_index = idx
+                out_name = trim(name)
+            else
+                error_msg = 'concat operand not declared: '//trim(name)
+            end if
+        type is (literal_node)
+            is_literal = .true.
+            out_name = node%value
+        class default
+            error_msg = 'expected identifier or literal in concat operand'
+        end select
+    end function resolve_concat_operand
+
+ subroutine lower_deferred_concat_assignment(arena, node, context, &
+                                                  dest_symbol_index, error_msg)
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(ast_arena_t), intent(in) :: arena
+        type(assignment_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: dest_symbol_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(binary_op_node) :: binop
+        integer :: left_idx
+        integer :: right_idx
+        type(lr_operand_desc_t) :: left_data
+        type(lr_operand_desc_t) :: left_len
+        type(lr_operand_desc_t) :: right_data
+        type(lr_operand_desc_t) :: right_len
+        type(lr_operand_desc_t) :: total_len
+        type(lr_operand_desc_t) :: new_ptr
+        type(lr_operand_desc_t) :: zero_i64
+        type(lr_operand_desc_t) :: one_i64
+        type(lr_operand_desc_t) :: running_offset
+        type(lr_operand_desc_t) :: old_data
+        type(lr_operand_desc_t) :: old_len_val
+        character(len=:), allocatable :: left_name
+        character(len=:), allocatable :: right_name
+        character(len=:), allocatable :: left_text
+        character(len=:), allocatable :: right_text
+        integer :: left_sym_idx
+        integer :: right_sym_idx
+        logical :: is_self_alias
+        logical :: left_is_literal
+        logical :: right_is_literal
+        character(len=:), allocatable :: literal_text
+        character(len=64) :: string_name
+        character(len=:), allocatable :: combined_text
+        integer(c_int64_t) :: combined_len
+
+        call set_empty(error_msg)
+        left_is_literal = .false.
+        right_is_literal = .false.
+        is_self_alias = .false.
+
+        ! Get the binary_op_node from the assignment value
+        if (.not. arena%has_node_at(node%value_index)) then
+            error_msg = 'concat assignment value does not reference an AST node'
+            return
+        end if
+        select type (binop => arena%entries(node%value_index)%node)
+        type is (binary_op_node)
+            if (trim(binop%operator) /= '//') then
+                error_msg = 'non-concat operator on deferred character: '// &
+                            trim(binop%operator)
+                return
+            end if
+            left_idx = binop%left_index
+            right_idx = binop%right_index
+        class default
+            error_msg = 'expected binary // operator for deferred character '// &
+                        'concatenation'
+            return
+        end select
+
+        ! Resolve left operand: get symbol index or mark as literal
+        left_sym_idx = resolve_concat_operand(arena, left_idx, context, &
+            left_name, left_is_literal, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        ! Resolve right operand
+        right_sym_idx = resolve_concat_operand(arena, right_idx, context, &
+            right_name, right_is_literal, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        ! Detect self-aliasing: dest is one of the operands
+        if (left_sym_idx == dest_symbol_index .or. &
+            right_sym_idx == dest_symbol_index) then
+            is_self_alias = .true.
+        end if
+
+        ! For self-aliasing, we need to capture the old content
+        ! We do this by loading the old data pointer and length
+        if (is_self_alias) then
+            if (.not. context%session%emit_i64_load( &
+                context%symbols(dest_symbol_index)%deferred_data, &
+                old_data, error_msg)) return
+            if (.not. context%session%emit_i64_load( &
+                context%symbols(dest_symbol_index)%deferred_length, &
+                old_len_val, error_msg)) return
+        end if
+
+        ! Get left operand text/content
+        if (left_is_literal) then
+            call strip_literal_quotes(left_name, left_text)
+        else
+            ! For identifier operands, we need to get the text from the
+            ! symbol's descriptor at runtime
+            if (.not. context%session%emit_i64_load( &
+                context%symbols(left_sym_idx)%deferred_data, &
+                left_data, error_msg)) return
+            if (.not. context%session%emit_i64_load( &
+                context%symbols(left_sym_idx)%deferred_length, &
+                left_len, error_msg)) return
+        end if
+
+        ! Get right operand text/content
+        if (right_is_literal) then
+            call strip_literal_quotes(right_name, right_text)
+        else
+            if (.not. context%session%emit_i64_load( &
+                context%symbols(right_sym_idx)%deferred_data, &
+                right_data, error_msg)) return
+            if (.not. context%session%emit_i64_load( &
+                context%symbols(right_sym_idx)%deferred_length, &
+                right_len, error_msg)) return
+        end if
+
+        ! Compute total length
+        if (left_is_literal .and. right_is_literal) then
+            combined_text = trim(left_text) // trim(right_text)
+            combined_len = int(len(combined_text), c_int64_t)
+        else
+            ! Runtime concatenation: compute lengths and add
+            if (left_is_literal) then
+                left_len = context%session%i64_immediate( &
+                    int(len(left_text), c_int64_t))
+            end if
+            if (right_is_literal) then
+                right_len = context%session%i64_immediate( &
+                    int(len(right_text), c_int64_t))
+            end if
+            if (.not. context%session%emit_i64_binary( &
+                LR_OP_ADD, left_len, right_len, total_len, error_msg)) return
+        end if
+
+        ! For literal-only concat, create a new global string
+        if (left_is_literal .and. right_is_literal) then
+            context%string_literal_count = context%string_literal_count + 1
+            write (string_name, '(A,I0)') '.ffc.cat.', &
+                context%string_literal_count
+            call materialize_liric_string(context%session, trim(string_name), &
+                                          combined_text, new_ptr, error_msg)
+            if (len_trim(error_msg) > 0) return
+
+            ! Store pointer and length in descriptor
+            if (.not. context%session%emit_ptr_store( &
+                new_ptr, &
+                context%symbols(dest_symbol_index)%deferred_data, error_msg)) return
+            if (.not. context%session%emit_i64_store( &
+                context%session%i64_immediate(combined_len), &
+                context%symbols(dest_symbol_index)%deferred_length, error_msg)) return
+
+            context%symbols(dest_symbol_index)%has_character_value = .true.
+            call set_empty(error_msg)
+            return
+        end if
+
+        ! Runtime concatenation: use alloca + memcpy
+        one_i64 = context%session%i64_immediate(1_c_int64_t)
+        if (.not. context%session%emit_i64_binary( &
+            LR_OP_ADD, total_len, one_i64, total_len, error_msg)) return
+
+        ! alloca(total_len) - returns pointer
+        if (.not. context%session%emit_alloca_bytes(total_len, new_ptr, &
+            error_msg)) return
+
+        ! Zero offset for first memcpy
+        zero_i64 = context%session%i64_immediate(0_c_int64_t)
+
+        ! memcpy(dest + 0, left_data, left_len)
+        if (.not. context%session%emit_memcpy( &
+            new_ptr, left_data, left_len, new_ptr, error_msg)) return
+
+        ! running_offset = left_len
+        running_offset = left_len
+
+        ! memcpy(dest + left_len, right_data, right_len)
+        if (.not. context%session%emit_i64_binary( &
+            LR_OP_ADD, new_ptr, running_offset, new_ptr, error_msg)) return
+        if (.not. context%session%emit_memcpy( &
+            new_ptr, right_data, right_len, new_ptr, error_msg)) return
+
+        ! Store new_ptr into s.data
+        if (.not. context%session%emit_i64_store( &
+            new_ptr, context%symbols(dest_symbol_index)%deferred_data, &
+            error_msg)) return
+
+        ! Store total_len into s.length
+        if (.not. context%session%emit_i64_store( &
+            total_len, context%symbols(dest_symbol_index)%deferred_length, &
+            error_msg)) return
+
+        context%symbols(dest_symbol_index)%has_character_value = .true.
+        call set_empty(error_msg)
+    end subroutine lower_deferred_concat_assignment

--- a/src/session_program_lowering_deferred_char.inc
+++ b/src/session_program_lowering_deferred_char.inc
@@ -130,26 +130,36 @@ integer function resolve_concat_operand(arena, node_index, context, &
         if (left_is_literal) then
             call strip_literal_quotes(left_name, left_text)
         else
-            ! For identifier operands, we need to get the text from the
-            ! symbol's descriptor at runtime
-            if (.not. context%session%emit_i64_load( &
-                context%symbols(left_sym_idx)%deferred_data, &
-                left_data, error_msg)) return
-            if (.not. context%session%emit_i64_load( &
-                context%symbols(left_sym_idx)%deferred_length, &
-                left_len, error_msg)) return
+            ! For self-aliasing, use captured old values
+            ! For non-self-aliasing, load from symbol
+            if (is_self_alias .and. left_sym_idx == dest_symbol_index) then
+                left_data = old_data
+                left_len = old_len_val
+            else
+                if (.not. context%session%emit_i64_load( &
+                    context%symbols(left_sym_idx)%deferred_data, &
+                    left_data, error_msg)) return
+                if (.not. context%session%emit_i64_load( &
+                    context%symbols(left_sym_idx)%deferred_length, &
+                    left_len, error_msg)) return
+            end if
         end if
 
         ! Get right operand text/content
         if (right_is_literal) then
             call strip_literal_quotes(right_name, right_text)
         else
-            if (.not. context%session%emit_i64_load( &
-                context%symbols(right_sym_idx)%deferred_data, &
-                right_data, error_msg)) return
-            if (.not. context%session%emit_i64_load( &
-                context%symbols(right_sym_idx)%deferred_length, &
-                right_len, error_msg)) return
+            if (is_self_alias .and. right_sym_idx == dest_symbol_index) then
+                right_data = old_data
+                right_len = old_len_val
+            else
+                if (.not. context%session%emit_i64_load( &
+                    context%symbols(right_sym_idx)%deferred_data, &
+                    right_data, error_msg)) return
+                if (.not. context%session%emit_i64_load( &
+                    context%symbols(right_sym_idx)%deferred_length, &
+                    right_len, error_msg)) return
+            end if
         end if
 
         ! Compute total length
@@ -193,29 +203,20 @@ integer function resolve_concat_operand(arena, node_index, context, &
         end if
 
         ! Runtime concatenation: use alloca + memcpy
-        one_i64 = context%session%i64_immediate(1_c_int64_t)
-        if (.not. context%session%emit_i64_binary( &
-            LR_OP_ADD, total_len, one_i64, total_len, error_msg)) return
-
-        ! alloca(total_len) - returns pointer
         if (.not. context%session%emit_alloca_bytes(total_len, new_ptr, &
             error_msg)) return
 
-        ! Zero offset for first memcpy
-        zero_i64 = context%session%i64_immediate(0_c_int64_t)
-
-        ! memcpy(dest + 0, left_data, left_len)
+        ! memcpy(dest, left_data, left_len)
         if (.not. context%session%emit_memcpy( &
-            new_ptr, left_data, left_len, new_ptr, error_msg)) return
+            new_ptr, left_data, left_len, error_msg)) return
 
-        ! running_offset = left_len
-        running_offset = left_len
-
-        ! memcpy(dest + left_len, right_data, right_len)
+        ! offset = new_ptr + left_len
         if (.not. context%session%emit_i64_binary( &
-            LR_OP_ADD, new_ptr, running_offset, new_ptr, error_msg)) return
+            LR_OP_ADD, new_ptr, left_len, running_offset, error_msg)) return
+
+        ! memcpy(offset, right_data, right_len)
         if (.not. context%session%emit_memcpy( &
-            new_ptr, right_data, right_len, new_ptr, error_msg)) return
+            running_offset, right_data, right_len, error_msg)) return
 
         ! Store new_ptr into s.data
         if (.not. context%session%emit_i64_store( &

--- a/test/test_self_concat_appends_literal.f90
+++ b/test/test_self_concat_appends_literal.f90
@@ -1,0 +1,114 @@
+program test_self_concat_appends_literal
+    use fortfront, only: compiler_frontend_options_t, &
+                         compiler_frontend_result_t, &
+                         compile_frontend_from_string, INPUT_MODE_STANDARD
+    use session_program_lowering, only: lower_program_to_liric_exe
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== self-aliasing concat test ==='
+
+    all_passed = .true.
+    if (.not. test_self_concat_appends_literal_case()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: self-aliasing deferred char concat'
+
+contains
+
+    logical function test_self_concat_appends_literal_case()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character :: s'//new_line('a')// &
+            '  s = "hi"'//new_line('a')// &
+            '  s = s // "!"'//new_line('a')// &
+            '  print *, s'//new_line('a')// &
+            'end program main'
+
+        test_self_concat_appends_literal_case = expect_output( &
+            source, 'hi!'//new_line('a'), &
+            '/tmp/ffc_self_concat_literal_test')
+    end function test_self_concat_appends_literal_case
+
+    logical function expect_output(source, expected, stem)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        character(len=*), intent(in) :: stem
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: exe_path
+        character(len=:), allocatable :: output_text
+        character(len=:), allocatable :: out_path
+        integer :: exit_stat
+        integer :: file_size
+        integer :: io_stat
+        integer :: unit
+
+        expect_output = .false.
+        exe_path = stem
+        out_path = stem//'.out'
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+        call compile_and_lower(source, exe_path, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: direct LIRIC lowering failed: ', trim(error_msg)
+            return
+        end if
+
+        call execute_command_line(exe_path//' > '//out_path, exitstat=exit_stat)
+        if (exit_stat /= 0) then
+            print *, 'FAIL: executable exit status ', exit_stat
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+
+        inquire (file=out_path, size=file_size)
+        if (file_size /= len(expected)) then
+            print *, 'FAIL: expected output size ', len(expected), &
+                ', got ', file_size
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+
+        allocate (character(len=file_size) :: output_text)
+        open (newunit=unit, file=out_path, status='old', access='stream', &
+              form='unformatted', action='read', iostat=io_stat)
+        if (io_stat /= 0) then
+            print *, 'FAIL: could not open captured output as stream'
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+        read (unit, iostat=io_stat) output_text
+        close (unit)
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+
+        if (io_stat /= 0 .or. output_text /= expected) then
+            print *, 'FAIL: unexpected character output bytes'
+            return
+        end if
+
+        expect_output = .true.
+    end function expect_output
+
+    subroutine compile_and_lower(source, exe_path, error_msg)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: exe_path
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: frontend_result
+
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+
+        call compile_frontend_from_string(source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            error_msg = 'FortFront rejected source: '// &
+                        trim(frontend_result%diagnostic_text)
+            return
+        end if
+
+        call lower_program_to_liric_exe(frontend_result%arena, &
+                                        frontend_result%root_index, exe_path, &
+                                        error_msg)
+    end subroutine compile_and_lower
+end program test_self_concat_appends_literal

--- a/test/test_self_concat_three_times.f90
+++ b/test/test_self_concat_three_times.f90
@@ -1,0 +1,116 @@
+program test_self_concat_three_times
+    use fortfront, only: compiler_frontend_options_t, &
+                         compiler_frontend_result_t, &
+                         compile_frontend_from_string, INPUT_MODE_STANDARD
+    use session_program_lowering, only: lower_program_to_liric_exe
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== self-aliasing triple concat test ==='
+
+    all_passed = .true.
+    if (.not. test_self_concat_three_times_case()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: triple self-aliasing deferred char concat'
+
+contains
+
+    logical function test_self_concat_three_times_case()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character :: s'//new_line('a')// &
+            '  s = "x"'//new_line('a')// &
+            '  s = s // "."'//new_line('a')// &
+            '  s = s // "."'//new_line('a')// &
+            '  s = s // "."'//new_line('a')// &
+            '  print *, s'//new_line('a')// &
+            'end program main'
+
+        test_self_concat_three_times_case = expect_output( &
+            source, 'x...'//new_line('a'), &
+            '/tmp/ffc_self_concat_triple_test')
+    end function test_self_concat_three_times_case
+
+    logical function expect_output(source, expected, stem)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        character(len=*), intent(in) :: stem
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: exe_path
+        character(len=:), allocatable :: output_text
+        character(len=:), allocatable :: out_path
+        integer :: exit_stat
+        integer :: file_size
+        integer :: io_stat
+        integer :: unit
+
+        expect_output = .false.
+        exe_path = stem
+        out_path = stem//'.out'
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+        call compile_and_lower(source, exe_path, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: direct LIRIC lowering failed: ', trim(error_msg)
+            return
+        end if
+
+        call execute_command_line(exe_path//' > '//out_path, exitstat=exit_stat)
+        if (exit_stat /= 0) then
+            print *, 'FAIL: executable exit status ', exit_stat
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+
+        inquire (file=out_path, size=file_size)
+        if (file_size /= len(expected)) then
+            print *, 'FAIL: expected output size ', len(expected), &
+                ', got ', file_size
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+
+        allocate (character(len=file_size) :: output_text)
+        open (newunit=unit, file=out_path, status='old', access='stream', &
+              form='unformatted', action='read', iostat=io_stat)
+        if (io_stat /= 0) then
+            print *, 'FAIL: could not open captured output as stream'
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+        read (unit, iostat=io_stat) output_text
+        close (unit)
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+
+        if (io_stat /= 0 .or. output_text /= expected) then
+            print *, 'FAIL: unexpected character output bytes'
+            return
+        end if
+
+        expect_output = .true.
+    end function expect_output
+
+    subroutine compile_and_lower(source, exe_path, error_msg)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: exe_path
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: frontend_result
+
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+
+        call compile_frontend_from_string(source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            error_msg = 'FortFront rejected source: '// &
+                        trim(frontend_result%diagnostic_text)
+            return
+        end if
+
+        call lower_program_to_liric_exe(frontend_result%arena, &
+                                        frontend_result%root_index, exe_path, &
+                                        error_msg)
+    end subroutine compile_and_lower
+end program test_self_concat_three_times


### PR DESCRIPTION
fix: support deferred char self-aliasing concat (refs #197)

## Requirements

- **REQ-001**: Create `src/session_program_lowering_deferred_char.inc` — satisfied
- **REQ-002**: Detect deferred-length character variables — satisfied
- **REQ-003**: Detect self-aliasing and capture old values — satisfied
- **REQ-004**: malloc/alloca, memcpy, free, store — partial (needs debugging)
- **REQ-005**: Test `test_self_concat_appends_literal` — created
- **REQ-006**: Test `test_self_concat_three_times` — created
- **REQ-007**: No realloc — satisfied

## File Set Enumeration

| File | Action |
|------|--------|
| `src/session_program_lowering.f90` | EDITED: added deferred char fields to symbol_t, included deferred_char.inc |
| `src/session_program_lowering_character.inc` | EDITED: added define_deferred_character_symbol, modified define_character_symbol |
| `src/session_program_lowering_deferred_char.inc` | CREATED: concat lowering with self-aliasing support |
| `src/liric_session_bindings.f90` | EDITED: added i64 alloca/load/store/binary/memcpy bindings |
| `src/liric_session_arrays.inc` | EDITED: added emit_alloca_i64 function |
| `test/test_self_concat_appends_literal.f90` | CREATED |
| `test/test_self_concat_three_times.f90` | CREATED |

## Verification

```bash
$ LIBRARY_PATH=/home/ert/code/liric/build fpm build
[100%] Project compiled successfully.
```

## Follow-up

Runtime tests need debugging. The segfault appears to be related to LIRIC structure layout mismatch between Fortran `lr_operand_desc_t` and C `lr_operand_t` (field order differs: Fortran has kind/payload/typ/global_offset, C has kind/type/global_offset/union).

(ref #197)