### PR TITLE
Fix deferred character result ABI

### DIFF
--- a/src/liric_session_memory_bindings.f90
+++ b/src/liric_session_memory_bindings.f90
@@ -45,9 +45,11 @@ module liric_session_memory_bindings
               reserve_i32_vreg, ptr_vreg, i64_vreg
     public :: emit_i32_binary, emit_i32_binary_into, emit_i32_copy_to
     public :: emit_i32_alloca, emit_i64_alloca
-    public :: emit_i32_load, emit_i64_load, emit_i32_store, emit_i64_store
+    public :: emit_i32_load, emit_i64_load, emit_ptr_load
+    public :: emit_i32_store, emit_i64_store
     public :: emit_i64_load_at, emit_i64_store_at
-    public :: emit_alloca_bytes, emit_ptr_store, emit_memcpy
+    public :: emit_ptr_offset
+    public :: emit_alloca_bytes, emit_malloc, emit_ptr_store, emit_memcpy
     public :: emit_i32_array_alloca, emit_i32_array_element_addr
     public :: emit_i64_binary
 
@@ -316,6 +318,25 @@ contains
         emit_i64_load = .true.
     end function emit_i64_load
 
+    logical function emit_ptr_load(session, address, value, error_msg)
+        type(liric_session_t), intent(inout) :: session
+        type(lr_operand_desc_t), intent(in) :: address
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        integer(c_int32_t) :: vreg
+
+        emit_ptr_load = .false.
+        if (.not. require_open_session(session, error_msg)) return
+
+        vreg = emit_load_ptr(session%handle, address, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        value = ptr_vreg(session, vreg)
+        call set_empty(error_msg)
+        emit_ptr_load = .true.
+    end function emit_ptr_load
+
     logical function emit_i32_store(session, value, address, error_msg)
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: value
@@ -421,6 +442,52 @@ contains
         call set_empty(error_msg)
         emit_i64_load_at = .true.
     end function emit_i64_load_at
+
+    logical function emit_ptr_offset(session, base, offset, result, error_msg)
+        type(liric_session_t), intent(inout) :: session
+        type(lr_operand_desc_t), intent(in) :: base
+        integer(c_int64_t), intent(in) :: offset
+        type(lr_operand_desc_t), intent(out) :: result
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        type(lr_operand_desc_t), target :: operands(2)
+        type(lr_operand_desc_t) :: offset_op
+        type(lr_inst_desc_t) :: inst
+        integer(c_int32_t) :: vreg
+
+        emit_ptr_offset = .false.
+        if (.not. require_open_session(session, error_msg)) return
+
+        offset_op%kind = LR_OP_KIND_IMM_I64
+        offset_op%payload = offset
+        offset_op%typ = lr_type_i64_s(session%handle)
+        offset_op%global_offset = 0_c_int64_t
+
+        operands(1) = base
+        operands(2) = offset_op
+
+        inst%op = LR_OP_GEP
+        inst%typ = lr_type_ptr_s(session%handle)
+        inst%dest = 0_c_int32_t
+        inst%operands = c_loc(operands)
+        inst%num_operands = 2_c_int32_t
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_false
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 0_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(session%handle, inst, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        result = ptr_vreg(session, vreg)
+        call set_empty(error_msg)
+        emit_ptr_offset = .true.
+    end function emit_ptr_offset
 
     logical function emit_i64_store_at(session, value, base, offset, &
                                        error_msg)
@@ -535,6 +602,27 @@ contains
         call set_empty(error_msg)
         emit_alloca_bytes = .true.
     end function emit_alloca_bytes
+
+    logical function emit_malloc(session, size, result, error_msg)
+        type(liric_session_t), intent(inout) :: session
+        type(lr_operand_desc_t), intent(in) :: size
+        type(lr_operand_desc_t), intent(out) :: result
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_error_t) :: error
+        type(lr_operand_desc_t) :: args(1)
+        integer(c_int32_t) :: vreg
+
+        emit_malloc = .false.
+        if (.not. require_open_session(session, error_msg)) return
+
+        args(1) = size
+        vreg = emit_malloc_call(session%handle, args, error)
+        if (.not. status_ok(error%code, error, error_msg)) return
+
+        result = ptr_vreg(session, vreg)
+        call set_empty(error_msg)
+        emit_malloc = .true.
+    end function emit_malloc
 
     logical function emit_ptr_store(session, value, address, error_msg)
         type(liric_session_t), intent(inout) :: session
@@ -878,6 +966,34 @@ contains
         vreg = lr_session_emit(handle, inst, error)
     end function emit_load_i64
 
+    function emit_load_ptr(handle, address, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        type(lr_operand_desc_t), intent(in) :: address
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_operand_desc_t), target :: operands(1)
+        type(lr_inst_desc_t) :: inst
+
+        operands(1) = address
+
+        inst%op = LR_OP_LOAD
+        inst%typ = lr_type_ptr_s(handle)
+        inst%dest = 0_c_int32_t
+        inst%operands = c_loc(operands)
+        inst%num_operands = 1_c_int32_t
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_false
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 0_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_load_ptr
+
     function emit_store_i64(handle, value, address, error) result(vreg)
         type(c_ptr), intent(in) :: handle
         type(lr_operand_desc_t), intent(in) :: value
@@ -1048,6 +1164,45 @@ contains
         vreg = lr_session_emit(handle, inst, error)
     end function emit_memcpy_call
 
+    function emit_malloc_call(handle, args, error) result(vreg)
+        type(c_ptr), intent(in) :: handle
+        type(lr_operand_desc_t), intent(in) :: args(:)
+        type(lr_error_t), intent(inout) :: error
+        integer(c_int32_t) :: vreg
+        type(lr_operand_desc_t), target :: operands(2)
+        type(lr_inst_desc_t) :: inst
+        character(kind=c_char), allocatable :: c_name(:)
+        integer(c_int32_t) :: symbol_id
+
+        call to_c_chars('malloc', c_name)
+        symbol_id = lr_session_intern(handle, c_name)
+        if (symbol_id < 0_c_int32_t .or. size(args) /= 1) then
+            call clear_liric_error(error)
+            error%code = 1_c_int
+            return
+        end if
+
+        operands(1) = ptr_global_operand(handle, symbol_id)
+        operands(2) = args(1)
+
+        inst%op = LR_OP_CALL
+        inst%typ = lr_type_ptr_s(handle)
+        inst%dest = 0_c_int32_t
+        inst%operands = c_loc(operands)
+        inst%num_operands = 2_c_int32_t
+        inst%indices = c_null_ptr
+        inst%num_indices = 0_c_int32_t
+        inst%align = 0_c_int32_t
+        inst%icmp_pred = 0_c_int
+        inst%fcmp_pred = 0_c_int
+        inst%call_external_abi = c_true
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 1_c_int32_t
+
+        call clear_liric_error(error)
+        vreg = lr_session_emit(handle, inst, error)
+    end function emit_malloc_call
+
     function global_operand_from_id(handle, symbol_id) result(operand)
         type(c_ptr), intent(in) :: handle
         integer(c_int32_t), intent(in) :: symbol_id
@@ -1058,6 +1213,17 @@ contains
         operand%typ = lr_type_i32_s(handle)
         operand%global_offset = 0_c_int64_t
     end function global_operand_from_id
+
+    function ptr_global_operand(handle, symbol_id) result(operand)
+        type(c_ptr), intent(in) :: handle
+        integer(c_int32_t), intent(in) :: symbol_id
+        type(lr_operand_desc_t) :: operand
+
+        operand%kind = LR_OP_KIND_GLOBAL
+        operand%payload = int(symbol_id, c_int64_t)
+        operand%typ = lr_type_ptr_s(handle)
+        operand%global_offset = 0_c_int64_t
+    end function ptr_global_operand
 
     logical function require_open_session(session, error_msg)
         type(liric_session_t), intent(in) :: session

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -33,13 +33,16 @@ use liric_session_bindings, only: destroy, begin_i32_main, &
                                               emit_i32_binary, emit_i32_binary_into, &
                                               emit_i32_copy_to, emit_i32_alloca, &
                                               emit_i32_load, emit_i32_store, &
-                                              emit_i64_load, emit_i64_store, &
+                                              emit_i64_load, emit_ptr_load, &
+                                              emit_i64_store, &
                                               emit_i64_binary, emit_i64_alloca, &
-                                              emit_alloca_bytes, emit_ptr_store, &
+                                              emit_alloca_bytes, emit_malloc, &
+                                              emit_ptr_store, &
                                                emit_memcpy, emit_i64_load_at, &
                                                emit_i64_store_at, &
                                                emit_i32_array_alloca, &
-                                              emit_i32_array_element_addr, ptr_param
+                                              emit_i32_array_element_addr, &
+                                              emit_ptr_offset, ptr_param
     use liric_session_control_bindings, only: create_liric_block, &
                                               emit_liric_br, &
                                               emit_liric_condbr, &
@@ -519,19 +522,7 @@ contains
         character(len=*), intent(in) :: name
         integer, intent(in) :: value_kind
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: existing_index
-        existing_index = find_symbol(context, name)
-        if (existing_index > 0) then
-            if (context%symbols(existing_index)%is_parameter .and. &
-                value_kind == VALUE_CHARACTER) then
-                call unsupported_feature_error( &
-                    'character parameter declaration', node%line, node%column, &
-                    'scalar character parameters are not supported '// &
-                    'by direct LIRIC session', error_msg)
-                return
-            end if
-        end if
- if (value_kind == VALUE_CHARACTER) then
+        if (value_kind == VALUE_CHARACTER) then
             call define_declared_character_symbol(context, node, name, error_msg)
         else
             call define_symbol(context, name, value_kind, error_msg)
@@ -541,7 +532,7 @@ contains
         type(parameter_declaration_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: symbol_index, value_kind
+        integer :: symbol_index, value_kind, character_length
         if (.not. allocated(node%name)) then
             error_msg = 'parameter declaration did not expose a name'
             return
@@ -557,14 +548,6 @@ contains
             call type_name_value_kind(node%type_name, node%line, node%column, &
                                       value_kind, error_msg)
             if (len_trim(error_msg) > 0) return
-            if (value_kind == VALUE_CHARACTER) then
-                call unsupported_feature_error( &
-                    'character parameter declaration', &
-                    node%line, node%column, &
-                    'scalar character parameters are not supported '// &
-                    'by direct LIRIC session', error_msg)
-                return
-            end if
         else
             value_kind = VALUE_I32
         end if
@@ -579,7 +562,21 @@ contains
                         trim(node%name)
             return
         end if
-        call update_parameter_symbol(context, symbol_index, value_kind, error_msg)
+        if (value_kind == VALUE_CHARACTER) then
+            call parse_character_length(node%type_name, character_length, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (character_length > 0) then
+                call unsupported_feature_error( &
+                    'character parameter declaration', node%line, node%column, &
+                    'only assumed-length character parameters are supported '// &
+                    'by direct LIRIC session', error_msg)
+                return
+            end if
+            call bind_character_parameter_symbol(context, symbol_index, error_msg)
+        else
+            call update_parameter_symbol(context, symbol_index, value_kind, &
+                                         error_msg)
+        end if
         if (len_trim(error_msg) > 0) return
         call set_empty(error_msg)
     end subroutine lower_parameter_declaration

--- a/src/session_program_lowering_character.inc
+++ b/src/session_program_lowering_character.inc
@@ -8,11 +8,36 @@
 
         existing_index = find_symbol(context, name)
         if (existing_index > 0) then
+            if (context%in_internal_function .and. &
+                existing_index == context%current_function_result_index) then
+                call declaration_character_length(node, character_length, &
+                                                  error_msg)
+                if (len_trim(error_msg) > 0) return
+                if (character_length > 0 .and. &
+                    context%symbols(existing_index)%is_deferred_character) then
+                    call unsupported_feature_error( &
+                        'character function result declaration', node%line, &
+                        node%column, 'deferred character result lowering '// &
+                        'requires character(len=:)', error_msg)
+                    return
+                end if
+                call set_empty(error_msg)
+                return
+            end if
             if (context%symbols(existing_index)%is_parameter) then
-                call unsupported_feature_error( &
-                    'character parameter declaration', node%line, node%column, &
-                    'scalar character parameters are not supported '// &
-                    'by direct LIRIC session', error_msg)
+                call declaration_character_length(node, character_length, &
+                                                  error_msg)
+                if (len_trim(error_msg) > 0) return
+                if (character_length > 0) then
+                    call unsupported_feature_error( &
+                        'character parameter declaration', node%line, &
+                        node%column, 'only assumed-length character '// &
+                        'parameters are supported by direct LIRIC session', &
+                        error_msg)
+                    return
+                end if
+                call bind_character_parameter_symbol(context, existing_index, &
+                                                     error_msg)
                 return
             end if
         end if
@@ -293,3 +318,20 @@
         context%symbol_count = index
         call set_empty(error_msg)
     end subroutine define_deferred_character_symbol
+
+    subroutine bind_character_parameter_symbol(context, symbol_index, error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        context%symbols(symbol_index)%value_kind = VALUE_CHARACTER
+        context%symbols(symbol_index)%is_deferred_character = .true.
+        context%symbols(symbol_index)%has_character_value = .true.
+        if (.not. emit_ptr_offset(context%session, &
+            context%symbols(symbol_index)%address, 0_c_int64_t, &
+            context%symbols(symbol_index)%deferred_data, error_msg)) return
+        if (.not. emit_ptr_offset(context%session, &
+            context%symbols(symbol_index)%address, 8_c_int64_t, &
+            context%symbols(symbol_index)%deferred_length, error_msg)) return
+        call set_empty(error_msg)
+    end subroutine bind_character_parameter_symbol

--- a/src/session_program_lowering_deferred_char.inc
+++ b/src/session_program_lowering_deferred_char.inc
@@ -122,7 +122,7 @@ integer function resolve_concat_operand(arena, node_index, context, &
         ! For self-aliasing, we need to capture the old content
         ! We do this by loading the old data pointer and length
         if (is_self_alias) then
-            if (.not. emit_i64_load(context%session,  &
+            if (.not. emit_ptr_load(context%session,  &
                 context%symbols(dest_symbol_index)%deferred_data, &
                 old_data, error_msg)) return
             if (.not. emit_i64_load(context%session,  &
@@ -143,10 +143,10 @@ integer function resolve_concat_operand(arena, node_index, context, &
                 left_data = old_data
                 left_len = old_len_val
             else
-                if (.not. emit_i64_load(context%session,  &
+                if (.not. emit_ptr_load(context%session,  &
                     context%symbols(left_sym_idx)%deferred_data, &
                     left_data, error_msg)) return
-                if (.not. emit_i64_load(context%session,  &
+                if (.not. emit_ptr_load(context%session,  &
                     context%symbols(left_sym_idx)%deferred_length, &
                     left_len, error_msg)) return
             end if
@@ -220,8 +220,14 @@ integer function resolve_concat_operand(arena, node_index, context, &
             i64_immediate(context%session, 1_c_int64_t), &
             alloca_size, error_msg)) return
 
-        if (.not. emit_alloca_bytes(context%session, alloca_size, new_ptr, &
-            error_msg)) return
+        if (context%in_internal_function .and. &
+            dest_symbol_index == context%current_function_result_index) then
+            if (.not. emit_malloc(context%session, alloca_size, new_ptr, &
+                error_msg)) return
+        else
+            if (.not. emit_alloca_bytes(context%session, alloca_size, new_ptr, &
+                error_msg)) return
+        end if
 
         if (.not. emit_memcpy(context%session,  &
             new_ptr, left_data, left_len, error_msg)) return
@@ -247,7 +253,7 @@ integer function resolve_concat_operand(arena, node_index, context, &
             null_dest, null_byte_ptr, &
             i64_immediate(context%session, 1_c_int64_t), error_msg)) return
 
-        if (.not. emit_i64_store(context%session,  &
+        if (.not. emit_ptr_store(context%session,  &
             new_ptr, context%symbols(dest_symbol_index)%deferred_data, &
             error_msg)) return
 
@@ -305,6 +311,128 @@ integer function resolve_concat_operand(arena, node_index, context, &
         call set_empty(error_msg)
     end subroutine lower_deferred_literal_assignment
 
+    subroutine allocate_deferred_char_descriptor(context, descriptor_ptr, &
+                                                  data_addr, len_addr, &
+                                                  error_msg)
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: descriptor_ptr
+        type(lr_operand_desc_t), intent(out) :: data_addr
+        type(lr_operand_desc_t), intent(out) :: len_addr
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (.not. emit_alloca_bytes(context%session, &
+            i64_immediate(context%session, 16_c_int64_t), descriptor_ptr, &
+            error_msg)) return
+        if (.not. emit_ptr_offset(context%session, descriptor_ptr, 0_c_int64_t, &
+            data_addr, error_msg)) return
+        if (.not. emit_ptr_offset(context%session, descriptor_ptr, 8_c_int64_t, &
+            len_addr, error_msg)) return
+        call set_empty(error_msg)
+    end subroutine allocate_deferred_char_descriptor
+
+    subroutine prepare_deferred_char_actual(arena, node_index, context, arg, &
+                                            error_msg)
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: arg
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: data_addr
+        type(lr_operand_desc_t) :: len_addr
+        type(lr_operand_desc_t) :: data_value
+        type(lr_operand_desc_t) :: len_value
+        character(len=:), allocatable :: literal_text
+        integer :: symbol_index
+
+        call allocate_deferred_char_descriptor(context, arg, data_addr, &
+                                               len_addr, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        select type (node => arena%entries(node_index)%node)
+        type is (literal_node)
+            call strip_literal_quotes(node%value, literal_text)
+            call materialize_concat_literal(context, literal_text, data_value, &
+                                            len_value, error_msg)
+            if (len_trim(error_msg) > 0) return
+        type is (identifier_node)
+            symbol_index = find_symbol(context, node%name)
+            if (symbol_index <= 0 .or. &
+                context%symbols(symbol_index)%value_kind /= VALUE_CHARACTER) then
+                error_msg = 'character argument is not declared: '//trim(node%name)
+                return
+            end if
+            if (context%symbols(symbol_index)%is_deferred_character) then
+                if (.not. emit_ptr_load(context%session, &
+                    context%symbols(symbol_index)%deferred_data, data_value, &
+                    error_msg)) return
+                if (.not. emit_i64_load(context%session, &
+                    context%symbols(symbol_index)%deferred_length, len_value, &
+                    error_msg)) return
+            else
+                data_value = context%symbols(symbol_index)%value
+                len_value = i64_immediate(context%session, &
+                    int(context%symbols(symbol_index)%character_length, c_int64_t))
+            end if
+        class default
+            error_msg = 'direct LIRIC session cannot pass this character argument'
+            return
+        end select
+
+        if (.not. emit_ptr_store(context%session, data_value, data_addr, &
+            error_msg)) return
+        if (.not. emit_i64_store(context%session, len_value, len_addr, &
+            error_msg)) return
+        call set_empty(error_msg)
+    end subroutine prepare_deferred_char_actual
+
+    subroutine prepare_deferred_char_call_args(arena, arg_indices, context, &
+                                               args, copyback_indices, &
+                                               error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: arg_indices(:)
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), allocatable, intent(out) :: args(:)
+        integer, allocatable, intent(out) :: copyback_indices(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        logical :: handled
+        integer :: i
+        integer :: symbol_index
+
+        allocate (args(size(arg_indices)))
+        allocate (copyback_indices(size(arg_indices)))
+        copyback_indices = 0
+
+        do i = 1, size(arg_indices)
+            handled = .false.
+            select type (node => arena%entries(arg_indices(i))%node)
+            type is (literal_node)
+                if (is_character_literal(node)) then
+                    call prepare_deferred_char_actual(arena, arg_indices(i), &
+                        context, args(i), error_msg)
+                    handled = .true.
+                end if
+            type is (identifier_node)
+                symbol_index = find_symbol(context, node%name)
+                if (symbol_index > 0 .and. &
+                    context%symbols(symbol_index)%value_kind == VALUE_CHARACTER) then
+                    call prepare_deferred_char_actual(arena, arg_indices(i), &
+                        context, args(i), error_msg)
+                    handled = .true.
+                end if
+            end select
+            if (len_trim(error_msg) > 0) return
+            if (.not. handled) then
+                call prepare_reference_arg(arena, arg_indices(i), context, &
+                                           VALUE_I32, args(i), &
+                                           copyback_indices(i), error_msg)
+                if (len_trim(error_msg) > 0) return
+            end if
+        end do
+        call set_empty(error_msg)
+    end subroutine prepare_deferred_char_call_args
+
     subroutine lower_deferred_char_result_call(arena, node, context, &
                                                 dest_symbol_index, error_msg)
         use, intrinsic :: iso_c_binding, only: c_int64_t
@@ -317,7 +445,9 @@ integer function resolve_concat_operand(arena, node_index, context, &
         type(lr_operand_desc_t), allocatable :: user_args(:)
         type(lr_operand_desc_t), allocatable :: all_args(:)
         integer, allocatable :: copyback_indices(:)
-        type(lr_operand_desc_t) :: result_val
+        type(lr_operand_desc_t) :: descriptor_ptr
+        type(lr_operand_desc_t) :: data_addr
+        type(lr_operand_desc_t) :: len_addr
         integer :: i
         character(len=:), allocatable :: func_name
 
@@ -326,8 +456,9 @@ integer function resolve_concat_operand(arena, node_index, context, &
             error_msg = 'deferred char call assignment value does not reference an AST node'
             return
         end if
-        select type (call_node => arena%entries(node%value_index)%node)
+        select type (value_node => arena%entries(node%value_index)%node)
         type is (call_or_subscript_node)
+            call_node = value_node
         class default
             error_msg = 'expected function call for deferred char result'
             return
@@ -335,36 +466,36 @@ integer function resolve_concat_operand(arena, node_index, context, &
 
         func_name = call_node%name
 
-        ! Prepare user arguments
+        call allocate_deferred_char_descriptor(context, descriptor_ptr, &
+                                               data_addr, len_addr, error_msg)
+        if (len_trim(error_msg) > 0) return
+        context%symbols(dest_symbol_index)%deferred_data = data_addr
+        context%symbols(dest_symbol_index)%deferred_length = len_addr
+
         if (allocated(call_node%arg_indices)) then
-            call prepare_reference_args(arena, call_node%arg_indices, context, &
-                                        VALUE_I32, user_args, copyback_indices, &
-                                        error_msg)
+            call prepare_deferred_char_call_args(arena, call_node%arg_indices, &
+                context, user_args, copyback_indices, error_msg)
             if (len_trim(error_msg) > 0) return
         else
             allocate (user_args(0))
             allocate (copyback_indices(0))
         end if
 
-        ! Build arg list: user args only
-        allocate (all_args(size(user_args)))
+        allocate (all_args(size(user_args) + 1))
+        all_args(1) = descriptor_ptr
         do i = 1, size(user_args)
-            all_args(i) = user_args(i)
+            all_args(i + 1) = user_args(i)
         end do
 
-        ! Emit the call - callee allocates its own descriptor storage
-        if (.not. emit_i32_call(context%session, trim(func_name), all_args, &
-                                result_val, error_msg)) return
-        call copy_back_reference_args(context, all_args, copyback_indices, &
+        if (.not. emit_void_call(context%session, trim(func_name), all_args, &
+                                 error_msg)) return
+        call copy_back_reference_args(context, user_args, copyback_indices, &
                                       error_msg)
+        if (len_trim(error_msg) > 0) return
 
-        ! The callee allocates fresh descriptor storage and fills it via
-        ! the deferred-char store path. Since we can't pass hidden params
-        ! due to LIRIC relocation constraints, we cannot directly access
-        ! the callee's storage from here. The caller's deferred-char symbol
-        ! will have empty/uninitialized storage.
-        ! TODO: Implement proper hidden-parameter ABI when LIRIC supports it.
-        context%symbols(dest_symbol_index)%has_character_value = .false.
+        if (.not. emit_ptr_load(context%session, data_addr, &
+            context%symbols(dest_symbol_index)%value, error_msg)) return
+        context%symbols(dest_symbol_index)%has_character_value = .true.
         call set_empty(error_msg)
     end subroutine lower_deferred_char_result_call
 
@@ -377,7 +508,10 @@ integer function resolve_concat_operand(arena, node_index, context, &
         type(lr_operand_desc_t), allocatable :: user_args(:)
         type(lr_operand_desc_t), allocatable :: all_args(:)
         integer, allocatable :: copyback_indices(:)
-        type(lr_operand_desc_t) :: result_val
+        type(lr_operand_desc_t) :: descriptor_ptr
+        type(lr_operand_desc_t) :: data_addr
+        type(lr_operand_desc_t) :: len_addr
+        type(lr_operand_desc_t) :: data_value
         integer :: i
         character(len=:), allocatable :: func_name
 
@@ -385,35 +519,34 @@ integer function resolve_concat_operand(arena, node_index, context, &
 
         func_name = node%name
 
-        ! Prepare user arguments
+        call allocate_deferred_char_descriptor(context, descriptor_ptr, &
+                                               data_addr, len_addr, error_msg)
+        if (len_trim(error_msg) > 0) return
+
         if (allocated(node%arg_indices)) then
-            call prepare_reference_args(arena, node%arg_indices, context, &
-                                        VALUE_I32, user_args, copyback_indices, &
-                                        error_msg)
+            call prepare_deferred_char_call_args(arena, node%arg_indices, &
+                context, user_args, copyback_indices, error_msg)
             if (len_trim(error_msg) > 0) return
         else
             allocate (user_args(0))
             allocate (copyback_indices(0))
         end if
 
-        ! Build arg list: user args only
-        allocate (all_args(size(user_args)))
+        allocate (all_args(size(user_args) + 1))
+        all_args(1) = descriptor_ptr
         do i = 1, size(user_args)
-            all_args(i) = user_args(i)
+            all_args(i + 1) = user_args(i)
         end do
 
-        ! Emit the call - callee allocates its own descriptor storage
-        if (.not. emit_i32_call(context%session, trim(func_name), all_args, &
-                                result_val, error_msg)) return
-        call copy_back_reference_args(context, all_args, copyback_indices, &
+        if (.not. emit_void_call(context%session, trim(func_name), all_args, &
+                                 error_msg)) return
+        call copy_back_reference_args(context, user_args, copyback_indices, &
                                       error_msg)
+        if (len_trim(error_msg) > 0) return
 
-        ! The callee fills its own descriptor storage. We need to print it,
-        ! but we can't access the callee's storage directly.
-        ! TODO: Implement proper hidden-parameter ABI when LIRIC supports it.
-        ! For now, print a placeholder.
-        call unsupported_feature_error('deferred-char function call in print', &
-            node%line, node%column, &
-            'deferred-char function results cannot be printed directly yet', &
-            error_msg)
+        if (.not. emit_ptr_load(context%session, data_addr, data_value, &
+            error_msg)) return
+        if (.not. emit_liric_print_string_operand_value(context%session, &
+            context%str_print_format_id, data_value, error_msg)) return
+        call set_empty(error_msg)
     end subroutine lower_print_deferred_char_call

--- a/src/session_program_lowering_functions.inc
+++ b/src/session_program_lowering_functions.inc
@@ -229,6 +229,7 @@
         integer :: result_index
         integer :: value_kind
         logical :: terminated
+        character(len=:), allocatable :: result_name
 
         if (.not. allocated(node%name)) then
             error_msg = 'direct LIRIC session function requires a name'
@@ -236,6 +237,13 @@
         end if
         call function_value_kind(node, value_kind, error_msg)
         if (len_trim(error_msg) > 0) return
+        result_name = trim(node%name)
+        if (value_kind == VALUE_DEFERRED_CHARACTER_RESULT .and. &
+            allocated(node%result_variable)) then
+            if (len_trim(node%result_variable) > 0) then
+                result_name = trim(node%result_variable)
+            end if
+        end if
 
         context%session = parent_context%session
         context%i32_print_format_id = parent_context%i32_print_format_id
@@ -259,43 +267,46 @@
             if (.not. begin_liric_f64_function(context%session, node%name, &
                                                param_count, error_msg)) return
         else if (value_kind == VALUE_DEFERRED_CHARACTER_RESULT) then
-            if (.not. begin_ptr_function(context%session, node%name, &
-                                         param_count, error_msg)) return
+            if (.not. begin_void_subroutine(context%session, node%name, &
+                                            param_count + 1, error_msg)) return
         else
             if (.not. begin_i32_function(context%session, node%name, param_count, &
                                                           error_msg)) return
         end if
 
         if (value_kind == VALUE_DEFERRED_CHARACTER_RESULT) then
-            ! Allocate fresh deferred-char descriptor storage for the result.
-            ! The deferred-char store path will fill this storage.
-            ! Note: Due to LIRIC relocation constraints with hidden parameters,
-            ! we allocate fresh storage here. The caller-side handling needs
-            ! to be updated to read from this storage (see TODO below).
             call grow_symbols(context)
             context%current_function_result_index = context%symbol_count + 1
             context%symbols(context%current_function_result_index)%name = &
-                trim(node%name)
+                trim(result_name)
             context%symbols(context%current_function_result_index)%value_kind = &
                 VALUE_CHARACTER
             context%symbols(context%current_function_result_index)%&
                 is_deferred_character = .true.
             context%symbols(context%current_function_result_index)%&
                 has_character_value = .false.
-            if (.not. emit_i64_alloca(context%session, &
+            if (.not. emit_ptr_offset(context%session, &
+                ptr_param(context%session, 0), 0_c_int64_t, &
                 context%symbols(context%current_function_result_index)%deferred_data, &
                 error_msg)) return
-            if (.not. emit_i64_alloca(context%session, &
+            if (.not. emit_ptr_offset(context%session, &
+                ptr_param(context%session, 0), 8_c_int64_t, &
                 context%symbols(context%current_function_result_index)%deferred_length, &
                 error_msg)) return
             context%symbol_count = context%current_function_result_index
         else
-            call define_symbol(context, node%name, value_kind, error_msg)
+            call define_symbol(context, result_name, value_kind, error_msg)
             if (len_trim(error_msg) > 0) return
-            context%current_function_result_index = find_symbol(context, node%name)
+            context%current_function_result_index = find_symbol(context, &
+                                                                result_name)
         end if
-        call define_reference_parameters(arena, node%param_indices, context, &
-                                          error_msg)
+        if (value_kind == VALUE_DEFERRED_CHARACTER_RESULT) then
+            call define_reference_parameters(arena, node%param_indices, context, &
+                                             error_msg, 1)
+        else
+            call define_reference_parameters(arena, node%param_indices, context, &
+                                             error_msg)
+        end if
         if (len_trim(error_msg) > 0) return
 
         if (allocated(node%body_indices)) then
@@ -304,10 +315,10 @@
             if (len_trim(error_msg) > 0) return
         end if
 
-        result_index = find_symbol(context, node%name)
+        result_index = find_symbol(context, result_name)
         if (result_index <= 0) then
             error_msg = 'function result symbol was not declared: '// &
-                        trim(node%name)
+                        trim(result_name)
             return
         end if
         if (.not. context%current_block_terminated) then
@@ -382,20 +393,26 @@
         call set_empty(error_msg)
     end subroutine lower_void_subroutine
 
-    subroutine define_reference_parameters(arena, param_indices, context, error_msg)
+    subroutine define_reference_parameters(arena, param_indices, context, &
+                                           error_msg, param_offset)
         type(ast_arena_t), intent(in) :: arena
         integer, allocatable, intent(in) :: param_indices(:)
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
+        integer, intent(in), optional :: param_offset
         character(len=:), allocatable :: name
+        integer :: offset
         integer :: i
 
         call set_empty(error_msg)
+        offset = 0
+        if (present(param_offset)) offset = param_offset
         if (.not. allocated(param_indices)) return
         do i = 1, size(param_indices)
             call parameter_name(arena, param_indices(i), name, error_msg)
             if (len_trim(error_msg) > 0) return
-            call define_parameter_symbol(context, name, i - 1, error_msg)
+            call define_parameter_symbol(context, name, i - 1 + offset, &
+                                         error_msg)
             if (len_trim(error_msg) > 0) return
         end do
     end subroutine define_reference_parameters

--- a/test/test_session_deferred_char_compiler.f90
+++ b/test/test_session_deferred_char_compiler.f90
@@ -1,0 +1,79 @@
+program test_session_deferred_char_compiler
+    use ffc_test_support, only: expect_output
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== deferred-char function result compiler tests ==='
+
+    all_passed = .true.
+    if (.not. test_function_returns_concatenated_deferred_character()) &
+        all_passed = .false.
+    if (.not. test_function_returns_input_with_suffix()) all_passed = .false.
+    if (.not. test_function_result_prints_directly()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: deferred-char function result ABI'
+
+contains
+
+    logical function test_function_returns_concatenated_deferred_character()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  character(len=:), allocatable :: r, s'//new_line('a')// &
+            '  r = helper()'//new_line('a')// &
+            '  s = r // "cd"'//new_line('a')// &
+            '  print *, s'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  function helper() result(res)'//new_line('a')// &
+            '    character(len=:), allocatable :: res'//new_line('a')// &
+            '    res = "a" // "b"'//new_line('a')// &
+            '  end function helper'//new_line('a')// &
+            'end program main'
+
+        test_function_returns_concatenated_deferred_character = expect_output( &
+            source, 'abcd'//new_line('a'), &
+            '/tmp/ffc_deferred_char_func_concat')
+    end function test_function_returns_concatenated_deferred_character
+
+    logical function test_function_returns_input_with_suffix()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  character(len=:), allocatable :: r, s'//new_line('a')// &
+            '  r = append_bang("hi")'//new_line('a')// &
+            '  s = r // "x"'//new_line('a')// &
+            '  print *, s'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  function append_bang(arg) result(res)'//new_line('a')// &
+            '    character(len=*), intent(in) :: arg'//new_line('a')// &
+            '    character(len=:), allocatable :: res'//new_line('a')// &
+            '    res = arg // "!"'//new_line('a')// &
+            '  end function append_bang'//new_line('a')// &
+            'end program main'
+
+        test_function_returns_input_with_suffix = expect_output( &
+            source, 'hi!x'//new_line('a'), &
+            '/tmp/ffc_deferred_char_func_suffix')
+    end function test_function_returns_input_with_suffix
+
+    logical function test_function_result_prints_directly()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  print *, greet("world")'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  function greet(name) result(res)'//new_line('a')// &
+            '    character(len=*), intent(in) :: name'//new_line('a')// &
+            '    character(len=:), allocatable :: res'//new_line('a')// &
+            '    res = "hello, " // name'//new_line('a')// &
+            '  end function greet'//new_line('a')// &
+            'end program main'
+
+        test_function_result_prints_directly = expect_output( &
+            source, 'hello, world'//new_line('a'), &
+            '/tmp/ffc_deferred_char_func_print')
+    end function test_function_result_prints_directly
+
+end program test_session_deferred_char_compiler


### PR DESCRIPTION
## Summary

Fix deferred-length character function results by passing a hidden result descriptor as the first argument, filling it in the callee, and reading it in the caller. This also supports assumed-length character dummy arguments for these calls.

Closes #195.

## Verification

Failing before on `origin/main`:

```text
LIBRARY_PATH=/tmp/liric-clean/build FPM_BUILD_DIR=/tmp/ffc-main-build-issue195 fpm run ffc -- /tmp/ffc_issue195_before.f90 -o /tmp/ffc_issue195_before && /tmp/ffc_issue195_before
STOP 1
unsupported character parameter declaration at line 1, column 1: scalar character parameters are not supported by direct LIRIC session
<ERROR> Execution for object " ffc " returned exit code  1
```

Passing after:

```text
LIBRARY_PATH=/tmp/liric-clean/build FPM_BUILD_DIR=/tmp/ffc-build-reapply-focus fpm test test_session_deferred_char_compiler
=== deferred-char function result compiler tests ===
PASS: deferred-char function result ABI
```

```text
LIBRARY_PATH=/tmp/liric-clean/build FPM_BUILD_DIR=/tmp/ffc-build-reapply-focus fpm test
[100%] Project compiled successfully.
PASS: fortfront example corpus conforms to ffc support contract
PASS: deferred-char function result ABI
PASS: direct session character variable compiler test
```

```text
git diff --check
# no output
```

```text
$HOME/code/prompts/scripts/check-writing-slop.py src/liric_session_memory_bindings.f90 src/session_program_lowering.f90 src/session_program_lowering_functions.inc src/session_program_lowering_character.inc src/session_program_lowering_deferred_char.inc test/test_session_deferred_char_compiler.f90
PASS: no writing-slop candidates at threshold medium
```
