### PR TITLE
[fmt] format all sources with fo fmt native style

### DIFF
--- a/app/ffc.f90
+++ b/app/ffc.f90
@@ -1,11 +1,11 @@
 program ffc_main
     use ffc_module_artefact, only: FFC_FMOD_VERSION
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                  compiler_frontend_result_t, &
-                                  compile_frontend_from_file, INPUT_MODE_LAZY, &
-                                  INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_file, INPUT_MODE_LAZY, &
+        INPUT_MODE_STANDARD
     use session_program_lowering, only: lower_program_to_liric_exe, &
-                                        lower_program_to_liric_object
+        lower_program_to_liric_object
     use ffc_cli_options, only: cli_options_t, parse_arguments, CLI_PATH_LEN
     implicit none
 
@@ -93,7 +93,7 @@ contains
         frontend_options%standardize = standardize
 
         call compile_frontend_from_file(trim(opts%input_file), frontend_result, &
-                                        frontend_options)
+            frontend_options)
         if (.not. frontend_result%success()) then
             diag_msg = trim(frontend_result%diagnostic_text)
             return
@@ -102,14 +102,14 @@ contains
         error_msg = ''
         if (opts%emit_object) then
             call lower_program_to_liric_object(frontend_result%arena, &
-                                               frontend_result%root_index, &
-                                               trim(output_file), error_msg, &
-                                               search_paths)
+                frontend_result%root_index, &
+                trim(output_file), error_msg, &
+                search_paths)
         else
             call lower_program_to_liric_exe(frontend_result%arena, &
-                                            frontend_result%root_index, &
-                                            trim(output_file), error_msg, &
-                                            search_paths)
+                frontend_result%root_index, &
+                trim(output_file), error_msg, &
+                search_paths)
         end if
         if (len_trim(error_msg) > 0) then
             diag_msg = trim(error_msg)
@@ -132,8 +132,8 @@ contains
         character(len=*), intent(in) :: diag
 
         infer = index(diag, 'not declared') > 0 .or. &
-                index(diag, 'not been declared') > 0 .or. &
-                index(diag, 'implicit none') > 0
+            index(diag, 'not been declared') > 0 .or. &
+            index(diag, 'implicit none') > 0
     end function needs_inference
 
     logical function is_lazy_source(path) result(lazy)

--- a/src/ffc_fortfront_queries.f90
+++ b/src/ffc_fortfront_queries.f90
@@ -1,14 +1,14 @@
 module ffc_fortfront_queries
     use fortfront_compiler, only: ast_arena_t, get_program_body_info, &
-                                  get_module_body_info, &
-                                  get_function_body_info, &
-                                  get_subroutine_body_info, &
-                                  get_select_case_info, get_case_block_info, &
-                                  get_case_default_body, get_case_range_info, &
-                                  get_select_type_info, get_type_guard_info
+        get_module_body_info, &
+        get_function_body_info, &
+        get_subroutine_body_info, &
+        get_select_case_info, get_case_block_info, &
+        get_case_default_body, get_case_range_info, &
+        get_select_type_info, get_type_guard_info
     use fortfront_utils, only: node_exists, get_node_type_at
     use fortfront, only: is_derived_type_node, derived_type_node, &
-                         is_declaration_node, declaration_node
+        is_declaration_node, declaration_node
     use ast_nodes_control, only: goto_node
     implicit none
     private
@@ -42,7 +42,7 @@ contains
             return
         end if
         select type (node => arena%entries(type_index)%node)
-        type is (derived_type_node)
+            type is (derived_type_node)
             if (allocated(node%name)) name = node%name
             call set_empty(error_msg)
         class default
@@ -60,7 +60,7 @@ contains
             return
         end if
         select type (node => arena%entries(type_index)%node)
-        type is (derived_type_node)
+            type is (derived_type_node)
             if (allocated(node%component_indices)) then
                 components = node%component_indices
             else
@@ -72,7 +72,7 @@ contains
     end subroutine get_derived_type_components
 
     subroutine get_declaration_var_name(arena, decl_index, var_name, &
-                                        error_msg)
+            error_msg)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: decl_index
         character(len=:), allocatable, intent(out) :: var_name
@@ -84,7 +84,7 @@ contains
             return
         end if
         select type (node => arena%entries(decl_index)%node)
-        type is (declaration_node)
+            type is (declaration_node)
             if (allocated(node%var_name)) var_name = node%var_name
             call set_empty(error_msg)
         class default
@@ -93,7 +93,7 @@ contains
     end subroutine get_declaration_var_name
 
     subroutine get_declaration_type_name(arena, decl_index, type_name, &
-                                         error_msg)
+            error_msg)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: decl_index
         character(len=:), allocatable, intent(out) :: type_name
@@ -105,7 +105,7 @@ contains
             return
         end if
         select type (node => arena%entries(decl_index)%node)
-        type is (declaration_node)
+            type is (declaration_node)
             if (allocated(node%type_name)) type_name = node%type_name
             call set_empty(error_msg)
         class default
@@ -114,20 +114,20 @@ contains
     end subroutine get_declaration_type_name
 
     logical function get_declaration_has_initializer(arena, decl_index) &
-        result(has_init)
+            result(has_init)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: decl_index
 
         has_init = .false.
         if (.not. node_exists(arena, decl_index)) return
         select type (node => arena%entries(decl_index)%node)
-        type is (declaration_node)
+            type is (declaration_node)
             has_init = node%has_initializer
         end select
     end function get_declaration_has_initializer
 
     function get_declaration_initializer_index(arena, decl_index) &
-        result(init_index)
+            result(init_index)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: decl_index
         integer :: init_index
@@ -135,7 +135,7 @@ contains
         init_index = 0
         if (.not. node_exists(arena, decl_index)) return
         select type (node => arena%entries(decl_index)%node)
-        type is (declaration_node)
+            type is (declaration_node)
             if (node%has_initializer .and. node%initializer_index > 0) then
                 init_index = node%initializer_index
             end if
@@ -166,7 +166,7 @@ contains
         call set_empty(label)
         if (.not. node_exists(arena, node_index)) return
         select type (node => arena%entries(node_index)%node)
-        type is (goto_node)
+            type is (goto_node)
             if (allocated(node%label)) label = node%label
         end select
     end function get_goto_label
@@ -180,9 +180,9 @@ contains
         is_computed = .false.
         if (.not. node_exists(arena, node_index)) return
         select type (node => arena%entries(node_index)%node)
-        type is (goto_node)
+            type is (goto_node)
             is_computed = node%selector_index /= 0 .or. &
-                          allocated(node%label_list)
+                allocated(node%label_list)
         end select
     end function goto_is_computed
 
@@ -196,7 +196,7 @@ contains
         call set_empty(label_list)
         if (.not. node_exists(arena, node_index)) return
         select type (node => arena%entries(node_index)%node)
-        type is (goto_node)
+            type is (goto_node)
             if (allocated(node%label_list)) label_list = node%label_list
         end select
     end function get_goto_label_list
@@ -209,7 +209,7 @@ contains
         idx = 0
         if (.not. node_exists(arena, node_index)) return
         select type (node => arena%entries(node_index)%node)
-        type is (goto_node)
+            type is (goto_node)
             idx = node%selector_index
         end select
     end function get_goto_selector_index

--- a/src/ffc_module_artefact.f90
+++ b/src/ffc_module_artefact.f90
@@ -55,7 +55,7 @@ contains
 
         allocate (character(len=0) :: error_msg)
         open (newunit=unit, file=path, status='replace', action='write', &
-              iostat=io_stat)
+            iostat=io_stat)
         if (io_stat /= 0) then
             error_msg = 'could not open .fmod artefact for writing: '//trim(path)
             return

--- a/src/ffc_test_support.f90
+++ b/src/ffc_test_support.f90
@@ -4,10 +4,10 @@ module ffc_test_support
     ! test programs only describe the source they want compiled and the
     ! expected behaviour of the resulting executable.
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                 compiler_frontend_result_t, &
-                                 compile_frontend_from_string, INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, INPUT_MODE_STANDARD
     use session_program_lowering, only: lower_program_to_liric_exe, &
-                                        lower_program_to_liric_object
+        lower_program_to_liric_object
     implicit none
     private
 
@@ -26,7 +26,7 @@ module ffc_test_support
 contains
 
     logical function expect_stderr_and_exit(source, expected, expected_exit, &
-                                            exe_path) result(ok)
+            exe_path) result(ok)
         ! Compiles source, runs it capturing combined stdout+stderr, and checks
         ! both that combined output and the exit status. Used for STOP banners,
         ! which gfortran writes to stderr.
@@ -47,7 +47,7 @@ contains
 
         out_path = exe_path//'.out'
         call execute_command_line(exe_path//' > '//out_path//' 2>&1', &
-                                  exitstat=exit_stat, cmdstat=cmd_stat)
+            exitstat=exit_stat, cmdstat=cmd_stat)
         if (cmd_stat /= 0) then
             print *, 'FAIL: emitted executable did not run: ', exe_path
             call execute_command_line('rm -f '//exe_path//' '//out_path)
@@ -75,7 +75,7 @@ contains
     end function expect_stderr_and_exit
 
     logical function expect_eof_stderr_and_exit(source, expected, expected_exit, &
-                                                exe_path) result(ok)
+            exe_path) result(ok)
         ! Like expect_stderr_and_exit but redirects stdin from /dev/null, so a
         ! PAUSE (which reads stdin) sees end-of-input and terminates exactly as
         ! the conformance gauntlet runs it.
@@ -96,7 +96,7 @@ contains
 
         out_path = exe_path//'.out'
         call execute_command_line(exe_path//' > '//out_path//' 2>&1 < /dev/null', &
-                                  exitstat=exit_stat, cmdstat=cmd_stat)
+            exitstat=exit_stat, cmdstat=cmd_stat)
         if (cmd_stat /= 0) then
             print *, 'FAIL: emitted executable did not run: ', exe_path
             call execute_command_line('rm -f '//exe_path//' '//out_path)
@@ -146,8 +146,8 @@ contains
         end if
         call execute_command_line('rm -f '//object_path)
         call lower_program_to_liric_object(frontend_result%arena, &
-                                           frontend_result%root_index, &
-                                           object_path, error_msg)
+            frontend_result%root_index, &
+            object_path, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL: object lowering failed: ', trim(error_msg)
             call execute_command_line('rm -f '//object_path)
@@ -155,7 +155,7 @@ contains
         end if
 
         call execute_command_line('nm '//object_path//' | grep -qw '//symbol, &
-                                  exitstat=stat, cmdstat=cmd_stat)
+            exitstat=stat, cmdstat=cmd_stat)
         call execute_command_line('rm -f '//object_path)
         if (cmd_stat /= 0) then
             print *, 'FAIL: could not run nm on ', object_path
@@ -216,7 +216,7 @@ contains
 
         stdout_path = exe_path//'.out'
         call execute_command_line(exe_path//' > '//stdout_path, &
-                                  exitstat=exit_stat, cmdstat=cmd_stat)
+            exitstat=exit_stat, cmdstat=cmd_stat)
         if (cmd_stat /= 0) then
             print *, 'FAIL: emitted executable did not run: ', exe_path
             call execute_command_line('rm -f '//exe_path//' '//stdout_path)
@@ -264,8 +264,8 @@ contains
 
         stdout_path = exe_path//'.out'
         call execute_command_line("echo '"//stdin_input//"' | "//exe_path// &
-                                  " > "//stdout_path, &
-                                  exitstat=exit_stat, cmdstat=cmd_stat)
+            " > "//stdout_path, &
+            exitstat=exit_stat, cmdstat=cmd_stat)
         if (cmd_stat /= 0) then
             print *, 'FAIL: emitted executable did not run: ', exe_path
             call execute_command_line('rm -f '//exe_path//' '//stdout_path)
@@ -333,17 +333,17 @@ contains
         output_path = stem//'.out'
         exe_path = stem//'.exe'
         call execute_command_line('rm -f '//source_path//' '//output_path//' '// &
-                                  exe_path)
+            exe_path)
         if (.not. write_source_file(source_path, source)) return
 
         command = "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc "// &
-                  "2>/dev/null | head -n 1); "// &
-                  "test -n ""$exe"" && ""$exe"" "// &
-                  source_path//' -o '//exe_path//' > '//output_path//" 2>&1'"
+            "2>/dev/null | head -n 1); "// &
+            "test -n ""$exe"" && ""$exe"" "// &
+            source_path//' -o '//exe_path//' > '//output_path//" 2>&1'"
         call execute_command_line(command, exitstat=exit_stat, cmdstat=cmd_stat)
         output = read_text_file(output_path)
         call execute_command_line('rm -f '//source_path//' '//output_path//' '// &
-                                  exe_path)
+            exe_path)
 
         if (cmd_stat /= 0) then
             print *, 'FAIL: ffc CLI command could not be executed'
@@ -384,17 +384,17 @@ contains
         output_path = stem//'.out'
         exe_path = stem//'.exe'
         call execute_command_line('rm -f '//source_path//' '//output_path//' '// &
-                                  exe_path)
+            exe_path)
         if (.not. write_source_file(source_path, source)) return
 
         command = "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc "// &
-                  "2>/dev/null | head -n 1); "// &
-                  "test -n ""$exe"" && ""$exe"" "// &
-                  source_path//' -o '//exe_path//' > '//output_path//" 2>&1'"
+            "2>/dev/null | head -n 1); "// &
+            "test -n ""$exe"" && ""$exe"" "// &
+            source_path//' -o '//exe_path//' > '//output_path//" 2>&1'"
         call execute_command_line(command, exitstat=exit_stat, cmdstat=cmd_stat)
         output = read_text_file(output_path)
         call execute_command_line('rm -f '//source_path//' '//output_path//' '// &
-                                  exe_path)
+            exe_path)
 
         if (cmd_stat /= 0) then
             print *, 'FAIL: ffc CLI command could not be executed'
@@ -459,7 +459,7 @@ contains
 
         write_source_file = .false.
         open (newunit=unit, file=path, status='replace', action='write', &
-              iostat=io_stat)
+            iostat=io_stat)
         if (io_stat /= 0) then
             print *, 'FAIL: could not create source file ', path
             return
@@ -484,7 +484,7 @@ contains
 
         text = ''
         open (newunit=unit, file=path, status='old', action='read', &
-              iostat=io_stat)
+            iostat=io_stat)
         if (io_stat /= 0) return
 
         do
@@ -509,14 +509,14 @@ contains
         call compile_frontend_from_string(source, frontend_result, options)
         if (.not. frontend_result%success()) then
             error_msg = 'FortFront rejected source: '// &
-                        trim(frontend_result%diagnostic_text)
+                trim(frontend_result%diagnostic_text)
             return
         end if
 
         call execute_command_line('rm -f '//exe_path)
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe_path, &
-                                        error_msg)
+            frontend_result%root_index, exe_path, &
+            error_msg)
     end subroutine compile_to_exe
 
     subroutine read_file(path, contents)
@@ -527,7 +527,7 @@ contains
         integer :: bytes
 
         open (newunit=unit, file=path, status='old', action='read', &
-              access='stream', form='unformatted', iostat=io_stat)
+            access='stream', form='unformatted', iostat=io_stat)
         if (io_stat /= 0) return
         inquire (unit=unit, size=bytes)
         if (bytes <= 0) then

--- a/src/liric_session_bindings.f90
+++ b/src/liric_session_bindings.f90
@@ -2,12 +2,12 @@ module liric_session_bindings
     use, intrinsic :: iso_c_binding, only: c_associated, c_bool, c_char
     use, intrinsic :: iso_c_binding, only: c_int, c_int32_t, c_int64_t
     use, intrinsic :: iso_c_binding, only: c_loc, c_null_char, c_null_ptr, c_ptr, &
-                                              c_size_t
+        c_size_t
     use liric_session_common, only: lr_session_config_t, lr_error_t, &
-                                    lr_operand_desc_t, lr_inst_desc_t, &
-                                    liric_session_t, require_open_session, &
-                                    status_ok, liric_session_error_message, &
-                                    clear_liric_error, to_c_chars, set_empty
+        lr_operand_desc_t, lr_inst_desc_t, &
+        liric_session_t, require_open_session, &
+        status_ok, liric_session_error_message, &
+        clear_liric_error, to_c_chars, set_empty
     implicit none
     private
 
@@ -51,24 +51,24 @@ module liric_session_bindings
     integer(c_int), parameter, public :: LR_OP_KIND_GLOBAL = 4_c_int
 
     public :: lr_session_config_t, lr_error_t, lr_operand_desc_t, &
-              lr_inst_desc_t, liric_session_t
+        lr_inst_desc_t, liric_session_t
     public :: liric_session_create
     public :: liric_session_error_message
     public :: i32_vreg, i32_immediate
     public :: global_operand
     public :: lr_type_i32_s, lr_type_i64_s, lr_type_f32_s, lr_type_f64_s, &
-              lr_type_ptr_s, lr_type_i8_s, lr_type_i16_s, lr_type_array_s, lr_type_void_s
+        lr_type_ptr_s, lr_type_i8_s, lr_type_i16_s, lr_type_array_s, lr_type_void_s
     public :: lr_session_emit, lr_session_vreg, lr_session_param, &
-              lr_session_intern, lr_session_global
+        lr_session_intern, lr_session_global
     public :: status_ok, clear_liric_error, set_empty, require_open_session, &
-              to_c_chars, liric_session_error_message
+        to_c_chars, liric_session_error_message
     public :: destroy, is_open, begin_i32_main, begin_i32_function, &
-              begin_void_subroutine, begin_ptr_function, &
-              emit_ret_i32_main_exe, &
-              emit_ret_i32_operand, emit_ret_void, finish_function, &
-              finish_and_emit_object, finish_and_emit_exe, &
-              emit_i32_call, emit_ptr_call, emit_void_call, &
-              emit_i32_indirect_call, emit_void_indirect_call
+        begin_void_subroutine, begin_ptr_function, &
+        emit_ret_i32_main_exe, &
+        emit_ret_i32_operand, emit_ret_void, finish_function, &
+        finish_and_emit_object, finish_and_emit_exe, &
+        emit_i32_call, emit_ptr_call, emit_void_call, &
+        emit_i32_indirect_call, emit_void_indirect_call
 
     interface
         function lr_session_create(cfg, err) result(handle) bind(c)
@@ -146,7 +146,7 @@ module liric_session_bindings
         end function lr_session_vreg
 
         function lr_session_func_begin(handle, name, ret, params, n, &
-                                       vararg, err) result(status) bind(c)
+                vararg, err) result(status) bind(c)
             import :: c_bool, c_char, c_int, c_int32_t, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             character(kind=c_char), intent(in) :: name(*)
@@ -159,7 +159,7 @@ module liric_session_bindings
         end function lr_session_func_begin
 
         function lr_session_func_end(handle, out_addr, err) result(status) &
-            bind(c)
+                bind(c)
             import :: c_int, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             type(c_ptr), intent(out) :: out_addr
@@ -181,7 +181,7 @@ module liric_session_bindings
         end function lr_session_block
 
         function lr_session_set_block(handle, block_id, err) result(status) &
-            bind(c)
+                bind(c)
             import :: c_int, c_int32_t, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             integer(c_int32_t), value :: block_id
@@ -198,7 +198,7 @@ module liric_session_bindings
         end function lr_session_emit
 
         function lr_session_emit_exe(handle, path, err) result(status) &
-            bind(c)
+                bind(c)
             import :: c_char, c_int, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             character(kind=c_char), intent(in) :: path(*)
@@ -207,7 +207,7 @@ module liric_session_bindings
         end function lr_session_emit_exe
 
         function lr_session_emit_object(handle, path, err) result(status) &
-            bind(c)
+                bind(c)
             import :: c_char, c_int, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             character(kind=c_char), intent(in) :: path(*)
@@ -223,7 +223,7 @@ module liric_session_bindings
         end function lr_session_intern
 
         function lr_session_global(handle, name, typ, is_const, init, &
-                                   init_size) result(global_id) bind(c)
+                init_size) result(global_id) bind(c)
             import :: c_bool, c_char, c_int32_t, c_ptr, c_size_t, c_int
             type(c_ptr), value :: handle
             character(kind=c_char), intent(in) :: name(*)
@@ -272,7 +272,7 @@ contains
     end function is_open
 
     logical function emit_ret_i32_main_exe(session, return_code, path, &
-                                           error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer, intent(in) :: return_code
         character(len=*), intent(in) :: path
@@ -320,14 +320,14 @@ contains
         call clear_liric_error(error)
         call to_c_chars('main', c_name)
         status = lr_session_func_begin(session%handle, c_name, i32_type, &
-                                       c_loc(params), 2_c_int32_t, c_false, &
-                                       error)
+            c_loc(params), 2_c_int32_t, c_false, &
+            error)
         if (.not. status_ok(status, error, error_msg)) return
 
         if (present(argc_vreg)) argc_vreg = lr_session_param(session%handle, &
-                                                             0_c_int32_t)
+            0_c_int32_t)
         if (present(argv_vreg)) argv_vreg = lr_session_param(session%handle, &
-                                                             1_c_int32_t)
+            1_c_int32_t)
 
         block_id = lr_session_block(session%handle)
         status = lr_session_set_block(session%handle, block_id, error)
@@ -338,7 +338,7 @@ contains
     end function begin_i32_main
 
     logical function begin_i32_function(session, name, param_count, &
-                                        error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         character(len=*), intent(in) :: name
         integer, intent(in) :: param_count
@@ -354,640 +354,640 @@ contains
         integer :: i
 
         begin_i32_function = .false.
-        if (.not. require_open_session(session, error_msg)) return
+            if (.not. require_open_session(session, error_msg)) return
+
+            i32_type = session_i32_type(session, error_msg)
+            if (len_trim(error_msg) > 0) return
+
+            param_type = lr_type_ptr_s(session%handle)
+            if (.not. c_associated(param_type)) then
+                error_msg = 'LIRIC did not return a pointer type'
+                return
+            end if
+
+            params_ptr = c_null_ptr
+            if (param_count > 0) then
+                allocate (params(param_count))
+                do i = 1, param_count
+                    params(i) = param_type
+                end do
+                params_ptr = c_loc(params)
+            end if
 
-        i32_type = session_i32_type(session, error_msg)
-        if (len_trim(error_msg) > 0) return
-
-        param_type = lr_type_ptr_s(session%handle)
-        if (.not. c_associated(param_type)) then
-            error_msg = 'LIRIC did not return a pointer type'
-            return
-        end if
-
-        params_ptr = c_null_ptr
-        if (param_count > 0) then
-            allocate (params(param_count))
-            do i = 1, param_count
-                params(i) = param_type
-            end do
-            params_ptr = c_loc(params)
-        end if
-
-        call clear_liric_error(error)
-        call to_c_chars(trim(name), c_name)
-        status = lr_session_func_begin(session%handle, c_name, i32_type, &
-                                       params_ptr, int(param_count, c_int32_t), &
-                                       c_false, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        block_id = lr_session_block(session%handle)
-        status = lr_session_set_block(session%handle, block_id, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        call set_empty(error_msg)
-        begin_i32_function = .true.
-    end function begin_i32_function
-
-    logical function begin_void_subroutine(session, name, param_count, &
-                                           error_msg)
-        type(liric_session_t), intent(inout) :: session
-        character(len=*), intent(in) :: name
-        integer, intent(in) :: param_count
-        character(len=:), allocatable, intent(out) :: error_msg
-        character(kind=c_char), allocatable :: c_name(:)
-        type(c_ptr), allocatable, target :: params(:)
-        type(c_ptr) :: param_type
-        type(c_ptr) :: i32_type
-        type(c_ptr) :: params_ptr
-        type(c_ptr) :: void_type
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: block_id
-        integer(c_int) :: status
-        integer :: i
-
-        begin_void_subroutine = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        i32_type = session_i32_type(session, error_msg)
-        if (len_trim(error_msg) > 0) return
-        void_type = lr_type_void_s(session%handle)
-        if (.not. c_associated(void_type)) then
-            error_msg = 'LIRIC did not return a void type'
-            return
-        end if
-
-        param_type = lr_type_ptr_s(session%handle)
-        if (.not. c_associated(param_type)) then
-            error_msg = 'LIRIC did not return a pointer type'
-            return
-        end if
-
-        params_ptr = c_null_ptr
-        if (param_count > 0) then
-            allocate (params(param_count))
-            do i = 1, param_count
-                params(i) = param_type
-            end do
-            params_ptr = c_loc(params)
-        end if
-
-        call clear_liric_error(error)
-        call to_c_chars(trim(name), c_name)
-        status = lr_session_func_begin(session%handle, c_name, void_type, &
-                                       params_ptr, int(param_count, c_int32_t), &
-                                       c_false, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        block_id = lr_session_block(session%handle)
-        status = lr_session_set_block(session%handle, block_id, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        call set_empty(error_msg)
-        begin_void_subroutine = .true.
-    end function begin_void_subroutine
-
-    logical function begin_ptr_function(session, name, param_count, &
-                                        error_msg)
-        type(liric_session_t), intent(inout) :: session
-        character(len=*), intent(in) :: name
-        integer, intent(in) :: param_count
-        character(len=:), allocatable, intent(out) :: error_msg
-        character(kind=c_char), allocatable :: c_name(:)
-        type(c_ptr), allocatable, target :: params(:)
-        type(c_ptr) :: param_type
-        type(c_ptr) :: params_ptr
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: block_id
-        integer(c_int) :: status
-        integer :: i
-
-        begin_ptr_function = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        param_type = lr_type_ptr_s(session%handle)
-        if (.not. c_associated(param_type)) then
-            error_msg = 'LIRIC did not return a pointer type'
-            return
-        end if
-
-        params_ptr = c_null_ptr
-        if (param_count > 0) then
-            allocate (params(param_count))
-            do i = 1, param_count
-                params(i) = param_type
-            end do
-            params_ptr = c_loc(params)
-        end if
-
-        call clear_liric_error(error)
-        call to_c_chars(trim(name), c_name)
-        status = lr_session_func_begin(session%handle, c_name, &
-                                       lr_type_ptr_s(session%handle), &
-                                       params_ptr, int(param_count, c_int32_t), &
-                                       c_false, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        block_id = lr_session_block(session%handle)
-        status = lr_session_set_block(session%handle, block_id, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        call set_empty(error_msg)
-        begin_ptr_function = .true.
-    end function begin_ptr_function
-
-    logical function emit_ret_i32_operand(session, value, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        type(lr_operand_desc_t), intent(in) :: value
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: unused_vreg
-
-        emit_ret_i32_operand = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        unused_vreg = emit_ret_i32(session%handle, value, error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-
-        call set_empty(error_msg)
-        emit_ret_i32_operand = .true.
-    end function emit_ret_i32_operand
-
-    logical function emit_ret_void(session, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: unused_vreg
-
-        emit_ret_void = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        unused_vreg = emit_ret_void_inst(session%handle, error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-
-        call set_empty(error_msg)
-        emit_ret_void = .true.
-    end function emit_ret_void
-
-    logical function finish_and_emit_exe(session, path, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        character(len=*), intent(in) :: path
-        character(len=:), allocatable, intent(out) :: error_msg
-        character(kind=c_char), allocatable :: c_path(:)
-        type(c_ptr) :: out_addr
-        type(lr_error_t) :: error
-        integer(c_int) :: status
-
-        finish_and_emit_exe = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        call clear_liric_error(error)
-        out_addr = c_null_ptr
-        status = lr_session_func_end(session%handle, out_addr, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        call to_c_chars(path, c_path)
-        status = lr_session_emit_exe(session%handle, c_path, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        call set_empty(error_msg)
-        finish_and_emit_exe = .true.
-    end function finish_and_emit_exe
-
-    logical function finish_and_emit_object(session, path, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        character(len=*), intent(in) :: path
-        character(len=:), allocatable, intent(out) :: error_msg
-        character(kind=c_char), allocatable :: c_path(:)
-        type(c_ptr) :: out_addr
-        type(lr_error_t) :: error
-        integer(c_int) :: status
-
-        finish_and_emit_object = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        call clear_liric_error(error)
-        out_addr = c_null_ptr
-        status = lr_session_func_end(session%handle, out_addr, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        call to_c_chars(path, c_path)
-        status = lr_session_emit_object(session%handle, c_path, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        call set_empty(error_msg)
-        finish_and_emit_object = .true.
-    end function finish_and_emit_object
-
-    logical function finish_function(session, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(c_ptr) :: out_addr
-        type(lr_error_t) :: error
-        integer(c_int) :: status
-
-        finish_function = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        call clear_liric_error(error)
-        out_addr = c_null_ptr
-        status = lr_session_func_end(session%handle, out_addr, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        call set_empty(error_msg)
-        finish_function = .true.
-    end function finish_function
-
-    logical function emit_i32_call(session, name, args, result, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        character(len=*), intent(in) :: name
-        type(lr_operand_desc_t), intent(in) :: args(:)
-        type(lr_operand_desc_t), intent(out) :: result
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: vreg
-
-        emit_i32_call = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        vreg = emit_call_i32(session%handle, name, args, error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-
-        result = i32_vreg(session, vreg)
-        call set_empty(error_msg)
-        emit_i32_call = .true.
-    end function emit_i32_call
-
-    logical function emit_void_call(session, name, args, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        character(len=*), intent(in) :: name
-        type(lr_operand_desc_t), intent(in) :: args(:)
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: unused_vreg
-
-        emit_void_call = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        unused_vreg = emit_call_void(session%handle, name, args, error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-
-        call set_empty(error_msg)
-        emit_void_call = .true.
-    end function emit_void_call
-
-    logical function emit_ptr_call(session, name, args, result, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        character(len=*), intent(in) :: name
-        type(lr_operand_desc_t), intent(in) :: args(:)
-        type(lr_operand_desc_t), intent(out) :: result
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: vreg
-        type(lr_operand_desc_t), target :: operands(9)
-        type(lr_inst_desc_t) :: inst
-        character(kind=c_char), allocatable :: c_name(:)
-        integer(c_int32_t) :: symbol_id
-        integer :: i
-
-        emit_ptr_call = .false.
-        if (.not. require_open_session(session, error_msg)) return
-        call to_c_chars(trim(name), c_name)
-        symbol_id = lr_session_intern(session%handle, c_name)
-        if (symbol_id < 0_c_int32_t .or. size(args) > 8) then
-            error_msg = 'could not intern symbol for ptr call: '//trim(name)
-            return
-        end if
-        operands(1) = global_operand(session%handle, symbol_id)
-        do i = 1, size(args)
-            operands(i + 1) = args(i)
-        end do
-        inst%op = LR_OP_CALL
-        inst%typ = lr_type_ptr_s(session%handle)
-        inst%dest = 0_c_int32_t
-        inst%operands = c_loc(operands)
-        inst%num_operands = int(size(args) + 1, c_int32_t)
-        inst%indices = c_null_ptr
-        inst%num_indices = 0_c_int32_t
-        inst%align = 0_c_int32_t
-        inst%icmp_pred = 0_c_int
-        inst%fcmp_pred = 0_c_int
-        inst%call_external_abi = c_false
-        inst%call_vararg = c_false
-        inst%call_fixed_args = 0_c_int32_t
-        call clear_liric_error(error)
-        vreg = lr_session_emit(session%handle, inst, error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-        ! Inline ptr_vreg: cannot use liric_session_memory_bindings here
-        ! (circular dependency); build the ptr operand directly.
-        result%kind = LR_OP_KIND_VREG
-        result%payload = int(vreg, c_int64_t)
-        result%typ = lr_type_ptr_s(session%handle)
-        result%global_offset = 0_c_int64_t
-        call set_empty(error_msg)
-        emit_ptr_call = .true.
-    end function emit_ptr_call
-
-    function emit_ret_i32(handle, value, error) result(vreg)
-        type(c_ptr), intent(in) :: handle
-        type(lr_operand_desc_t), intent(in) :: value
-        type(lr_error_t), intent(inout) :: error
-        integer(c_int32_t) :: vreg
-        type(lr_operand_desc_t), target :: operands(1)
-        type(lr_inst_desc_t) :: inst
-
-        operands(1) = value
-
-        inst%op = LR_OP_RET
-        inst%typ = value%typ
-        inst%dest = 0_c_int32_t
-        inst%operands = c_loc(operands)
-        inst%num_operands = 1_c_int32_t
-        inst%indices = c_null_ptr
-        inst%num_indices = 0_c_int32_t
-        inst%align = 0_c_int32_t
-        inst%icmp_pred = 0_c_int
-        inst%fcmp_pred = 0_c_int
-        inst%call_external_abi = c_false
-        inst%call_vararg = c_false
-        inst%call_fixed_args = 0_c_int32_t
-
-        call clear_liric_error(error)
-        vreg = lr_session_emit(handle, inst, error)
-    end function emit_ret_i32
-
-    function emit_ret_void_inst(handle, error) result(vreg)
-        type(c_ptr), intent(in) :: handle
-        type(lr_error_t), intent(inout) :: error
-        integer(c_int32_t) :: vreg
-        type(lr_inst_desc_t) :: inst
-
-        inst%op = LR_OP_RET_VOID
-        inst%typ = lr_type_void_s(handle)
-        inst%dest = 0_c_int32_t
-        inst%operands = c_null_ptr
-        inst%num_operands = 0_c_int32_t
-        inst%indices = c_null_ptr
-        inst%num_indices = 0_c_int32_t
-        inst%align = 0_c_int32_t
-        inst%icmp_pred = 0_c_int
-        inst%fcmp_pred = 0_c_int
-        inst%call_external_abi = c_false
-        inst%call_vararg = c_false
-        inst%call_fixed_args = 0_c_int32_t
-
-        call clear_liric_error(error)
-        vreg = lr_session_emit(handle, inst, error)
-    end function emit_ret_void_inst
-
-    function emit_binary(handle, opcode, lhs, rhs, error) result(vreg)
-        type(c_ptr), intent(in) :: handle
-        integer(c_int), intent(in) :: opcode
-        type(lr_operand_desc_t), intent(in) :: lhs
-        type(lr_operand_desc_t), intent(in) :: rhs
-        type(lr_error_t), intent(inout) :: error
-        integer(c_int32_t) :: vreg
-        type(lr_operand_desc_t), target :: operands(2)
-        type(lr_inst_desc_t) :: inst
-
-        operands = [lhs, rhs]
-
-        inst%op = opcode
-        inst%typ = lhs%typ
-        inst%dest = 0_c_int32_t
-        inst%operands = c_loc(operands)
-        inst%num_operands = 2_c_int32_t
-        inst%indices = c_null_ptr
-        inst%num_indices = 0_c_int32_t
-        inst%align = 0_c_int32_t
-        inst%icmp_pred = 0_c_int
-        inst%fcmp_pred = 0_c_int
-        inst%call_external_abi = c_false
-        inst%call_vararg = c_false
-        inst%call_fixed_args = 0_c_int32_t
-
-        call clear_liric_error(error)
-        vreg = lr_session_emit(handle, inst, error)
-    end function emit_binary
-
-    function emit_call_i32(handle, name, args, error) result(vreg)
-        type(c_ptr), intent(in) :: handle
-        character(len=*), intent(in) :: name
-        type(lr_operand_desc_t), intent(in) :: args(:)
-        type(lr_error_t), intent(inout) :: error
-        integer(c_int32_t) :: vreg
-        type(lr_operand_desc_t), target :: operands(9)
-        type(lr_inst_desc_t) :: inst
-        character(kind=c_char), allocatable :: c_name(:)
-        integer(c_int32_t) :: symbol_id
-        integer :: i
-
-        call to_c_chars(trim(name), c_name)
-        symbol_id = lr_session_intern(handle, c_name)
-        if (symbol_id < 0_c_int32_t .or. size(args) > 8) then
             call clear_liric_error(error)
-            error%code = 1_c_int
-            return
-        end if
+            call to_c_chars(trim(name), c_name)
+            status = lr_session_func_begin(session%handle, c_name, i32_type, &
+                params_ptr, int(param_count, c_int32_t), &
+                c_false, error)
+            if (.not. status_ok(status, error, error_msg)) return
 
-        operands(1) = global_operand(handle, symbol_id)
-        do i = 1, size(args)
-            operands(i + 1) = args(i)
-        end do
+            block_id = lr_session_block(session%handle)
+            status = lr_session_set_block(session%handle, block_id, error)
+            if (.not. status_ok(status, error, error_msg)) return
 
-        inst%op = LR_OP_CALL
-        inst%typ = lr_type_i32_s(handle)
-        inst%dest = 0_c_int32_t
-        inst%operands = c_loc(operands)
-        inst%num_operands = int(size(args) + 1, c_int32_t)
-        inst%indices = c_null_ptr
-        inst%num_indices = 0_c_int32_t
-        inst%align = 0_c_int32_t
-        inst%icmp_pred = 0_c_int
-        inst%fcmp_pred = 0_c_int
-        inst%call_external_abi = c_false
-        inst%call_vararg = c_false
-        inst%call_fixed_args = 0_c_int32_t
-
-        call clear_liric_error(error)
-        vreg = lr_session_emit(handle, inst, error)
-    end function emit_call_i32
-
-    function emit_call_void(handle, name, args, error) result(vreg)
-        type(c_ptr), intent(in) :: handle
-        character(len=*), intent(in) :: name
-        type(lr_operand_desc_t), intent(in) :: args(:)
-        type(lr_error_t), intent(inout) :: error
-        integer(c_int32_t) :: vreg
-        type(lr_operand_desc_t), target :: operands(9)
-        type(lr_inst_desc_t) :: inst
-        character(kind=c_char), allocatable :: c_name(:)
-        integer(c_int32_t) :: symbol_id
-        integer :: i
-
-        call to_c_chars(trim(name), c_name)
-        symbol_id = lr_session_intern(handle, c_name)
-        if (symbol_id < 0_c_int32_t .or. size(args) > 8) then
-            call clear_liric_error(error)
-            error%code = 1_c_int
-            return
-        end if
-
-        operands(1) = global_operand(handle, symbol_id)
-        do i = 1, size(args)
-            operands(i + 1) = args(i)
-        end do
-
-        inst%op = LR_OP_CALL
-        inst%typ = lr_type_void_s(handle)
-        inst%dest = 0_c_int32_t
-        inst%operands = c_loc(operands)
-        inst%num_operands = int(size(args) + 1, c_int32_t)
-        inst%indices = c_null_ptr
-        inst%num_indices = 0_c_int32_t
-        inst%align = 0_c_int32_t
-        inst%icmp_pred = 0_c_int
-        inst%fcmp_pred = 0_c_int
-        inst%call_external_abi = c_false
-        inst%call_vararg = c_false
-        inst%call_fixed_args = 0_c_int32_t
-
-        call clear_liric_error(error)
-        vreg = lr_session_emit(handle, inst, error)
-    end function emit_call_void
-
-    logical function emit_i32_indirect_call(session, callee_ptr, args, result, &
-                                            error_msg)
-        ! Indirect i32 call: callee_ptr is a loaded function pointer (ptr vreg).
-        ! First operand of LR_OP_CALL is the ptr vreg, not a global symbol.
-        type(liric_session_t), intent(inout) :: session
-        type(lr_operand_desc_t), intent(in) :: callee_ptr
-        type(lr_operand_desc_t), intent(in) :: args(:)
-        type(lr_operand_desc_t), intent(out) :: result
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t), target :: operands(9)
-        type(lr_inst_desc_t) :: inst
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: vreg
-        integer :: i
-
-        emit_i32_indirect_call = .false.
-        if (.not. require_open_session(session, error_msg)) return
-        if (size(args) > 8) then
-            error_msg = 'indirect i32 call has too many arguments'
-            return
-        end if
-        operands(1) = callee_ptr
-        do i = 1, size(args)
-            operands(i + 1) = args(i)
-        end do
-        inst%op = LR_OP_CALL
-        inst%typ = lr_type_i32_s(session%handle)
-        inst%dest = 0_c_int32_t
-        inst%operands = c_loc(operands)
-        inst%num_operands = int(size(args) + 1, c_int32_t)
-        inst%indices = c_null_ptr
-        inst%num_indices = 0_c_int32_t
-        inst%align = 0_c_int32_t
-        inst%icmp_pred = 0_c_int
-        inst%fcmp_pred = 0_c_int
-        inst%call_external_abi = c_false
-        inst%call_vararg = c_false
-        inst%call_fixed_args = 0_c_int32_t
-        call clear_liric_error(error)
-        vreg = lr_session_emit(session%handle, inst, error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-        result = i32_vreg(session, vreg)
-        call set_empty(error_msg)
-        emit_i32_indirect_call = .true.
-    end function emit_i32_indirect_call
-
-    logical function emit_void_indirect_call(session, callee_ptr, args, error_msg)
-        ! Indirect void call: callee_ptr is a loaded function pointer (ptr vreg).
-        type(liric_session_t), intent(inout) :: session
-        type(lr_operand_desc_t), intent(in) :: callee_ptr
-        type(lr_operand_desc_t), intent(in) :: args(:)
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t), target :: operands(9)
-        type(lr_inst_desc_t) :: inst
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: unused_vreg
-        integer :: i
-
-        emit_void_indirect_call = .false.
-        if (.not. require_open_session(session, error_msg)) return
-        if (size(args) > 8) then
-            error_msg = 'indirect void call has too many arguments'
-            return
-        end if
-        operands(1) = callee_ptr
-        do i = 1, size(args)
-            operands(i + 1) = args(i)
-        end do
-        inst%op = LR_OP_CALL
-        inst%typ = lr_type_void_s(session%handle)
-        inst%dest = 0_c_int32_t
-        inst%operands = c_loc(operands)
-        inst%num_operands = int(size(args) + 1, c_int32_t)
-        inst%indices = c_null_ptr
-        inst%num_indices = 0_c_int32_t
-        inst%align = 0_c_int32_t
-        inst%icmp_pred = 0_c_int
-        inst%fcmp_pred = 0_c_int
-        inst%call_external_abi = c_false
-        inst%call_vararg = c_false
-        inst%call_fixed_args = 0_c_int32_t
-        call clear_liric_error(error)
-        unused_vreg = lr_session_emit(session%handle, inst, error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-        call set_empty(error_msg)
-        emit_void_indirect_call = .true.
-    end function emit_void_indirect_call
-
-    function global_operand(handle, symbol_id) result(operand)
-        type(c_ptr), intent(in) :: handle
-        integer(c_int32_t), intent(in) :: symbol_id
-        type(lr_operand_desc_t) :: operand
-
-        operand%kind = LR_OP_KIND_GLOBAL
-        operand%payload = int(symbol_id, c_int64_t)
-        operand%typ = lr_type_i32_s(handle)
-        operand%global_offset = 0_c_int64_t
-    end function global_operand
-
-    function session_i32_type(session, error_msg) result(i32_type)
-        type(liric_session_t), intent(in) :: session
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(c_ptr) :: i32_type
-
-        i32_type = lr_type_i32_s(session%handle)
-        if (c_associated(i32_type)) then
             call set_empty(error_msg)
-        else
-            error_msg = 'LIRIC did not return an i32 type'
-        end if
-    end function session_i32_type
+            begin_i32_function = .true.
+            end function begin_i32_function
 
-    function i32_immediate(session, value) result(operand)
-        type(liric_session_t), intent(in) :: session
-        integer(c_int64_t), intent(in) :: value
-        type(lr_operand_desc_t) :: operand
+            logical function begin_void_subroutine(session, name, param_count, &
+                    error_msg)
+                type(liric_session_t), intent(inout) :: session
+                character(len=*), intent(in) :: name
+                integer, intent(in) :: param_count
+                character(len=:), allocatable, intent(out) :: error_msg
+                character(kind=c_char), allocatable :: c_name(:)
+                type(c_ptr), allocatable, target :: params(:)
+                type(c_ptr) :: param_type
+                type(c_ptr) :: i32_type
+                type(c_ptr) :: params_ptr
+                type(c_ptr) :: void_type
+                type(lr_error_t) :: error
+                integer(c_int32_t) :: block_id
+                integer(c_int) :: status
+                integer :: i
 
-        operand%kind = LR_OP_KIND_IMM_I64
-        operand%payload = value
-        operand%typ = lr_type_i32_s(session%handle)
-        operand%global_offset = 0_c_int64_t
-    end function i32_immediate
+                begin_void_subroutine = .false.
+                    if (.not. require_open_session(session, error_msg)) return
 
-    function i32_vreg(session, vreg) result(operand)
-        type(liric_session_t), intent(in) :: session
-        integer(c_int32_t), intent(in) :: vreg
-        type(lr_operand_desc_t) :: operand
+                    i32_type = session_i32_type(session, error_msg)
+                    if (len_trim(error_msg) > 0) return
+                    void_type = lr_type_void_s(session%handle)
+                    if (.not. c_associated(void_type)) then
+                        error_msg = 'LIRIC did not return a void type'
+                        return
+                    end if
 
-        operand%kind = LR_OP_KIND_VREG
-        operand%payload = int(vreg, c_int64_t)
-        operand%typ = lr_type_i32_s(session%handle)
-        operand%global_offset = 0_c_int64_t
-    end function i32_vreg
+                    param_type = lr_type_ptr_s(session%handle)
+                    if (.not. c_associated(param_type)) then
+                        error_msg = 'LIRIC did not return a pointer type'
+                        return
+                    end if
 
-end module liric_session_bindings
+                    params_ptr = c_null_ptr
+                    if (param_count > 0) then
+                        allocate (params(param_count))
+                        do i = 1, param_count
+                            params(i) = param_type
+                        end do
+                        params_ptr = c_loc(params)
+                    end if
+
+                    call clear_liric_error(error)
+                    call to_c_chars(trim(name), c_name)
+                    status = lr_session_func_begin(session%handle, c_name, void_type, &
+                        params_ptr, int(param_count, c_int32_t), &
+                        c_false, error)
+                    if (.not. status_ok(status, error, error_msg)) return
+
+                    block_id = lr_session_block(session%handle)
+                    status = lr_session_set_block(session%handle, block_id, error)
+                    if (.not. status_ok(status, error, error_msg)) return
+
+                    call set_empty(error_msg)
+                    begin_void_subroutine = .true.
+                    end function begin_void_subroutine
+
+                    logical function begin_ptr_function(session, name, param_count, &
+                            error_msg)
+                        type(liric_session_t), intent(inout) :: session
+                        character(len=*), intent(in) :: name
+                        integer, intent(in) :: param_count
+                        character(len=:), allocatable, intent(out) :: error_msg
+                        character(kind=c_char), allocatable :: c_name(:)
+                        type(c_ptr), allocatable, target :: params(:)
+                        type(c_ptr) :: param_type
+                        type(c_ptr) :: params_ptr
+                        type(lr_error_t) :: error
+                        integer(c_int32_t) :: block_id
+                        integer(c_int) :: status
+                        integer :: i
+
+                        begin_ptr_function = .false.
+                            if (.not. require_open_session(session, error_msg)) return
+
+                            param_type = lr_type_ptr_s(session%handle)
+                            if (.not. c_associated(param_type)) then
+                                error_msg = 'LIRIC did not return a pointer type'
+                                return
+                            end if
+
+                            params_ptr = c_null_ptr
+                            if (param_count > 0) then
+                                allocate (params(param_count))
+                                do i = 1, param_count
+                                    params(i) = param_type
+                                end do
+                                params_ptr = c_loc(params)
+                            end if
+
+                            call clear_liric_error(error)
+                            call to_c_chars(trim(name), c_name)
+                            status = lr_session_func_begin(session%handle, c_name, &
+                                lr_type_ptr_s(session%handle), &
+                                params_ptr, int(param_count, c_int32_t), &
+                                c_false, error)
+                            if (.not. status_ok(status, error, error_msg)) return
+
+                            block_id = lr_session_block(session%handle)
+                            status = lr_session_set_block(session%handle, block_id, error)
+                            if (.not. status_ok(status, error, error_msg)) return
+
+                            call set_empty(error_msg)
+                            begin_ptr_function = .true.
+                            end function begin_ptr_function
+
+                            logical function emit_ret_i32_operand(session, value, error_msg)
+                                type(liric_session_t), intent(inout) :: session
+                                type(lr_operand_desc_t), intent(in) :: value
+                                character(len=:), allocatable, intent(out) :: error_msg
+                                type(lr_error_t) :: error
+                                integer(c_int32_t) :: unused_vreg
+
+                                emit_ret_i32_operand = .false.
+                                if (.not. require_open_session(session, error_msg)) return
+
+                                unused_vreg = emit_ret_i32(session%handle, value, error)
+                                if (.not. status_ok(error%code, error, error_msg)) return
+
+                                call set_empty(error_msg)
+                                emit_ret_i32_operand = .true.
+                            end function emit_ret_i32_operand
+
+                            logical function emit_ret_void(session, error_msg)
+                                type(liric_session_t), intent(inout) :: session
+                                character(len=:), allocatable, intent(out) :: error_msg
+                                type(lr_error_t) :: error
+                                integer(c_int32_t) :: unused_vreg
+
+                                emit_ret_void = .false.
+                                if (.not. require_open_session(session, error_msg)) return
+
+                                unused_vreg = emit_ret_void_inst(session%handle, error)
+                                if (.not. status_ok(error%code, error, error_msg)) return
+
+                                call set_empty(error_msg)
+                                emit_ret_void = .true.
+                            end function emit_ret_void
+
+                            logical function finish_and_emit_exe(session, path, error_msg)
+                                type(liric_session_t), intent(inout) :: session
+                                character(len=*), intent(in) :: path
+                                character(len=:), allocatable, intent(out) :: error_msg
+                                character(kind=c_char), allocatable :: c_path(:)
+                                type(c_ptr) :: out_addr
+                                type(lr_error_t) :: error
+                                integer(c_int) :: status
+
+                                finish_and_emit_exe = .false.
+                                if (.not. require_open_session(session, error_msg)) return
+
+                                call clear_liric_error(error)
+                                out_addr = c_null_ptr
+                                status = lr_session_func_end(session%handle, out_addr, error)
+                                if (.not. status_ok(status, error, error_msg)) return
+
+                                call to_c_chars(path, c_path)
+                                status = lr_session_emit_exe(session%handle, c_path, error)
+                                if (.not. status_ok(status, error, error_msg)) return
+
+                                call set_empty(error_msg)
+                                finish_and_emit_exe = .true.
+                            end function finish_and_emit_exe
+
+                            logical function finish_and_emit_object(session, path, error_msg)
+                                type(liric_session_t), intent(inout) :: session
+                                character(len=*), intent(in) :: path
+                                character(len=:), allocatable, intent(out) :: error_msg
+                                character(kind=c_char), allocatable :: c_path(:)
+                                type(c_ptr) :: out_addr
+                                type(lr_error_t) :: error
+                                integer(c_int) :: status
+
+                                finish_and_emit_object = .false.
+                                if (.not. require_open_session(session, error_msg)) return
+
+                                call clear_liric_error(error)
+                                out_addr = c_null_ptr
+                                status = lr_session_func_end(session%handle, out_addr, error)
+                                if (.not. status_ok(status, error, error_msg)) return
+
+                                call to_c_chars(path, c_path)
+                                status = lr_session_emit_object(session%handle, c_path, error)
+                                if (.not. status_ok(status, error, error_msg)) return
+
+                                call set_empty(error_msg)
+                                finish_and_emit_object = .true.
+                            end function finish_and_emit_object
+
+                            logical function finish_function(session, error_msg)
+                                type(liric_session_t), intent(inout) :: session
+                                character(len=:), allocatable, intent(out) :: error_msg
+                                type(c_ptr) :: out_addr
+                                type(lr_error_t) :: error
+                                integer(c_int) :: status
+
+                                finish_function = .false.
+                                    if (.not. require_open_session(session, error_msg)) return
+
+                                    call clear_liric_error(error)
+                                    out_addr = c_null_ptr
+                                    status = lr_session_func_end(session%handle, out_addr, error)
+                                    if (.not. status_ok(status, error, error_msg)) return
+
+                                    call set_empty(error_msg)
+                                    finish_function = .true.
+                                    end function finish_function
+
+                                    logical function emit_i32_call(session, name, args, result, error_msg)
+                                        type(liric_session_t), intent(inout) :: session
+                                        character(len=*), intent(in) :: name
+                                        type(lr_operand_desc_t), intent(in) :: args(:)
+                                        type(lr_operand_desc_t), intent(out) :: result
+                                        character(len=:), allocatable, intent(out) :: error_msg
+                                        type(lr_error_t) :: error
+                                        integer(c_int32_t) :: vreg
+
+                                        emit_i32_call = .false.
+                                        if (.not. require_open_session(session, error_msg)) return
+
+                                        vreg = emit_call_i32(session%handle, name, args, error)
+                                        if (.not. status_ok(error%code, error, error_msg)) return
+
+                                        result = i32_vreg(session, vreg)
+                                        call set_empty(error_msg)
+                                        emit_i32_call = .true.
+                                    end function emit_i32_call
+
+                                    logical function emit_void_call(session, name, args, error_msg)
+                                        type(liric_session_t), intent(inout) :: session
+                                        character(len=*), intent(in) :: name
+                                        type(lr_operand_desc_t), intent(in) :: args(:)
+                                        character(len=:), allocatable, intent(out) :: error_msg
+                                        type(lr_error_t) :: error
+                                        integer(c_int32_t) :: unused_vreg
+
+                                        emit_void_call = .false.
+                                        if (.not. require_open_session(session, error_msg)) return
+
+                                        unused_vreg = emit_call_void(session%handle, name, args, error)
+                                        if (.not. status_ok(error%code, error, error_msg)) return
+
+                                        call set_empty(error_msg)
+                                        emit_void_call = .true.
+                                    end function emit_void_call
+
+                                    logical function emit_ptr_call(session, name, args, result, error_msg)
+                                        type(liric_session_t), intent(inout) :: session
+                                        character(len=*), intent(in) :: name
+                                        type(lr_operand_desc_t), intent(in) :: args(:)
+                                        type(lr_operand_desc_t), intent(out) :: result
+                                        character(len=:), allocatable, intent(out) :: error_msg
+                                        type(lr_error_t) :: error
+                                        integer(c_int32_t) :: vreg
+                                        type(lr_operand_desc_t), target :: operands(9)
+                                        type(lr_inst_desc_t) :: inst
+                                        character(kind=c_char), allocatable :: c_name(:)
+                                        integer(c_int32_t) :: symbol_id
+                                        integer :: i
+
+                                        emit_ptr_call = .false.
+                                        if (.not. require_open_session(session, error_msg)) return
+                                        call to_c_chars(trim(name), c_name)
+                                        symbol_id = lr_session_intern(session%handle, c_name)
+                                        if (symbol_id < 0_c_int32_t .or. size(args) > 8) then
+                                            error_msg = 'could not intern symbol for ptr call: '//trim(name)
+                                            return
+                                        end if
+                                        operands(1) = global_operand(session%handle, symbol_id)
+                                        do i = 1, size(args)
+                                            operands(i + 1) = args(i)
+                                        end do
+                                        inst%op = LR_OP_CALL
+                                        inst%typ = lr_type_ptr_s(session%handle)
+                                        inst%dest = 0_c_int32_t
+                                        inst%operands = c_loc(operands)
+                                        inst%num_operands = int(size(args) + 1, c_int32_t)
+                                        inst%indices = c_null_ptr
+                                        inst%num_indices = 0_c_int32_t
+                                        inst%align = 0_c_int32_t
+                                        inst%icmp_pred = 0_c_int
+                                        inst%fcmp_pred = 0_c_int
+                                        inst%call_external_abi = c_false
+                                        inst%call_vararg = c_false
+                                        inst%call_fixed_args = 0_c_int32_t
+                                        call clear_liric_error(error)
+                                        vreg = lr_session_emit(session%handle, inst, error)
+                                        if (.not. status_ok(error%code, error, error_msg)) return
+                                        ! Inline ptr_vreg: cannot use liric_session_memory_bindings here
+                                        ! (circular dependency); build the ptr operand directly.
+                                        result%kind = LR_OP_KIND_VREG
+                                        result%payload = int(vreg, c_int64_t)
+                                        result%typ = lr_type_ptr_s(session%handle)
+                                        result%global_offset = 0_c_int64_t
+                                        call set_empty(error_msg)
+                                        emit_ptr_call = .true.
+                                    end function emit_ptr_call
+
+                                    function emit_ret_i32(handle, value, error) result(vreg)
+                                        type(c_ptr), intent(in) :: handle
+                                        type(lr_operand_desc_t), intent(in) :: value
+                                        type(lr_error_t), intent(inout) :: error
+                                        integer(c_int32_t) :: vreg
+                                        type(lr_operand_desc_t), target :: operands(1)
+                                        type(lr_inst_desc_t) :: inst
+
+                                        operands(1) = value
+
+                                        inst%op = LR_OP_RET
+                                        inst%typ = value%typ
+                                        inst%dest = 0_c_int32_t
+                                        inst%operands = c_loc(operands)
+                                        inst%num_operands = 1_c_int32_t
+                                        inst%indices = c_null_ptr
+                                        inst%num_indices = 0_c_int32_t
+                                        inst%align = 0_c_int32_t
+                                        inst%icmp_pred = 0_c_int
+                                        inst%fcmp_pred = 0_c_int
+                                        inst%call_external_abi = c_false
+                                        inst%call_vararg = c_false
+                                        inst%call_fixed_args = 0_c_int32_t
+
+                                        call clear_liric_error(error)
+                                        vreg = lr_session_emit(handle, inst, error)
+                                    end function emit_ret_i32
+
+                                    function emit_ret_void_inst(handle, error) result(vreg)
+                                        type(c_ptr), intent(in) :: handle
+                                        type(lr_error_t), intent(inout) :: error
+                                        integer(c_int32_t) :: vreg
+                                        type(lr_inst_desc_t) :: inst
+
+                                        inst%op = LR_OP_RET_VOID
+                                        inst%typ = lr_type_void_s(handle)
+                                        inst%dest = 0_c_int32_t
+                                        inst%operands = c_null_ptr
+                                        inst%num_operands = 0_c_int32_t
+                                        inst%indices = c_null_ptr
+                                        inst%num_indices = 0_c_int32_t
+                                        inst%align = 0_c_int32_t
+                                        inst%icmp_pred = 0_c_int
+                                        inst%fcmp_pred = 0_c_int
+                                        inst%call_external_abi = c_false
+                                        inst%call_vararg = c_false
+                                        inst%call_fixed_args = 0_c_int32_t
+
+                                        call clear_liric_error(error)
+                                        vreg = lr_session_emit(handle, inst, error)
+                                    end function emit_ret_void_inst
+
+                                    function emit_binary(handle, opcode, lhs, rhs, error) result(vreg)
+                                        type(c_ptr), intent(in) :: handle
+                                        integer(c_int), intent(in) :: opcode
+                                        type(lr_operand_desc_t), intent(in) :: lhs
+                                        type(lr_operand_desc_t), intent(in) :: rhs
+                                        type(lr_error_t), intent(inout) :: error
+                                        integer(c_int32_t) :: vreg
+                                        type(lr_operand_desc_t), target :: operands(2)
+                                        type(lr_inst_desc_t) :: inst
+
+                                        operands = [lhs, rhs]
+
+                                        inst%op = opcode
+                                        inst%typ = lhs%typ
+                                        inst%dest = 0_c_int32_t
+                                        inst%operands = c_loc(operands)
+                                        inst%num_operands = 2_c_int32_t
+                                        inst%indices = c_null_ptr
+                                        inst%num_indices = 0_c_int32_t
+                                        inst%align = 0_c_int32_t
+                                        inst%icmp_pred = 0_c_int
+                                        inst%fcmp_pred = 0_c_int
+                                        inst%call_external_abi = c_false
+                                        inst%call_vararg = c_false
+                                        inst%call_fixed_args = 0_c_int32_t
+
+                                        call clear_liric_error(error)
+                                        vreg = lr_session_emit(handle, inst, error)
+                                    end function emit_binary
+
+                                    function emit_call_i32(handle, name, args, error) result(vreg)
+                                        type(c_ptr), intent(in) :: handle
+                                        character(len=*), intent(in) :: name
+                                        type(lr_operand_desc_t), intent(in) :: args(:)
+                                        type(lr_error_t), intent(inout) :: error
+                                        integer(c_int32_t) :: vreg
+                                        type(lr_operand_desc_t), target :: operands(9)
+                                        type(lr_inst_desc_t) :: inst
+                                        character(kind=c_char), allocatable :: c_name(:)
+                                        integer(c_int32_t) :: symbol_id
+                                        integer :: i
+
+                                        call to_c_chars(trim(name), c_name)
+                                        symbol_id = lr_session_intern(handle, c_name)
+                                        if (symbol_id < 0_c_int32_t .or. size(args) > 8) then
+                                            call clear_liric_error(error)
+                                            error%code = 1_c_int
+                                            return
+                                        end if
+
+                                        operands(1) = global_operand(handle, symbol_id)
+                                        do i = 1, size(args)
+                                            operands(i + 1) = args(i)
+                                        end do
+
+                                        inst%op = LR_OP_CALL
+                                        inst%typ = lr_type_i32_s(handle)
+                                        inst%dest = 0_c_int32_t
+                                        inst%operands = c_loc(operands)
+                                        inst%num_operands = int(size(args) + 1, c_int32_t)
+                                        inst%indices = c_null_ptr
+                                        inst%num_indices = 0_c_int32_t
+                                        inst%align = 0_c_int32_t
+                                        inst%icmp_pred = 0_c_int
+                                        inst%fcmp_pred = 0_c_int
+                                        inst%call_external_abi = c_false
+                                        inst%call_vararg = c_false
+                                        inst%call_fixed_args = 0_c_int32_t
+
+                                        call clear_liric_error(error)
+                                        vreg = lr_session_emit(handle, inst, error)
+                                    end function emit_call_i32
+
+                                    function emit_call_void(handle, name, args, error) result(vreg)
+                                        type(c_ptr), intent(in) :: handle
+                                        character(len=*), intent(in) :: name
+                                        type(lr_operand_desc_t), intent(in) :: args(:)
+                                        type(lr_error_t), intent(inout) :: error
+                                        integer(c_int32_t) :: vreg
+                                        type(lr_operand_desc_t), target :: operands(9)
+                                        type(lr_inst_desc_t) :: inst
+                                        character(kind=c_char), allocatable :: c_name(:)
+                                        integer(c_int32_t) :: symbol_id
+                                        integer :: i
+
+                                        call to_c_chars(trim(name), c_name)
+                                        symbol_id = lr_session_intern(handle, c_name)
+                                        if (symbol_id < 0_c_int32_t .or. size(args) > 8) then
+                                            call clear_liric_error(error)
+                                            error%code = 1_c_int
+                                            return
+                                        end if
+
+                                        operands(1) = global_operand(handle, symbol_id)
+                                        do i = 1, size(args)
+                                            operands(i + 1) = args(i)
+                                        end do
+
+                                        inst%op = LR_OP_CALL
+                                        inst%typ = lr_type_void_s(handle)
+                                        inst%dest = 0_c_int32_t
+                                        inst%operands = c_loc(operands)
+                                        inst%num_operands = int(size(args) + 1, c_int32_t)
+                                        inst%indices = c_null_ptr
+                                        inst%num_indices = 0_c_int32_t
+                                        inst%align = 0_c_int32_t
+                                        inst%icmp_pred = 0_c_int
+                                        inst%fcmp_pred = 0_c_int
+                                        inst%call_external_abi = c_false
+                                        inst%call_vararg = c_false
+                                        inst%call_fixed_args = 0_c_int32_t
+
+                                        call clear_liric_error(error)
+                                        vreg = lr_session_emit(handle, inst, error)
+                                    end function emit_call_void
+
+                                    logical function emit_i32_indirect_call(session, callee_ptr, args, result, &
+                                            error_msg)
+                                        ! Indirect i32 call: callee_ptr is a loaded function pointer (ptr vreg).
+                                        ! First operand of LR_OP_CALL is the ptr vreg, not a global symbol.
+                                        type(liric_session_t), intent(inout) :: session
+                                        type(lr_operand_desc_t), intent(in) :: callee_ptr
+                                        type(lr_operand_desc_t), intent(in) :: args(:)
+                                        type(lr_operand_desc_t), intent(out) :: result
+                                        character(len=:), allocatable, intent(out) :: error_msg
+                                        type(lr_operand_desc_t), target :: operands(9)
+                                        type(lr_inst_desc_t) :: inst
+                                        type(lr_error_t) :: error
+                                        integer(c_int32_t) :: vreg
+                                        integer :: i
+
+                                        emit_i32_indirect_call = .false.
+                                        if (.not. require_open_session(session, error_msg)) return
+                                        if (size(args) > 8) then
+                                            error_msg = 'indirect i32 call has too many arguments'
+                                            return
+                                        end if
+                                        operands(1) = callee_ptr
+                                        do i = 1, size(args)
+                                            operands(i + 1) = args(i)
+                                        end do
+                                        inst%op = LR_OP_CALL
+                                        inst%typ = lr_type_i32_s(session%handle)
+                                        inst%dest = 0_c_int32_t
+                                        inst%operands = c_loc(operands)
+                                        inst%num_operands = int(size(args) + 1, c_int32_t)
+                                        inst%indices = c_null_ptr
+                                        inst%num_indices = 0_c_int32_t
+                                        inst%align = 0_c_int32_t
+                                        inst%icmp_pred = 0_c_int
+                                        inst%fcmp_pred = 0_c_int
+                                        inst%call_external_abi = c_false
+                                        inst%call_vararg = c_false
+                                        inst%call_fixed_args = 0_c_int32_t
+                                        call clear_liric_error(error)
+                                        vreg = lr_session_emit(session%handle, inst, error)
+                                        if (.not. status_ok(error%code, error, error_msg)) return
+                                        result = i32_vreg(session, vreg)
+                                        call set_empty(error_msg)
+                                        emit_i32_indirect_call = .true.
+                                    end function emit_i32_indirect_call
+
+                                    logical function emit_void_indirect_call(session, callee_ptr, args, error_msg)
+                                        ! Indirect void call: callee_ptr is a loaded function pointer (ptr vreg).
+                                        type(liric_session_t), intent(inout) :: session
+                                        type(lr_operand_desc_t), intent(in) :: callee_ptr
+                                        type(lr_operand_desc_t), intent(in) :: args(:)
+                                        character(len=:), allocatable, intent(out) :: error_msg
+                                        type(lr_operand_desc_t), target :: operands(9)
+                                        type(lr_inst_desc_t) :: inst
+                                        type(lr_error_t) :: error
+                                        integer(c_int32_t) :: unused_vreg
+                                        integer :: i
+
+                                        emit_void_indirect_call = .false.
+                                        if (.not. require_open_session(session, error_msg)) return
+                                        if (size(args) > 8) then
+                                            error_msg = 'indirect void call has too many arguments'
+                                            return
+                                        end if
+                                        operands(1) = callee_ptr
+                                        do i = 1, size(args)
+                                            operands(i + 1) = args(i)
+                                        end do
+                                        inst%op = LR_OP_CALL
+                                        inst%typ = lr_type_void_s(session%handle)
+                                        inst%dest = 0_c_int32_t
+                                        inst%operands = c_loc(operands)
+                                        inst%num_operands = int(size(args) + 1, c_int32_t)
+                                        inst%indices = c_null_ptr
+                                        inst%num_indices = 0_c_int32_t
+                                        inst%align = 0_c_int32_t
+                                        inst%icmp_pred = 0_c_int
+                                        inst%fcmp_pred = 0_c_int
+                                        inst%call_external_abi = c_false
+                                        inst%call_vararg = c_false
+                                        inst%call_fixed_args = 0_c_int32_t
+                                        call clear_liric_error(error)
+                                        unused_vreg = lr_session_emit(session%handle, inst, error)
+                                        if (.not. status_ok(error%code, error, error_msg)) return
+                                        call set_empty(error_msg)
+                                        emit_void_indirect_call = .true.
+                                    end function emit_void_indirect_call
+
+                                    function global_operand(handle, symbol_id) result(operand)
+                                        type(c_ptr), intent(in) :: handle
+                                        integer(c_int32_t), intent(in) :: symbol_id
+                                        type(lr_operand_desc_t) :: operand
+
+                                        operand%kind = LR_OP_KIND_GLOBAL
+                                        operand%payload = int(symbol_id, c_int64_t)
+                                        operand%typ = lr_type_i32_s(handle)
+                                        operand%global_offset = 0_c_int64_t
+                                    end function global_operand
+
+                                    function session_i32_type(session, error_msg) result(i32_type)
+                                        type(liric_session_t), intent(in) :: session
+                                        character(len=:), allocatable, intent(out) :: error_msg
+                                        type(c_ptr) :: i32_type
+
+                                        i32_type = lr_type_i32_s(session%handle)
+                                        if (c_associated(i32_type)) then
+                                            call set_empty(error_msg)
+                                        else
+                                            error_msg = 'LIRIC did not return an i32 type'
+                                        end if
+                                    end function session_i32_type
+
+                                    function i32_immediate(session, value) result(operand)
+                                        type(liric_session_t), intent(in) :: session
+                                        integer(c_int64_t), intent(in) :: value
+                                        type(lr_operand_desc_t) :: operand
+
+                                        operand%kind = LR_OP_KIND_IMM_I64
+                                        operand%payload = value
+                                        operand%typ = lr_type_i32_s(session%handle)
+                                        operand%global_offset = 0_c_int64_t
+                                    end function i32_immediate
+
+                                    function i32_vreg(session, vreg) result(operand)
+                                        type(liric_session_t), intent(in) :: session
+                                        integer(c_int32_t), intent(in) :: vreg
+                                        type(lr_operand_desc_t) :: operand
+
+                                        operand%kind = LR_OP_KIND_VREG
+                                        operand%payload = int(vreg, c_int64_t)
+                                        operand%typ = lr_type_i32_s(session%handle)
+                                        operand%global_offset = 0_c_int64_t
+                                    end function i32_vreg
+
+                                end module liric_session_bindings

--- a/src/liric_session_common.f90
+++ b/src/liric_session_common.f90
@@ -2,16 +2,16 @@ module liric_session_common
     use, intrinsic :: iso_c_binding, only: c_associated, c_bool, c_char
     use, intrinsic :: iso_c_binding, only: c_int, c_int32_t, c_int64_t
     use, intrinsic :: iso_c_binding, only: c_loc, c_null_char, c_null_ptr, c_ptr, &
-                                              c_size_t
+        c_size_t
     implicit none
     private
 
     public :: lr_session_config_t, lr_error_t, lr_operand_desc_t, &
-              lr_inst_desc_t, liric_session_t
+        lr_inst_desc_t, liric_session_t
     public :: LR_OK, LR_OP_KIND_VREG, LR_OP_KIND_IMM_I64, LR_OP_KIND_GLOBAL, &
-              LR_OP_KIND_BLOCK
+        LR_OP_KIND_BLOCK
     public :: require_open_session, status_ok, liric_session_error_message, &
-              clear_liric_error, to_c_chars, set_empty
+        clear_liric_error, to_c_chars, set_empty
 
     integer(c_int), parameter :: LR_OK = 0_c_int
     integer(c_int), parameter :: LR_OP_RET = 0_c_int
@@ -55,8 +55,8 @@ module liric_session_common
     end type lr_inst_desc_t
 
     type, public :: liric_session_t
-         type(c_ptr) :: handle = c_null_ptr
-     end type liric_session_t
+        type(c_ptr) :: handle = c_null_ptr
+    end type liric_session_t
 
 contains
 

--- a/src/liric_session_complex_print_bindings.f90
+++ b/src/liric_session_complex_print_bindings.f90
@@ -15,31 +15,31 @@ module liric_session_complex_print_bindings
     ! and .ffc.fmt_r8(f64 x, ptr buf) -> i32, then .ffc.print_c4 and
     ! .ffc.print_c8 call these for re and im, compute padding, and printf.
     use, intrinsic :: iso_c_binding, only: c_bool, c_char, c_int, c_int32_t, &
-                                           c_int64_t, c_loc, c_null_char, &
-                                           c_null_ptr, c_ptr, c_size_t
+        c_int64_t, c_loc, c_null_char, &
+        c_null_ptr, c_ptr, c_size_t
     use liric_session_bindings, only: liric_session_t, lr_error_t, &
-                                      lr_inst_desc_t, lr_operand_desc_t, LR_OK, &
-                                      LR_OP_CALL, LR_OP_TRUNC, LR_OP_FPEXT, &
-                                      LR_OP_ADD, LR_OP_SUB, &
-                                      LR_OP_STORE, LR_OP_GEP, LR_OP_RET, &
-                                      LR_OP_RET_VOID, &
-                                      LR_OP_KIND_VREG, LR_OP_KIND_IMM_I64, &
-                                      LR_OP_KIND_GLOBAL, &
-                                      lr_type_i32_s, lr_type_f32_s, lr_type_f64_s, &
-                                      lr_type_i64_s, lr_type_ptr_s, lr_type_i8_s, &
-                                      lr_type_array_s, lr_type_void_s, &
-                                      lr_session_emit, lr_session_intern, &
-                                      lr_session_global, lr_session_param, &
-                                      status_ok, clear_liric_error, &
-                                      set_empty, require_open_session, to_c_chars, &
-                                      i32_vreg, i32_immediate
+        lr_inst_desc_t, lr_operand_desc_t, LR_OK, &
+        LR_OP_CALL, LR_OP_TRUNC, LR_OP_FPEXT, &
+        LR_OP_ADD, LR_OP_SUB, &
+        LR_OP_STORE, LR_OP_GEP, LR_OP_RET, &
+        LR_OP_RET_VOID, &
+        LR_OP_KIND_VREG, LR_OP_KIND_IMM_I64, &
+        LR_OP_KIND_GLOBAL, &
+        lr_type_i32_s, lr_type_f32_s, lr_type_f64_s, &
+        lr_type_i64_s, lr_type_ptr_s, lr_type_i8_s, &
+        lr_type_array_s, lr_type_void_s, &
+        lr_session_emit, lr_session_intern, &
+        lr_session_global, lr_session_param, &
+        status_ok, clear_liric_error, &
+        set_empty, require_open_session, to_c_chars, &
+        i32_vreg, i32_immediate
     use liric_session_memory_bindings, only: ptr_vreg, i64_vreg, i64_immediate, &
-                                             emit_alloca_bytes, emit_i32_binary
+        emit_alloca_bytes, emit_i32_binary
     use liric_session_control_bindings, only: create_liric_block, set_liric_block, &
-                                              emit_liric_br, emit_liric_condbr, &
-                                              emit_liric_i32_icmp, &
-                                              LR_CMP_NE, LR_CMP_SGE, &
-                                              LR_CMP_SLE, LR_CMP_SLT
+        emit_liric_br, emit_liric_condbr, &
+        emit_liric_i32_icmp, &
+        LR_CMP_NE, LR_CMP_SGE, &
+        LR_CMP_SLE, LR_CMP_SLT
     implicit none
     private
 
@@ -58,7 +58,7 @@ module liric_session_complex_print_bindings
 
     interface
         function lr_session_func_begin(handle, name, ret, params, n, &
-                                       vararg, err) result(status) bind(c)
+                vararg, err) result(status) bind(c)
             import :: c_bool, c_char, c_int, c_int32_t, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             character(kind=c_char), intent(in) :: name(*)
@@ -79,7 +79,7 @@ module liric_session_complex_print_bindings
         end function lr_session_func_end
 
         function lr_session_declare(handle, name, ret, params, n, vararg, &
-                                    err) result(status) bind(c)
+                err) result(status) bind(c)
             import :: c_bool, c_char, c_int, c_int32_t, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             character(kind=c_char), intent(in) :: name(*)
@@ -109,15 +109,15 @@ contains
         integer(c_int32_t) :: vreg
 
         emit_extern_i32_call = cx_emit_call(session, name, args, &
-                                            lr_type_i32_s(session%handle), &
-                                            0_c_int32_t, c_false, &
-                                            vreg, error_msg)
+            lr_type_i32_s(session%handle), &
+            0_c_int32_t, c_false, &
+            vreg, error_msg)
         if (.not. emit_extern_i32_call) return
         result = i32_vreg(session, vreg)
     end function emit_extern_i32_call
 
     logical function cx_emit_call(session, name, args, ret_typ, fixed_args, &
-                                  vararg, vreg, error_msg)
+            vararg, vreg, error_msg)
         type(liric_session_t), intent(inout) :: session
         character(len=*), intent(in) :: name
         type(lr_operand_desc_t), intent(in) :: args(:)
@@ -361,10 +361,10 @@ contains
         end do
         bytes(n) = c_null_char
         array_type = lr_type_array_s(session%handle, lr_type_i8_s(session%handle), &
-                                     int(n, c_int64_t))
+            int(n, c_int64_t))
         call to_c_chars(name, c_name)
         global_id = lr_session_global(session%handle, c_name, array_type, c_true, &
-                                      c_loc(bytes), int(n, c_size_t))
+            c_loc(bytes), int(n, c_size_t))
         if (global_id < 0_c_int32_t) then
             error_msg = 'cx: cannot create string global '//trim(name)
             return
@@ -383,7 +383,7 @@ contains
     end function cx_create_cstring
 
     logical function cx_declare_one(session, name, ret, params_ptr, n, vararg, &
-                                    error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         character(len=*), intent(in) :: name
         type(c_ptr), intent(in) :: ret, params_ptr
@@ -398,7 +398,7 @@ contains
         call clear_liric_error(error)
         call to_c_chars(name, c_name)
         status = lr_session_declare(session%handle, c_name, ret, params_ptr, n, &
-                                    vararg, error)
+            vararg, error)
         if (.not. status_ok(status, error, error_msg)) return
         cx_declare_one = .true.
     end function cx_declare_one
@@ -413,18 +413,18 @@ contains
         p3(2) = lr_type_i64_s(session%handle)
         p3(3) = lr_type_ptr_s(session%handle)
         if (.not. cx_declare_one(session, 'snprintf', lr_type_i32_s(session%handle), &
-                                 c_loc(p3), 3_c_int32_t, c_true, error_msg)) return
+            c_loc(p3), 3_c_int32_t, c_true, error_msg)) return
         p1(1) = lr_type_ptr_s(session%handle)
         if (.not. cx_declare_one(session, 'printf', lr_type_i32_s(session%handle), &
-                                 c_loc(p1), 1_c_int32_t, c_true, error_msg)) return
+            c_loc(p1), 1_c_int32_t, c_true, error_msg)) return
         if (.not. cx_declare_one(session, 'strlen', lr_type_i64_s(session%handle), &
-                                 c_loc(p1), 1_c_int32_t, c_false, error_msg)) return
+            c_loc(p1), 1_c_int32_t, c_false, error_msg)) return
         if (.not. cx_declare_one(session, 'atoi', lr_type_i32_s(session%handle), &
-                                 c_loc(p1), 1_c_int32_t, c_false, error_msg)) return
+            c_loc(p1), 1_c_int32_t, c_false, error_msg)) return
         p2(1) = lr_type_ptr_s(session%handle)
         p2(2) = lr_type_i32_s(session%handle)
         if (.not. cx_declare_one(session, 'strchr', lr_type_ptr_s(session%handle), &
-                                 c_loc(p2), 2_c_int32_t, c_false, error_msg)) return
+            c_loc(p2), 2_c_int32_t, c_false, error_msg)) return
         cx_declare_libc = .true.
     end function cx_declare_libc
 
@@ -467,19 +467,19 @@ contains
         ! gfortran complex(4) exponential form carries 9 fraction digits
         ! (d.dddddddddE+nn, 9 significant). %.9e matches; %.8e drops one.
         if (.not. cx_create_cstring(session, '.ffc.c4.fe', '%.9e', g_fe, &
-                                    error_msg)) return
+            error_msg)) return
         if (.not. cx_create_cstring(session, '.ffc.c4.ff', '%#.*f', g_ff, &
-                                    error_msg)) return
+            error_msg)) return
         if (.not. cx_create_cstring(session, '.ffc.c4.feo', '%sE%c%02d', g_feo, &
-                                    error_msg)) return
+            error_msg)) return
 
         params(1) = lr_type_f64_s(session%handle)
         params(2) = lr_type_ptr_s(session%handle)
         call clear_liric_error(error)
         call to_c_chars(FMT_R4_HELPER, c_name)
         status = lr_session_func_begin(session%handle, c_name, &
-                                       lr_type_i32_s(session%handle), &
-                                       c_loc(params), 2_c_int32_t, c_false, error)
+            lr_type_i32_s(session%handle), &
+            c_loc(params), 2_c_int32_t, c_false, error)
         if (.not. status_ok(status, error, error_msg)) return
 
         x = cx_typed_param(session, 0_c_int32_t, lr_type_f64_s(session%handle))
@@ -499,23 +499,23 @@ contains
         ! entry: tmp = alloca 36; num = alloca 32; snprintf(tmp, 36, "%.8e", x)
         if (.not. set_liric_block(session, entry_blk, error_msg)) return
         if (.not. emit_alloca_bytes(session, i64_immediate(session, 36_c_int64_t), &
-                                    tmp, error_msg)) return
+            tmp, error_msg)) return
         if (.not. emit_alloca_bytes(session, i64_immediate(session, 32_c_int64_t), &
-                                    num, error_msg)) return
+            num, error_msg)) return
         args(1) = tmp
         args(2) = i64_immediate(session, 36_c_int64_t)
         args(3) = g_fe
         args(4) = x
         if (.not. cx_emit_call(session, 'snprintf', args(1:4), &
-                               lr_type_i32_s(session%handle), 3_c_int32_t, &
-                               c_true, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_true, vreg, error_msg)) return
 
         ! p = strchr(tmp, 'e')
         args(1) = tmp
         args(2) = i32_immediate(session, int(iachar('e'), c_int64_t))
         if (.not. cx_emit_call(session, 'strchr', args(1:2), &
-                               lr_type_ptr_s(session%handle), 2_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_ptr_s(session%handle), 2_c_int32_t, &
+            c_false, vreg, error_msg)) return
         p = ptr_vreg(session, vreg)
 
         nullptr%kind = LR_OP_KIND_IMM_I64
@@ -523,7 +523,7 @@ contains
         nullptr%typ = lr_type_ptr_s(session%handle)
         nullptr%global_offset = 0_c_int64_t
         if (.not. emit_liric_i32_icmp(session, LR_CMP_NE, p, nullptr, cond, &
-                                      error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_condbr(session, cond, finblk, nfblk, error_msg)) return
 
         ! finblk: pe1 = p+1; ex = atoi(pe1); *p = '\0'
@@ -531,43 +531,43 @@ contains
         if (.not. cx_gep_byte(session, p, 1_c_int64_t, pe1, error_msg)) return
         args(1) = pe1
         if (.not. cx_emit_call(session, 'atoi', args(1:1), &
-                               lr_type_i32_s(session%handle), 1_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 1_c_int32_t, &
+            c_false, vreg, error_msg)) return
         ex = i32_vreg(session, vreg)
         if (.not. cx_store_zero_byte(session, p, error_msg)) return
 
         if (.not. emit_liric_i32_icmp(session, LR_CMP_SGE, ex, &
-                i32_immediate(session, -1_c_int64_t), cond, error_msg)) return
+            i32_immediate(session, -1_c_int64_t), cond, error_msg)) return
         if (.not. emit_liric_condbr(session, cond, chkhi, eblk, error_msg)) return
 
         if (.not. set_liric_block(session, chkhi, error_msg)) return
         if (.not. emit_liric_i32_icmp(session, LR_CMP_SLE, ex, &
-                i32_immediate(session, 8_c_int64_t), cond, error_msg)) return
+            i32_immediate(session, 8_c_int64_t), cond, error_msg)) return
         if (.not. emit_liric_condbr(session, cond, fblk, eblk, error_msg)) return
 
         ! fblk: buf = snprintf("%#.*f", 8-ex, x)
         if (.not. set_liric_block(session, fblk, error_msg)) return
         if (.not. emit_i32_binary(session, LR_OP_SUB, &
-                i32_immediate(session, 8_c_int64_t), ex, prec, error_msg)) return
+            i32_immediate(session, 8_c_int64_t), ex, prec, error_msg)) return
         args(1) = buf
         args(2) = i64_immediate(session, 32_c_int64_t)
         args(3) = g_ff
         args(4) = prec
         args(5) = x
         if (.not. cx_emit_call(session, 'snprintf', args(1:5), &
-                               lr_type_i32_s(session%handle), 3_c_int32_t, &
-                               c_true, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_true, vreg, error_msg)) return
         if (.not. emit_liric_br(session, exitb, error_msg)) return
 
         ! eblk: exponential. eneg: negative exponent; epos: positive.
         if (.not. set_liric_block(session, eblk, error_msg)) return
         if (.not. emit_liric_i32_icmp(session, LR_CMP_SLT, ex, &
-                i32_immediate(session, 0_c_int64_t), cond, error_msg)) return
+            i32_immediate(session, 0_c_int64_t), cond, error_msg)) return
         if (.not. emit_liric_condbr(session, cond, eneg, epos, error_msg)) return
 
         if (.not. set_liric_block(session, eneg, error_msg)) return
         if (.not. emit_i32_binary(session, LR_OP_SUB, &
-                i32_immediate(session, 0_c_int64_t), ex, negex, error_msg)) return
+            i32_immediate(session, 0_c_int64_t), ex, negex, error_msg)) return
         args(1) = num
         args(2) = i64_immediate(session, 32_c_int64_t)
         args(3) = g_feo
@@ -575,16 +575,16 @@ contains
         args(5) = i32_immediate(session, int(iachar('-'), c_int64_t))
         args(6) = negex
         if (.not. cx_emit_call(session, 'snprintf', args, &
-                               lr_type_i32_s(session%handle), 3_c_int32_t, &
-                               c_true, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_true, vreg, error_msg)) return
         if (.not. emit_liric_br(session, eprint, error_msg)) return
 
         if (.not. set_liric_block(session, epos, error_msg)) return
         args(5) = i32_immediate(session, int(iachar('+'), c_int64_t))
         args(6) = ex
         if (.not. cx_emit_call(session, 'snprintf', args, &
-                               lr_type_i32_s(session%handle), 3_c_int32_t, &
-                               c_true, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_true, vreg, error_msg)) return
         if (.not. emit_liric_br(session, eprint, error_msg)) return
 
         ! eprint: copy num -> buf
@@ -593,8 +593,8 @@ contains
         args(2) = i64_immediate(session, 32_c_int64_t)
         args(3) = num
         if (.not. cx_emit_call(session, 'snprintf', args(1:3), &
-                               lr_type_i32_s(session%handle), 3_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_false, vreg, error_msg)) return
         if (.not. emit_liric_br(session, exitb, error_msg)) return
 
         ! nfblk: non-finite (Inf/NaN). Copy tmp -> buf.
@@ -603,18 +603,18 @@ contains
         args(2) = i64_immediate(session, 32_c_int64_t)
         args(3) = tmp
         if (.not. cx_emit_call(session, 'snprintf', args(1:3), &
-                               lr_type_i32_s(session%handle), 3_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_false, vreg, error_msg)) return
         if (.not. emit_liric_br(session, exitb, error_msg)) return
 
         ! exitb: return (i32) strlen(buf)
         if (.not. set_liric_block(session, exitb, error_msg)) return
         args(1) = buf
         if (.not. cx_emit_call(session, 'strlen', args(1:1), &
-                               lr_type_i64_s(session%handle), 1_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_i64_s(session%handle), 1_c_int32_t, &
+            c_false, vreg, error_msg)) return
         if (.not. cx_emit_cast(session, LR_OP_TRUNC, i64_vreg(session, vreg), &
-                               lr_type_i32_s(session%handle), slen, error_msg)) return
+            lr_type_i32_s(session%handle), slen, error_msg)) return
         if (.not. cx_ret_i32(session, slen, error_msg)) return
 
         call clear_liric_error(error)
@@ -648,19 +648,19 @@ contains
         if (.not. require_open_session(session, error_msg)) return
 
         if (.not. cx_create_cstring(session, '.ffc.c8.fe', '%.17e', g_fe, &
-                                    error_msg)) return
+            error_msg)) return
         if (.not. cx_create_cstring(session, '.ffc.c8.ff', '%#.*f', g_ff, &
-                                    error_msg)) return
+            error_msg)) return
         if (.not. cx_create_cstring(session, '.ffc.c8.feo', '%sE%c%03d', g_feo, &
-                                    error_msg)) return
+            error_msg)) return
 
         params(1) = lr_type_f64_s(session%handle)
         params(2) = lr_type_ptr_s(session%handle)
         call clear_liric_error(error)
         call to_c_chars(FMT_R8_HELPER, c_name)
         status = lr_session_func_begin(session%handle, c_name, &
-                                       lr_type_i32_s(session%handle), &
-                                       c_loc(params), 2_c_int32_t, c_false, error)
+            lr_type_i32_s(session%handle), &
+            c_loc(params), 2_c_int32_t, c_false, error)
         if (.not. status_ok(status, error, error_msg)) return
 
         x = cx_typed_param(session, 0_c_int32_t, lr_type_f64_s(session%handle))
@@ -679,22 +679,22 @@ contains
 
         if (.not. set_liric_block(session, entry_blk, error_msg)) return
         if (.not. emit_alloca_bytes(session, i64_immediate(session, 48_c_int64_t), &
-                                    tmp, error_msg)) return
+            tmp, error_msg)) return
         if (.not. emit_alloca_bytes(session, i64_immediate(session, 48_c_int64_t), &
-                                    num, error_msg)) return
+            num, error_msg)) return
         args(1) = tmp
         args(2) = i64_immediate(session, 48_c_int64_t)
         args(3) = g_fe
         args(4) = x
         if (.not. cx_emit_call(session, 'snprintf', args(1:4), &
-                               lr_type_i32_s(session%handle), 3_c_int32_t, &
-                               c_true, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_true, vreg, error_msg)) return
 
         args(1) = tmp
         args(2) = i32_immediate(session, int(iachar('e'), c_int64_t))
         if (.not. cx_emit_call(session, 'strchr', args(1:2), &
-                               lr_type_ptr_s(session%handle), 2_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_ptr_s(session%handle), 2_c_int32_t, &
+            c_false, vreg, error_msg)) return
         p = ptr_vreg(session, vreg)
 
         nullptr%kind = LR_OP_KIND_IMM_I64
@@ -702,48 +702,48 @@ contains
         nullptr%typ = lr_type_ptr_s(session%handle)
         nullptr%global_offset = 0_c_int64_t
         if (.not. emit_liric_i32_icmp(session, LR_CMP_NE, p, nullptr, cond, &
-                                      error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_condbr(session, cond, finblk, nfblk, error_msg)) return
 
         if (.not. set_liric_block(session, finblk, error_msg)) return
         if (.not. cx_gep_byte(session, p, 1_c_int64_t, pe1, error_msg)) return
         args(1) = pe1
         if (.not. cx_emit_call(session, 'atoi', args(1:1), &
-                               lr_type_i32_s(session%handle), 1_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 1_c_int32_t, &
+            c_false, vreg, error_msg)) return
         ex = i32_vreg(session, vreg)
         if (.not. cx_store_zero_byte(session, p, error_msg)) return
 
         if (.not. emit_liric_i32_icmp(session, LR_CMP_SGE, ex, &
-                i32_immediate(session, -1_c_int64_t), cond, error_msg)) return
+            i32_immediate(session, -1_c_int64_t), cond, error_msg)) return
         if (.not. emit_liric_condbr(session, cond, chkhi, eblk, error_msg)) return
 
         if (.not. set_liric_block(session, chkhi, error_msg)) return
         if (.not. emit_liric_i32_icmp(session, LR_CMP_SLE, ex, &
-                i32_immediate(session, 16_c_int64_t), cond, error_msg)) return
+            i32_immediate(session, 16_c_int64_t), cond, error_msg)) return
         if (.not. emit_liric_condbr(session, cond, fblk, eblk, error_msg)) return
 
         if (.not. set_liric_block(session, fblk, error_msg)) return
         if (.not. emit_i32_binary(session, LR_OP_SUB, &
-                i32_immediate(session, 16_c_int64_t), ex, prec, error_msg)) return
+            i32_immediate(session, 16_c_int64_t), ex, prec, error_msg)) return
         args(1) = buf
         args(2) = i64_immediate(session, 48_c_int64_t)
         args(3) = g_ff
         args(4) = prec
         args(5) = x
         if (.not. cx_emit_call(session, 'snprintf', args(1:5), &
-                               lr_type_i32_s(session%handle), 3_c_int32_t, &
-                               c_true, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_true, vreg, error_msg)) return
         if (.not. emit_liric_br(session, exitb, error_msg)) return
 
         if (.not. set_liric_block(session, eblk, error_msg)) return
         if (.not. emit_liric_i32_icmp(session, LR_CMP_SLT, ex, &
-                i32_immediate(session, 0_c_int64_t), cond, error_msg)) return
+            i32_immediate(session, 0_c_int64_t), cond, error_msg)) return
         if (.not. emit_liric_condbr(session, cond, eneg, epos, error_msg)) return
 
         if (.not. set_liric_block(session, eneg, error_msg)) return
         if (.not. emit_i32_binary(session, LR_OP_SUB, &
-                i32_immediate(session, 0_c_int64_t), ex, negex, error_msg)) return
+            i32_immediate(session, 0_c_int64_t), ex, negex, error_msg)) return
         args(1) = num
         args(2) = i64_immediate(session, 48_c_int64_t)
         args(3) = g_feo
@@ -751,16 +751,16 @@ contains
         args(5) = i32_immediate(session, int(iachar('-'), c_int64_t))
         args(6) = negex
         if (.not. cx_emit_call(session, 'snprintf', args, &
-                               lr_type_i32_s(session%handle), 3_c_int32_t, &
-                               c_true, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_true, vreg, error_msg)) return
         if (.not. emit_liric_br(session, eprint, error_msg)) return
 
         if (.not. set_liric_block(session, epos, error_msg)) return
         args(5) = i32_immediate(session, int(iachar('+'), c_int64_t))
         args(6) = ex
         if (.not. cx_emit_call(session, 'snprintf', args, &
-                               lr_type_i32_s(session%handle), 3_c_int32_t, &
-                               c_true, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_true, vreg, error_msg)) return
         if (.not. emit_liric_br(session, eprint, error_msg)) return
 
         if (.not. set_liric_block(session, eprint, error_msg)) return
@@ -768,8 +768,8 @@ contains
         args(2) = i64_immediate(session, 48_c_int64_t)
         args(3) = num
         if (.not. cx_emit_call(session, 'snprintf', args(1:3), &
-                               lr_type_i32_s(session%handle), 3_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_false, vreg, error_msg)) return
         if (.not. emit_liric_br(session, exitb, error_msg)) return
 
         if (.not. set_liric_block(session, nfblk, error_msg)) return
@@ -777,17 +777,17 @@ contains
         args(2) = i64_immediate(session, 48_c_int64_t)
         args(3) = tmp
         if (.not. cx_emit_call(session, 'snprintf', args(1:3), &
-                               lr_type_i32_s(session%handle), 3_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_false, vreg, error_msg)) return
         if (.not. emit_liric_br(session, exitb, error_msg)) return
 
         if (.not. set_liric_block(session, exitb, error_msg)) return
         args(1) = buf
         if (.not. cx_emit_call(session, 'strlen', args(1:1), &
-                               lr_type_i64_s(session%handle), 1_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_i64_s(session%handle), 1_c_int32_t, &
+            c_false, vreg, error_msg)) return
         if (.not. cx_emit_cast(session, LR_OP_TRUNC, i64_vreg(session, vreg), &
-                               lr_type_i32_s(session%handle), slen, error_msg)) return
+            lr_type_i32_s(session%handle), slen, error_msg)) return
         if (.not. cx_ret_i32(session, slen, error_msg)) return
 
         call clear_liric_error(error)
@@ -822,17 +822,17 @@ contains
         if (.not. synthesize_fmt_r4_helper(session, error_msg)) return
 
         if (.not. cx_create_cstring(session, '.ffc.c4.pf', '%*s(%s,%s)', g_pf, &
-                                    error_msg)) return
+            error_msg)) return
         if (.not. cx_create_cstring(session, '.ffc.c4.es', '', empty, &
-                                    error_msg)) return
+            error_msg)) return
 
         params(1) = lr_type_f32_s(session%handle)
         params(2) = lr_type_f32_s(session%handle)
         call clear_liric_error(error)
         call to_c_chars(COMPLEX4_PRINTER, c_name)
         status = lr_session_func_begin(session%handle, c_name, &
-                                       lr_type_void_s(session%handle), &
-                                       c_loc(params), 2_c_int32_t, c_false, error)
+            lr_type_void_s(session%handle), &
+            c_loc(params), 2_c_int32_t, c_false, error)
         if (.not. status_ok(status, error, error_msg)) return
 
         re = cx_typed_param(session, 0_c_int32_t, lr_type_f32_s(session%handle))
@@ -843,36 +843,36 @@ contains
 
         ! Extend f32 params to f64 for fmt_r4 (takes f64)
         if (.not. cx_emit_cast(session, LR_OP_FPEXT, re, &
-                lr_type_f64_s(session%handle), re_f64, error_msg)) return
+            lr_type_f64_s(session%handle), re_f64, error_msg)) return
         if (.not. cx_emit_cast(session, LR_OP_FPEXT, im, &
-                lr_type_f64_s(session%handle), im_f64, error_msg)) return
+            lr_type_f64_s(session%handle), im_f64, error_msg)) return
 
         if (.not. emit_alloca_bytes(session, i64_immediate(session, 36_c_int64_t), &
-                                    re_buf, error_msg)) return
+            re_buf, error_msg)) return
         if (.not. emit_alloca_bytes(session, i64_immediate(session, 36_c_int64_t), &
-                                    im_buf, error_msg)) return
+            im_buf, error_msg)) return
 
         ! w1 = .ffc.fmt_r4(re_f64, re_buf)
         args(1) = re_f64
         args(2) = re_buf
         if (.not. cx_emit_call(session, FMT_R4_HELPER, args(1:2), &
-                               lr_type_i32_s(session%handle), 2_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 2_c_int32_t, &
+            c_false, vreg, error_msg)) return
         w1 = i32_vreg(session, vreg)
 
         ! w2 = .ffc.fmt_r4(im_f64, im_buf)
         args(1) = im_f64
         args(2) = im_buf
         if (.not. cx_emit_call(session, FMT_R4_HELPER, args(1:2), &
-                               lr_type_i32_s(session%handle), 2_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 2_c_int32_t, &
+            c_false, vreg, error_msg)) return
         w2 = i32_vreg(session, vreg)
 
         ! pad = 32 - w1 - w2  (field 35, parens/comma occupy 3 chars)
         if (.not. emit_i32_binary(session, LR_OP_ADD, w1, w2, wsum, &
-                                  error_msg)) return
+            error_msg)) return
         if (.not. emit_i32_binary(session, LR_OP_SUB, &
-                i32_immediate(session, 32_c_int64_t), wsum, pad, error_msg)) return
+            i32_immediate(session, 32_c_int64_t), wsum, pad, error_msg)) return
 
         ! printf("%*s(%s,%s)", pad, "", re_buf, im_buf)
         args(1) = g_pf
@@ -881,7 +881,7 @@ contains
         args(4) = re_buf
         args(5) = im_buf
         if (.not. cx_emit_call(session, 'printf', args, lr_type_i32_s(session%handle), &
-                               1_c_int32_t, c_true, vreg, error_msg)) return
+            1_c_int32_t, c_true, vreg, error_msg)) return
 
         if (.not. cx_ret_void(session, error_msg)) return
 
@@ -917,17 +917,17 @@ contains
         if (.not. synthesize_fmt_r8_helper(session, error_msg)) return
 
         if (.not. cx_create_cstring(session, '.ffc.c8.pf', '%*s(%s,%s)', g_pf, &
-                                    error_msg)) return
+            error_msg)) return
         if (.not. cx_create_cstring(session, '.ffc.c8.es', '', empty, &
-                                    error_msg)) return
+            error_msg)) return
 
         params(1) = lr_type_f64_s(session%handle)
         params(2) = lr_type_f64_s(session%handle)
         call clear_liric_error(error)
         call to_c_chars(COMPLEX8_PRINTER, c_name)
         status = lr_session_func_begin(session%handle, c_name, &
-                                       lr_type_void_s(session%handle), &
-                                       c_loc(params), 2_c_int32_t, c_false, error)
+            lr_type_void_s(session%handle), &
+            c_loc(params), 2_c_int32_t, c_false, error)
         if (.not. status_ok(status, error, error_msg)) return
 
         re = cx_typed_param(session, 0_c_int32_t, lr_type_f64_s(session%handle))
@@ -937,29 +937,29 @@ contains
         if (.not. set_liric_block(session, entry_blk, error_msg)) return
 
         if (.not. emit_alloca_bytes(session, i64_immediate(session, 48_c_int64_t), &
-                                    re_buf, error_msg)) return
+            re_buf, error_msg)) return
         if (.not. emit_alloca_bytes(session, i64_immediate(session, 48_c_int64_t), &
-                                    im_buf, error_msg)) return
+            im_buf, error_msg)) return
 
         args(1) = re
         args(2) = re_buf
         if (.not. cx_emit_call(session, FMT_R8_HELPER, args(1:2), &
-                               lr_type_i32_s(session%handle), 2_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 2_c_int32_t, &
+            c_false, vreg, error_msg)) return
         w1 = i32_vreg(session, vreg)
 
         args(1) = im
         args(2) = im_buf
         if (.not. cx_emit_call(session, FMT_R8_HELPER, args(1:2), &
-                               lr_type_i32_s(session%handle), 2_c_int32_t, &
-                               c_false, vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 2_c_int32_t, &
+            c_false, vreg, error_msg)) return
         w2 = i32_vreg(session, vreg)
 
         ! pad = 50 - w1 - w2  (field 53, parens/comma = 3)
         if (.not. emit_i32_binary(session, LR_OP_ADD, w1, w2, wsum, &
-                                  error_msg)) return
+            error_msg)) return
         if (.not. emit_i32_binary(session, LR_OP_SUB, &
-                i32_immediate(session, 50_c_int64_t), wsum, pad, error_msg)) return
+            i32_immediate(session, 50_c_int64_t), wsum, pad, error_msg)) return
 
         args(1) = g_pf
         args(2) = pad
@@ -967,7 +967,7 @@ contains
         args(4) = re_buf
         args(5) = im_buf
         if (.not. cx_emit_call(session, 'printf', args, lr_type_i32_s(session%handle), &
-                               1_c_int32_t, c_true, vreg, error_msg)) return
+            1_c_int32_t, c_true, vreg, error_msg)) return
 
         if (.not. cx_ret_void(session, error_msg)) return
 
@@ -992,8 +992,8 @@ contains
         args(1) = re
         args(2) = im
         emit_complex4_print_call = cx_emit_call(session, COMPLEX4_PRINTER, args, &
-                                                lr_type_void_s(session%handle), &
-                                                2_c_int32_t, c_false, vreg, error_msg)
+            lr_type_void_s(session%handle), &
+            2_c_int32_t, c_false, vreg, error_msg)
     end function emit_complex4_print_call
 
     logical function emit_complex8_print_call(session, re, im, error_msg)
@@ -1006,8 +1006,8 @@ contains
         args(1) = re
         args(2) = im
         emit_complex8_print_call = cx_emit_call(session, COMPLEX8_PRINTER, args, &
-                                                lr_type_void_s(session%handle), &
-                                                2_c_int32_t, c_false, vreg, error_msg)
+            lr_type_void_s(session%handle), &
+            2_c_int32_t, c_false, vreg, error_msg)
     end function emit_complex8_print_call
 
 end module liric_session_complex_print_bindings

--- a/src/liric_session_control_bindings.f90
+++ b/src/liric_session_control_bindings.f90
@@ -3,11 +3,11 @@ module liric_session_control_bindings
     use, intrinsic :: iso_c_binding, only: c_int, c_int32_t, c_int64_t
     use, intrinsic :: iso_c_binding, only: c_loc, c_null_ptr, c_ptr
     use liric_session_common, only: require_open_session, status_ok, &
-                                    clear_liric_error, set_empty, &
-                                    liric_session_error_message, lr_error_t, &
-                                    lr_inst_desc_t, lr_operand_desc_t, &
-                                    liric_session_t, LR_OK, LR_OP_KIND_BLOCK, &
-                                    LR_OP_KIND_VREG
+        clear_liric_error, set_empty, &
+        liric_session_error_message, lr_error_t, &
+        lr_inst_desc_t, lr_operand_desc_t, &
+        liric_session_t, LR_OK, LR_OP_KIND_BLOCK, &
+        LR_OP_KIND_VREG
     use liric_session_bindings, only: i32_vreg
     implicit none
     private
@@ -57,7 +57,7 @@ module liric_session_control_bindings
         end function lr_session_block
 
         function lr_session_set_block(handle, block_id, err) result(status) &
-            bind(c)
+                bind(c)
             import :: c_int, c_int32_t, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             integer(c_int32_t), value :: block_id
@@ -112,7 +112,7 @@ contains
         if (.not. require_open_session(session, error_msg)) return
 
         unused_vreg = emit_br_inst(session%handle, block_operand(target_block), &
-                                   error)
+            error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
         call set_empty(error_msg)
@@ -120,7 +120,7 @@ contains
     end function emit_liric_br
 
     logical function emit_liric_i32_icmp(session, pred, lhs, rhs, result, &
-                                         error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int), intent(in) :: pred
         type(lr_operand_desc_t), intent(in) :: lhs
@@ -142,7 +142,7 @@ contains
     end function emit_liric_i32_icmp
 
     logical function emit_liric_f32_fcmp(session, pred, lhs, rhs, result, &
-                                         error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int), intent(in) :: pred
         type(lr_operand_desc_t), intent(in) :: lhs
@@ -164,7 +164,7 @@ contains
     end function emit_liric_f32_fcmp
 
     logical function emit_liric_f64_fcmp(session, pred, lhs, rhs, result, &
-                                         error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int), intent(in) :: pred
         type(lr_operand_desc_t), intent(in) :: lhs
@@ -186,7 +186,7 @@ contains
     end function emit_liric_f64_fcmp
 
     logical function emit_liric_condbr(session, condition, true_block, &
-                                       false_block, error_msg)
+            false_block, error_msg)
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: condition
         integer(c_int32_t), intent(in) :: true_block
@@ -199,8 +199,8 @@ contains
         if (.not. require_open_session(session, error_msg)) return
 
         unused_vreg = emit_condbr_inst(session%handle, condition, &
-                                       block_operand(true_block), &
-                                       block_operand(false_block), error)
+            block_operand(true_block), &
+            block_operand(false_block), error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
         call set_empty(error_msg)
@@ -208,7 +208,7 @@ contains
     end function emit_liric_condbr
 
     logical function emit_liric_phi(session, lhs, lhs_block, rhs, rhs_block, &
-                                    result, error_msg)
+            result, error_msg)
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: lhs
         integer(c_int32_t), intent(in) :: lhs_block
@@ -223,7 +223,7 @@ contains
         if (.not. require_open_session(session, error_msg)) return
 
         vreg = emit_phi_inst(session%handle, lhs, block_operand(lhs_block), rhs, &
-                             block_operand(rhs_block), error)
+            block_operand(rhs_block), error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
         result = vreg_like(vreg, lhs)
@@ -232,7 +232,7 @@ contains
     end function emit_liric_phi
 
     logical function emit_liric_i32_phi(session, lhs, lhs_block, rhs, rhs_block, &
-                                        result, error_msg)
+            result, error_msg)
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: lhs
         integer(c_int32_t), intent(in) :: lhs_block
@@ -242,7 +242,7 @@ contains
         character(len=:), allocatable, intent(out) :: error_msg
 
         emit_liric_i32_phi = emit_liric_phi(session, lhs, lhs_block, rhs, &
-                                            rhs_block, result, error_msg)
+            rhs_block, result, error_msg)
         if (.not. emit_liric_i32_phi) return
         result = i32_vreg(session, int(result%payload, c_int32_t))
         emit_liric_i32_phi = .true.
@@ -386,7 +386,7 @@ contains
     end function emit_fcmp
 
     function emit_condbr_inst(handle, condition, true_target, false_target, &
-                              error) result(vreg)
+            error) result(vreg)
         type(c_ptr), intent(in) :: handle
         type(lr_operand_desc_t), intent(in) :: condition
         type(lr_operand_desc_t), intent(in) :: true_target
@@ -408,7 +408,7 @@ contains
     end function emit_condbr_inst
 
     function emit_phi_inst(handle, lhs, lhs_block, rhs, rhs_block, error) &
-        result(vreg)
+            result(vreg)
         type(c_ptr), intent(in) :: handle
         type(lr_operand_desc_t), intent(in) :: lhs
         type(lr_operand_desc_t), intent(in) :: lhs_block

--- a/src/liric_session_format_bindings.f90
+++ b/src/liric_session_format_bindings.f90
@@ -2,27 +2,27 @@ module liric_session_format_bindings
     use, intrinsic :: iso_c_binding, only: c_associated, c_bool, c_char
     use, intrinsic :: iso_c_binding, only: c_double, c_int, c_int32_t, c_int64_t
     use, intrinsic :: iso_c_binding, only: c_loc, c_null_char, c_null_ptr, c_ptr, &
-                                              c_size_t
+        c_size_t
     use liric_session_common, only: require_open_session, status_ok, &
-                                    clear_liric_error, to_c_chars, set_empty, &
-                                    liric_session_error_message, lr_error_t, &
-                                    lr_operand_desc_t, lr_inst_desc_t, &
-                                    liric_session_t, LR_OP_KIND_GLOBAL, &
-                                    LR_OP_KIND_VREG, LR_OP_KIND_IMM_I64
+        clear_liric_error, to_c_chars, set_empty, &
+        liric_session_error_message, lr_error_t, &
+        lr_operand_desc_t, lr_inst_desc_t, &
+        liric_session_t, LR_OP_KIND_GLOBAL, &
+        LR_OP_KIND_VREG, LR_OP_KIND_IMM_I64
     use liric_session_bindings, only: LR_OP_CALL, LR_OP_RET, LR_OP_FDIV, &
-                                      LR_OP_SDIV, LR_OP_MUL, LR_OP_SUB, &
-                                      LR_OP_ADD, LR_OP_SITOFP, LR_OP_FPTOSI, &
-                                      lr_type_f64_s, lr_type_i64_s, &
-                                      lr_session_param, &
-                                      lr_session_emit, i32_immediate, i32_vreg
+        LR_OP_SDIV, LR_OP_MUL, LR_OP_SUB, &
+        LR_OP_ADD, LR_OP_SITOFP, LR_OP_FPTOSI, &
+        lr_type_f64_s, lr_type_i64_s, &
+        lr_session_param, &
+        lr_session_emit, i32_immediate, i32_vreg
     use liric_session_memory_bindings, only: emit_alloca_bytes, &
-                                             emit_i32_binary, i64_immediate, &
-                                             ptr_vreg
+        emit_i32_binary, i64_immediate, &
+        ptr_vreg
     use liric_session_control_bindings, only: create_liric_block, &
-                                              set_liric_block, emit_liric_br, &
-                                              emit_liric_condbr, &
-                                              emit_liric_i32_icmp, LR_CMP_EQ, &
-                                              LR_CMP_NE, LR_CMP_SLT
+        set_liric_block, emit_liric_br, &
+        emit_liric_condbr, &
+        emit_liric_i32_icmp, LR_CMP_EQ, &
+        LR_CMP_NE, LR_CMP_SLT
     implicit none
     private
 
@@ -69,7 +69,7 @@ module liric_session_format_bindings
         end function lr_type_array_s
 
         function lr_session_declare(handle, name, ret, params, n, vararg, &
-                                    err) result(status) bind(c)
+                err) result(status) bind(c)
             import :: c_bool, c_char, c_int, c_int32_t, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             character(kind=c_char), intent(in) :: name(*)
@@ -82,7 +82,7 @@ module liric_session_format_bindings
         end function lr_session_declare
 
         function lr_session_global(handle, name, typ, is_const, init, &
-                                   init_size) result(global_id) bind(c)
+                init_size) result(global_id) bind(c)
             import :: c_bool, c_char, c_int32_t, c_ptr, c_size_t
             type(c_ptr), value :: handle
             character(kind=c_char), intent(in) :: name(*)
@@ -101,7 +101,7 @@ module liric_session_format_bindings
         end function lr_session_intern
 
         function lr_session_func_begin(handle, name, ret, params, n, &
-                                       vararg, err) result(status) bind(c)
+                vararg, err) result(status) bind(c)
             import :: c_bool, c_char, c_int, c_int32_t, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             character(kind=c_char), intent(in) :: name(*)
@@ -125,9 +125,9 @@ module liric_session_format_bindings
 contains
 
     logical function prepare_liric_print_runtime(session, i32_format_id, &
-                                                 str_format_id, error_msg, &
-                                                 i64_format_id, i8_format_id, &
-                                                 i16_format_id)
+            str_format_id, error_msg, &
+            i64_format_id, i8_format_id, &
+            i16_format_id)
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(out) :: i32_format_id
         integer(c_int32_t), intent(out) :: str_format_id
@@ -142,27 +142,27 @@ contains
         prepare_liric_print_runtime = .false.
         if (.not. declare_printf_i32(session, error_msg)) return
         call create_i32_format_global_no_newline(session, &
-                                                 '.ffc.fmt.i32', &
-                                                 i32_format_id, error_msg)
+            '.ffc.fmt.i32', &
+            i32_format_id, error_msg)
         if (len_trim(error_msg) > 0) return
         call create_i64_format_global_no_newline(session, &
-                                                 '.ffc.fmt.i64', &
-                                                 local_i64_format_id, error_msg)
+            '.ffc.fmt.i64', &
+            local_i64_format_id, error_msg)
         if (len_trim(error_msg) > 0) return
         if (present(i64_format_id)) i64_format_id = local_i64_format_id
         call create_i8_format_global_no_newline(session, &
-                                                '.ffc.fmt.i8', &
-                                                local_i8_format_id, error_msg)
+            '.ffc.fmt.i8', &
+            local_i8_format_id, error_msg)
         if (len_trim(error_msg) > 0) return
         if (present(i8_format_id)) i8_format_id = local_i8_format_id
         call create_i16_format_global_no_newline(session, &
-                                                 '.ffc.fmt.i16', &
-                                                 local_i16_format_id, error_msg)
+            '.ffc.fmt.i16', &
+            local_i16_format_id, error_msg)
         if (len_trim(error_msg) > 0) return
         if (present(i16_format_id)) i16_format_id = local_i16_format_id
         call create_str_format_global_no_newline(session, &
-                                                 '.ffc.fmt.str', &
-                                                 str_format_id, error_msg)
+            '.ffc.fmt.str', &
+            str_format_id, error_msg)
         if (len_trim(error_msg) > 0) return
         if (.not. synthesize_e_en_format_helper(session, error_msg)) return
 
@@ -186,9 +186,9 @@ contains
         call clear_liric_error(error)
         call to_c_chars('printf', c_name)
         status = lr_session_declare(session%handle, c_name, &
-                                    lr_type_i32_s(session%handle), &
-                                    c_loc(params), 1_c_int32_t, c_true, &
-                                    error)
+            lr_type_i32_s(session%handle), &
+            c_loc(params), 1_c_int32_t, c_true, &
+            error)
         if (.not. status_ok(status, error, error_msg)) return
 
         call set_empty(error_msg)
@@ -196,58 +196,58 @@ contains
     end function declare_printf_i32
 
     subroutine create_i32_format_global_no_newline(session, name, global_id, &
-                                                   error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         character(len=*), intent(in) :: name
         integer(c_int32_t), intent(out) :: global_id
         character(len=:), allocatable, intent(out) :: error_msg
 
         call create_printf_format_global(session, name, '%11d', global_id, &
-                                         error_msg)
+            error_msg)
     end subroutine create_i32_format_global_no_newline
 
     subroutine create_str_format_global_no_newline(session, name, global_id, &
-                                                   error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         character(len=*), intent(in) :: name
         integer(c_int32_t), intent(out) :: global_id
         character(len=:), allocatable, intent(out) :: error_msg
 
         call create_printf_format_global(session, name, '%s', global_id, &
-                                         error_msg)
+            error_msg)
     end subroutine create_str_format_global_no_newline
 
     subroutine create_i8_format_global_no_newline(session, name, global_id, &
-                                                  error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         character(len=*), intent(in) :: name
         integer(c_int32_t), intent(out) :: global_id
         character(len=:), allocatable, intent(out) :: error_msg
 
         call create_printf_format_global(session, name, '%4d', global_id, &
-                                         error_msg)
+            error_msg)
     end subroutine create_i8_format_global_no_newline
 
     subroutine create_i16_format_global_no_newline(session, name, global_id, &
-                                                   error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         character(len=*), intent(in) :: name
         integer(c_int32_t), intent(out) :: global_id
         character(len=:), allocatable, intent(out) :: error_msg
 
         call create_printf_format_global(session, name, '%6d', global_id, &
-                                         error_msg)
+            error_msg)
     end subroutine create_i16_format_global_no_newline
 
     subroutine create_i64_format_global_no_newline(session, name, global_id, &
-                                                   error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         character(len=*), intent(in) :: name
         integer(c_int32_t), intent(out) :: global_id
         character(len=:), allocatable, intent(out) :: error_msg
 
         call create_printf_format_global(session, name, '%20ld', global_id, &
-                                         error_msg)
+            error_msg)
     end subroutine create_i64_format_global_no_newline
 
     function printf_format_ptr(session, global_id) result(operand)
@@ -263,7 +263,7 @@ contains
     end function printf_format_ptr
 
     subroutine create_printf_format_global(session, name, text, global_id, &
-                                           error_msg)
+            error_msg)
         ! Build an interned const [len(text)+1 x i8] global holding text plus a
         ! null terminator, for use as a printf format string.
         type(liric_session_t), intent(inout) :: session
@@ -285,14 +285,14 @@ contains
 
         call to_c_chars(name, c_name)
         array_type = lr_type_array_s(session%handle, lr_type_i8_s(session%handle), &
-                                     int(n, c_int64_t))
+            int(n, c_int64_t))
         if (.not. c_associated(array_type)) then
             error_msg = 'LIRIC did not return a format string array type'
             return
         end if
 
         global_id = lr_session_global(session%handle, c_name, array_type, &
-                                      c_true, c_loc(bytes), int(n, c_size_t))
+            c_true, c_loc(bytes), int(n, c_size_t))
         if (global_id < 0_c_int32_t) then
             error_msg = 'LIRIC could not create printf format string'
             return
@@ -306,7 +306,7 @@ contains
     end subroutine create_printf_format_global
 
     subroutine create_type_info_global(session, name, type_id, size_bytes, &
-                                        error_msg)
+            error_msg)
         ! Emit a compile-time ffc_type_info_t constant {i64 id; i64 size_bytes}
         ! as a 16-byte const global under the given (already-mangled) symbol.
         ! Not interned, so it keeps its symbol name for cross-unit comparison.
@@ -332,13 +332,13 @@ contains
 
         call to_c_chars(name, c_name)
         array_type = lr_type_array_s(session%handle, lr_type_i8_s(session%handle), &
-                                     16_c_int64_t)
+            16_c_int64_t)
         if (.not. c_associated(array_type)) then
             error_msg = 'LIRIC did not return a type-info array type'
             return
         end if
         global_id = lr_session_global(session%handle, c_name, array_type, &
-                                      c_true, c_loc(bytes), 16_c_size_t)
+            c_true, c_loc(bytes), 16_c_size_t)
         if (global_id < 0_c_int32_t) then
             error_msg = 'LIRIC could not create type-info global '//trim(name)
             return

--- a/src/liric_session_io_bindings.f90
+++ b/src/liric_session_io_bindings.f90
@@ -1,39 +1,39 @@
 module liric_session_io_bindings
     use liric_session_format_bindings, only: prepare_liric_print_runtime, &
-                                              LR_OP_FSUB
+        LR_OP_FSUB
     use liric_session_io_emission_bindings, only: emit_liric_f32_binary, &
-                                                  emit_liric_i32_to_f32, &
-                                                  emit_liric_f32_to_i32, &
-                                                  emit_liric_f32_to_f64, &
-                                                  emit_liric_print_f32, &
-                                                  emit_liric_print_f32_value, &
-                                                  emit_liric_f64_binary, &
-                                                  materialize_liric_string, &
-                                                  emit_liric_i32_to_f64, &
-                                                  emit_liric_f64_to_i32, &
-                                                  emit_liric_char_byte_zext, &
-                                                  emit_liric_i32_to_i64, &
-                                                  emit_liric_store_char_byte, &
-                                                  emit_liric_print_f64, &
-                                                  emit_liric_print_f64_value, &
-                                                  emit_liric_print_i32, &
-                                                  emit_liric_print_i32_value, &
-                                                  emit_liric_print_i64, &
-                                                  emit_liric_print_i64_value, &
-                                                  emit_liric_print_newline, &
-                                                  emit_liric_print_space, &
-                                                  emit_liric_print_string, &
-                                                  emit_liric_print_string_operand, &
-                                                  emit_liric_print_string_operand_value, &
-                                                  emit_liric_print_string_value, &
-                                                  liric_f32_immediate, &
-                                                  liric_f64_immediate, &
-                                                  emit_liric_i8_to_i32, &
-                                                  emit_liric_i16_to_i32, &
-                                                  emit_liric_print_i8, &
-                                                  emit_liric_print_i8_value, &
-                                                  emit_liric_print_i16, &
-                                                  emit_liric_print_i16_value
+        emit_liric_i32_to_f32, &
+        emit_liric_f32_to_i32, &
+        emit_liric_f32_to_f64, &
+        emit_liric_print_f32, &
+        emit_liric_print_f32_value, &
+        emit_liric_f64_binary, &
+        materialize_liric_string, &
+        emit_liric_i32_to_f64, &
+        emit_liric_f64_to_i32, &
+        emit_liric_char_byte_zext, &
+        emit_liric_i32_to_i64, &
+        emit_liric_store_char_byte, &
+        emit_liric_print_f64, &
+        emit_liric_print_f64_value, &
+        emit_liric_print_i32, &
+        emit_liric_print_i32_value, &
+        emit_liric_print_i64, &
+        emit_liric_print_i64_value, &
+        emit_liric_print_newline, &
+        emit_liric_print_space, &
+        emit_liric_print_string, &
+        emit_liric_print_string_operand, &
+        emit_liric_print_string_operand_value, &
+        emit_liric_print_string_value, &
+        liric_f32_immediate, &
+        liric_f64_immediate, &
+        emit_liric_i8_to_i32, &
+        emit_liric_i16_to_i32, &
+        emit_liric_print_i8, &
+        emit_liric_print_i8_value, &
+        emit_liric_print_i16, &
+        emit_liric_print_i16_value
     implicit none
     private
 

--- a/src/liric_session_io_emission_bindings.f90
+++ b/src/liric_session_io_emission_bindings.f90
@@ -1,32 +1,32 @@
 module liric_session_io_emission_bindings
     use, intrinsic :: iso_c_binding, only: c_associated, c_bool, c_char
     use, intrinsic :: iso_c_binding, only: c_double, c_int, c_int32_t, &
-                                              c_int64_t
+        c_int64_t
     use, intrinsic :: iso_c_binding, only: c_loc, c_null_char, c_null_ptr, c_ptr, &
-                                              c_size_t
+        c_size_t
     use liric_session_bindings, only: liric_session_t, lr_error_t, &
-                                      lr_inst_desc_t, lr_operand_desc_t, LR_OK, &
-                                      LR_OP_KIND_VREG, LR_OP_KIND_GLOBAL, &
-                                      LR_OP_CALL, LR_OP_BITCAST, LR_OP_SITOFP, &
-                                      LR_OP_FPTOSI, LR_OP_FPEXT, LR_OP_FPTRUNC, &
-                                      LR_OP_SEXT, LR_OP_ZEXT, LR_OP_TRUNC, &
-                                      LR_OP_GEP, LR_OP_LOAD, LR_OP_STORE, &
-                                      LR_OP_KIND_IMM_I64, &
-                                      LR_OP_FADD, LR_OP_FMUL, LR_OP_FDIV, &
-                                      liric_session_error_message, &
-                                      lr_type_i32_s, lr_type_f32_s, lr_type_f64_s, &
-                                      lr_type_i64_s, &
-                                      lr_type_ptr_s, lr_type_i8_s, lr_type_i16_s, &
-                                      lr_type_array_s, lr_session_emit, &
-                                      lr_session_intern, lr_session_global, &
-                                      global_operand, &
-                                      status_ok, clear_liric_error, &
-                                      set_empty, require_open_session, &
-                                      to_c_chars, i32_vreg
+        lr_inst_desc_t, lr_operand_desc_t, LR_OK, &
+        LR_OP_KIND_VREG, LR_OP_KIND_GLOBAL, &
+        LR_OP_CALL, LR_OP_BITCAST, LR_OP_SITOFP, &
+        LR_OP_FPTOSI, LR_OP_FPEXT, LR_OP_FPTRUNC, &
+        LR_OP_SEXT, LR_OP_ZEXT, LR_OP_TRUNC, &
+        LR_OP_GEP, LR_OP_LOAD, LR_OP_STORE, &
+        LR_OP_KIND_IMM_I64, &
+        LR_OP_FADD, LR_OP_FMUL, LR_OP_FDIV, &
+        liric_session_error_message, &
+        lr_type_i32_s, lr_type_f32_s, lr_type_f64_s, &
+        lr_type_i64_s, &
+        lr_type_ptr_s, lr_type_i8_s, lr_type_i16_s, &
+        lr_type_array_s, lr_session_emit, &
+        lr_session_intern, lr_session_global, &
+        global_operand, &
+        status_ok, clear_liric_error, &
+        set_empty, require_open_session, &
+        to_c_chars, i32_vreg
     use liric_session_memory_bindings, only: ptr_vreg, i64_vreg
     use liric_session_format_bindings, only: LR_OP_FSUB
     use liric_session_real_print_bindings, only: emit_real8_print_call, &
-                                                 emit_real4_print_call
+        emit_real4_print_call
     implicit none
     private
 
@@ -86,7 +86,7 @@ contains
     end function global_operand_session
 
     logical function emit_liric_print_i32(session, format_global_id, value, &
-                                          error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(in) :: format_global_id
         type(lr_operand_desc_t), intent(in) :: value
@@ -94,7 +94,7 @@ contains
 
         emit_liric_print_i32 = .false.
         if (.not. emit_liric_print_i32_value(session, format_global_id, value, &
-                                             error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_print_newline(session, error_msg)) return
         call set_empty(error_msg)
         emit_liric_print_i32 = .true.
@@ -112,8 +112,8 @@ contains
         emit_liric_print_f64 = .true.
     end function emit_liric_print_f64
 
-  logical function emit_liric_print_string(session, format_global_id, &
-                                              string_global_name, text, error_msg)
+    logical function emit_liric_print_string(session, format_global_id, &
+            string_global_name, text, error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(in) :: format_global_id
         character(len=*), intent(in) :: string_global_name
@@ -122,15 +122,15 @@ contains
 
         emit_liric_print_string = .false.
         if (.not. emit_liric_print_string_value(session, format_global_id, &
-                                                string_global_name, text, &
-                                                error_msg)) return
+            string_global_name, text, &
+            error_msg)) return
         if (.not. emit_liric_print_newline(session, error_msg)) return
         call set_empty(error_msg)
         emit_liric_print_string = .true.
     end function emit_liric_print_string
 
-  logical function emit_liric_print_string_operand(session, format_global_id, &
-                                                       string_ptr, error_msg)
+    logical function emit_liric_print_string_operand(session, format_global_id, &
+            string_ptr, error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(in) :: format_global_id
         type(lr_operand_desc_t), intent(in) :: string_ptr
@@ -138,14 +138,14 @@ contains
 
         emit_liric_print_string_operand = .false.
         if (.not. emit_liric_print_string_operand_value(session, format_global_id, &
-                                                        string_ptr, error_msg)) return
+            string_ptr, error_msg)) return
         if (.not. emit_liric_print_newline(session, error_msg)) return
         call set_empty(error_msg)
         emit_liric_print_string_operand = .true.
     end function emit_liric_print_string_operand
 
     logical function emit_liric_print_i32_value(session, format_global_id, &
-                                                value, error_msg)
+            value, error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(in) :: format_global_id
         type(lr_operand_desc_t), intent(in) :: value
@@ -162,11 +162,11 @@ contains
         if (len_trim(error_msg) > 0) return
 
         call materialize_global_pointer(session, format_global_id, format_ptr, &
-                                        error_msg)
+            error_msg)
         if (len_trim(error_msg) > 0) return
 
         unused_vreg = emit_call_i32(session%handle, callee, format_ptr, value, &
-                                    error)
+            error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
         call set_empty(error_msg)
@@ -174,7 +174,7 @@ contains
     end function emit_liric_print_i32_value
 
     logical function emit_liric_print_i64(session, format_global_id, value, &
-                                          error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(in) :: format_global_id
         type(lr_operand_desc_t), intent(in) :: value
@@ -182,14 +182,14 @@ contains
 
         emit_liric_print_i64 = .false.
         if (.not. emit_liric_print_i64_value(session, format_global_id, value, &
-                                             error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_print_newline(session, error_msg)) return
         call set_empty(error_msg)
         emit_liric_print_i64 = .true.
     end function emit_liric_print_i64
 
     logical function emit_liric_print_i64_value(session, format_global_id, &
-                                                value, error_msg)
+            value, error_msg)
         ! Print an i64 value via printf with the %20ld format global. The
         ! variadic printf call promotes the i64 value verbatim.
         type(liric_session_t), intent(inout) :: session
@@ -208,11 +208,11 @@ contains
         if (len_trim(error_msg) > 0) return
 
         call materialize_global_pointer(session, format_global_id, format_ptr, &
-                                        error_msg)
+            error_msg)
         if (len_trim(error_msg) > 0) return
 
         unused_vreg = emit_call_i32(session%handle, callee, format_ptr, value, &
-                                    error)
+            error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
         call set_empty(error_msg)
@@ -256,8 +256,8 @@ contains
     end function emit_liric_print_f32_value
 
     logical function emit_liric_print_string_value(session, format_global_id, &
-                                                   string_global_name, text, &
-                                                   error_msg)
+            string_global_name, text, &
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(in) :: format_global_id
         character(len=*), intent(in) :: string_global_name
@@ -267,18 +267,18 @@ contains
 
         emit_liric_print_string_value = .false.
         call materialize_liric_string(session, string_global_name, text, &
-                                      string_ptr, error_msg)
+            string_ptr, error_msg)
         if (len_trim(error_msg) > 0) return
 
         emit_liric_print_string_value = emit_liric_print_string_operand_value( &
-                                          session, format_global_id, string_ptr, &
-                                          error_msg)
+            session, format_global_id, string_ptr, &
+            error_msg)
     end function emit_liric_print_string_value
 
     logical function emit_liric_print_string_operand_value(session, &
-                                                           format_global_id, &
-                                                           string_ptr, &
-                                                           error_msg)
+            format_global_id, &
+            string_ptr, &
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(in) :: format_global_id
         type(lr_operand_desc_t), intent(in) :: string_ptr
@@ -295,11 +295,11 @@ contains
         if (len_trim(error_msg) > 0) return
 
         call materialize_global_pointer(session, format_global_id, format_ptr, &
-                                        error_msg)
+            error_msg)
         if (len_trim(error_msg) > 0) return
 
         unused_vreg = emit_call_ptr(session%handle, callee, format_ptr, &
-                                    string_ptr, error)
+            string_ptr, error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
         call set_empty(error_msg)
@@ -347,7 +347,7 @@ contains
     end function emit_liric_print_space
 
     subroutine materialize_liric_string(session, string_global_name, text, &
-                                        operand, error_msg)
+            operand, error_msg)
         type(liric_session_t), intent(inout) :: session
         character(len=*), intent(in) :: string_global_name
         character(len=*), intent(in) :: text
@@ -355,7 +355,7 @@ contains
         character(len=:), allocatable, intent(out) :: error_msg
 
         call make_string_literal_operand(session, string_global_name, text, &
-                                         operand, error_msg)
+            operand, error_msg)
     end subroutine materialize_liric_string
 
     subroutine make_printf_operand(session, operand, error_msg)
@@ -374,10 +374,10 @@ contains
 
         operand = global_operand_session(session, symbol_id, lr_type_ptr_s(session%handle))
         call set_empty(error_msg)
-   end subroutine make_printf_operand
+    end subroutine make_printf_operand
 
     subroutine make_string_literal_operand(session, name, text, operand, &
-                                           error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         character(len=*), intent(in) :: name
         character(len=*), intent(in) :: text
@@ -397,15 +397,15 @@ contains
         text_chars(len(text) + 1) = c_null_char
 
         array_type = lr_type_array_s(session%handle, lr_type_i8_s(session%handle), &
-                                      int(len(text) + 1, c_int64_t))
+            int(len(text) + 1, c_int64_t))
         if (.not. c_associated(array_type)) then
             error_msg = 'LIRIC did not return a string literal array type'
             return
         end if
 
         global_id = lr_session_global(session%handle, c_name, array_type, &
-                                      c_true, c_loc(text_chars(1)), &
-                                      int(len(text) + 1, c_size_t))
+            c_true, c_loc(text_chars(1)), &
+            int(len(text) + 1, c_size_t))
         if (global_id < 0_c_int32_t) then
             error_msg = 'LIRIC could not create string literal'
             return
@@ -421,8 +421,8 @@ contains
     end subroutine make_string_literal_operand
 
     subroutine make_string_literal_operand_from_chars(handle, name, text_chars, &
-                                                      total_size, operand, &
-                                                      error)
+            total_size, operand, &
+            error)
         type(c_ptr), intent(in) :: handle
         character(len=*), intent(in) :: name
         character(kind=c_char), intent(in), target :: text_chars(:)
@@ -443,8 +443,8 @@ contains
         end if
 
         global_id = lr_session_global(handle, c_name, array_type, c_true, &
-                                      c_loc(text_chars(1)), &
-                                      int(total_size, c_size_t))
+            c_loc(text_chars(1)), &
+            int(total_size, c_size_t))
         if (global_id < 0_c_int32_t) then
             error%code = 1_c_int
             error%msg = c_null_char
@@ -465,7 +465,7 @@ contains
     end subroutine make_string_literal_operand_from_chars
 
     subroutine materialize_global_pointer(session, global_id, operand, &
-                                          error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(in) :: global_id
         type(lr_operand_desc_t), intent(out) :: operand
@@ -474,8 +474,8 @@ contains
         type(lr_error_t) :: error
         integer(c_int32_t) :: vreg
 
-      global_ref = global_operand_session(session, global_id, &
-                                           lr_type_ptr_s(session%handle))
+        global_ref = global_operand_session(session, global_id, &
+            lr_type_ptr_s(session%handle))
         vreg = emit_bitcast_ptr(session%handle, global_ref, error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
@@ -648,7 +648,7 @@ contains
     end function liric_f64_immediate
 
     logical function emit_liric_f32_binary(session, opcode, lhs, rhs, result, &
-                                           error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int), intent(in) :: opcode
         type(lr_operand_desc_t), intent(in) :: lhs
@@ -736,7 +736,7 @@ contains
     end function emit_liric_f32_to_f64
 
     logical function emit_liric_f64_binary(session, opcode, lhs, rhs, result, &
-                                           error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int), intent(in) :: opcode
         type(lr_operand_desc_t), intent(in) :: lhs
@@ -831,7 +831,7 @@ contains
     end function emit_cast_i32
 
     logical function emit_liric_char_byte_zext(session, base, index_op, result, &
-                                               error_msg)
+            error_msg)
         ! Load the byte at base[index] and zero-extend it to i32.
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: base
@@ -891,7 +891,7 @@ contains
     end function emit_liric_char_byte_zext
 
     logical function emit_liric_store_char_byte(session, base, index_op, value, &
-                                                error_msg)
+            error_msg)
         ! Store the low byte of value (i32) at base[index].
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: base
@@ -1219,7 +1219,7 @@ contains
     end function emit_liric_i16_to_i32
 
     logical function emit_liric_print_i8(session, format_global_id, value, &
-                                         error_msg)
+            error_msg)
         ! Print an i8 value: sext to i32, then printf with i8 format.
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(in) :: format_global_id
@@ -1228,14 +1228,14 @@ contains
 
         emit_liric_print_i8 = .false.
         if (.not. emit_liric_print_i8_value(session, format_global_id, value, &
-                                             error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_print_newline(session, error_msg)) return
         call set_empty(error_msg)
         emit_liric_print_i8 = .true.
     end function emit_liric_print_i8
 
     logical function emit_liric_print_i8_value(session, format_global_id, &
-                                               value, error_msg)
+            value, error_msg)
         ! Emit printf(fmt, (i32)value) for an i8 value (sext to i32 first).
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(in) :: format_global_id
@@ -1251,17 +1251,17 @@ contains
         call make_printf_operand(session, callee, error_msg)
         if (len_trim(error_msg) > 0) return
         call materialize_global_pointer(session, format_global_id, format_ptr, &
-                                        error_msg)
+            error_msg)
         if (len_trim(error_msg) > 0) return
         unused_vreg = emit_call_i32(session%handle, callee, format_ptr, i32_value, &
-                                    error)
+            error)
         if (.not. status_ok(error%code, error, error_msg)) return
         call set_empty(error_msg)
         emit_liric_print_i8_value = .true.
     end function emit_liric_print_i8_value
 
     logical function emit_liric_print_i16(session, format_global_id, value, &
-                                          error_msg)
+            error_msg)
         ! Print an i16 value: sext to i32, then printf with i16 format.
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(in) :: format_global_id
@@ -1270,14 +1270,14 @@ contains
 
         emit_liric_print_i16 = .false.
         if (.not. emit_liric_print_i16_value(session, format_global_id, value, &
-                                              error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_print_newline(session, error_msg)) return
         call set_empty(error_msg)
         emit_liric_print_i16 = .true.
     end function emit_liric_print_i16
 
     logical function emit_liric_print_i16_value(session, format_global_id, &
-                                                value, error_msg)
+            value, error_msg)
         ! Emit printf(fmt, (i32)value) for an i16 value (sext to i32 first).
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(in) :: format_global_id
@@ -1293,10 +1293,10 @@ contains
         call make_printf_operand(session, callee, error_msg)
         if (len_trim(error_msg) > 0) return
         call materialize_global_pointer(session, format_global_id, format_ptr, &
-                                        error_msg)
+            error_msg)
         if (len_trim(error_msg) > 0) return
         unused_vreg = emit_call_i32(session%handle, callee, format_ptr, i32_value, &
-                                    error)
+            error)
         if (.not. status_ok(error%code, error, error_msg)) return
         call set_empty(error_msg)
         emit_liric_print_i16_value = .true.

--- a/src/liric_session_memory_bindings.f90
+++ b/src/liric_session_memory_bindings.f90
@@ -1,13 +1,13 @@
 module liric_session_memory_bindings
     use, intrinsic :: iso_c_binding, only: c_associated, c_bool, c_char, c_int, &
-                                              c_int32_t, c_int64_t
+        c_int32_t, c_int64_t
     use, intrinsic :: iso_c_binding, only: c_loc, c_null_char, c_null_ptr, c_ptr
     use liric_session_common, only: require_open_session, status_ok, &
-                                    liric_session_error_message, &
-                                    clear_liric_error, to_c_chars, set_empty, &
-                                    lr_error_t, lr_inst_desc_t
+        liric_session_error_message, &
+        clear_liric_error, to_c_chars, set_empty, &
+        lr_error_t, lr_inst_desc_t
     use liric_session_bindings, only: liric_session_t, lr_operand_desc_t, &
-                                      i32_vreg, i32_immediate
+        i32_vreg, i32_immediate
     implicit none
     private
 
@@ -25,7 +25,7 @@ module liric_session_memory_bindings
     logical(c_bool), parameter :: c_true = .true.
 
     public :: i64_immediate, ptr_param, &
-              reserve_i32_vreg, ptr_vreg, i64_vreg
+        reserve_i32_vreg, ptr_vreg, i64_vreg
     public :: emit_i32_binary, emit_i32_binary_into, emit_i32_copy_to
     public :: emit_i32_alloca, emit_i64_alloca, emit_ptr_alloca
     public :: emit_i32_load, emit_i64_load, emit_ptr_load
@@ -184,7 +184,7 @@ contains
     end function i64_immediate
 
     logical function emit_i32_binary(session, opcode, lhs, rhs, result, &
-                                     error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int), intent(in) :: opcode
         type(lr_operand_desc_t), intent(in) :: lhs
@@ -206,7 +206,7 @@ contains
     end function emit_i32_binary
 
     logical function emit_i32_binary_into(session, opcode, lhs, rhs, &
-                                          dest_vreg, result, error_msg)
+            dest_vreg, result, error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int), intent(in) :: opcode
         type(lr_operand_desc_t), intent(in) :: lhs
@@ -225,7 +225,7 @@ contains
         end if
 
         vreg = emit_binary_with_dest(session%handle, opcode, lhs, rhs, &
-                                     error, dest_vreg)
+            error, dest_vreg)
         if (.not. status_ok(error%code, error, error_msg)) return
         if (vreg /= dest_vreg) then
             error_msg = 'LIRIC did not honor explicit binary destination vreg'
@@ -238,7 +238,7 @@ contains
     end function emit_i32_binary_into
 
     logical function emit_i32_copy_to(session, value, dest_vreg, result, &
-                                      error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: value
         integer(c_int32_t), intent(in) :: dest_vreg
@@ -246,8 +246,8 @@ contains
         character(len=:), allocatable, intent(out) :: error_msg
 
         emit_i32_copy_to = emit_i32_binary_into(session, &
-                           LR_OP_ADD, value, i32_immediate(session, 0_c_int64_t), &
-                           dest_vreg, result, error_msg)
+            LR_OP_ADD, value, i32_immediate(session, 0_c_int64_t), &
+            dest_vreg, result, error_msg)
     end function emit_i32_copy_to
 
     logical function emit_i32_alloca(session, address, error_msg)
@@ -380,7 +380,7 @@ contains
     end function emit_i64_store
 
     logical function emit_i64_load_at(session, base, offset, result, &
-                                      error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: base
         integer(c_int64_t), intent(in) :: offset
@@ -537,7 +537,7 @@ contains
     end function emit_ptr_offset_dyn
 
     logical function emit_i64_store_at(session, value, base, offset, &
-                                       error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: value
         type(lr_operand_desc_t), intent(in) :: base
@@ -610,7 +610,7 @@ contains
     end function emit_i64_store_at
 
     logical function emit_i64_binary(session, opcode, lhs, rhs, result, &
-                                     error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int), intent(in) :: opcode
         type(lr_operand_desc_t), intent(in) :: lhs
@@ -771,7 +771,7 @@ contains
     end function emit_memcpy
 
     logical function emit_i32_array_alloca(session, array_size, address, &
-                                           error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer, intent(in) :: array_size
         type(lr_operand_desc_t), intent(out) :: address
@@ -785,8 +785,8 @@ contains
         if (.not. require_open_session(session, error_msg)) return
 
         array_type = lr_type_array_s(session%handle, &
-                                     lr_type_i32_s(session%handle), &
-                                     int(array_size, c_int64_t))
+            lr_type_i32_s(session%handle), &
+            int(array_size, c_int64_t))
         if (.not. c_associated(array_type)) then
             error_msg = 'LIRIC did not return an integer array type'
             return
@@ -818,8 +818,8 @@ contains
     end function emit_i32_array_alloca
 
     logical function emit_i32_array_element_addr(session, array_size, &
-                                                 base_ptr, index_0based, &
-                                                 element_addr, error_msg)
+            base_ptr, index_0based, &
+            element_addr, error_msg)
         type(liric_session_t), intent(inout) :: session
         integer, intent(in) :: array_size
         type(lr_operand_desc_t), intent(in) :: base_ptr
@@ -837,8 +837,8 @@ contains
         if (.not. require_open_session(session, error_msg)) return
 
         array_type = lr_type_array_s(session%handle, &
-                                     lr_type_i32_s(session%handle), &
-                                     int(array_size, c_int64_t))
+            lr_type_i32_s(session%handle), &
+            int(array_size, c_int64_t))
 
         zero64%kind = LR_OP_KIND_IMM_I64
         zero64%payload = 0_c_int64_t
@@ -875,7 +875,7 @@ contains
         emit_i32_array_element_addr = .true.
     end function emit_i32_array_element_addr
     logical function emit_f32_array_alloca(session, array_size, address, &
-                                           error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer, intent(in) :: array_size
         type(lr_operand_desc_t), intent(out) :: address
@@ -889,8 +889,8 @@ contains
         if (.not. require_open_session(session, error_msg)) return
 
         array_type = lr_type_array_s(session%handle, &
-                                     lr_type_f32_s(session%handle), &
-                                     int(array_size, c_int64_t))
+            lr_type_f32_s(session%handle), &
+            int(array_size, c_int64_t))
         if (.not. c_associated(array_type)) then
             error_msg = 'LIRIC did not return an f32 array type'
             return
@@ -922,8 +922,8 @@ contains
     end function emit_f32_array_alloca
 
     logical function emit_f32_array_element_addr(session, array_size, &
-                                                  base_ptr, index_0based, &
-                                                  element_addr, error_msg)
+            base_ptr, index_0based, &
+            element_addr, error_msg)
         type(liric_session_t), intent(inout) :: session
         integer, intent(in) :: array_size
         type(lr_operand_desc_t), intent(in) :: base_ptr
@@ -941,8 +941,8 @@ contains
         if (.not. require_open_session(session, error_msg)) return
 
         array_type = lr_type_array_s(session%handle, &
-                                     lr_type_f32_s(session%handle), &
-                                     int(array_size, c_int64_t))
+            lr_type_f32_s(session%handle), &
+            int(array_size, c_int64_t))
 
         zero64%kind = LR_OP_KIND_IMM_I64
         zero64%payload = 0_c_int64_t
@@ -980,7 +980,7 @@ contains
     end function emit_f32_array_element_addr
 
     logical function emit_f64_array_alloca(session, array_size, address, &
-                                           error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer, intent(in) :: array_size
         type(lr_operand_desc_t), intent(out) :: address
@@ -994,8 +994,8 @@ contains
         if (.not. require_open_session(session, error_msg)) return
 
         array_type = lr_type_array_s(session%handle, &
-                                     lr_type_f64_s(session%handle), &
-                                     int(array_size, c_int64_t))
+            lr_type_f64_s(session%handle), &
+            int(array_size, c_int64_t))
         if (.not. c_associated(array_type)) then
             error_msg = 'LIRIC did not return an f64 array type'
             return
@@ -1027,8 +1027,8 @@ contains
     end function emit_f64_array_alloca
 
     logical function emit_f64_array_element_addr(session, array_size, &
-                                                  base_ptr, index_0based, &
-                                                  element_addr, error_msg)
+            base_ptr, index_0based, &
+            element_addr, error_msg)
         type(liric_session_t), intent(inout) :: session
         integer, intent(in) :: array_size
         type(lr_operand_desc_t), intent(in) :: base_ptr
@@ -1046,8 +1046,8 @@ contains
         if (.not. require_open_session(session, error_msg)) return
 
         array_type = lr_type_array_s(session%handle, &
-                                     lr_type_f64_s(session%handle), &
-                                     int(array_size, c_int64_t))
+            lr_type_f64_s(session%handle), &
+            int(array_size, c_int64_t))
 
         zero64%kind = LR_OP_KIND_IMM_I64
         zero64%payload = 0_c_int64_t
@@ -1098,7 +1098,7 @@ contains
         emit_ptr_alloca = .false.
         if (.not. require_open_session(session, error_msg)) return
         vreg = emit_alloca_typed(session%handle, &
-                                  lr_type_ptr_s(session%handle), error)
+            lr_type_ptr_s(session%handle), error)
         if (.not. status_ok(error%code, error, error_msg)) return
         address = ptr_vreg(session, vreg)
         call set_empty(error_msg)

--- a/src/liric_session_procedure_bindings.f90
+++ b/src/liric_session_procedure_bindings.f90
@@ -3,13 +3,13 @@ module liric_session_procedure_bindings
     use, intrinsic :: iso_c_binding, only: c_int, c_int32_t, c_int64_t
     use, intrinsic :: iso_c_binding, only: c_loc, c_null_char, c_null_ptr, c_ptr
     use liric_session_common, only: require_open_session, status_ok, &
-                                    liric_session_error_message, &
-                                    clear_liric_error, to_c_chars, set_empty, &
-                                    lr_error_t, lr_inst_desc_t, lr_operand_desc_t, &
-                                    LR_OK, LR_OP_KIND_GLOBAL, LR_OP_KIND_VREG
+        liric_session_error_message, &
+        clear_liric_error, to_c_chars, set_empty, &
+        lr_error_t, lr_inst_desc_t, lr_operand_desc_t, &
+        LR_OK, LR_OP_KIND_GLOBAL, LR_OP_KIND_VREG
     use liric_session_bindings, only: liric_session_t
     use liric_session_memory_bindings, only: ptr_param, &
-              emit_alloca_typed, emit_load_typed, emit_store_typed
+        emit_alloca_typed, emit_load_typed, emit_store_typed
     implicit none
     private
 
@@ -50,7 +50,7 @@ module liric_session_procedure_bindings
         end function lr_type_ptr_s
 
         function lr_session_func_begin(handle, name, ret, params, n, &
-                                       vararg, err) result(status) bind(c)
+                vararg, err) result(status) bind(c)
             import :: c_bool, c_char, c_int, c_int32_t, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             character(kind=c_char), intent(in) :: name(*)
@@ -69,7 +69,7 @@ module liric_session_procedure_bindings
         end function lr_session_block
 
         function lr_session_set_block(handle, block_id, err) result(status) &
-            bind(c)
+                bind(c)
             import :: c_int, c_int32_t, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             integer(c_int32_t), value :: block_id
@@ -96,7 +96,7 @@ module liric_session_procedure_bindings
 contains
 
     logical function begin_liric_f32_function(session, name, param_count, &
-                                              error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         character(len=*), intent(in) :: name
         integer, intent(in) :: param_count
@@ -111,370 +111,370 @@ contains
         integer :: i
 
         begin_liric_f32_function = .false.
-        if (.not. require_open_session(session, error_msg)) return
+            if (.not. require_open_session(session, error_msg)) return
 
-        param_type = lr_type_ptr_s(session%handle)
-        if (.not. c_associated(param_type)) then
-            error_msg = 'LIRIC did not return a pointer type'
-            return
-        end if
+            param_type = lr_type_ptr_s(session%handle)
+            if (.not. c_associated(param_type)) then
+                error_msg = 'LIRIC did not return a pointer type'
+                return
+            end if
 
-        params_ptr = c_null_ptr
-        if (param_count > 0) then
-            allocate (params(param_count))
-            do i = 1, param_count
-                params(i) = param_type
-            end do
-            params_ptr = c_loc(params)
-        end if
+            params_ptr = c_null_ptr
+            if (param_count > 0) then
+                allocate (params(param_count))
+                do i = 1, param_count
+                    params(i) = param_type
+                end do
+                params_ptr = c_loc(params)
+            end if
 
-        call clear_liric_error(error)
-        call to_c_chars(trim(name), c_name)
-        status = lr_session_func_begin(session%handle, c_name, &
-                                       lr_type_f32_s(session%handle), &
-                                       params_ptr, int(param_count, c_int32_t), &
-                                       c_false, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        block_id = lr_session_block(session%handle)
-        status = lr_session_set_block(session%handle, block_id, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        call set_empty(error_msg)
-        begin_liric_f32_function = .true.
-    end function begin_liric_f32_function
-
-    logical function emit_liric_f32_alloca(session, address, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        type(lr_operand_desc_t), intent(out) :: address
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: vreg
-
-        emit_liric_f32_alloca = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        vreg = emit_alloca_typed(session%handle, lr_type_f32_s(session%handle), &
-                                 error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-
-        address = ptr_vreg(session%handle, vreg)
-        call set_empty(error_msg)
-        emit_liric_f32_alloca = .true.
-    end function emit_liric_f32_alloca
-
-    logical function emit_liric_f32_load(session, address, value, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        type(lr_operand_desc_t), intent(in) :: address
-        type(lr_operand_desc_t), intent(out) :: value
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: vreg
-
-        emit_liric_f32_load = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        vreg = emit_load_typed(session%handle, lr_type_f32_s(session%handle), &
-                               address, error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-
-        value = f32_vreg(session%handle, vreg)
-        call set_empty(error_msg)
-        emit_liric_f32_load = .true.
-    end function emit_liric_f32_load
-
-    logical function emit_liric_f32_store(session, value, address, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        type(lr_operand_desc_t), intent(in) :: value
-        type(lr_operand_desc_t), intent(in) :: address
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: unused_vreg
-
-        emit_liric_f32_store = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        unused_vreg = emit_store_typed(session%handle, value, address, error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-
-        call set_empty(error_msg)
-        emit_liric_f32_store = .true.
-    end function emit_liric_f32_store
-
-    logical function emit_liric_f32_call(session, name, args, result, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        character(len=*), intent(in) :: name
-        type(lr_operand_desc_t), intent(in) :: args(:)
-        type(lr_operand_desc_t), intent(out) :: result
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: vreg
-
-        emit_liric_f32_call = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        vreg = emit_call_f32_function(session%handle, name, args, error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-
-        result = f32_vreg(session%handle, vreg)
-        call set_empty(error_msg)
-        emit_liric_f32_call = .true.
-    end function emit_liric_f32_call
-
-    logical function begin_liric_f64_function(session, name, param_count, &
-                                              error_msg)
-        type(liric_session_t), intent(inout) :: session
-        character(len=*), intent(in) :: name
-        integer, intent(in) :: param_count
-        character(len=:), allocatable, intent(out) :: error_msg
-        character(kind=c_char), allocatable :: c_name(:)
-        type(c_ptr), allocatable, target :: params(:)
-        type(c_ptr) :: params_ptr
-        type(c_ptr) :: param_type
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: block_id
-        integer(c_int) :: status
-        integer :: i
-
-        begin_liric_f64_function = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        param_type = lr_type_ptr_s(session%handle)
-        if (.not. c_associated(param_type)) then
-            error_msg = 'LIRIC did not return a pointer type'
-            return
-        end if
-
-        params_ptr = c_null_ptr
-        if (param_count > 0) then
-            allocate (params(param_count))
-            do i = 1, param_count
-                params(i) = param_type
-            end do
-            params_ptr = c_loc(params)
-        end if
-
-        call clear_liric_error(error)
-        call to_c_chars(trim(name), c_name)
-        status = lr_session_func_begin(session%handle, c_name, &
-                                       lr_type_f64_s(session%handle), &
-                                       params_ptr, int(param_count, c_int32_t), &
-                                       c_false, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        block_id = lr_session_block(session%handle)
-        status = lr_session_set_block(session%handle, block_id, error)
-        if (.not. status_ok(status, error, error_msg)) return
-
-        call set_empty(error_msg)
-        begin_liric_f64_function = .true.
-    end function begin_liric_f64_function
-
-    logical function emit_liric_f64_alloca(session, address, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        type(lr_operand_desc_t), intent(out) :: address
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: vreg
-
-        emit_liric_f64_alloca = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        vreg = emit_alloca_typed(session%handle, lr_type_f64_s(session%handle), &
-                                 error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-
-        address = ptr_vreg(session%handle, vreg)
-        call set_empty(error_msg)
-        emit_liric_f64_alloca = .true.
-    end function emit_liric_f64_alloca
-
-    logical function emit_liric_f64_load(session, address, value, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        type(lr_operand_desc_t), intent(in) :: address
-        type(lr_operand_desc_t), intent(out) :: value
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: vreg
-
-        emit_liric_f64_load = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        vreg = emit_load_typed(session%handle, lr_type_f64_s(session%handle), &
-                               address, error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-
-        value = f64_vreg(session%handle, vreg)
-        call set_empty(error_msg)
-        emit_liric_f64_load = .true.
-    end function emit_liric_f64_load
-
-    logical function emit_liric_f64_store(session, value, address, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        type(lr_operand_desc_t), intent(in) :: value
-        type(lr_operand_desc_t), intent(in) :: address
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: unused_vreg
-
-        emit_liric_f64_store = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        unused_vreg = emit_store_typed(session%handle, value, address, error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-
-        call set_empty(error_msg)
-        emit_liric_f64_store = .true.
-    end function emit_liric_f64_store
-
-    logical function emit_liric_f64_call(session, name, args, result, error_msg)
-        type(liric_session_t), intent(inout) :: session
-        character(len=*), intent(in) :: name
-        type(lr_operand_desc_t), intent(in) :: args(:)
-        type(lr_operand_desc_t), intent(out) :: result
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_error_t) :: error
-        integer(c_int32_t) :: vreg
-
-        emit_liric_f64_call = .false.
-        if (.not. require_open_session(session, error_msg)) return
-
-        vreg = emit_call_f64_function(session%handle, name, args, error)
-        if (.not. status_ok(error%code, error, error_msg)) return
-
-        result = f64_vreg(session%handle, vreg)
-        call set_empty(error_msg)
-        emit_liric_f64_call = .true.
-    end function emit_liric_f64_call
-
-    function emit_call_f32_function(handle, name, args, error) result(vreg)
-        type(c_ptr), intent(in) :: handle
-        character(len=*), intent(in) :: name
-        type(lr_operand_desc_t), intent(in) :: args(:)
-        type(lr_error_t), intent(inout) :: error
-        integer(c_int32_t) :: vreg
-        type(lr_operand_desc_t), target :: operands(9)
-        type(lr_inst_desc_t) :: inst
-        character(kind=c_char), allocatable :: c_name(:)
-        integer(c_int32_t) :: symbol_id
-        integer :: i
-
-        call to_c_chars(trim(name), c_name)
-        symbol_id = lr_session_intern(handle, c_name)
-        if (symbol_id < 0_c_int32_t .or. size(args) > 8) then
             call clear_liric_error(error)
-            error%code = 1_c_int
-            return
-        end if
+            call to_c_chars(trim(name), c_name)
+            status = lr_session_func_begin(session%handle, c_name, &
+                lr_type_f32_s(session%handle), &
+                params_ptr, int(param_count, c_int32_t), &
+                c_false, error)
+            if (.not. status_ok(status, error, error_msg)) return
 
-        operands(1) = global_operand(handle, symbol_id)
-        do i = 1, size(args)
-            operands(i + 1) = args(i)
-        end do
+            block_id = lr_session_block(session%handle)
+            status = lr_session_set_block(session%handle, block_id, error)
+            if (.not. status_ok(status, error, error_msg)) return
 
-        inst%op = LR_OP_CALL
-        inst%typ = lr_type_f32_s(handle)
-        inst%dest = 0_c_int32_t
-        inst%operands = c_loc(operands)
-        inst%num_operands = int(size(args) + 1, c_int32_t)
-        inst%indices = c_null_ptr
-        inst%num_indices = 0_c_int32_t
-        inst%align = 0_c_int32_t
-        inst%icmp_pred = 0_c_int
-        inst%fcmp_pred = 0_c_int
-        inst%call_external_abi = c_false
-        inst%call_vararg = c_false
-        inst%call_fixed_args = 0_c_int32_t
+            call set_empty(error_msg)
+            begin_liric_f32_function = .true.
+            end function begin_liric_f32_function
 
-        call clear_liric_error(error)
-        vreg = lr_session_emit(handle, inst, error)
-    end function emit_call_f32_function
+            logical function emit_liric_f32_alloca(session, address, error_msg)
+                type(liric_session_t), intent(inout) :: session
+                type(lr_operand_desc_t), intent(out) :: address
+                character(len=:), allocatable, intent(out) :: error_msg
+                type(lr_error_t) :: error
+                integer(c_int32_t) :: vreg
 
-    function f32_vreg(handle, vreg) result(operand)
-        type(c_ptr), intent(in) :: handle
-        integer(c_int32_t), intent(in) :: vreg
-        type(lr_operand_desc_t) :: operand
+                emit_liric_f32_alloca = .false.
+                if (.not. require_open_session(session, error_msg)) return
 
-        operand%kind = LR_OP_KIND_VREG
-        operand%payload = int(vreg, c_int64_t)
-        operand%typ = lr_type_f32_s(handle)
-        operand%global_offset = 0_c_int64_t
-    end function f32_vreg
+                vreg = emit_alloca_typed(session%handle, lr_type_f32_s(session%handle), &
+                    error)
+                if (.not. status_ok(error%code, error, error_msg)) return
 
-    function emit_call_f64_function(handle, name, args, error) result(vreg)
-        type(c_ptr), intent(in) :: handle
-        character(len=*), intent(in) :: name
-        type(lr_operand_desc_t), intent(in) :: args(:)
-        type(lr_error_t), intent(inout) :: error
-        integer(c_int32_t) :: vreg
-        type(lr_operand_desc_t), target :: operands(9)
-        type(lr_inst_desc_t) :: inst
-        character(kind=c_char), allocatable :: c_name(:)
-        integer(c_int32_t) :: symbol_id
-        integer :: i
+                address = ptr_vreg(session%handle, vreg)
+                call set_empty(error_msg)
+                emit_liric_f32_alloca = .true.
+            end function emit_liric_f32_alloca
 
-        call to_c_chars(trim(name), c_name)
-        symbol_id = lr_session_intern(handle, c_name)
-        if (symbol_id < 0_c_int32_t .or. size(args) > 8) then
-            call clear_liric_error(error)
-            error%code = 1_c_int
-            return
-        end if
+            logical function emit_liric_f32_load(session, address, value, error_msg)
+                type(liric_session_t), intent(inout) :: session
+                type(lr_operand_desc_t), intent(in) :: address
+                type(lr_operand_desc_t), intent(out) :: value
+                character(len=:), allocatable, intent(out) :: error_msg
+                type(lr_error_t) :: error
+                integer(c_int32_t) :: vreg
 
-        operands(1) = global_operand(handle, symbol_id)
-        do i = 1, size(args)
-            operands(i + 1) = args(i)
-        end do
+                emit_liric_f32_load = .false.
+                if (.not. require_open_session(session, error_msg)) return
 
-        inst%op = LR_OP_CALL
-        inst%typ = lr_type_f64_s(handle)
-        inst%dest = 0_c_int32_t
-        inst%operands = c_loc(operands)
-        inst%num_operands = int(size(args) + 1, c_int32_t)
-        inst%indices = c_null_ptr
-        inst%num_indices = 0_c_int32_t
-        inst%align = 0_c_int32_t
-        inst%icmp_pred = 0_c_int
-        inst%fcmp_pred = 0_c_int
-        inst%call_external_abi = c_false
-        inst%call_vararg = c_false
-        inst%call_fixed_args = 0_c_int32_t
+                vreg = emit_load_typed(session%handle, lr_type_f32_s(session%handle), &
+                    address, error)
+                if (.not. status_ok(error%code, error, error_msg)) return
 
-        call clear_liric_error(error)
-        vreg = lr_session_emit(handle, inst, error)
-    end function emit_call_f64_function
+                value = f32_vreg(session%handle, vreg)
+                call set_empty(error_msg)
+                emit_liric_f32_load = .true.
+            end function emit_liric_f32_load
 
-    function f64_vreg(handle, vreg) result(operand)
-        type(c_ptr), intent(in) :: handle
-        integer(c_int32_t), intent(in) :: vreg
-        type(lr_operand_desc_t) :: operand
+            logical function emit_liric_f32_store(session, value, address, error_msg)
+                type(liric_session_t), intent(inout) :: session
+                type(lr_operand_desc_t), intent(in) :: value
+                type(lr_operand_desc_t), intent(in) :: address
+                character(len=:), allocatable, intent(out) :: error_msg
+                type(lr_error_t) :: error
+                integer(c_int32_t) :: unused_vreg
 
-        operand%kind = LR_OP_KIND_VREG
-        operand%payload = int(vreg, c_int64_t)
-        operand%typ = lr_type_f64_s(handle)
-        operand%global_offset = 0_c_int64_t
-    end function f64_vreg
+                emit_liric_f32_store = .false.
+                if (.not. require_open_session(session, error_msg)) return
 
-    function ptr_vreg(handle, vreg) result(operand)
-        type(c_ptr), intent(in) :: handle
-        integer(c_int32_t), intent(in) :: vreg
-        type(lr_operand_desc_t) :: operand
+                unused_vreg = emit_store_typed(session%handle, value, address, error)
+                if (.not. status_ok(error%code, error, error_msg)) return
 
-        operand%kind = LR_OP_KIND_VREG
-        operand%payload = int(vreg, c_int64_t)
-        operand%typ = lr_type_ptr_s(handle)
-        operand%global_offset = 0_c_int64_t
-    end function ptr_vreg
+                call set_empty(error_msg)
+                emit_liric_f32_store = .true.
+            end function emit_liric_f32_store
 
-    function global_operand(handle, id) result(operand)
-        type(c_ptr), intent(in) :: handle
-        integer(c_int32_t), intent(in) :: id
-        type(lr_operand_desc_t) :: operand
+            logical function emit_liric_f32_call(session, name, args, result, error_msg)
+                type(liric_session_t), intent(inout) :: session
+                character(len=*), intent(in) :: name
+                type(lr_operand_desc_t), intent(in) :: args(:)
+                type(lr_operand_desc_t), intent(out) :: result
+                character(len=:), allocatable, intent(out) :: error_msg
+                type(lr_error_t) :: error
+                integer(c_int32_t) :: vreg
 
-        operand%kind = LR_OP_KIND_GLOBAL
-        operand%payload = int(id, c_int64_t)
-        operand%typ = lr_type_ptr_s(handle)
-        operand%global_offset = 0_c_int64_t
-    end function global_operand
+                emit_liric_f32_call = .false.
+                if (.not. require_open_session(session, error_msg)) return
 
-end module liric_session_procedure_bindings
+                vreg = emit_call_f32_function(session%handle, name, args, error)
+                if (.not. status_ok(error%code, error, error_msg)) return
+
+                result = f32_vreg(session%handle, vreg)
+                call set_empty(error_msg)
+                emit_liric_f32_call = .true.
+            end function emit_liric_f32_call
+
+            logical function begin_liric_f64_function(session, name, param_count, &
+                    error_msg)
+                type(liric_session_t), intent(inout) :: session
+                character(len=*), intent(in) :: name
+                integer, intent(in) :: param_count
+                character(len=:), allocatable, intent(out) :: error_msg
+                character(kind=c_char), allocatable :: c_name(:)
+                type(c_ptr), allocatable, target :: params(:)
+                type(c_ptr) :: params_ptr
+                type(c_ptr) :: param_type
+                type(lr_error_t) :: error
+                integer(c_int32_t) :: block_id
+                integer(c_int) :: status
+                integer :: i
+
+                begin_liric_f64_function = .false.
+                    if (.not. require_open_session(session, error_msg)) return
+
+                    param_type = lr_type_ptr_s(session%handle)
+                    if (.not. c_associated(param_type)) then
+                        error_msg = 'LIRIC did not return a pointer type'
+                        return
+                    end if
+
+                    params_ptr = c_null_ptr
+                    if (param_count > 0) then
+                        allocate (params(param_count))
+                        do i = 1, param_count
+                            params(i) = param_type
+                        end do
+                        params_ptr = c_loc(params)
+                    end if
+
+                    call clear_liric_error(error)
+                    call to_c_chars(trim(name), c_name)
+                    status = lr_session_func_begin(session%handle, c_name, &
+                        lr_type_f64_s(session%handle), &
+                        params_ptr, int(param_count, c_int32_t), &
+                        c_false, error)
+                    if (.not. status_ok(status, error, error_msg)) return
+
+                    block_id = lr_session_block(session%handle)
+                    status = lr_session_set_block(session%handle, block_id, error)
+                    if (.not. status_ok(status, error, error_msg)) return
+
+                    call set_empty(error_msg)
+                    begin_liric_f64_function = .true.
+                    end function begin_liric_f64_function
+
+                    logical function emit_liric_f64_alloca(session, address, error_msg)
+                        type(liric_session_t), intent(inout) :: session
+                        type(lr_operand_desc_t), intent(out) :: address
+                        character(len=:), allocatable, intent(out) :: error_msg
+                        type(lr_error_t) :: error
+                        integer(c_int32_t) :: vreg
+
+                        emit_liric_f64_alloca = .false.
+                        if (.not. require_open_session(session, error_msg)) return
+
+                        vreg = emit_alloca_typed(session%handle, lr_type_f64_s(session%handle), &
+                            error)
+                        if (.not. status_ok(error%code, error, error_msg)) return
+
+                        address = ptr_vreg(session%handle, vreg)
+                        call set_empty(error_msg)
+                        emit_liric_f64_alloca = .true.
+                    end function emit_liric_f64_alloca
+
+                    logical function emit_liric_f64_load(session, address, value, error_msg)
+                        type(liric_session_t), intent(inout) :: session
+                        type(lr_operand_desc_t), intent(in) :: address
+                        type(lr_operand_desc_t), intent(out) :: value
+                        character(len=:), allocatable, intent(out) :: error_msg
+                        type(lr_error_t) :: error
+                        integer(c_int32_t) :: vreg
+
+                        emit_liric_f64_load = .false.
+                        if (.not. require_open_session(session, error_msg)) return
+
+                        vreg = emit_load_typed(session%handle, lr_type_f64_s(session%handle), &
+                            address, error)
+                        if (.not. status_ok(error%code, error, error_msg)) return
+
+                        value = f64_vreg(session%handle, vreg)
+                        call set_empty(error_msg)
+                        emit_liric_f64_load = .true.
+                    end function emit_liric_f64_load
+
+                    logical function emit_liric_f64_store(session, value, address, error_msg)
+                        type(liric_session_t), intent(inout) :: session
+                        type(lr_operand_desc_t), intent(in) :: value
+                        type(lr_operand_desc_t), intent(in) :: address
+                        character(len=:), allocatable, intent(out) :: error_msg
+                        type(lr_error_t) :: error
+                        integer(c_int32_t) :: unused_vreg
+
+                        emit_liric_f64_store = .false.
+                        if (.not. require_open_session(session, error_msg)) return
+
+                        unused_vreg = emit_store_typed(session%handle, value, address, error)
+                        if (.not. status_ok(error%code, error, error_msg)) return
+
+                        call set_empty(error_msg)
+                        emit_liric_f64_store = .true.
+                    end function emit_liric_f64_store
+
+                    logical function emit_liric_f64_call(session, name, args, result, error_msg)
+                        type(liric_session_t), intent(inout) :: session
+                        character(len=*), intent(in) :: name
+                        type(lr_operand_desc_t), intent(in) :: args(:)
+                        type(lr_operand_desc_t), intent(out) :: result
+                        character(len=:), allocatable, intent(out) :: error_msg
+                        type(lr_error_t) :: error
+                        integer(c_int32_t) :: vreg
+
+                        emit_liric_f64_call = .false.
+                        if (.not. require_open_session(session, error_msg)) return
+
+                        vreg = emit_call_f64_function(session%handle, name, args, error)
+                        if (.not. status_ok(error%code, error, error_msg)) return
+
+                        result = f64_vreg(session%handle, vreg)
+                        call set_empty(error_msg)
+                        emit_liric_f64_call = .true.
+                    end function emit_liric_f64_call
+
+                    function emit_call_f32_function(handle, name, args, error) result(vreg)
+                        type(c_ptr), intent(in) :: handle
+                        character(len=*), intent(in) :: name
+                        type(lr_operand_desc_t), intent(in) :: args(:)
+                        type(lr_error_t), intent(inout) :: error
+                        integer(c_int32_t) :: vreg
+                        type(lr_operand_desc_t), target :: operands(9)
+                        type(lr_inst_desc_t) :: inst
+                        character(kind=c_char), allocatable :: c_name(:)
+                        integer(c_int32_t) :: symbol_id
+                        integer :: i
+
+                        call to_c_chars(trim(name), c_name)
+                        symbol_id = lr_session_intern(handle, c_name)
+                        if (symbol_id < 0_c_int32_t .or. size(args) > 8) then
+                            call clear_liric_error(error)
+                            error%code = 1_c_int
+                            return
+                        end if
+
+                        operands(1) = global_operand(handle, symbol_id)
+                        do i = 1, size(args)
+                            operands(i + 1) = args(i)
+                        end do
+
+                        inst%op = LR_OP_CALL
+                        inst%typ = lr_type_f32_s(handle)
+                        inst%dest = 0_c_int32_t
+                        inst%operands = c_loc(operands)
+                        inst%num_operands = int(size(args) + 1, c_int32_t)
+                        inst%indices = c_null_ptr
+                        inst%num_indices = 0_c_int32_t
+                        inst%align = 0_c_int32_t
+                        inst%icmp_pred = 0_c_int
+                        inst%fcmp_pred = 0_c_int
+                        inst%call_external_abi = c_false
+                        inst%call_vararg = c_false
+                        inst%call_fixed_args = 0_c_int32_t
+
+                        call clear_liric_error(error)
+                        vreg = lr_session_emit(handle, inst, error)
+                    end function emit_call_f32_function
+
+                    function f32_vreg(handle, vreg) result(operand)
+                        type(c_ptr), intent(in) :: handle
+                        integer(c_int32_t), intent(in) :: vreg
+                        type(lr_operand_desc_t) :: operand
+
+                        operand%kind = LR_OP_KIND_VREG
+                        operand%payload = int(vreg, c_int64_t)
+                        operand%typ = lr_type_f32_s(handle)
+                        operand%global_offset = 0_c_int64_t
+                    end function f32_vreg
+
+                    function emit_call_f64_function(handle, name, args, error) result(vreg)
+                        type(c_ptr), intent(in) :: handle
+                        character(len=*), intent(in) :: name
+                        type(lr_operand_desc_t), intent(in) :: args(:)
+                        type(lr_error_t), intent(inout) :: error
+                        integer(c_int32_t) :: vreg
+                        type(lr_operand_desc_t), target :: operands(9)
+                        type(lr_inst_desc_t) :: inst
+                        character(kind=c_char), allocatable :: c_name(:)
+                        integer(c_int32_t) :: symbol_id
+                        integer :: i
+
+                        call to_c_chars(trim(name), c_name)
+                        symbol_id = lr_session_intern(handle, c_name)
+                        if (symbol_id < 0_c_int32_t .or. size(args) > 8) then
+                            call clear_liric_error(error)
+                            error%code = 1_c_int
+                            return
+                        end if
+
+                        operands(1) = global_operand(handle, symbol_id)
+                        do i = 1, size(args)
+                            operands(i + 1) = args(i)
+                        end do
+
+                        inst%op = LR_OP_CALL
+                        inst%typ = lr_type_f64_s(handle)
+                        inst%dest = 0_c_int32_t
+                        inst%operands = c_loc(operands)
+                        inst%num_operands = int(size(args) + 1, c_int32_t)
+                        inst%indices = c_null_ptr
+                        inst%num_indices = 0_c_int32_t
+                        inst%align = 0_c_int32_t
+                        inst%icmp_pred = 0_c_int
+                        inst%fcmp_pred = 0_c_int
+                        inst%call_external_abi = c_false
+                        inst%call_vararg = c_false
+                        inst%call_fixed_args = 0_c_int32_t
+
+                        call clear_liric_error(error)
+                        vreg = lr_session_emit(handle, inst, error)
+                    end function emit_call_f64_function
+
+                    function f64_vreg(handle, vreg) result(operand)
+                        type(c_ptr), intent(in) :: handle
+                        integer(c_int32_t), intent(in) :: vreg
+                        type(lr_operand_desc_t) :: operand
+
+                        operand%kind = LR_OP_KIND_VREG
+                        operand%payload = int(vreg, c_int64_t)
+                        operand%typ = lr_type_f64_s(handle)
+                        operand%global_offset = 0_c_int64_t
+                    end function f64_vreg
+
+                    function ptr_vreg(handle, vreg) result(operand)
+                        type(c_ptr), intent(in) :: handle
+                        integer(c_int32_t), intent(in) :: vreg
+                        type(lr_operand_desc_t) :: operand
+
+                        operand%kind = LR_OP_KIND_VREG
+                        operand%payload = int(vreg, c_int64_t)
+                        operand%typ = lr_type_ptr_s(handle)
+                        operand%global_offset = 0_c_int64_t
+                    end function ptr_vreg
+
+                    function global_operand(handle, id) result(operand)
+                        type(c_ptr), intent(in) :: handle
+                        integer(c_int32_t), intent(in) :: id
+                        type(lr_operand_desc_t) :: operand
+
+                        operand%kind = LR_OP_KIND_GLOBAL
+                        operand%payload = int(id, c_int64_t)
+                        operand%typ = lr_type_ptr_s(handle)
+                        operand%global_offset = 0_c_int64_t
+                    end function global_operand
+
+                end module liric_session_procedure_bindings

--- a/src/liric_session_real_print_bindings.f90
+++ b/src/liric_session_real_print_bindings.f90
@@ -14,32 +14,32 @@ module liric_session_real_print_bindings
     ! exponent), right-justified in a 25-wide field. The list-directed
     ! leading blank is emitted by the print statement, not here.
     use, intrinsic :: iso_c_binding, only: c_associated, c_bool, c_char, c_double, &
-                                           c_int, c_int32_t, c_int64_t, c_loc, &
-                                           c_null_char, c_null_ptr, c_ptr, c_size_t
+        c_int, c_int32_t, c_int64_t, c_loc, &
+        c_null_char, c_null_ptr, c_ptr, c_size_t
     use liric_session_bindings, only: liric_session_t, lr_error_t, &
-                                      lr_operand_desc_t, lr_inst_desc_t, LR_OK, &
-                                      LR_OP_CALL, LR_OP_SUB, LR_OP_STORE, &
-                                      LR_OP_GEP, LR_OP_LOAD, LR_OP_ZEXT, &
-                                      LR_OP_ADD, LR_OP_TRUNC, LR_OP_FPEXT, &
-                                      LR_OP_KIND_VREG, &
-                                      LR_OP_KIND_IMM_I64, &
-                                      LR_OP_KIND_GLOBAL, lr_type_i32_s, &
-                                      lr_type_i64_s, lr_type_f32_s, lr_type_f64_s, &
-                                      lr_type_i8_s, &
-                                      lr_type_ptr_s, lr_type_array_s, &
-                                      lr_session_emit, lr_session_intern, &
-                                      lr_session_global, lr_session_vreg, &
-                                      lr_session_param, status_ok, clear_liric_error, &
-                                      set_empty, require_open_session, to_c_chars, &
-                                      i32_vreg, i32_immediate
+        lr_operand_desc_t, lr_inst_desc_t, LR_OK, &
+        LR_OP_CALL, LR_OP_SUB, LR_OP_STORE, &
+        LR_OP_GEP, LR_OP_LOAD, LR_OP_ZEXT, &
+        LR_OP_ADD, LR_OP_TRUNC, LR_OP_FPEXT, &
+        LR_OP_KIND_VREG, &
+        LR_OP_KIND_IMM_I64, &
+        LR_OP_KIND_GLOBAL, lr_type_i32_s, &
+        lr_type_i64_s, lr_type_f32_s, lr_type_f64_s, &
+        lr_type_i8_s, &
+        lr_type_ptr_s, lr_type_array_s, &
+        lr_session_emit, lr_session_intern, &
+        lr_session_global, lr_session_vreg, &
+        lr_session_param, status_ok, clear_liric_error, &
+        set_empty, require_open_session, to_c_chars, &
+        i32_vreg, i32_immediate
     use liric_session_memory_bindings, only: emit_alloca_bytes, emit_memcpy, &
-                                             emit_i32_binary, emit_i64_binary, &
-                                             ptr_vreg, i64_vreg, i64_immediate
+        emit_i32_binary, emit_i64_binary, &
+        ptr_vreg, i64_vreg, i64_immediate
     use liric_session_control_bindings, only: create_liric_block, set_liric_block, &
-                                              emit_liric_br, emit_liric_condbr, &
-                                              emit_liric_i32_icmp, LR_CMP_SGE, &
-                                              LR_CMP_SLE, LR_CMP_SLT, &
-                                              LR_CMP_NE, LR_CMP_EQ
+        emit_liric_br, emit_liric_condbr, &
+        emit_liric_i32_icmp, LR_CMP_SGE, &
+        LR_CMP_SLE, LR_CMP_SLT, &
+        LR_CMP_NE, LR_CMP_EQ
     implicit none
     private
 
@@ -66,7 +66,7 @@ module liric_session_real_print_bindings
 
     interface
         function lr_session_declare(handle, name, ret, params, n, vararg, &
-                                    err) result(status) bind(c)
+                err) result(status) bind(c)
             import :: c_bool, c_char, c_int, c_int32_t, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             character(kind=c_char), intent(in) :: name(*)
@@ -79,7 +79,7 @@ module liric_session_real_print_bindings
         end function lr_session_declare
 
         function lr_session_func_begin(handle, name, ret, params, n, &
-                                       vararg, err) result(status) bind(c)
+                vararg, err) result(status) bind(c)
             import :: c_bool, c_char, c_int, c_int32_t, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             character(kind=c_char), intent(in) :: name(*)
@@ -126,24 +126,24 @@ contains
 
         if (.not. declare_libc(session, error_msg)) return
         if (.not. create_cstring(session, '.ffc.r8.fe', '%.16e', g_fe, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r8.ff', '%#.*f', g_ff, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r8.feo', '%sE%c%03d', g_feo, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r8.padf', '%20s     ', g_padf, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r8.pade', '%25s', g_pade, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r8.inf', 'Infinity', g_inf, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r8.ninf', '-Infinity', g_ninf, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r8.nan', 'NaN', g_nan, &
-                                 error_msg)) return
+            error_msg)) return
 
         if (.not. begin_real8_printer(session, param_vreg, entry_block, &
-                                      error_msg)) return
+            error_msg)) return
         x%kind = LR_OP_KIND_VREG
         x%payload = int(param_vreg, c_int64_t)
         x%typ = lr_type_f64_s(session%handle)
@@ -161,7 +161,7 @@ contains
 
         if (.not. set_liric_block(session, entry_block, error_msg)) return
         if (.not. build_head(session, x, g_fe, tmp, num, p, finblk, nfblk, &
-                             error_msg)) return
+            error_msg)) return
 
         if (.not. set_liric_block(session, finblk, error_msg)) return
         if (.not. build_finite(session, tmp, p, ex, chkhi, eblk, error_msg)) return
@@ -171,15 +171,15 @@ contains
 
         if (.not. set_liric_block(session, fblk, error_msg)) return
         if (.not. build_fixed(session, x, ex, num, g_ff, g_padf, exitb, &
-                              error_msg)) return
+            error_msg)) return
 
         if (.not. build_exponential(session, ex, tmp, num, g_feo, g_pade, &
-                                    eblk, eneg, epos, eprint, exitb, error_msg)) &
+            eblk, eneg, epos, eprint, exitb, error_msg)) &
             return
 
         if (.not. set_liric_block(session, nfblk, error_msg)) return
         if (.not. build_nonfinite(session, tmp, g_inf, g_ninf, g_nan, g_pade, &
-                                  exitb, error_msg)) return
+            exitb, error_msg)) return
 
         if (.not. set_liric_block(session, exitb, error_msg)) return
         if (.not. emit_ret_void_local(session, error_msg)) return
@@ -194,7 +194,7 @@ contains
     end function synthesize_real8_printer
 
     logical function build_head(session, x, g_fe, tmp, num, p, finblk, nfblk, &
-                                error_msg)
+            error_msg)
         ! tmp = "%.16e" of x; p = strchr(tmp,'e'). A finite value has an 'e';
         ! inf/nan do not, so a null p routes to the non-finite handler.
         type(liric_session_t), intent(inout) :: session
@@ -207,22 +207,22 @@ contains
 
         build_head = .false.
         if (.not. emit_alloca_bytes(session, i64_immediate(session, 64_c_int64_t), &
-                                    tmp, error_msg)) return
+            tmp, error_msg)) return
         if (.not. emit_alloca_bytes(session, i64_immediate(session, 48_c_int64_t), &
-                                    num, error_msg)) return
+            num, error_msg)) return
 
         args(1) = tmp
         args(2) = i64_immediate(session, 64_c_int64_t)
         args(3) = g_fe
         args(4) = x
         if (.not. emit_call(session, 'snprintf', args, lr_type_i32_s(session%handle), &
-                            3_c_int32_t, c_true, vreg, error_msg)) return
+            3_c_int32_t, c_true, vreg, error_msg)) return
 
         args(1) = tmp
         args(2) = i32_immediate(session, int(iachar('e'), c_int64_t))
         if (.not. emit_call(session, 'strchr', args(1:2), &
-                            lr_type_ptr_s(session%handle), 2_c_int32_t, c_false, &
-                            vreg, error_msg)) return
+            lr_type_ptr_s(session%handle), 2_c_int32_t, c_false, &
+            vreg, error_msg)) return
         p = ptr_vreg(session, vreg)
 
         nullptr%kind = LR_OP_KIND_IMM_I64
@@ -230,7 +230,7 @@ contains
         nullptr%typ = lr_type_ptr_s(session%handle)
         nullptr%global_offset = 0_c_int64_t
         if (.not. emit_liric_i32_icmp(session, LR_CMP_NE, p, nullptr, cond, &
-                                      error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_condbr(session, cond, finblk, nfblk, error_msg)) return
         build_head = .true.
     end function build_head
@@ -250,20 +250,20 @@ contains
         if (.not. gep_byte(session, p, 1_c_int64_t, pe1, error_msg)) return
         args(1) = pe1
         if (.not. emit_call(session, 'atoi', args(1:1), &
-                            lr_type_i32_s(session%handle), 1_c_int32_t, c_false, &
-                            vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 1_c_int32_t, c_false, &
+            vreg, error_msg)) return
         ex = i32_vreg(session, vreg)
 
         if (.not. store_zero_byte(session, p, error_msg)) return
 
         if (.not. emit_liric_i32_icmp(session, LR_CMP_SGE, ex, &
-                i32_immediate(session, -1_c_int64_t), cond, error_msg)) return
+            i32_immediate(session, -1_c_int64_t), cond, error_msg)) return
         if (.not. emit_liric_condbr(session, cond, chkhi, eblk, error_msg)) return
         build_finite = .true.
     end function build_finite
 
     logical function build_nonfinite(session, buf, g_inf, g_ninf, g_nan, g_pade, &
-                                     exitb, error_msg)
+            exitb, error_msg)
         ! buf holds glibc's "inf"/"-inf"/"nan". Map to gfortran's
         ! "Infinity"/"-Infinity"/"NaN", right-justified in the 25-wide field.
         type(liric_session_t), intent(inout) :: session
@@ -282,15 +282,15 @@ contains
 
         if (.not. load_byte(session, buf, 0_c_int64_t, b0, error_msg)) return
         if (.not. emit_liric_i32_icmp(session, LR_CMP_EQ, b0, &
-                i32_immediate(session, int(iachar('-'), c_int64_t)), cond, &
-                error_msg)) return
+            i32_immediate(session, int(iachar('-'), c_int64_t)), cond, &
+            error_msg)) return
         if (.not. emit_liric_condbr(session, cond, nf_neg, nf_pos, error_msg)) return
 
         ! positive: 'i' -> Infinity, else NaN
         if (.not. set_liric_block(session, nf_pos, error_msg)) return
         if (.not. emit_liric_i32_icmp(session, LR_CMP_EQ, b0, &
-                i32_immediate(session, int(iachar('i'), c_int64_t)), cond, &
-                error_msg)) return
+            i32_immediate(session, int(iachar('i'), c_int64_t)), cond, &
+            error_msg)) return
         if (.not. emit_liric_condbr(session, cond, prt_inf, prt_nan, error_msg)) &
             return
 
@@ -298,17 +298,17 @@ contains
         if (.not. set_liric_block(session, nf_neg, error_msg)) return
         if (.not. load_byte(session, buf, 1_c_int64_t, b1, error_msg)) return
         if (.not. emit_liric_i32_icmp(session, LR_CMP_EQ, b1, &
-                i32_immediate(session, int(iachar('i'), c_int64_t)), cond, &
-                error_msg)) return
+            i32_immediate(session, int(iachar('i'), c_int64_t)), cond, &
+            error_msg)) return
         if (.not. emit_liric_condbr(session, cond, prt_ninf, prt_nan, error_msg)) &
             return
 
         if (.not. nonfinite_leaf(session, prt_inf, g_pade, g_inf, exitb, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. nonfinite_leaf(session, prt_ninf, g_pade, g_ninf, exitb, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. nonfinite_leaf(session, prt_nan, g_pade, g_nan, exitb, &
-                                 error_msg)) return
+            error_msg)) return
         build_nonfinite = .true.
     end function build_nonfinite
 
@@ -385,13 +385,13 @@ contains
 
         branch_on_high = .false.
         if (.not. emit_liric_i32_icmp(session, LR_CMP_SLE, ex, &
-                i32_immediate(session, 16_c_int64_t), cond, error_msg)) return
+            i32_immediate(session, 16_c_int64_t), cond, error_msg)) return
         if (.not. emit_liric_condbr(session, cond, fblk, eblk, error_msg)) return
         branch_on_high = .true.
     end function branch_on_high
 
     logical function build_fixed(session, x, ex, num, g_ff, g_padf, exitb, &
-                                 error_msg)
+            error_msg)
         ! num = snprintf("%#.*f", 16 - ex, x); printf(" %20s     ", num)
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: x, ex, num, g_ff, g_padf
@@ -402,7 +402,7 @@ contains
 
         build_fixed = .false.
         if (.not. emit_i32_binary(session, LR_OP_SUB, &
-                i32_immediate(session, 16_c_int64_t), ex, dd, error_msg)) return
+            i32_immediate(session, 16_c_int64_t), ex, dd, error_msg)) return
 
         args(1) = num
         args(2) = i64_immediate(session, 48_c_int64_t)
@@ -410,7 +410,7 @@ contains
         args(4) = dd
         args(5) = x
         if (.not. emit_call(session, 'snprintf', args, lr_type_i32_s(session%handle), &
-                            3_c_int32_t, c_true, vreg, error_msg)) return
+            3_c_int32_t, c_true, vreg, error_msg)) return
 
         if (.not. emit_print(session, g_padf, num, error_msg)) return
         if (.not. emit_liric_br(session, exitb, error_msg)) return
@@ -418,7 +418,7 @@ contains
     end function build_fixed
 
     logical function build_exponential(session, ex, tmp, num, g_feo, g_pade, &
-                                       eblk, eneg, epos, eprint, exitb, error_msg)
+            eblk, eneg, epos, eprint, exitb, error_msg)
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: ex, tmp, num, g_feo, g_pade
         integer(c_int32_t), intent(in) :: eblk, eneg, epos, eprint, exitb
@@ -428,19 +428,19 @@ contains
         build_exponential = .false.
         if (.not. set_liric_block(session, eblk, error_msg)) return
         if (.not. emit_liric_i32_icmp(session, LR_CMP_SLT, ex, &
-                i32_immediate(session, 0_c_int64_t), cond, error_msg)) return
+            i32_immediate(session, 0_c_int64_t), cond, error_msg)) return
         if (.not. emit_liric_condbr(session, cond, eneg, epos, error_msg)) return
 
         if (.not. set_liric_block(session, eneg, error_msg)) return
         if (.not. emit_i32_binary(session, LR_OP_SUB, &
-                i32_immediate(session, 0_c_int64_t), ex, negex, error_msg)) return
+            i32_immediate(session, 0_c_int64_t), ex, negex, error_msg)) return
         if (.not. emit_exp_format(session, num, g_feo, tmp, iachar('-'), negex, &
-                                  error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_br(session, eprint, error_msg)) return
 
         if (.not. set_liric_block(session, epos, error_msg)) return
         if (.not. emit_exp_format(session, num, g_feo, tmp, iachar('+'), ex, &
-                                  error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_br(session, eprint, error_msg)) return
 
         if (.not. set_liric_block(session, eprint, error_msg)) return
@@ -450,7 +450,7 @@ contains
     end function build_exponential
 
     logical function emit_exp_format(session, num, g_feo, tmp, sign_char, expval, &
-                                     error_msg)
+            error_msg)
         ! num = snprintf("%sE%c%03d", tmp, sign_char, expval)
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: num, g_feo, tmp, expval
@@ -466,8 +466,8 @@ contains
         args(5) = i32_immediate(session, int(sign_char, c_int64_t))
         args(6) = expval
         emit_exp_format = emit_call(session, 'snprintf', args, &
-                                    lr_type_i32_s(session%handle), 3_c_int32_t, &
-                                    c_true, vreg, error_msg)
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_true, vreg, error_msg)
     end function emit_exp_format
 
     logical function emit_print(session, fmt, str, error_msg)
@@ -480,8 +480,8 @@ contains
         args(1) = fmt
         args(2) = str
         emit_print = emit_call(session, 'printf', args, &
-                               lr_type_i32_s(session%handle), 1_c_int32_t, c_true, &
-                               vreg, error_msg)
+            lr_type_i32_s(session%handle), 1_c_int32_t, c_true, &
+            vreg, error_msg)
     end function emit_print
 
     logical function emit_real8_print_call(session, value, error_msg)
@@ -493,8 +493,8 @@ contains
 
         args(1) = value
         emit_real8_print_call = emit_call(session, REAL8_PRINTER, args, &
-                                          lr_type_void_s(session%handle), &
-                                          1_c_int32_t, c_false, vreg, error_msg)
+            lr_type_void_s(session%handle), &
+            1_c_int32_t, c_false, vreg, error_msg)
     end function emit_real8_print_call
 
     logical function synthesize_real4_printer(session, error_msg)
@@ -519,24 +519,24 @@ contains
 
         if (.not. declare_libc(session, error_msg)) return
         if (.not. create_cstring(session, '.ffc.r4.fe', '%.8e', g_fe, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r4.ff', '%#.*f', g_ff, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r4.feo', '%sE%c%02d', g_feo, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r4.padf', '%12s    ', g_padf, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r4.pade', '%16s', g_pade, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r4.inf', 'Infinity', g_inf, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r4.ninf', '-Infinity', g_ninf, &
-                                 error_msg)) return
+            error_msg)) return
         if (.not. create_cstring(session, '.ffc.r4.nan', 'NaN', g_nan, &
-                                 error_msg)) return
+            error_msg)) return
 
         if (.not. begin_real4_printer(session, param_vreg, entry_block, &
-                                      error_msg)) return
+            error_msg)) return
         ! The f32 parameter must be extended to f64 before passing to
         ! snprintf because printf/snprintf is variadic and f32 is not
         ! automatically promoted by the LIRIC external ABI.
@@ -561,26 +561,26 @@ contains
         if (.not. fpext_to_f64(session, x, xf64, error_msg)) return
 
         if (.not. build_head_r4(session, xf64, g_fe, tmp, num, p, finblk, &
-                                 nfblk, error_msg)) return
+            nfblk, error_msg)) return
 
         if (.not. set_liric_block(session, finblk, error_msg)) return
         if (.not. build_finite_r4(session, tmp, p, ex, chkhi, eblk, &
-                                  error_msg)) return
+            error_msg)) return
 
         if (.not. set_liric_block(session, chkhi, error_msg)) return
         if (.not. branch_on_high_r4(session, ex, fblk, eblk, error_msg)) return
 
         if (.not. set_liric_block(session, fblk, error_msg)) return
         if (.not. build_fixed_r4(session, xf64, ex, num, g_ff, g_padf, exitb, &
-                                  error_msg)) return
+            error_msg)) return
 
         if (.not. build_exponential_r4(session, ex, tmp, num, g_feo, g_pade, &
-                                       eblk, eneg, epos, eprint, exitb, &
-                                       error_msg)) return
+            eblk, eneg, epos, eprint, exitb, &
+            error_msg)) return
 
         if (.not. set_liric_block(session, nfblk, error_msg)) return
         if (.not. build_nonfinite(session, tmp, g_inf, g_ninf, g_nan, g_pade, &
-                                  exitb, error_msg)) return
+            exitb, error_msg)) return
 
         if (.not. set_liric_block(session, exitb, error_msg)) return
         if (.not. emit_ret_void_local(session, error_msg)) return
@@ -603,8 +603,8 @@ contains
 
         args(1) = value
         emit_real4_print_call = emit_call(session, REAL4_PRINTER, args, &
-                                          lr_type_void_s(session%handle), &
-                                          1_c_int32_t, c_false, vreg, error_msg)
+            lr_type_void_s(session%handle), &
+            1_c_int32_t, c_false, vreg, error_msg)
     end function emit_real4_print_call
 
     ! --- real4 printer helpers ---
@@ -647,7 +647,7 @@ contains
     end function fpext_to_f64
 
     logical function begin_real4_printer(session, param_vreg, entry_block, &
-                                         error_msg)
+            error_msg)
         type(liric_session_t), intent(inout) :: session
         integer(c_int32_t), intent(out) :: param_vreg
         integer(c_int32_t), intent(out) :: entry_block
@@ -662,8 +662,8 @@ contains
         call clear_liric_error(error)
         call to_c_chars(REAL4_PRINTER, c_name)
         status = lr_session_func_begin(session%handle, c_name, &
-                                       lr_type_void_s(session%handle), &
-                                       c_loc(params), 1_c_int32_t, c_false, error)
+            lr_type_void_s(session%handle), &
+            c_loc(params), 1_c_int32_t, c_false, error)
         if (.not. status_ok(status, error, error_msg)) return
 
         param_vreg = lr_session_param(session%handle, 0_c_int32_t)
@@ -673,7 +673,7 @@ contains
     end function begin_real4_printer
 
     logical function build_head_r4(session, x, g_fe, tmp, num, p, finblk, &
-                                   nfblk, error_msg)
+            nfblk, error_msg)
         ! Same as build_head but with the r4 format string (%.8e).
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: x, g_fe
@@ -685,22 +685,22 @@ contains
 
         build_head_r4 = .false.
         if (.not. emit_alloca_bytes(session, i64_immediate(session, 36_c_int64_t), &
-                                    tmp, error_msg)) return
+            tmp, error_msg)) return
         if (.not. emit_alloca_bytes(session, i64_immediate(session, 32_c_int64_t), &
-                                    num, error_msg)) return
+            num, error_msg)) return
 
         args(1) = tmp
         args(2) = i64_immediate(session, 36_c_int64_t)
         args(3) = g_fe
         args(4) = x
         if (.not. emit_call(session, 'snprintf', args, lr_type_i32_s(session%handle), &
-                            3_c_int32_t, c_true, vreg, error_msg)) return
+            3_c_int32_t, c_true, vreg, error_msg)) return
 
         args(1) = tmp
         args(2) = i32_immediate(session, int(iachar('e'), c_int64_t))
         if (.not. emit_call(session, 'strchr', args(1:2), &
-                            lr_type_ptr_s(session%handle), 2_c_int32_t, c_false, &
-                            vreg, error_msg)) return
+            lr_type_ptr_s(session%handle), 2_c_int32_t, c_false, &
+            vreg, error_msg)) return
         p = ptr_vreg(session, vreg)
 
         nullptr%kind = LR_OP_KIND_IMM_I64
@@ -708,7 +708,7 @@ contains
         nullptr%typ = lr_type_ptr_s(session%handle)
         nullptr%global_offset = 0_c_int64_t
         if (.not. emit_liric_i32_icmp(session, LR_CMP_NE, p, nullptr, cond, &
-                                      error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_condbr(session, cond, finblk, nfblk, error_msg)) return
         build_head_r4 = .true.
     end function build_head_r4
@@ -727,14 +727,14 @@ contains
         if (.not. gep_byte(session, p, 1_c_int64_t, pe1, error_msg)) return
         args(1) = pe1
         if (.not. emit_call(session, 'atoi', args(1:1), &
-                            lr_type_i32_s(session%handle), 1_c_int32_t, c_false, &
-                            vreg, error_msg)) return
+            lr_type_i32_s(session%handle), 1_c_int32_t, c_false, &
+            vreg, error_msg)) return
         ex = i32_vreg(session, vreg)
 
         if (.not. store_zero_byte(session, p, error_msg)) return
 
         if (.not. emit_liric_i32_icmp(session, LR_CMP_SGE, ex, &
-                i32_immediate(session, -1_c_int64_t), cond, error_msg)) return
+            i32_immediate(session, -1_c_int64_t), cond, error_msg)) return
         if (.not. emit_liric_condbr(session, cond, chkhi, eblk, error_msg)) return
         build_finite_r4 = .true.
     end function build_finite_r4
@@ -749,13 +749,13 @@ contains
 
         branch_on_high_r4 = .false.
         if (.not. emit_liric_i32_icmp(session, LR_CMP_SLE, ex, &
-                i32_immediate(session, 8_c_int64_t), cond, error_msg)) return
+            i32_immediate(session, 8_c_int64_t), cond, error_msg)) return
         if (.not. emit_liric_condbr(session, cond, fblk, eblk, error_msg)) return
         branch_on_high_r4 = .true.
     end function branch_on_high_r4
 
     logical function build_fixed_r4(session, x, ex, num, g_ff, g_padf, exitb, &
-                                    error_msg)
+            error_msg)
         ! num = snprintf("%#.*f", 8 - ex, x); printf("%12s    ", num)
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: x, ex, num, g_ff, g_padf
@@ -766,7 +766,7 @@ contains
 
         build_fixed_r4 = .false.
         if (.not. emit_i32_binary(session, LR_OP_SUB, &
-                i32_immediate(session, 8_c_int64_t), ex, dd, error_msg)) return
+            i32_immediate(session, 8_c_int64_t), ex, dd, error_msg)) return
 
         args(1) = num
         args(2) = i64_immediate(session, 32_c_int64_t)
@@ -774,7 +774,7 @@ contains
         args(4) = dd
         args(5) = x
         if (.not. emit_call(session, 'snprintf', args, lr_type_i32_s(session%handle), &
-                            3_c_int32_t, c_true, vreg, error_msg)) return
+            3_c_int32_t, c_true, vreg, error_msg)) return
 
         if (.not. emit_print(session, g_padf, num, error_msg)) return
         if (.not. emit_liric_br(session, exitb, error_msg)) return
@@ -782,7 +782,7 @@ contains
     end function build_fixed_r4
 
     logical function build_exponential_r4(session, ex, tmp, num, g_feo, g_pade, &
-                                          eblk, eneg, epos, eprint, exitb, error_msg)
+            eblk, eneg, epos, eprint, exitb, error_msg)
         ! Two-digit exponent: %02d.
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: ex, tmp, num, g_feo, g_pade
@@ -793,19 +793,19 @@ contains
         build_exponential_r4 = .false.
         if (.not. set_liric_block(session, eblk, error_msg)) return
         if (.not. emit_liric_i32_icmp(session, LR_CMP_SLT, ex, &
-                i32_immediate(session, 0_c_int64_t), cond, error_msg)) return
+            i32_immediate(session, 0_c_int64_t), cond, error_msg)) return
         if (.not. emit_liric_condbr(session, cond, eneg, epos, error_msg)) return
 
         if (.not. set_liric_block(session, eneg, error_msg)) return
         if (.not. emit_i32_binary(session, LR_OP_SUB, &
-                i32_immediate(session, 0_c_int64_t), ex, negex, error_msg)) return
+            i32_immediate(session, 0_c_int64_t), ex, negex, error_msg)) return
         if (.not. emit_exp_format_r4(session, num, g_feo, tmp, iachar('-'), &
-                                     negex, error_msg)) return
+            negex, error_msg)) return
         if (.not. emit_liric_br(session, eprint, error_msg)) return
 
         if (.not. set_liric_block(session, epos, error_msg)) return
         if (.not. emit_exp_format_r4(session, num, g_feo, tmp, iachar('+'), &
-                                     ex, error_msg)) return
+            ex, error_msg)) return
         if (.not. emit_liric_br(session, eprint, error_msg)) return
 
         if (.not. set_liric_block(session, eprint, error_msg)) return
@@ -815,7 +815,7 @@ contains
     end function build_exponential_r4
 
     logical function emit_exp_format_r4(session, num, g_feo, tmp, sign_char, &
-                                        expval, error_msg)
+            expval, error_msg)
         ! num = snprintf(num, 32, "%sE%c%02d", tmp, sign_char, expval)
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: num, g_feo, tmp, expval
@@ -831,8 +831,8 @@ contains
         args(5) = i32_immediate(session, int(sign_char, c_int64_t))
         args(6) = expval
         emit_exp_format_r4 = emit_call(session, 'snprintf', args, &
-                                       lr_type_i32_s(session%handle), 3_c_int32_t, &
-                                       c_true, vreg, error_msg)
+            lr_type_i32_s(session%handle), 3_c_int32_t, &
+            c_true, vreg, error_msg)
     end function emit_exp_format_r4
 
     include 'liric_session_real_print_bindings_tail.inc'

--- a/src/liric_session_timing_bindings.f90
+++ b/src/liric_session_timing_bindings.f90
@@ -8,20 +8,20 @@ module liric_session_timing_bindings
     ! structure. The actual magnitudes are nondeterministic; the conformance
     ! gauntlet compares such programs structurally (see lib_conformance.sh).
     use, intrinsic :: iso_c_binding, only: c_bool, c_char, c_float, c_int, &
-                                           c_int32_t, c_int64_t, c_loc, &
-                                           c_null_ptr, c_ptr
+        c_int32_t, c_int64_t, c_loc, &
+        c_null_ptr, c_ptr
     use liric_session_bindings, only: liric_session_t, lr_error_t, &
-                                      lr_inst_desc_t, lr_operand_desc_t, &
-                                      LR_OP_CALL, LR_OP_TRUNC, LR_OP_SITOFP, &
-                                      LR_OP_FMUL, LR_OP_KIND_VREG, &
-                                      LR_OP_KIND_GLOBAL, LR_OP_KIND_IMM_I64, &
-                                      lr_type_i32_s, lr_type_f32_s, &
-                                      lr_type_i64_s, lr_type_ptr_s, &
-                                      lr_session_emit, lr_session_intern, &
-                                      status_ok, clear_liric_error, set_empty, &
-                                      require_open_session, to_c_chars
+        lr_inst_desc_t, lr_operand_desc_t, &
+        LR_OP_CALL, LR_OP_TRUNC, LR_OP_SITOFP, &
+        LR_OP_FMUL, LR_OP_KIND_VREG, &
+        LR_OP_KIND_GLOBAL, LR_OP_KIND_IMM_I64, &
+        lr_type_i32_s, lr_type_f32_s, &
+        lr_type_i64_s, lr_type_ptr_s, &
+        lr_session_emit, lr_session_intern, &
+        status_ok, clear_liric_error, set_empty, &
+        require_open_session, to_c_chars
     use liric_session_io_bindings, only: liric_f32_immediate, &
-                                         emit_liric_f32_binary
+        emit_liric_f32_binary
     implicit none
     private
 
@@ -32,7 +32,7 @@ module liric_session_timing_bindings
 
     interface
         function lr_session_declare(handle, name, ret, params, n, vararg, &
-                                    err) result(status) bind(c)
+                err) result(status) bind(c)
             import :: c_bool, c_char, c_int, c_int32_t, c_ptr, lr_error_t
             type(c_ptr), value :: handle
             character(kind=c_char), intent(in) :: name(*)
@@ -57,14 +57,14 @@ contains
         emit_cpu_time_value = .false.
         if (.not. require_open_session(session, error_msg)) return
         if (.not. declare_extern(session, 'clock', &
-                                 lr_type_i64_s(session%handle), error_msg)) return
+            lr_type_i64_s(session%handle), error_msg)) return
         if (.not. call_extern_i64(session, 'clock', ticks_i64, error_msg)) return
         if (.not. emit_cast(session, LR_OP_SITOFP, ticks_i64, &
-                            lr_type_f32_s(session%handle), ticks_f32, &
-                            error_msg)) return
+            lr_type_f32_s(session%handle), ticks_f32, &
+            error_msg)) return
         scale = liric_f32_immediate(session, 1.0e-6_c_float)
         if (.not. emit_liric_f32_binary(session, LR_OP_FMUL, ticks_f32, scale, &
-                                        result, error_msg)) return
+            result, error_msg)) return
         call set_empty(error_msg)
         emit_cpu_time_value = .true.
     end function emit_cpu_time_value
@@ -79,15 +79,15 @@ contains
         emit_system_clock_value = .false.
         if (.not. require_open_session(session, error_msg)) return
         if (.not. declare_extern_ptr_arg(session, 'time', &
-                                         lr_type_i64_s(session%handle), &
-                                         error_msg)) return
+            lr_type_i64_s(session%handle), &
+            error_msg)) return
         args(1) = i64_null_ptr(session)
         if (.not. call_extern(session, 'time', args, &
-                              lr_type_i64_s(session%handle), 1_c_int32_t, &
-                              secs_i64, error_msg)) return
+            lr_type_i64_s(session%handle), 1_c_int32_t, &
+            secs_i64, error_msg)) return
         if (.not. emit_cast(session, LR_OP_TRUNC, secs_i64, &
-                            lr_type_i32_s(session%handle), result, &
-                            error_msg)) return
+            lr_type_i32_s(session%handle), result, &
+            error_msg)) return
         call set_empty(error_msg)
         emit_system_clock_value = .true.
     end function emit_system_clock_value
@@ -117,7 +117,7 @@ contains
         call clear_liric_error(error)
         call to_c_chars(name, c_name)
         status = lr_session_declare(session%handle, c_name, ret_typ, c_null_ptr, &
-                                    0_c_int32_t, c_false, error)
+            0_c_int32_t, c_false, error)
         if (.not. status_ok(status, error, error_msg)) return
         declare_extern = .true.
     end function declare_extern
@@ -138,7 +138,7 @@ contains
         call clear_liric_error(error)
         call to_c_chars(name, c_name)
         status = lr_session_declare(session%handle, c_name, ret_typ, &
-                                    c_loc(params), 1_c_int32_t, c_false, error)
+            c_loc(params), 1_c_int32_t, c_false, error)
         if (.not. status_ok(status, error, error_msg)) return
         declare_extern_ptr_arg = .true.
     end function declare_extern_ptr_arg
@@ -152,12 +152,12 @@ contains
         type(lr_operand_desc_t) :: args(0)
 
         call_extern_i64 = call_extern(session, name, args, &
-                                      lr_type_i64_s(session%handle), &
-                                      0_c_int32_t, result, error_msg)
+            lr_type_i64_s(session%handle), &
+            0_c_int32_t, result, error_msg)
     end function call_extern_i64
 
     logical function call_extern(session, name, args, ret_typ, fixed_args, &
-                                 result, error_msg)
+            result, error_msg)
         ! Emit a fixed-arg external-ABI call and capture its result vreg.
         type(liric_session_t), intent(inout) :: session
         character(len=*), intent(in) :: name

--- a/src/session_lowering_ops.f90
+++ b/src/session_lowering_ops.f90
@@ -2,10 +2,10 @@ module session_lowering_ops
     use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
     use ffc_strings, only: set_empty
     use liric_session_bindings, only: LR_OP_ADD, LR_OP_MUL, LR_OP_SDIV, &
-                                      LR_OP_SUB
+        LR_OP_SUB
     use liric_session_control_bindings, only: LR_CMP_EQ, LR_CMP_NE, &
-                                              LR_CMP_SGE, LR_CMP_SGT, &
-                                              LR_CMP_SLE, LR_CMP_SLT
+        LR_CMP_SGE, LR_CMP_SGT, &
+        LR_CMP_SLE, LR_CMP_SLT
     implicit none
     private
 
@@ -43,7 +43,7 @@ contains
             call set_empty(error_msg)
         else
             error_msg = 'invalid integer literal for direct LIRIC lowering: '// &
-                        trim(text)
+                trim(text)
         end if
     end subroutine parse_i32_literal
 
@@ -167,7 +167,7 @@ contains
             opcode = LR_OP_SDIV
         case default
             error_msg = 'ffc direct-session lowering does not support operator: '// &
-                        trim(source_op)
+                trim(source_op)
             opcode = 0
         end select
     end subroutine integer_opcode
@@ -193,7 +193,7 @@ contains
             predicate = LR_CMP_SLE
         case default
             error_msg = 'ffc direct-session lowering does not support comparison: '// &
-                        trim(source_op)
+                trim(source_op)
             predicate = LR_CMP_EQ
         end select
     end subroutine integer_compare_predicate

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -1,274 +1,274 @@
 module session_program_lowering
     use, intrinsic :: iso_c_binding, only: c_char, c_double, c_float, c_int, &
-                                           c_int32_t, c_int64_t
+        c_int32_t, c_int64_t
     use ast_base, only: LITERAL_INTEGER
     use ast_nodes_bounds, only: array_slice_node, array_bounds_node, &
-                                range_expression_node
+        range_expression_node
     use ast_nodes_core, only: component_access_node, array_literal_node, &
-                              pointer_assignment_node, literal_node, &
-                              identifier_node
+        pointer_assignment_node, literal_node, &
+        identifier_node
     use ast_nodes_transfer, only: nullify_node
     use ast_nodes_data, only: derived_type_node, type_binding_node, &
-                              block_data_node
+        block_data_node
     use ast_nodes_legacy, only: common_block_node, enum_node
     use string_types, only: string_t
     use ast_nodes_io, only: open_statement_node, close_statement_node, &
-                            rewind_statement_node, io_implied_do_node
+        rewind_statement_node, io_implied_do_node
     use ast_nodes_misc, only: use_statement_node, interface_block_node, &
-                              module_procedure_node, &
-                              visibility_statement_node, data_statement_node, &
-                              complex_literal_node, comment_node, &
-                              namelist_statement_node, statement_function_node, &
-                              end_statement_node
+        module_procedure_node, &
+        visibility_statement_node, data_statement_node, &
+        complex_literal_node, comment_node, &
+        namelist_statement_node, statement_function_node, &
+        end_statement_node
     use ast_nodes_conditional, only: select_type_node, type_guard_block_node, &
-                                     select_rank_node, rank_block_node
+        select_rank_node, rank_block_node
     use ast_nodes_associate, only: associate_node, association_t
     use ast_nodes_control, only: block_construct_node, where_stmt_node, &
-                                 elsewhere_clause_t, goto_node, pause_node, &
-                                 continue_node
+        elsewhere_clause_t, goto_node, pause_node, &
+        continue_node
     use fortfront, only: assignment_node, ast_arena_t, &
-                         call_or_subscript_node, case_block_node, &
-                         case_range_node, &
-                         case_default_node, declaration_node, do_loop_node, &
-                         do_while_node, cycle_node, exit_node, function_def_node, &
-                         if_node, &
-                         parameter_declaration_node, &
-                         print_statement_node, program_node, read_statement_node, &
-                         module_node, &
-                         return_node, select_case_node, stop_node, &
-                         error_stop_node, &
-                         subroutine_def_node, write_statement_node, &
-                         allocate_statement_node, deallocate_statement_node, &
-                         where_node, forall_node, &
-                         get_subroutine_call_arg_indices, &
-                         get_subroutine_call_name, is_subroutine_call_statement, &
-                         is_binary_op, get_binary_op_info, &
-                         is_literal, get_literal_info, &
-                         is_identifier, get_identifier_name, &
-                         is_declaration_node, is_module_node, is_program_node
+        call_or_subscript_node, case_block_node, &
+        case_range_node, &
+        case_default_node, declaration_node, do_loop_node, &
+        do_while_node, cycle_node, exit_node, function_def_node, &
+        if_node, &
+        parameter_declaration_node, &
+        print_statement_node, program_node, read_statement_node, &
+        module_node, &
+        return_node, select_case_node, stop_node, &
+        error_stop_node, &
+        subroutine_def_node, write_statement_node, &
+        allocate_statement_node, deallocate_statement_node, &
+        where_node, forall_node, &
+        get_subroutine_call_arg_indices, &
+        get_subroutine_call_name, is_subroutine_call_statement, &
+        is_binary_op, get_binary_op_info, &
+        is_literal, get_literal_info, &
+        is_identifier, get_identifier_name, &
+        is_declaration_node, is_module_node, is_program_node
     use liric_session_bindings, only: destroy, begin_i32_main, &
-                                       begin_i32_function, begin_void_subroutine, &
-                                       begin_ptr_function, &
-                                       emit_ret_i32_operand, emit_ret_void, &
-                                       finish_function, finish_and_emit_exe, &
-                                       finish_and_emit_object, emit_void_call, &
-                                       emit_i32_call, emit_ptr_call, &
-                                       emit_i32_indirect_call, &
-                                       emit_void_indirect_call, &
-                                       liric_session_create, &
-                                       i32_immediate, i32_vreg, lr_operand_desc_t, &
-                                       lr_type_i32_s, lr_type_ptr_s, lr_type_i64_s, &
-                                       lr_type_array_s, &
-                                       lr_session_global, lr_session_intern, &
-                                       lr_session_emit, lr_inst_desc_t, lr_error_t, &
-                                       clear_liric_error, status_ok, to_c_chars, &
-                                       LR_OP_ADD, LR_OP_SREM, LR_OP_SUB, &
-                                       LR_OP_MUL, LR_OP_FADD, LR_OP_FMUL, &
-                                       LR_OP_AND, LR_OP_OR, LR_OP_XOR, &
-                                       LR_OP_SHL, LR_OP_LSHR, LR_OP_KIND_IMM_I64, &
-                                       LR_OP_KIND_GLOBAL
+        begin_i32_function, begin_void_subroutine, &
+        begin_ptr_function, &
+        emit_ret_i32_operand, emit_ret_void, &
+        finish_function, finish_and_emit_exe, &
+        finish_and_emit_object, emit_void_call, &
+        emit_i32_call, emit_ptr_call, &
+        emit_i32_indirect_call, &
+        emit_void_indirect_call, &
+        liric_session_create, &
+        i32_immediate, i32_vreg, lr_operand_desc_t, &
+        lr_type_i32_s, lr_type_ptr_s, lr_type_i64_s, &
+        lr_type_array_s, &
+        lr_session_global, lr_session_intern, &
+        lr_session_emit, lr_inst_desc_t, lr_error_t, &
+        clear_liric_error, status_ok, to_c_chars, &
+        LR_OP_ADD, LR_OP_SREM, LR_OP_SUB, &
+        LR_OP_MUL, LR_OP_FADD, LR_OP_FMUL, &
+        LR_OP_AND, LR_OP_OR, LR_OP_XOR, &
+        LR_OP_SHL, LR_OP_LSHR, LR_OP_KIND_IMM_I64, &
+        LR_OP_KIND_GLOBAL
     use liric_session_memory_bindings, only: reserve_i32_vreg, i64_immediate, &
-                                              ptr_vreg, &
-                                              emit_i32_binary, emit_i32_binary_into, &
-                                              emit_i32_copy_to, emit_i32_alloca, &
-                                              emit_ptr_alloca, &
-                                              emit_i32_load, emit_i32_store, &
-                                              emit_i64_load, emit_ptr_load, &
-                                              emit_i64_store, &
-                                              emit_i64_binary, emit_i64_alloca, &
-                                              emit_alloca_bytes, emit_malloc, &
-                                              emit_free, emit_ptr_store, &
-                                               emit_memcpy, emit_i64_load_at, &
-                                               emit_i64_store_at, &
-                                               emit_i32_array_alloca, &
-                                              emit_i32_array_element_addr, &
-                                              emit_f32_array_alloca, &
-                                              emit_f32_array_element_addr, &
-                                              emit_f64_array_alloca, &
-                                              emit_f64_array_element_addr, &
-                                              emit_ptr_offset, emit_ptr_offset_dyn, &
-                                              ptr_param, &
-                                              i8_immediate, emit_i8_alloca, &
-                                              emit_i8_load, emit_i8_store, emit_i8_binary, &
-                                              i16_immediate, emit_i16_alloca, &
-                                              emit_i16_load, emit_i16_store, emit_i16_binary
+        ptr_vreg, &
+        emit_i32_binary, emit_i32_binary_into, &
+        emit_i32_copy_to, emit_i32_alloca, &
+        emit_ptr_alloca, &
+        emit_i32_load, emit_i32_store, &
+        emit_i64_load, emit_ptr_load, &
+        emit_i64_store, &
+        emit_i64_binary, emit_i64_alloca, &
+        emit_alloca_bytes, emit_malloc, &
+        emit_free, emit_ptr_store, &
+        emit_memcpy, emit_i64_load_at, &
+        emit_i64_store_at, &
+        emit_i32_array_alloca, &
+        emit_i32_array_element_addr, &
+        emit_f32_array_alloca, &
+        emit_f32_array_element_addr, &
+        emit_f64_array_alloca, &
+        emit_f64_array_element_addr, &
+        emit_ptr_offset, emit_ptr_offset_dyn, &
+        ptr_param, &
+        i8_immediate, emit_i8_alloca, &
+        emit_i8_load, emit_i8_store, emit_i8_binary, &
+        i16_immediate, emit_i16_alloca, &
+        emit_i16_load, emit_i16_store, emit_i16_binary
     use liric_session_control_bindings, only: create_liric_block, &
-                                              emit_liric_br, &
-                                              emit_liric_condbr, &
-                                              emit_liric_f32_fcmp, &
-                                              emit_liric_f64_fcmp, &
-                                              emit_liric_i32_icmp, &
-                                              emit_liric_i32_phi, &
-                                              emit_liric_phi, &
-                                              emit_liric_phi_n, &
-                                              LR_FCMP_OGT, &
-                                              LR_FCMP_OGE, &
-                                              LR_FCMP_OLT, &
-                                              LR_FCMP_OLE, &
-                                              LR_FCMP_OEQ, &
-                                              LR_FCMP_ONE, &
-                                              LR_CMP_SGE, &
-                                              LR_CMP_SGT, &
-                                              LR_CMP_SLE, &
-                                              LR_CMP_SLT, &
-                                              LR_CMP_NE, &
-                                              LR_CMP_EQ, &
-                                              set_liric_block
-use liric_session_format_bindings, only: LR_OP_FSUB, &
-                                            prepare_liric_print_runtime, &
-                                            create_printf_format_global, &
-                                            printf_format_ptr, &
-                                            create_type_info_global
+        emit_liric_br, &
+        emit_liric_condbr, &
+        emit_liric_f32_fcmp, &
+        emit_liric_f64_fcmp, &
+        emit_liric_i32_icmp, &
+        emit_liric_i32_phi, &
+        emit_liric_phi, &
+        emit_liric_phi_n, &
+        LR_FCMP_OGT, &
+        LR_FCMP_OGE, &
+        LR_FCMP_OLT, &
+        LR_FCMP_OLE, &
+        LR_FCMP_OEQ, &
+        LR_FCMP_ONE, &
+        LR_CMP_SGE, &
+        LR_CMP_SGT, &
+        LR_CMP_SLE, &
+        LR_CMP_SLT, &
+        LR_CMP_NE, &
+        LR_CMP_EQ, &
+        set_liric_block
+    use liric_session_format_bindings, only: LR_OP_FSUB, &
+        prepare_liric_print_runtime, &
+        create_printf_format_global, &
+        printf_format_ptr, &
+        create_type_info_global
     use liric_session_real_print_bindings, only: synthesize_real8_printer, &
-                                                 synthesize_real4_printer, &
-                                                 synthesize_get_arg_helper, &
-                                                 emit_get_arg_call, emit_snprintf, &
-                                                 emit_sscanf, emit_scanf, &
-                                                 emit_fscanf, &
-                                                 emit_fprintf, emit_dprintf, &
-                                                 emit_getchar, emit_exit
+        synthesize_real4_printer, &
+        synthesize_get_arg_helper, &
+        emit_get_arg_call, emit_snprintf, &
+        emit_sscanf, emit_scanf, &
+        emit_fscanf, &
+        emit_fprintf, emit_dprintf, &
+        emit_getchar, emit_exit
     use liric_session_complex_print_bindings, only: synthesize_complex4_printer, &
-                                                    synthesize_complex8_printer, &
-                                                    emit_complex4_print_call, &
-                                                    emit_complex8_print_call
+        synthesize_complex8_printer, &
+        emit_complex4_print_call, &
+        emit_complex8_print_call
     use liric_session_io_bindings, only: emit_liric_f32_binary, &
-                                          emit_liric_i32_to_f32, &
-                                          emit_liric_f32_to_i32, &
-                                          emit_liric_f32_to_f64, &
-                                          emit_liric_print_f32, &
-                                          emit_liric_print_f32_value, &
-                                          emit_liric_f64_binary, &
-                                          emit_liric_i32_to_f64, &
-                                          emit_liric_f64_to_i32, &
-                                          emit_liric_char_byte_zext, &
-                                          emit_liric_i32_to_i64, &
-                                          emit_liric_store_char_byte, &
-                                          emit_liric_print_f64, &
-                                          emit_liric_print_f64_value, &
-                                          emit_liric_print_i32, &
-                                          emit_liric_print_i32_value, &
-                                          emit_liric_print_i64, &
-                                          emit_liric_print_i64_value, &
-                                          emit_liric_print_newline, &
-                                          emit_liric_print_space, &
-                                          emit_liric_print_string_operand, &
-                                          emit_liric_print_string_operand_value, &
-                                          emit_liric_print_string, &
-                                          emit_liric_print_string_value, &
-                                          liric_f32_immediate, &
-                                          liric_f64_immediate, &
-                                          materialize_liric_string, &
-                                          emit_liric_i8_to_i32, &
-                                          emit_liric_i16_to_i32, &
-                                          emit_liric_print_i8, &
-                                          emit_liric_print_i8_value, &
-                                          emit_liric_print_i16, &
-                                          emit_liric_print_i16_value
+        emit_liric_i32_to_f32, &
+        emit_liric_f32_to_i32, &
+        emit_liric_f32_to_f64, &
+        emit_liric_print_f32, &
+        emit_liric_print_f32_value, &
+        emit_liric_f64_binary, &
+        emit_liric_i32_to_f64, &
+        emit_liric_f64_to_i32, &
+        emit_liric_char_byte_zext, &
+        emit_liric_i32_to_i64, &
+        emit_liric_store_char_byte, &
+        emit_liric_print_f64, &
+        emit_liric_print_f64_value, &
+        emit_liric_print_i32, &
+        emit_liric_print_i32_value, &
+        emit_liric_print_i64, &
+        emit_liric_print_i64_value, &
+        emit_liric_print_newline, &
+        emit_liric_print_space, &
+        emit_liric_print_string_operand, &
+        emit_liric_print_string_operand_value, &
+        emit_liric_print_string, &
+        emit_liric_print_string_value, &
+        liric_f32_immediate, &
+        liric_f64_immediate, &
+        materialize_liric_string, &
+        emit_liric_i8_to_i32, &
+        emit_liric_i16_to_i32, &
+        emit_liric_print_i8, &
+        emit_liric_print_i8_value, &
+        emit_liric_print_i16, &
+        emit_liric_print_i16_value
     use liric_session_procedure_bindings, only: begin_liric_f32_function, &
-                                                emit_liric_f32_alloca, &
-                                                emit_liric_f32_call, &
-                                                emit_liric_f32_load, &
-                                                emit_liric_f32_store, &
-                                                begin_liric_f64_function, &
-                                                emit_liric_f64_alloca, &
-                                                emit_liric_f64_call, &
-                                                emit_liric_f64_load, &
-                                                emit_liric_f64_store
+        emit_liric_f32_alloca, &
+        emit_liric_f32_call, &
+        emit_liric_f32_load, &
+        emit_liric_f32_store, &
+        begin_liric_f64_function, &
+        emit_liric_f64_alloca, &
+        emit_liric_f64_call, &
+        emit_liric_f64_load, &
+        emit_liric_f64_store
     use liric_session_timing_bindings, only: emit_cpu_time_value, &
-                                             emit_system_clock_value
+        emit_system_clock_value
     use session_lowering_ops, only: integer_compare_predicate, &
-                                    integer_opcode, parse_i32_literal
-  use ffc_strings, only: set_empty
+        integer_opcode, parse_i32_literal
+    use ffc_strings, only: set_empty
     use ffc_fortfront_queries, only: node_exists, get_node_type_at, &
-                                     get_program_body_info, get_module_body_info, &
-                                     get_function_body_info, get_subroutine_body_info, &
-                                     get_select_case_info, get_case_block_info, &
-                                     get_case_default_body, get_case_range_info, &
-                                     get_select_type_info, get_type_guard_info, &
-                                     is_derived_type_node, is_declaration_node, &
-                                     get_derived_type_name, get_derived_type_components, &
-                                     get_declaration_var_name, get_declaration_type_name, &
-                                     get_declaration_has_initializer, &
-                                     get_declaration_initializer_index, &
-                                     get_node_stmt_label, get_goto_label, &
-                                     goto_is_computed, get_goto_label_list, &
-                                     get_goto_selector_index
+        get_program_body_info, get_module_body_info, &
+        get_function_body_info, get_subroutine_body_info, &
+        get_select_case_info, get_case_block_info, &
+        get_case_default_body, get_case_range_info, &
+        get_select_type_info, get_type_guard_info, &
+        is_derived_type_node, is_declaration_node, &
+        get_derived_type_name, get_derived_type_components, &
+        get_declaration_var_name, get_declaration_type_name, &
+        get_declaration_has_initializer, &
+        get_declaration_initializer_index, &
+        get_node_stmt_label, get_goto_label, &
+        goto_is_computed, get_goto_label_list, &
+        get_goto_selector_index
     use fortfront_utils, only: get_node_as_function_def, &
-                               get_node_as_program, &
-                               get_node_as_subroutine_def
+        get_node_as_program, &
+        get_node_as_subroutine_def
     use ast_nodes_data, only: mixed_construct_container_node, &
-                              multi_unit_container_node
+        multi_unit_container_node
     use fortfront, only: get_node_line, get_node_column
     use ast_arena_source_text, only: get_source_line
     use session_program_lowering_types, only: lowering_context_t, &
-                                                branch_result_t, symbol_t, &
-                                                array_section_info_t, &
-                                                derived_type_info_t, &
-                                                module_exports_t, &
-                                                external_procedure_t, &
-                                                generic_interface_t, &
-                                                operator_interface_t, &
-                                                MAX_PROC_ARGS, &
-                                                MAX_GENERIC_SPECIFICS, &
-                                                MODVAR_OK, MODVAR_UNSUPPORTED, &
-                                                common_slot_t, COMMON_MAX_SLOTS, &
-                                                EQUIV_MAX_MEMBERS, &
-                                                namelist_group_t, &
-                                                statement_function_t, &
-                                                MAX_STMT_FN_ARGS, &
-                                                MAX_NAMELIST_MEMBERS, &
-                                                VALUE_I8, VALUE_I16, VALUE_I32, VALUE_I64, VALUE_F32, VALUE_F64, &
-                                                VALUE_C4, VALUE_C8, &
-                                                 VALUE_LOGICAL, VALUE_CHARACTER, &
-                                                 VALUE_DERIVED, &
-                                                 VALUE_DEFERRED_CHARACTER_RESULT, &
-                                                 VALUE_SUBROUTINE, VALUE_C_PTR, &
-                                                 VALUE_CLASS_STAR, VALUE_PROC_PTR, &
-                                                 VALUE_ARRAY_RESULT, &
-                                                 TYPE_ID_INTEGER, TYPE_ID_REAL, &
-                                                 TYPE_ID_LOGICAL, &
-                                                 I32_INTRINSIC_NONE, &
-                                                I32_INTRINSIC_ABS, I32_INTRINSIC_MIN, &
-                                                I32_INTRINSIC_MAX, I32_INTRINSIC_MOD, &
-                                                I32_INTRINSIC_IAND, I32_INTRINSIC_IOR, &
-                                                I32_INTRINSIC_IEOR, I32_INTRINSIC_NOT, &
-                                                I32_INTRINSIC_ISHFT, &
-                                                I32_INTRINSIC_ISHFTC, &
-                                                I32_INTRINSIC_SIGN, &
-                                                I32_INTRINSIC_INT, I32_INTRINSIC_NINT, &
-                                                I32_INTRINSIC_FLOOR, &
-                                                I32_INTRINSIC_CEILING, &
-                                                 I32_INTRINSIC_MATMUL, &
-                                                 I32_INTRINSIC_TRANSPOSE, &
-                                                 I32_INTRINSIC_DOT_PRODUCT, &
-                                                 I32_INTRINSIC_RESHAPE, &
-                                                 I32_INTRINSIC_SELECTED_INT_KIND, &
-                                                 I32_INTRINSIC_SELECTED_REAL_KIND, &
-                                                I32_INTRINSIC_MODULO, &
-                                                I32_INTRINSIC_DIM, &
-                                                 F64_INTRINSIC_SIGN, &
-                                                F64_INTRINSIC_SQRT, F64_INTRINSIC_EXP, &
-                                                F64_INTRINSIC_LOG, F64_INTRINSIC_SIN, &
-                                                F64_INTRINSIC_COS, F64_INTRINSIC_TAN, &
-                                                F64_INTRINSIC_ATAN, F64_INTRINSIC_ATAN2, &
-                                                F64_INTRINSIC_ASIN, F64_INTRINSIC_ACOS, &
-                                                F64_INTRINSIC_SINH, F64_INTRINSIC_COSH, &
-                                                F64_INTRINSIC_TANH, F64_INTRINSIC_ASINH, &
-                                                F64_INTRINSIC_ACOSH, F64_INTRINSIC_ATANH, &
-                                                F64_INTRINSIC_LOG10, F64_INTRINSIC_ERF, &
-                                                F64_INTRINSIC_ERFC, F64_INTRINSIC_GAMMA, &
-                                                F64_INTRINSIC_LOG_GAMMA, &
-                                                F64_INTRINSIC_HYPOT, &
-                                                F64_INTRINSIC_AINT, &
-                                                F64_INTRINSIC_ANINT, &
-                                                F64_INTRINSIC_NONE, F64_INTRINSIC_ABS, &
-                                                F64_INTRINSIC_MIN, F64_INTRINSIC_MAX, &
-                                                F64_INTRINSIC_REAL, I32_INTRINSIC_NAMES, &
-                                                I32_INTRINSIC_IDS, F64_INTRINSIC_NAMES, &
-                                                F64_INTRINSIC_IDS
+        branch_result_t, symbol_t, &
+        array_section_info_t, &
+        derived_type_info_t, &
+        module_exports_t, &
+        external_procedure_t, &
+        generic_interface_t, &
+        operator_interface_t, &
+        MAX_PROC_ARGS, &
+        MAX_GENERIC_SPECIFICS, &
+        MODVAR_OK, MODVAR_UNSUPPORTED, &
+        common_slot_t, COMMON_MAX_SLOTS, &
+        EQUIV_MAX_MEMBERS, &
+        namelist_group_t, &
+        statement_function_t, &
+        MAX_STMT_FN_ARGS, &
+        MAX_NAMELIST_MEMBERS, &
+        VALUE_I8, VALUE_I16, VALUE_I32, VALUE_I64, VALUE_F32, VALUE_F64, &
+        VALUE_C4, VALUE_C8, &
+        VALUE_LOGICAL, VALUE_CHARACTER, &
+        VALUE_DERIVED, &
+        VALUE_DEFERRED_CHARACTER_RESULT, &
+        VALUE_SUBROUTINE, VALUE_C_PTR, &
+        VALUE_CLASS_STAR, VALUE_PROC_PTR, &
+        VALUE_ARRAY_RESULT, &
+        TYPE_ID_INTEGER, TYPE_ID_REAL, &
+        TYPE_ID_LOGICAL, &
+        I32_INTRINSIC_NONE, &
+        I32_INTRINSIC_ABS, I32_INTRINSIC_MIN, &
+        I32_INTRINSIC_MAX, I32_INTRINSIC_MOD, &
+        I32_INTRINSIC_IAND, I32_INTRINSIC_IOR, &
+        I32_INTRINSIC_IEOR, I32_INTRINSIC_NOT, &
+        I32_INTRINSIC_ISHFT, &
+        I32_INTRINSIC_ISHFTC, &
+        I32_INTRINSIC_SIGN, &
+        I32_INTRINSIC_INT, I32_INTRINSIC_NINT, &
+        I32_INTRINSIC_FLOOR, &
+        I32_INTRINSIC_CEILING, &
+        I32_INTRINSIC_MATMUL, &
+        I32_INTRINSIC_TRANSPOSE, &
+        I32_INTRINSIC_DOT_PRODUCT, &
+        I32_INTRINSIC_RESHAPE, &
+        I32_INTRINSIC_SELECTED_INT_KIND, &
+        I32_INTRINSIC_SELECTED_REAL_KIND, &
+        I32_INTRINSIC_MODULO, &
+        I32_INTRINSIC_DIM, &
+        F64_INTRINSIC_SIGN, &
+        F64_INTRINSIC_SQRT, F64_INTRINSIC_EXP, &
+        F64_INTRINSIC_LOG, F64_INTRINSIC_SIN, &
+        F64_INTRINSIC_COS, F64_INTRINSIC_TAN, &
+        F64_INTRINSIC_ATAN, F64_INTRINSIC_ATAN2, &
+        F64_INTRINSIC_ASIN, F64_INTRINSIC_ACOS, &
+        F64_INTRINSIC_SINH, F64_INTRINSIC_COSH, &
+        F64_INTRINSIC_TANH, F64_INTRINSIC_ASINH, &
+        F64_INTRINSIC_ACOSH, F64_INTRINSIC_ATANH, &
+        F64_INTRINSIC_LOG10, F64_INTRINSIC_ERF, &
+        F64_INTRINSIC_ERFC, F64_INTRINSIC_GAMMA, &
+        F64_INTRINSIC_LOG_GAMMA, &
+        F64_INTRINSIC_HYPOT, &
+        F64_INTRINSIC_AINT, &
+        F64_INTRINSIC_ANINT, &
+        F64_INTRINSIC_NONE, F64_INTRINSIC_ABS, &
+        F64_INTRINSIC_MIN, F64_INTRINSIC_MAX, &
+        F64_INTRINSIC_REAL, I32_INTRINSIC_NAMES, &
+        I32_INTRINSIC_IDS, F64_INTRINSIC_NAMES, &
+        F64_INTRINSIC_IDS
     use ffc_module_artefact, only: module_info_t, fmod_parameter_t, &
-                                   fmod_component_t, fmod_derived_type_t, &
-                                   fmod_variable_t, write_fmod, read_fmod
+        fmod_component_t, fmod_derived_type_t, &
+        fmod_variable_t, write_fmod, read_fmod
     implicit none
     private
     public :: lower_program_to_liric_exe
@@ -278,12 +278,12 @@ use liric_session_format_bindings, only: LR_OP_FSUB, &
     ! implied-do value (e.g. (i*1.0, i=1,2)) unrolls its inner expression,
     ! binding the control variable before each is handed to the consumer.
     type :: data_value_cursor_t
-        integer :: vpos = 0      ! index into value_indices
-        integer :: count = 0     ! values remaining in active implied-do
-        integer :: var_sym = 0   ! control symbol of active implied-do
-        integer :: cur = 0       ! current control value
+        integer :: vpos = 0 ! index into value_indices
+        integer :: count = 0 ! values remaining in active implied-do
+        integer :: var_sym = 0 ! control symbol of active implied-do
+        integer :: cur = 0 ! current control value
         integer :: step = 1
-        integer :: inner = 0     ! single inner value expression index
+        integer :: inner = 0 ! single inner value expression index
     end type data_value_cursor_t
 
     ! Body emitter for the reusable counted-loop scaffold. lower_counted_loop
@@ -314,14 +314,14 @@ contains
         derived_type_index = declaration_derived_type_index(context, node)
         if (derived_type_index > 0) then
             call lower_derived_type_declaration(node, context, derived_type_index, &
-                                                error_msg)
+                error_msg)
             return
         end if
         ! Procedure pointer: procedure(iface), pointer :: fp (#245 B3d).
         ! Detected by type_name starting with "procedure" and is_pointer.
         if (node%is_pointer .and. allocated(node%type_name)) then
             if (lowercase_text(trim(adjustl(node%type_name(1:min(9, &
-                    len_trim(node%type_name)))))) == 'procedure') then
+                len_trim(node%type_name)))))) == 'procedure') then
                 call lower_proc_pointer_declaration(node, context, error_msg)
                 return
             end if
@@ -359,11 +359,11 @@ contains
             if (value_kind /= VALUE_I32 .and. value_kind /= VALUE_F32 .and. &
                 value_kind /= VALUE_F64 .and. value_kind /= VALUE_LOGICAL) then
                 call unsupported_feature_error('array declaration', node%line, &
-                                               node%column, &
-                                               'ffc direct-session lowering only '// &
-                                               'supports integer, real, and '// &
-                                               'logical arrays', &
-                                               error_msg)
+                    node%column, &
+                    'ffc direct-session lowering only '// &
+                    'supports integer, real, and '// &
+                    'logical arrays', &
+                    error_msg)
                 return
             end if
             if (node%is_allocatable) then
@@ -375,7 +375,7 @@ contains
             ! select rank dispatches on that resolved rank (#273).
             if (declaration_is_assumed_rank(node, context)) then
                 call lower_assumed_rank_declaration(node, context, value_kind, &
-                                                    error_msg)
+                    error_msg)
                 return
             end if
             ! Assumed-shape dummy a(:): no compile-time bound on the colon
@@ -383,7 +383,7 @@ contains
             ! from the caller's actual instead of folding the declaration.
             if (declaration_is_assumed_shape(node, context)) then
                 call lower_assumed_shape_declaration(node, context, value_kind, &
-                                                     error_msg)
+                    error_msg)
                 return
             end if
             ! A runtime-sized array function result (dimension(n) with dummy n):
@@ -395,7 +395,7 @@ contains
                 array_size = 0
             else
                 call get_array_bounds(node, context, array_lower_bound, &
-                                      array_size, error_msg)
+                    array_size, error_msg)
                 if (len_trim(error_msg) > 0) return
             end if
             if (node%is_multi_declaration .and. allocated(node%var_names)) then
@@ -407,8 +407,8 @@ contains
                 end do
             else if (allocated(node%var_name)) then
                 call define_declared_array_symbol(context, node, node%var_name, &
-                                                  array_lower_bound, array_size, &
-                                                  value_kind, error_msg)
+                    array_lower_bound, array_size, &
+                    value_kind, error_msg)
             else
                 error_msg = 'array declaration did not expose a variable name'
             end if
@@ -430,29 +430,29 @@ contains
         ! so it is backed by a global with a once-applied initializer (#1541).
         if (node%is_save) then
             call lower_saved_scalar_declaration(node, node_index, context, &
-                                                value_kind, error_msg)
+                value_kind, error_msg)
             return
         end if
         if (node%is_multi_declaration .and. allocated(node%var_names)) then
             do i = 1, size(node%var_names)
                 call define_declared_symbol(context, node, node%var_names(i), &
-                                            value_kind, error_msg)
+                    value_kind, error_msg)
                 if (len_trim(error_msg) > 0) return
             end do
         else if (allocated(node%var_name)) then
             call define_declared_symbol(context, node, node%var_name, &
-                                        value_kind, error_msg)
+                value_kind, error_msg)
             if (len_trim(error_msg) > 0) return
             if (node%has_initializer .and. node%initializer_index > 0) then
                 if (value_kind == VALUE_CHARACTER) then
                     call lower_character_initializer(context, node%var_name, &
-                                                     node%initializer_index, &
-                                                     error_msg)
+                        node%initializer_index, &
+                        error_msg)
                 else
                     call lower_scalar_initializer(context, node%var_name, &
-                                                  value_kind, &
-                                                  node%initializer_index, &
-                                                  error_msg)
+                        value_kind, &
+                        node%initializer_index, &
+                        error_msg)
                 end if
             end if
         else
@@ -461,7 +461,7 @@ contains
     end subroutine lower_declaration
 
     subroutine lower_scalar_initializer(context, name, value_kind, init_index, &
-                                        error_msg)
+            error_msg)
         !! Apply a scalar declaration initializer (integer :: x = 2) by lowering
         !! the initializer expression and storing it into the variable, mirroring
         !! a plain assignment. Without this the variable keeps its zero default.
@@ -478,35 +478,35 @@ contains
         select case (value_kind)
         case (VALUE_F32)
             call lower_f32_expression(context%arena, init_index, context, value, &
-                                      error_msg)
+                error_msg)
         case (VALUE_F64)
             call lower_f64_expression(context%arena, init_index, context, value, &
-                                      error_msg)
+                error_msg)
         case (VALUE_LOGICAL)
             call lower_logical_expression(context%arena, init_index, context, &
-                                          value, error_msg)
+                value, error_msg)
         case (VALUE_I32)
             call lower_i32_expression(context%arena, init_index, context, value, &
-                                      error_msg)
+                error_msg)
         case (VALUE_I8)
             call lower_i8_expression(context%arena, init_index, context, value, &
-                                     error_msg)
+                error_msg)
         case (VALUE_I16)
             call lower_i16_expression(context%arena, init_index, context, value, &
-                                      error_msg)
+                error_msg)
         case (VALUE_I64)
             call lower_i64_expression(context%arena, init_index, context, value, &
-                                      error_msg)
+                error_msg)
         case (VALUE_C4)
             ! Complex initializers write re/im into the symbol's two slots
             ! directly, so reuse the assignment helper and skip the scalar
             ! value-store path below.
             call lower_c4_assignment(context%arena, init_index, symbol_index, &
-                                     context, error_msg)
+                context, error_msg)
             return
         case (VALUE_C8)
             call lower_c8_assignment(context%arena, init_index, symbol_index, &
-                                     context, error_msg)
+                context, error_msg)
             return
         case default
             return
@@ -538,7 +538,7 @@ contains
         symbol_index = find_symbol(context, name)
         if (symbol_index <= 0) return
         call concat_character_literals(context%arena, init_index, literal_text, &
-                                       fold_ok)
+            fold_ok)
         if (.not. fold_ok) then
             call unsupported_feature_error('character initializer', 0, 0, &
                 'only character-literal initializers are supported by direct '// &
@@ -550,9 +550,9 @@ contains
         context%string_literal_count = context%string_literal_count + 1
         write (string_name, '(A,I0)') '.ffc.char.', context%string_literal_count
         call materialize_liric_string(context%session, trim(string_name), &
-                                      literal_text, &
-                                      context%symbols(symbol_index)%value, &
-                                      error_msg)
+            literal_text, &
+            context%symbols(symbol_index)%value, &
+            error_msg)
         if (len_trim(error_msg) > 0) return
         context%symbols(symbol_index)%has_character_value = .true.
     end subroutine lower_character_initializer
@@ -651,14 +651,14 @@ contains
         end if
         if (node%is_array) then
             call unsupported_feature_error('array parameter declaration', &
-                                           node%line, node%column, &
-                                           'array parameters are not supported '// &
-                                           'by direct LIRIC session', error_msg)
+                node%line, node%column, &
+                'array parameters are not supported '// &
+                'by direct LIRIC session', error_msg)
             return
         end if
         if (allocated(node%type_name)) then
             call type_name_value_kind(node%type_name, node%line, node%column, &
-                                      value_kind, error_msg)
+                value_kind, error_msg)
             if (len_trim(error_msg) > 0) return
         else
             value_kind = VALUE_I32
@@ -666,12 +666,12 @@ contains
         symbol_index = find_symbol(context, node%name)
         if (symbol_index <= 0) then
             error_msg = 'parameter declaration did not match a dummy argument: '// &
-                        trim(node%name)
+                trim(node%name)
             return
         end if
         if (.not. context%symbols(symbol_index)%is_parameter) then
             error_msg = 'parameter declaration did not match a dummy argument: '// &
-                        trim(node%name)
+                trim(node%name)
             return
         end if
         if (value_kind == VALUE_CHARACTER) then
@@ -687,7 +687,7 @@ contains
             call bind_character_parameter_symbol(context, symbol_index, error_msg)
         else
             call update_parameter_symbol(context, symbol_index, value_kind, &
-                                         error_msg)
+                error_msg)
         end if
         if (len_trim(error_msg) > 0) return
         call set_empty(error_msg)
@@ -710,7 +710,7 @@ contains
         if (existing_index > 0 .and. existing_index > context%block_scope_floor) then
             if (context%symbols(existing_index)%is_parameter) then
                 call update_parameter_symbol(context, existing_index, value_kind, &
-                                             error_msg)
+                    error_msg)
                 return
             end if
             ! A re-declaration of an existing same-kind symbol is benign (e.g. a
@@ -763,10 +763,10 @@ contains
         context%symbols(index)%value_kind = value_kind
         if (value_kind == VALUE_F32) then
             context%symbols(index)%value = liric_f32_immediate(context%session, &
-                                                               0.0_c_float)
+                0.0_c_float)
         else if (value_kind == VALUE_F64) then
             context%symbols(index)%value = liric_f64_immediate(context%session, &
-                                                               0.0_c_double)
+                0.0_c_double)
         else if (value_kind == VALUE_LOGICAL .or. value_kind == VALUE_I32) then
             context%symbols(index)%value = i32_immediate(context%session, 0_c_int64_t)
         else if (value_kind == VALUE_C_PTR) then
@@ -864,7 +864,7 @@ contains
         context%symbols(index)%name = trim(name)
         context%symbols(index)%value_kind = VALUE_F32
         context%symbols(index)%value = liric_f32_immediate(context%session, &
-                                                           0.0_c_float)
+            0.0_c_float)
         context%symbol_count = index
         call set_empty(error_msg)
     end subroutine define_f32_symbol
@@ -882,7 +882,7 @@ contains
         context%symbols(index)%name = trim(name)
         context%symbols(index)%value_kind = VALUE_F64
         context%symbols(index)%value = liric_f64_immediate(context%session, &
-                                                           0.0_c_double)
+            0.0_c_double)
         context%symbol_count = index
         call set_empty(error_msg)
     end subroutine define_f64_symbol
@@ -902,11 +902,11 @@ contains
         context%symbols(index)%value_kind = VALUE_C4
         ! Alloca re and im slots; re in address, im in element_address.
         if (.not. emit_liric_f32_alloca(context%session, &
-                                        context%symbols(index)%address, &
-                                        error_msg)) return
+            context%symbols(index)%address, &
+            error_msg)) return
         if (.not. emit_liric_f32_alloca(context%session, &
-                                        context%symbols(index)%element_address, &
-                                        error_msg)) return
+            context%symbols(index)%element_address, &
+            error_msg)) return
         context%symbols(index)%has_address = .true.
         context%symbols(index)%value = liric_f32_immediate(context%session, 0.0_c_float)
         context%symbol_count = index
@@ -927,11 +927,11 @@ contains
         context%symbols(index)%name = trim(name)
         context%symbols(index)%value_kind = VALUE_C8
         if (.not. emit_liric_f64_alloca(context%session, &
-                                        context%symbols(index)%address, &
-                                        error_msg)) return
+            context%symbols(index)%address, &
+            error_msg)) return
         if (.not. emit_liric_f64_alloca(context%session, &
-                                        context%symbols(index)%element_address, &
-                                        error_msg)) return
+            context%symbols(index)%element_address, &
+            error_msg)) return
         context%symbols(index)%has_address = .true.
         context%symbols(index)%value = liric_f64_immediate(context%session, 0.0_c_double)
         context%symbol_count = index
@@ -946,7 +946,7 @@ contains
             error_msg = 'duplicate logical declaration: '//trim(name)
             return
         end if
-       call grow_symbols(context)
+        call grow_symbols(context)
         index = context%symbol_count + 1
         context%symbols(index)%name = trim(name)
         context%symbols(index)%value_kind = VALUE_LOGICAL
@@ -965,7 +965,7 @@ contains
         logical :: handled
 
         call try_lower_overloaded_assignment(arena, node, context, handled, &
-                                             error_msg)
+            error_msg)
         if (handled .or. len_trim(error_msg) > 0) return
         ! A spec-section assignment that defines a statement function (the
         ! explicit-program path leaves it as an assignment) emits no code; the
@@ -975,7 +975,7 @@ contains
             return
         end if
         select type (target => arena%entries(node%target_index)%node)
-        type is (call_or_subscript_node)
+            type is (call_or_subscript_node)
             if (target%base_expr_index > 0) then
                 call lower_derived_component_element_assignment(arena, node, &
                     target, context, error_msg)
@@ -983,7 +983,7 @@ contains
             end if
             if (target%is_array_access) then
                 call lower_array_element_assignment(arena, node, target, context, &
-                                                    value, error_msg)
+                    value, error_msg)
                 return
             end if
             if (allocated(target%name) .and. allocated(target%arg_indices)) then
@@ -991,18 +991,18 @@ contains
                 if (symbol_index > 0) then
                     if (context%symbols(symbol_index)%is_allocatable) then
                         call lower_array_element_assignment(arena, node, target, &
-                                                            context, value, error_msg)
+                            context, value, error_msg)
                         return
                     end if
                 end if
             end if
-        type is (component_access_node)
+            type is (component_access_node)
             call lower_derived_component_assignment(arena, node, target, context, &
-                                                    value, error_msg)
+                value, error_msg)
             return
-        type is (array_slice_node)
+            type is (array_slice_node)
             call lower_array_section_assignment(arena, node, target, context, &
-                                                error_msg)
+                error_msg)
             return
         end select
         call identifier_name(arena, node%target_index, name, error_msg)
@@ -1015,14 +1015,14 @@ contains
         if (context%symbols(symbol_index)%is_allocatable) then
             if (node_exists(arena, node%value_index)) then
                 select type (rhs => arena%entries(node%value_index)%node)
-                type is (array_literal_node)
+                    type is (array_literal_node)
                     call lower_allocatable_constructor_assignment(arena, rhs, &
                         symbol_index, context, error_msg)
                     return
                 end select
             end if
             if (is_scalar_broadcast_to_allocatable(arena, node%value_index, &
-                                                   context)) then
+                context)) then
                 call lower_allocatable_scalar_broadcast(arena, node%value_index, &
                     symbol_index, context, error_msg)
                 return
@@ -1036,18 +1036,18 @@ contains
         if (context%symbols(symbol_index)%is_array) then
             if (is_array_result_call(arena, node%value_index, context)) then
                 call lower_array_result_call(arena, node%value_index, &
-                                             symbol_index, context, error_msg)
+                    symbol_index, context, error_msg)
                 return
             end if
             if (node_exists(arena, node%value_index)) then
                 select type (val => arena%entries(node%value_index)%node)
-                type is (array_literal_node)
+                    type is (array_literal_node)
                     call lower_array_constructor_assignment(arena, val, &
                         symbol_index, context, error_msg)
                     return
                 class default
                     call lower_array_whole_assignment(arena, node, symbol_index, &
-                                                      context, error_msg)
+                        context, error_msg)
                     return
                 end select
             end if
@@ -1058,59 +1058,59 @@ contains
                     'whole-array assignment is not supported', error_msg)
             else
                 call unsupported_feature_error('array assignment target', &
-                                               node%line, node%column, &
-                                               'whole-array assignment is not '// &
-                                               'supported', error_msg)
+                    node%line, node%column, &
+                    'whole-array assignment is not '// &
+                    'supported', error_msg)
             end if
             return
         end if
         if (context%symbols(symbol_index)%is_derived) then
             if (is_derived_result_call(arena, node%value_index, context)) then
                 call lower_derived_result_call(arena, node%value_index, &
-                                               symbol_index, context, error_msg)
+                    symbol_index, context, error_msg)
                 return
             end if
             call lower_derived_whole_assignment_diagnostic(arena, node, &
-                                                           context, symbol_index, &
-                                                           error_msg)
+                context, symbol_index, &
+                error_msg)
             return
         end if
         if (context%symbols(symbol_index)%value_kind == VALUE_I8) then
             call lower_i8_expression(arena, node%value_index, context, value, &
-                                     error_msg)
+                error_msg)
         else if (context%symbols(symbol_index)%value_kind == VALUE_I16) then
             call lower_i16_expression(arena, node%value_index, context, value, &
-                                      error_msg)
+                error_msg)
         else if (context%symbols(symbol_index)%value_kind == VALUE_I64) then
             call lower_i64_expression(arena, node%value_index, context, value, &
-                                      error_msg)
+                error_msg)
         else if (context%symbols(symbol_index)%value_kind == VALUE_F32) then
             call lower_f32_expression(arena, node%value_index, context, value, &
-                                      error_msg)
+                error_msg)
         else if (context%symbols(symbol_index)%value_kind == VALUE_F64) then
             call lower_f64_expression(arena, node%value_index, context, value, &
-                                      error_msg)
+                error_msg)
         else if (context%symbols(symbol_index)%value_kind == VALUE_LOGICAL) then
             call lower_logical_expression(arena, node%value_index, context, &
-                                          value, error_msg)
+                value, error_msg)
         else if (context%symbols(symbol_index)%value_kind == VALUE_CHARACTER) then
             call lower_character_assignment(arena, node, context, symbol_index, &
-                                            error_msg)
+                error_msg)
             return
         else if (context%symbols(symbol_index)%value_kind == VALUE_C_PTR) then
             call lower_c_ptr_expression(arena, node%value_index, context, value, &
-                                        error_msg)
+                error_msg)
         else if (context%symbols(symbol_index)%value_kind == VALUE_C4) then
             call lower_c4_assignment(arena, node%value_index, symbol_index, &
-                                     context, error_msg)
+                context, error_msg)
             return
         else if (context%symbols(symbol_index)%value_kind == VALUE_C8) then
             call lower_c8_assignment(arena, node%value_index, symbol_index, &
-                                     context, error_msg)
+                context, error_msg)
             return
         else
             call lower_i32_expression(arena, node%value_index, context, value, &
-                                      error_msg)
+                error_msg)
         end if
         if (len_trim(error_msg) > 0) return
         context%symbols(symbol_index)%value = value
@@ -1120,7 +1120,7 @@ contains
             if (len_trim(error_msg) > 0) return
         end if
         call track_assigned_i32_constant(arena, node%value_index, context, &
-                                         symbol_index)
+            symbol_index)
         call set_empty(error_msg)
     end subroutine lower_assignment
 
@@ -1150,7 +1150,7 @@ contains
     end subroutine track_assigned_i32_constant
 
     subroutine try_lower_overloaded_assignment(arena, node, context, handled, &
-                                               error_msg)
+            error_msg)
         ! An interface assignment(=) maps `lhs = rhs` to a subroutine call
         ! specific(lhs, rhs) when the operand kinds match a registered overload.
         ! The LHS is the intent(out)/(inout) first dummy, so it is passed by
@@ -1174,11 +1174,11 @@ contains
         if (slot == 0) return
         specific = operator_specific_name(context, slot)
         call prepare_reference_args(arena, [node%target_index, node%value_index], &
-                                    context, VALUE_I32, specific, args, &
-                                    copyback_indices, error_msg)
+            context, VALUE_I32, specific, args, &
+            copyback_indices, error_msg)
         if (len_trim(error_msg) > 0) return
         if (.not. emit_void_call(context%session, &
-                call_emit_name(arena, specific), args, error_msg)) return
+            call_emit_name(arena, specific), args, error_msg)) return
         call copy_back_reference_args(context, args, copyback_indices, error_msg)
         handled = len_trim(error_msg) == 0
     end subroutine try_lower_overloaded_assignment
@@ -1200,14 +1200,14 @@ contains
         case (VALUE_I32, VALUE_LOGICAL, VALUE_F32, VALUE_F64)
             result_value = context%symbols(idx)%value
             if (.not. emit_ret_i32_operand(context%session, result_value, &
-                                                           error_msg)) return
+                error_msg)) return
             context%current_block_terminated = .true.
         case default
             call unsupported_feature_error('return from non-scalar function', &
-                                           node%line, node%column, &
-                                           'only integer, logical and real '// &
-                                           'function returns are supported', &
-                                           error_msg)
+                node%line, node%column, &
+                'only integer, logical and real '// &
+                'function returns are supported', &
+                error_msg)
         end select
     end subroutine lower_function_return
     subroutine lower_stop(arena, node, context, value, error_msg)
@@ -1221,7 +1221,7 @@ contains
             call set_empty(error_msg)
         else
             call lower_i32_expression(arena, node%stop_code_index, context, &
-                                      value, error_msg)
+                value, error_msg)
         end if
     end subroutine lower_stop
 
@@ -1244,14 +1244,14 @@ contains
             context%string_literal_count = context%string_literal_count + 1
             write (gname, '(A,I0)') '.ffc.stop.msg.', context%string_literal_count
             call create_printf_format_global(context%session, trim(gname), &
-                                             msg_text, msg_gid, error_msg)
+                msg_text, msg_gid, error_msg)
             if (len_trim(error_msg) > 0) return
             msgop = printf_format_ptr(context%session, msg_gid)
             context%string_literal_count = context%string_literal_count + 1
             write (gname, '(A,I0)') '.ffc.stop.fmt.', context%string_literal_count
             call create_printf_format_global(context%session, trim(gname), &
-                                             'STOP %s'//achar(10), fmt_gid, &
-                                             error_msg)
+                'STOP %s'//achar(10), fmt_gid, &
+                error_msg)
             if (len_trim(error_msg) > 0) return
             fmtop = printf_format_ptr(context%session, fmt_gid)
             fa(1) = i32_immediate(context%session, 2_c_int64_t)
@@ -1262,8 +1262,8 @@ contains
             context%string_literal_count = context%string_literal_count + 1
             write (gname, '(A,I0)') '.ffc.stop.fmt.', context%string_literal_count
             call create_printf_format_global(context%session, trim(gname), &
-                                             'STOP %d'//achar(10), fmt_gid, &
-                                             error_msg)
+                'STOP %d'//achar(10), fmt_gid, &
+                error_msg)
             if (len_trim(error_msg) > 0) return
             fmtop = printf_format_ptr(context%session, fmt_gid)
             fa(1) = i32_immediate(context%session, 2_c_int64_t)
@@ -1287,7 +1287,7 @@ contains
             call set_empty(error_msg)
         else
             call lower_i32_expression(arena, node%error_code_index, context, &
-                                      value, error_msg)
+                value, error_msg)
         end if
     end subroutine lower_error_stop
 
@@ -1309,14 +1309,14 @@ contains
             context%string_literal_count = context%string_literal_count + 1
             write (gname, '(A,I0)') '.ffc.estop.msg.', context%string_literal_count
             call create_printf_format_global(context%session, trim(gname), &
-                                             msg_text, msg_gid, error_msg)
+                msg_text, msg_gid, error_msg)
             if (len_trim(error_msg) > 0) return
             msgop = printf_format_ptr(context%session, msg_gid)
             context%string_literal_count = context%string_literal_count + 1
             write (gname, '(A,I0)') '.ffc.estop.fmt.', context%string_literal_count
             call create_printf_format_global(context%session, trim(gname), &
-                                             'ERROR STOP %s'//achar(10), fmt_gid, &
-                                             error_msg)
+                'ERROR STOP %s'//achar(10), fmt_gid, &
+                error_msg)
             if (len_trim(error_msg) > 0) return
             fmtop = printf_format_ptr(context%session, fmt_gid)
             fa(1) = i32_immediate(context%session, 2_c_int64_t)
@@ -1327,8 +1327,8 @@ contains
             context%string_literal_count = context%string_literal_count + 1
             write (gname, '(A,I0)') '.ffc.estop.fmt.', context%string_literal_count
             call create_printf_format_global(context%session, trim(gname), &
-                                             'ERROR STOP %d'//achar(10), fmt_gid, &
-                                             error_msg)
+                'ERROR STOP %d'//achar(10), fmt_gid, &
+                error_msg)
             if (len_trim(error_msg) > 0) return
             fmtop = printf_format_ptr(context%session, fmt_gid)
             fa(1) = i32_immediate(context%session, 2_c_int64_t)
@@ -1371,14 +1371,14 @@ contains
             return
         end if
         call get_subroutine_call_arg_indices(arena, node_index, arg_indices, &
-                                             error_msg)
+            error_msg)
         if (len_trim(error_msg) > 0) return
         ! Resolve generic -> specific (#249 B7c).
         first_arg_kind = VALUE_I32
         if (allocated(arg_indices)) then
             if (size(arg_indices) > 0) then
                 first_arg_kind = expression_value_kind(arena, arg_indices(1), &
-                                                       context, VALUE_I32)
+                    context, VALUE_I32)
             end if
         end if
         call_name = degeneric_call_name(context, name, first_arg_kind)
@@ -1404,7 +1404,7 @@ contains
         end if
         if (is_method_subroutine_call(call_name)) then
             call lower_method_subroutine_call(arena, call_name, arg_indices, &
-                                              context, error_msg)
+                context, error_msg)
             return
         end if
         if (external_procedure_index(context, call_name) > 0) then
@@ -1413,10 +1413,10 @@ contains
             return
         end if
         call prepare_reference_args(arena, arg_indices, context, VALUE_I32, &
-                                    call_name, args, copyback_indices, error_msg)
+            call_name, args, copyback_indices, error_msg)
         if (len_trim(error_msg) > 0) return
         if (.not. emit_call_with_optional_padding(context, &
-                call_emit_name(arena, call_name), args, error_msg)) &
+            call_emit_name(arena, call_name), args, error_msg)) &
             return
         call copy_back_reference_args(context, args, copyback_indices, error_msg)
     end subroutine lower_subroutine_call
@@ -1432,7 +1432,7 @@ contains
         integer :: symbol_index
 
         call intrinsic_out_scalar(arena, arg_indices, context, 'cpu_time', &
-                                  VALUE_F32, symbol_index, error_msg)
+            VALUE_F32, symbol_index, error_msg)
         if (len_trim(error_msg) > 0) return
         if (.not. emit_cpu_time_value(context%session, value, error_msg)) return
         call store_intrinsic_scalar_result(context, symbol_index, value, error_msg)
@@ -1449,14 +1449,14 @@ contains
         integer :: symbol_index
 
         call intrinsic_out_scalar(arena, arg_indices, context, 'system_clock', &
-                                  VALUE_I32, symbol_index, error_msg)
+            VALUE_I32, symbol_index, error_msg)
         if (len_trim(error_msg) > 0) return
         if (.not. emit_system_clock_value(context%session, value, error_msg)) return
         call store_intrinsic_scalar_result(context, symbol_index, value, error_msg)
     end subroutine lower_system_clock
 
     subroutine intrinsic_out_scalar(arena, arg_indices, context, name, kind, &
-                                    symbol_index, error_msg)
+            symbol_index, error_msg)
         ! Resolve the single intent(out) scalar argument of a timing intrinsic
         ! and verify its declared kind.
         type(ast_arena_t), intent(in) :: arena
@@ -1492,7 +1492,7 @@ contains
     end subroutine intrinsic_out_scalar
 
     subroutine store_intrinsic_scalar_result(context, symbol_index, value, &
-                                             error_msg)
+            error_msg)
         ! Write a freshly computed scalar into its symbol, persisting through the
         ! backing address when the variable lives in memory.
         type(lowering_context_t), intent(inout) :: context
@@ -1509,7 +1509,7 @@ contains
     end subroutine store_intrinsic_scalar_result
 
     logical function emit_call_with_optional_padding(context, name, args, &
-                                                     error_msg) result(ok)
+            error_msg) result(ok)
         ! Emit a void call to a contained subroutine, padding omitted trailing
         ! optional dummies with null pointers up to the callee's declared
         ! parameter count.
@@ -1540,7 +1540,7 @@ contains
         ok = emit_void_call(context%session, name, padded, error_msg)
     end function emit_call_with_optional_padding
     recursive subroutine lower_i1_condition(arena, node_index, context, &
-                                            value, error_msg)
+            value, error_msg)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: node_index
         type(lowering_context_t), intent(inout) :: context
@@ -1557,19 +1557,19 @@ contains
         end if
         if (is_binary_op(arena, node_index)) then
             call get_binary_op_info(arena, node_index, bin_op, bin_left, &
-                                    bin_right, bin_line, bin_col, error_msg)
+                bin_right, bin_line, bin_col, error_msg)
             if (len_trim(error_msg) > 0) return
             if (trim(adjustl(lowercase_text(bin_op))) == '.not.') then
                 ! Unary .not. is parsed as a binary op with a virtual operand;
                 ! the real condition is the right operand. Invert it.
                 call lower_i1_condition(arena, bin_right, context, lhs, &
-                                        error_msg)
+                    error_msg)
                 if (len_trim(error_msg) > 0) return
                 rhs = lhs
                 rhs%kind = LR_OP_KIND_IMM_I64
                 rhs%payload = 0_c_int64_t
                 if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, lhs, &
-                                              rhs, value, error_msg)) return
+                    rhs, value, error_msg)) return
                 call set_empty(error_msg)
                 return
             end if
@@ -1578,7 +1578,7 @@ contains
                 ! operands are lowered (Fortran does not short-circuit), then
                 ! combined with the matching bitwise op on the i1 values.
                 call lower_logical_connective(arena, bin_op, bin_left, &
-                                              bin_right, context, value, error_msg)
+                    bin_right, context, value, error_msg)
                 return
             end if
             ! A comparison whose operands are real (including libm intrinsic
@@ -1594,7 +1594,7 @@ contains
                 call real_compare_predicate(bin_op, pred, error_msg)
                 if (len_trim(error_msg) > 0) return
                 if (.not. emit_liric_f32_fcmp(context%session, pred, lhs, rhs, &
-                                              value, error_msg)) return
+                    value, error_msg)) return
                 return
             end if
             if (is_f64_expression(arena, bin_left, context) .or. &
@@ -1606,7 +1606,7 @@ contains
                 call real_compare_predicate(bin_op, pred, error_msg)
                 if (len_trim(error_msg) > 0) return
                 if (.not. emit_liric_f64_fcmp(context%session, pred, lhs, rhs, &
-                                              value, error_msg)) return
+                    value, error_msg)) return
                 return
             end if
             call lower_i32_expression(arena, bin_left, context, lhs, error_msg)
@@ -1616,66 +1616,66 @@ contains
             call integer_compare_predicate(bin_op, pred, error_msg)
             if (len_trim(error_msg) > 0) return
             if (.not. emit_liric_i32_icmp(context%session, pred, lhs, rhs, &
-                                          value, error_msg)) return
+                value, error_msg)) return
             return
         end if
         if (is_literal(arena, node_index)) then
             call lower_logical_expression(arena, node_index, context, lhs, &
-                                          error_msg)
+                error_msg)
             if (len_trim(error_msg) > 0) return
             rhs = i32_immediate(context%session, 0_c_int64_t)
             if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, lhs, &
-                                          rhs, value, error_msg)) return
+                rhs, value, error_msg)) return
             return
         end if
         if (is_identifier(arena, node_index)) then
             call lower_logical_expression(arena, node_index, context, lhs, &
-                                          error_msg)
+                error_msg)
             if (len_trim(error_msg) > 0) return
             rhs = i32_immediate(context%session, 0_c_int64_t)
             if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, lhs, &
-                                          rhs, value, error_msg)) return
+                rhs, value, error_msg)) return
             return
         end if
         select type (node => arena%entries(node_index)%node)
-        type is (component_access_node)
+            type is (component_access_node)
             ! Scalar logical component used directly as a condition: x%flag.
             call lower_logical_expression(arena, node_index, context, lhs, &
-                                          error_msg)
+                error_msg)
             if (len_trim(error_msg) > 0) return
             rhs = i32_immediate(context%session, 0_c_int64_t)
             if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, lhs, &
-                                          rhs, value, error_msg)) return
-        type is (call_or_subscript_node)
+                rhs, value, error_msg)) return
+            type is (call_or_subscript_node)
             if (node%base_expr_index > 0) then
                 ! Logical array-component element used as a condition: x%flag(i).
                 call lower_logical_expression(arena, node_index, context, lhs, &
-                                              error_msg)
+                    error_msg)
                 if (len_trim(error_msg) > 0) return
                 rhs = i32_immediate(context%session, 0_c_int64_t)
                 if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, lhs, &
-                                              rhs, value, error_msg)) return
+                    rhs, value, error_msg)) return
             else if (is_present_call(arena, node_index)) then
                 call lower_present_condition(arena, node_index, context, value, &
-                                             error_msg)
+                    error_msg)
             else if (allocated(node%name)) then
                 if (same_name(node%name, 'c_associated')) then
                     call lower_c_associated(arena, node%arg_indices, context, &
-                                            value, error_msg)
+                        value, error_msg)
                 else if (same_name(node%name, 'associated')) then
                     call lower_associated(arena, node%arg_indices, context, &
-                                          value, error_msg)
+                        value, error_msg)
                 else
                     error_msg = 'direct LIRIC session IF condition supports '// &
-                                'comparisons, logicals, and present()'
+                        'comparisons, logicals, and present()'
                 end if
             else
                 error_msg = 'direct LIRIC session IF condition supports '// &
-                            'comparisons, logicals, and present()'
+                    'comparisons, logicals, and present()'
             end if
         class default
             error_msg = 'direct LIRIC session IF requires an integer '// &
-                        'comparison or logical expression'
+                'comparison or logical expression'
         end select
     end subroutine lower_i1_condition
 
@@ -1690,7 +1690,7 @@ contains
     end function is_logical_connective
 
     subroutine lower_logical_connective(arena, op, left_index, right_index, &
-                                        context, value, error_msg)
+            context, value, error_msg)
         type(ast_arena_t), intent(in) :: arena
         character(len=*), intent(in) :: op
         integer, intent(in) :: left_index, right_index
@@ -1714,17 +1714,17 @@ contains
         case ('.eqv.')
             ! a .eqv. b is .not. (a .neqv. b): xor then invert the i1.
             if (.not. emit_i32_binary(context%session, LR_OP_XOR, lhs, rhs, &
-                                      value, error_msg)) return
+                value, error_msg)) return
             if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, value, &
-                    i32_immediate(context%session, 0_c_int64_t), value, &
-                    error_msg)) return
+                i32_immediate(context%session, 0_c_int64_t), value, &
+                error_msg)) return
             return
         case default
             error_msg = 'unsupported logical connective: '//trim(op)
             return
         end select
         if (.not. emit_i32_binary(context%session, opcode, lhs, rhs, value, &
-                                  error_msg)) return
+            error_msg)) return
     end subroutine lower_logical_connective
 
     subroutine identifier_name(arena, node_index, name, error_msg)
@@ -1742,7 +1742,7 @@ contains
             return
         end if
         select type (node => arena%entries(node_index)%node)
-        type is (call_or_subscript_node)
+            type is (call_or_subscript_node)
             if (allocated(node%arg_indices)) then
                 error_msg = 'expected scalar assignment target'
                 call set_empty(name)
@@ -1750,12 +1750,12 @@ contains
             end if
             name = node%name
             call set_empty(error_msg)
-        type is (component_access_node)
+            type is (component_access_node)
             call unsupported_feature_error('derived type component assignment target', &
-                                           node%line, node%column, &
-                                           'direct LIRIC session does not '// &
-                                           'support assigning to components', &
-                                           error_msg)
+                node%line, node%column, &
+                'direct LIRIC session does not '// &
+                'support assigning to components', &
+                error_msg)
             call set_empty(name)
         class default
             error_msg = 'expected identifier assignment target'

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -31,388 +31,388 @@ module session_program_lowering_types
     integer, parameter, public :: VALUE_DERIVED = 5
     integer, parameter, public :: VALUE_DEFERRED_CHARACTER_RESULT = 6
     integer, parameter, public :: VALUE_SUBROUTINE = 7
-    integer, parameter, public :: VALUE_C_PTR = 8
-    integer, parameter, public :: VALUE_CLASS_STAR = 9
-    ! VALUE_PROC_PTR is a procedure pointer; stored as a ptr alloca slot holding
-    ! the callee function address.  Lowering for #245 slice B3d.
-    integer, parameter, public :: VALUE_PROC_PTR = 16
-    ! VALUE_ARRAY_RESULT is a fixed-size rank-1 array function result. Like the
-    ! derived and complex results it returns via a leading sret pointer: the
-    ! caller passes the destination array's base address as param 0 and the
-    ! callee binds the result symbol's element storage onto that pointer. The
-    ! element scalar kind comes from the result variable's body declaration.
-    integer, parameter, public :: VALUE_ARRAY_RESULT = 17
-    ! Runtime type ids carried in a class(*) descriptor's type slot. Intrinsic
-    ! ids are fixed and disjoint from derived-type ids (a derived type's id is
-    ! its 1-based table index, always small).
-    integer, parameter, public :: TYPE_ID_INTEGER = 1000001
-    integer, parameter, public :: TYPE_ID_REAL = 1000002
-    integer, parameter, public :: TYPE_ID_LOGICAL = 1000003
-    integer, parameter, public :: I32_INTRINSIC_NONE = 0
-    integer, parameter, public :: I32_INTRINSIC_ABS = 1
-    integer, parameter, public :: I32_INTRINSIC_MIN = 2
-    integer, parameter, public :: I32_INTRINSIC_MAX = 3
-    integer, parameter, public :: I32_INTRINSIC_MOD = 4
-    integer, parameter, public :: I32_INTRINSIC_IAND = 5
-    integer, parameter, public :: I32_INTRINSIC_IOR = 6
-    integer, parameter, public :: I32_INTRINSIC_IEOR = 7
-    integer, parameter, public :: I32_INTRINSIC_NOT = 8
-    integer, parameter, public :: I32_INTRINSIC_ISHFT = 9
-    integer, parameter, public :: I32_INTRINSIC_ISHFTC = 10
-    integer, parameter, public :: I32_INTRINSIC_SIGN = 11
-    integer, parameter, public :: I32_INTRINSIC_INT = 12
-    integer, parameter, public :: I32_INTRINSIC_NINT = 13
-    integer, parameter, public :: I32_INTRINSIC_FLOOR = 14
-    integer, parameter, public :: I32_INTRINSIC_CEILING = 15
-    integer, parameter, public :: I32_INTRINSIC_MATMUL = 16
-    integer, parameter, public :: I32_INTRINSIC_TRANSPOSE = 17
-    integer, parameter, public :: I32_INTRINSIC_DOT_PRODUCT = 18
-    integer, parameter, public :: I32_INTRINSIC_RESHAPE = 19
-    integer, parameter, public :: I32_INTRINSIC_SELECTED_INT_KIND = 20
-    integer, parameter, public :: I32_INTRINSIC_SELECTED_REAL_KIND = 21
-    integer, parameter, public :: I32_INTRINSIC_MODULO = 22
-    integer, parameter, public :: I32_INTRINSIC_DIM = 23
-    integer, parameter, public :: F64_INTRINSIC_NONE = 0
-    integer, parameter, public :: F64_INTRINSIC_ABS = 1
-    integer, parameter, public :: F64_INTRINSIC_MIN = 2
-    integer, parameter, public :: F64_INTRINSIC_MAX = 3
-    integer, parameter, public :: F64_INTRINSIC_REAL = 4
-    integer, parameter, public :: F64_INTRINSIC_SIGN = 5
-    integer, parameter, public :: F64_INTRINSIC_SQRT = 6
-    integer, parameter, public :: F64_INTRINSIC_EXP = 7
-    integer, parameter, public :: F64_INTRINSIC_LOG = 8
-    integer, parameter, public :: F64_INTRINSIC_SIN = 9
-    integer, parameter, public :: F64_INTRINSIC_COS = 10
-    integer, parameter, public :: F64_INTRINSIC_TAN = 11
-    integer, parameter, public :: F64_INTRINSIC_ATAN = 12
-    integer, parameter, public :: F64_INTRINSIC_ATAN2 = 13
-    integer, parameter, public :: F64_INTRINSIC_ASIN = 14
-    integer, parameter, public :: F64_INTRINSIC_ACOS = 15
-    integer, parameter, public :: F64_INTRINSIC_SINH = 16
-    integer, parameter, public :: F64_INTRINSIC_COSH = 17
-    integer, parameter, public :: F64_INTRINSIC_TANH = 18
-    integer, parameter, public :: F64_INTRINSIC_ASINH = 19
-    integer, parameter, public :: F64_INTRINSIC_ACOSH = 20
-    integer, parameter, public :: F64_INTRINSIC_ATANH = 21
-    integer, parameter, public :: F64_INTRINSIC_LOG10 = 22
-    integer, parameter, public :: F64_INTRINSIC_ERF = 23
-    integer, parameter, public :: F64_INTRINSIC_ERFC = 24
-    integer, parameter, public :: F64_INTRINSIC_GAMMA = 25
-    integer, parameter, public :: F64_INTRINSIC_LOG_GAMMA = 26
-    integer, parameter, public :: F64_INTRINSIC_HYPOT = 27
-    integer, parameter, public :: F64_INTRINSIC_MOD = 28
-    integer, parameter, public :: F64_INTRINSIC_MODULO = 29
-    integer, parameter, public :: F64_INTRINSIC_AINT = 30
-    integer, parameter, public :: F64_INTRINSIC_ANINT = 31
-    character(len=18), parameter, public :: I32_INTRINSIC_NAMES(23) = &
-                                   [character(len=18) :: 'abs', 'min', 'max', 'mod', &
-                                    'iand', 'ior', 'ieor', 'not', 'ishft', &
-                                    'ishftc', 'sign', 'int', 'nint', 'floor', &
-                                    'ceiling', 'matmul', 'transpose', &
-                                    'dot_product', 'reshape', 'selected_int_kind', &
-                                    'selected_real_kind', 'modulo', 'dim']
-    integer, parameter, public :: I32_INTRINSIC_IDS(23) = &
-                          [I32_INTRINSIC_ABS, I32_INTRINSIC_MIN, I32_INTRINSIC_MAX, &
-                           I32_INTRINSIC_MOD, I32_INTRINSIC_IAND, I32_INTRINSIC_IOR, &
-                           I32_INTRINSIC_IEOR, I32_INTRINSIC_NOT, I32_INTRINSIC_ISHFT, &
-                           I32_INTRINSIC_ISHFTC, I32_INTRINSIC_SIGN, I32_INTRINSIC_INT, &
-                           I32_INTRINSIC_NINT, I32_INTRINSIC_FLOOR, &
-                           I32_INTRINSIC_CEILING, I32_INTRINSIC_MATMUL, &
-                           I32_INTRINSIC_TRANSPOSE, I32_INTRINSIC_DOT_PRODUCT, &
-                           I32_INTRINSIC_RESHAPE, I32_INTRINSIC_SELECTED_INT_KIND, &
-                           I32_INTRINSIC_SELECTED_REAL_KIND, I32_INTRINSIC_MODULO, &
-                           I32_INTRINSIC_DIM]
-    character(len=9), parameter, public :: F64_INTRINSIC_NAMES(31) = &
-                                   [character(len=9) :: 'abs', 'min', 'max', 'real', &
-                                    'sign', 'sqrt', 'exp', 'log', 'sin', 'cos', &
-                                    'tan', 'atan', 'atan2', 'asin', 'acos', 'sinh', &
-                                    'cosh', 'tanh', 'asinh', 'acosh', 'atanh', &
-                                    'log10', 'erf', 'erfc', 'gamma', 'log_gamma', &
-                                    'hypot', 'mod', 'modulo', 'aint', 'anint']
-    integer, parameter, public :: F64_INTRINSIC_IDS(31) = &
-                          [F64_INTRINSIC_ABS, F64_INTRINSIC_MIN, F64_INTRINSIC_MAX, &
-                           F64_INTRINSIC_REAL, F64_INTRINSIC_SIGN, F64_INTRINSIC_SQRT, &
-                           F64_INTRINSIC_EXP, F64_INTRINSIC_LOG, F64_INTRINSIC_SIN, &
-                           F64_INTRINSIC_COS, F64_INTRINSIC_TAN, F64_INTRINSIC_ATAN, &
-                           F64_INTRINSIC_ATAN2, F64_INTRINSIC_ASIN, &
-                           F64_INTRINSIC_ACOS, F64_INTRINSIC_SINH, &
-                           F64_INTRINSIC_COSH, F64_INTRINSIC_TANH, &
-                           F64_INTRINSIC_ASINH, F64_INTRINSIC_ACOSH, &
-                           F64_INTRINSIC_ATANH, F64_INTRINSIC_LOG10, &
-                           F64_INTRINSIC_ERF, F64_INTRINSIC_ERFC, &
-                           F64_INTRINSIC_GAMMA, F64_INTRINSIC_LOG_GAMMA, &
-                           F64_INTRINSIC_HYPOT, F64_INTRINSIC_MOD, &
-                           F64_INTRINSIC_MODULO, F64_INTRINSIC_AINT, &
-                           F64_INTRINSIC_ANINT]
+        integer, parameter, public :: VALUE_C_PTR = 8
+        integer, parameter, public :: VALUE_CLASS_STAR = 9
+        ! VALUE_PROC_PTR is a procedure pointer; stored as a ptr alloca slot holding
+        ! the callee function address.  Lowering for #245 slice B3d.
+        integer, parameter, public :: VALUE_PROC_PTR = 16
+        ! VALUE_ARRAY_RESULT is a fixed-size rank-1 array function result. Like the
+        ! derived and complex results it returns via a leading sret pointer: the
+        ! caller passes the destination array's base address as param 0 and the
+        ! callee binds the result symbol's element storage onto that pointer. The
+        ! element scalar kind comes from the result variable's body declaration.
+        integer, parameter, public :: VALUE_ARRAY_RESULT = 17
+        ! Runtime type ids carried in a class(*) descriptor's type slot. Intrinsic
+        ! ids are fixed and disjoint from derived-type ids (a derived type's id is
+        ! its 1-based table index, always small).
+        integer, parameter, public :: TYPE_ID_INTEGER = 1000001
+        integer, parameter, public :: TYPE_ID_REAL = 1000002
+        integer, parameter, public :: TYPE_ID_LOGICAL = 1000003
+        integer, parameter, public :: I32_INTRINSIC_NONE = 0
+        integer, parameter, public :: I32_INTRINSIC_ABS = 1
+        integer, parameter, public :: I32_INTRINSIC_MIN = 2
+        integer, parameter, public :: I32_INTRINSIC_MAX = 3
+        integer, parameter, public :: I32_INTRINSIC_MOD = 4
+        integer, parameter, public :: I32_INTRINSIC_IAND = 5
+        integer, parameter, public :: I32_INTRINSIC_IOR = 6
+        integer, parameter, public :: I32_INTRINSIC_IEOR = 7
+        integer, parameter, public :: I32_INTRINSIC_NOT = 8
+        integer, parameter, public :: I32_INTRINSIC_ISHFT = 9
+        integer, parameter, public :: I32_INTRINSIC_ISHFTC = 10
+        integer, parameter, public :: I32_INTRINSIC_SIGN = 11
+        integer, parameter, public :: I32_INTRINSIC_INT = 12
+        integer, parameter, public :: I32_INTRINSIC_NINT = 13
+        integer, parameter, public :: I32_INTRINSIC_FLOOR = 14
+        integer, parameter, public :: I32_INTRINSIC_CEILING = 15
+        integer, parameter, public :: I32_INTRINSIC_MATMUL = 16
+        integer, parameter, public :: I32_INTRINSIC_TRANSPOSE = 17
+        integer, parameter, public :: I32_INTRINSIC_DOT_PRODUCT = 18
+        integer, parameter, public :: I32_INTRINSIC_RESHAPE = 19
+        integer, parameter, public :: I32_INTRINSIC_SELECTED_INT_KIND = 20
+        integer, parameter, public :: I32_INTRINSIC_SELECTED_REAL_KIND = 21
+        integer, parameter, public :: I32_INTRINSIC_MODULO = 22
+        integer, parameter, public :: I32_INTRINSIC_DIM = 23
+        integer, parameter, public :: F64_INTRINSIC_NONE = 0
+        integer, parameter, public :: F64_INTRINSIC_ABS = 1
+        integer, parameter, public :: F64_INTRINSIC_MIN = 2
+        integer, parameter, public :: F64_INTRINSIC_MAX = 3
+        integer, parameter, public :: F64_INTRINSIC_REAL = 4
+        integer, parameter, public :: F64_INTRINSIC_SIGN = 5
+        integer, parameter, public :: F64_INTRINSIC_SQRT = 6
+        integer, parameter, public :: F64_INTRINSIC_EXP = 7
+        integer, parameter, public :: F64_INTRINSIC_LOG = 8
+        integer, parameter, public :: F64_INTRINSIC_SIN = 9
+        integer, parameter, public :: F64_INTRINSIC_COS = 10
+        integer, parameter, public :: F64_INTRINSIC_TAN = 11
+        integer, parameter, public :: F64_INTRINSIC_ATAN = 12
+        integer, parameter, public :: F64_INTRINSIC_ATAN2 = 13
+        integer, parameter, public :: F64_INTRINSIC_ASIN = 14
+        integer, parameter, public :: F64_INTRINSIC_ACOS = 15
+        integer, parameter, public :: F64_INTRINSIC_SINH = 16
+        integer, parameter, public :: F64_INTRINSIC_COSH = 17
+        integer, parameter, public :: F64_INTRINSIC_TANH = 18
+        integer, parameter, public :: F64_INTRINSIC_ASINH = 19
+        integer, parameter, public :: F64_INTRINSIC_ACOSH = 20
+        integer, parameter, public :: F64_INTRINSIC_ATANH = 21
+        integer, parameter, public :: F64_INTRINSIC_LOG10 = 22
+        integer, parameter, public :: F64_INTRINSIC_ERF = 23
+        integer, parameter, public :: F64_INTRINSIC_ERFC = 24
+        integer, parameter, public :: F64_INTRINSIC_GAMMA = 25
+        integer, parameter, public :: F64_INTRINSIC_LOG_GAMMA = 26
+        integer, parameter, public :: F64_INTRINSIC_HYPOT = 27
+        integer, parameter, public :: F64_INTRINSIC_MOD = 28
+        integer, parameter, public :: F64_INTRINSIC_MODULO = 29
+        integer, parameter, public :: F64_INTRINSIC_AINT = 30
+        integer, parameter, public :: F64_INTRINSIC_ANINT = 31
+        character(len=18), parameter, public :: I32_INTRINSIC_NAMES(23) = &
+            [character(len=18) :: 'abs', 'min', 'max', 'mod', &
+            'iand', 'ior', 'ieor', 'not', 'ishft', &
+            'ishftc', 'sign', 'int', 'nint', 'floor', &
+            'ceiling', 'matmul', 'transpose', &
+            'dot_product', 'reshape', 'selected_int_kind', &
+            'selected_real_kind', 'modulo', 'dim']
+        integer, parameter, public :: I32_INTRINSIC_IDS(23) = &
+            [I32_INTRINSIC_ABS, I32_INTRINSIC_MIN, I32_INTRINSIC_MAX, &
+            I32_INTRINSIC_MOD, I32_INTRINSIC_IAND, I32_INTRINSIC_IOR, &
+            I32_INTRINSIC_IEOR, I32_INTRINSIC_NOT, I32_INTRINSIC_ISHFT, &
+            I32_INTRINSIC_ISHFTC, I32_INTRINSIC_SIGN, I32_INTRINSIC_INT, &
+            I32_INTRINSIC_NINT, I32_INTRINSIC_FLOOR, &
+            I32_INTRINSIC_CEILING, I32_INTRINSIC_MATMUL, &
+            I32_INTRINSIC_TRANSPOSE, I32_INTRINSIC_DOT_PRODUCT, &
+            I32_INTRINSIC_RESHAPE, I32_INTRINSIC_SELECTED_INT_KIND, &
+            I32_INTRINSIC_SELECTED_REAL_KIND, I32_INTRINSIC_MODULO, &
+            I32_INTRINSIC_DIM]
+        character(len=9), parameter, public :: F64_INTRINSIC_NAMES(31) = &
+            [character(len=9) :: 'abs', 'min', 'max', 'real', &
+            'sign', 'sqrt', 'exp', 'log', 'sin', 'cos', &
+            'tan', 'atan', 'atan2', 'asin', 'acos', 'sinh', &
+            'cosh', 'tanh', 'asinh', 'acosh', 'atanh', &
+            'log10', 'erf', 'erfc', 'gamma', 'log_gamma', &
+            'hypot', 'mod', 'modulo', 'aint', 'anint']
+        integer, parameter, public :: F64_INTRINSIC_IDS(31) = &
+            [F64_INTRINSIC_ABS, F64_INTRINSIC_MIN, F64_INTRINSIC_MAX, &
+            F64_INTRINSIC_REAL, F64_INTRINSIC_SIGN, F64_INTRINSIC_SQRT, &
+            F64_INTRINSIC_EXP, F64_INTRINSIC_LOG, F64_INTRINSIC_SIN, &
+            F64_INTRINSIC_COS, F64_INTRINSIC_TAN, F64_INTRINSIC_ATAN, &
+            F64_INTRINSIC_ATAN2, F64_INTRINSIC_ASIN, &
+            F64_INTRINSIC_ACOS, F64_INTRINSIC_SINH, &
+            F64_INTRINSIC_COSH, F64_INTRINSIC_TANH, &
+            F64_INTRINSIC_ASINH, F64_INTRINSIC_ACOSH, &
+            F64_INTRINSIC_ATANH, F64_INTRINSIC_LOG10, &
+            F64_INTRINSIC_ERF, F64_INTRINSIC_ERFC, &
+            F64_INTRINSIC_GAMMA, F64_INTRINSIC_LOG_GAMMA, &
+            F64_INTRINSIC_HYPOT, F64_INTRINSIC_MOD, &
+            F64_INTRINSIC_MODULO, F64_INTRINSIC_AINT, &
+            F64_INTRINSIC_ANINT]
 
-    ! COMMON-block slot (#1578, #1900): one shared global per variable in a
-    ! COMMON block, keyed by block name and position. has_init/init_text carry
-    ! a BLOCK DATA literal initialiser folded later into the global.
-    integer, parameter, public :: COMMON_MAX_SLOTS = 64
-    integer, parameter, public :: EQUIV_MAX_MEMBERS = 32
-    type, public :: common_slot_t
-        character(len=:), allocatable :: block_name
-        character(len=:), allocatable :: var_name
-        integer :: value_kind = VALUE_I32
-        logical :: has_init = .false.
-        character(len=:), allocatable :: init_text
-    end type common_slot_t
+        ! COMMON-block slot (#1578, #1900): one shared global per variable in a
+        ! COMMON block, keyed by block name and position. has_init/init_text carry
+        ! a BLOCK DATA literal initialiser folded later into the global.
+        integer, parameter, public :: COMMON_MAX_SLOTS = 64
+        integer, parameter, public :: EQUIV_MAX_MEMBERS = 32
+        type, public :: common_slot_t
+            character(len=:), allocatable :: block_name
+            character(len=:), allocatable :: var_name
+            integer :: value_kind = VALUE_I32
+            logical :: has_init = .false.
+            character(len=:), allocatable :: init_text
+        end type common_slot_t
 
-    type, public :: symbol_t
-        character(len=64) :: name = ''
-        integer :: value_kind = VALUE_I32
-        type(lr_operand_desc_t) :: value
-        type(lr_operand_desc_t) :: address
-        logical :: is_parameter = .false.
-        logical :: is_reference = .false.
-        logical :: has_address = .false.
-        integer :: character_length = 0
-        logical :: has_character_value = .false.
-        logical :: is_array = .false.
-        integer :: array_rank = 0
-        integer :: array_size = 0
-        integer :: array_lower_bound = 1
-        integer, dimension(2) :: array_dim_sizes = 0
-        integer, dimension(2) :: array_dim_lowers = 0
-        logical :: is_derived = .false.
-        integer :: derived_type_index = 0
-        type(lr_operand_desc_t) :: element_address
-        ! A rank-1 array function result bound to the sret buffer (param 0). The
-        ! body array declaration rebinds its shape/element kind onto this symbol's
-        ! element_address instead of allocating fresh storage (array results).
-        logical :: is_array_result = .false.
-        logical :: has_i32_constant = .false.
-        integer(c_int64_t) :: i32_constant = 0_c_int64_t
-        logical :: is_deferred_character = .false.
-        type(lr_operand_desc_t) :: deferred_data
-        type(lr_operand_desc_t) :: deferred_length
-        logical :: is_allocatable = .false.
-        type(lr_operand_desc_t) :: allocatable_descriptor_address
-        ! Compile-time element count of a rank-1 allocatable when the most
-        ! recent allocate/constructor used a constant size; 0 when unknown.
-        ! Drives compile-time-unrolled whole-array print without a runtime loop.
-        integer :: allocatable_static_size = 0
-        ! Scalar POINTER/TARGET (#245, slice B3a). A target lives in memory at
-        ! `address`; a pointer carries the current target's `address` once
-        ! associated. `is_associated` tracks straight-line association at compile
-        ! time for `associated`/`nullify`.
-        logical :: is_pointer = .false.
-        logical :: is_target = .false.
-        logical :: is_associated = .false.
-        ! Procedure pointer (#245 B3d): `address` holds the ptr alloca slot;
-        ! after assignment `value` holds the loaded callee ptr operand.
-        logical :: is_proc_pointer = .false.
-        ! File I/O (#247 B5c). When this symbol holds a Fortran unit number that
-        ! was opened via OPEN, file_ptr_address is the alloca'd ptr holding the
-        ! FILE* handle. is_file_unit is set to .true. at that point.
-        logical :: is_file_unit = .false.
-        type(lr_operand_desc_t) :: file_ptr_address
-        ! Straight-line constant integer assigned to this scalar, tracked only to
-        ! link a unit number used by name (unit = 10) with WRITE/READ/REWIND that
-        ! reference it by number. Kept separate from has_i32_constant so it does
-        ! not affect array-bound or kind-inquiry constant folding.
-        logical :: has_unit_const = .false.
-        integer :: unit_const = 0
-    end type symbol_t
+        type, public :: symbol_t
+            character(len=64) :: name = ''
+            integer :: value_kind = VALUE_I32
+            type(lr_operand_desc_t) :: value
+            type(lr_operand_desc_t) :: address
+            logical :: is_parameter = .false.
+            logical :: is_reference = .false.
+            logical :: has_address = .false.
+            integer :: character_length = 0
+            logical :: has_character_value = .false.
+            logical :: is_array = .false.
+            integer :: array_rank = 0
+            integer :: array_size = 0
+            integer :: array_lower_bound = 1
+            integer, dimension(2) :: array_dim_sizes = 0
+            integer, dimension(2) :: array_dim_lowers = 0
+            logical :: is_derived = .false.
+            integer :: derived_type_index = 0
+            type(lr_operand_desc_t) :: element_address
+            ! A rank-1 array function result bound to the sret buffer (param 0). The
+            ! body array declaration rebinds its shape/element kind onto this symbol's
+            ! element_address instead of allocating fresh storage (array results).
+            logical :: is_array_result = .false.
+            logical :: has_i32_constant = .false.
+            integer(c_int64_t) :: i32_constant = 0_c_int64_t
+            logical :: is_deferred_character = .false.
+            type(lr_operand_desc_t) :: deferred_data
+            type(lr_operand_desc_t) :: deferred_length
+            logical :: is_allocatable = .false.
+            type(lr_operand_desc_t) :: allocatable_descriptor_address
+            ! Compile-time element count of a rank-1 allocatable when the most
+            ! recent allocate/constructor used a constant size; 0 when unknown.
+            ! Drives compile-time-unrolled whole-array print without a runtime loop.
+            integer :: allocatable_static_size = 0
+            ! Scalar POINTER/TARGET (#245, slice B3a). A target lives in memory at
+            ! `address`; a pointer carries the current target's `address` once
+            ! associated. `is_associated` tracks straight-line association at compile
+            ! time for `associated`/`nullify`.
+            logical :: is_pointer = .false.
+            logical :: is_target = .false.
+            logical :: is_associated = .false.
+            ! Procedure pointer (#245 B3d): `address` holds the ptr alloca slot;
+            ! after assignment `value` holds the loaded callee ptr operand.
+            logical :: is_proc_pointer = .false.
+            ! File I/O (#247 B5c). When this symbol holds a Fortran unit number that
+            ! was opened via OPEN, file_ptr_address is the alloca'd ptr holding the
+            ! FILE* handle. is_file_unit is set to .true. at that point.
+            logical :: is_file_unit = .false.
+            type(lr_operand_desc_t) :: file_ptr_address
+            ! Straight-line constant integer assigned to this scalar, tracked only to
+            ! link a unit number used by name (unit = 10) with WRITE/READ/REWIND that
+            ! reference it by number. Kept separate from has_i32_constant so it does
+            ! not affect array-bound or kind-inquiry constant folding.
+            logical :: has_unit_const = .false.
+            integer :: unit_const = 0
+        end type symbol_t
 
-    type, public :: array_section_info_t
-        character(len=64) :: source_name = ''
-        integer :: source_index = 0
-        integer :: source_rank = 0
-        integer :: result_rank = 0
-        integer :: kept_dims(2) = 0
-        logical :: keep_dim(2) = .false.
-        integer(c_int64_t) :: source_lowers(2) = 0_c_int64_t
-        integer(c_int64_t) :: source_sizes(2) = 0_c_int64_t
-        integer(c_int64_t) :: section_lowers(2) = 0_c_int64_t
-        integer(c_int64_t) :: section_uppers(2) = 0_c_int64_t
-        integer(c_int64_t) :: section_strides(2) = 1_c_int64_t
-        integer(c_int64_t) :: section_extents(2) = 0_c_int64_t
-        integer(c_int64_t) :: scalar_indices(2) = 0_c_int64_t
-    end type array_section_info_t
+        type, public :: array_section_info_t
+            character(len=64) :: source_name = ''
+            integer :: source_index = 0
+            integer :: source_rank = 0
+            integer :: result_rank = 0
+            integer :: kept_dims(2) = 0
+            logical :: keep_dim(2) = .false.
+            integer(c_int64_t) :: source_lowers(2) = 0_c_int64_t
+            integer(c_int64_t) :: source_sizes(2) = 0_c_int64_t
+            integer(c_int64_t) :: section_lowers(2) = 0_c_int64_t
+            integer(c_int64_t) :: section_uppers(2) = 0_c_int64_t
+            integer(c_int64_t) :: section_strides(2) = 1_c_int64_t
+            integer(c_int64_t) :: section_extents(2) = 0_c_int64_t
+            integer(c_int64_t) :: scalar_indices(2) = 0_c_int64_t
+        end type array_section_info_t
 
-    type, public :: derived_type_info_t
-        character(len=64) :: name = ''
-        integer :: component_count = 0
-        character(len=64), allocatable :: component_names(:)
-        logical, allocatable :: component_has_default(:)
-        integer(c_int64_t), allocatable :: component_default_value(:)
-        integer, allocatable :: component_array_size(:)
-        ! Scalar value kind of each component (VALUE_I32, VALUE_F64, VALUE_F32,
-        ! VALUE_LOGICAL, VALUE_C_PTR, or VALUE_DERIVED for a nested derived
-        ! component). Drives slot width and typed load/store.
-        integer, allocatable :: component_value_kind(:)
-        ! Derived type index of a nested derived component (0 for scalars and
-        ! intrinsic arrays). A nested component occupies the inner type's slots
-        ! inline; component_array_size holds that slot count.
-        integer, allocatable :: component_type_index(:)
-        integer :: binding_count = 0
-        character(len=64), allocatable :: binding_method_names(:)
-        character(len=64), allocatable :: binding_target_names(:)
-        ! Empty unless the binding declared pass(name); names the dummy that
-        ! receives the passed object.
-        character(len=64), allocatable :: binding_pass_names(:)
-    end type derived_type_info_t
+        type, public :: derived_type_info_t
+            character(len=64) :: name = ''
+            integer :: component_count = 0
+            character(len=64), allocatable :: component_names(:)
+            logical, allocatable :: component_has_default(:)
+            integer(c_int64_t), allocatable :: component_default_value(:)
+            integer, allocatable :: component_array_size(:)
+            ! Scalar value kind of each component (VALUE_I32, VALUE_F64, VALUE_F32,
+            ! VALUE_LOGICAL, VALUE_C_PTR, or VALUE_DERIVED for a nested derived
+            ! component). Drives slot width and typed load/store.
+            integer, allocatable :: component_value_kind(:)
+            ! Derived type index of a nested derived component (0 for scalars and
+            ! intrinsic arrays). A nested component occupies the inner type's slots
+            ! inline; component_array_size holds that slot count.
+            integer, allocatable :: component_type_index(:)
+            integer :: binding_count = 0
+            character(len=64), allocatable :: binding_method_names(:)
+            character(len=64), allocatable :: binding_target_names(:)
+            ! Empty unless the binding declared pass(name); names the dummy that
+            ! receives the passed object.
+            character(len=64), allocatable :: binding_pass_names(:)
+        end type derived_type_info_t
 
-    type, public :: module_exports_t
-        character(len=64) :: module_name = ''
-        integer, allocatable :: derived_type_indices(:)
-        integer :: derived_type_count = 0
-        integer, allocatable :: parameter_indices(:)
-        integer :: parameter_count = 0
-        ! Non-parameter variable declarations exported from the module (#249 B7a).
-        integer, allocatable :: variable_indices(:)
-        integer :: variable_count = 0
-        ! enum_node definitions exported from the module so a module procedure
-        ! can host-associate the enumerators (#1826).
-        integer, allocatable :: enum_indices(:)
-        integer :: enum_count = 0
-    end type module_exports_t
+        type, public :: module_exports_t
+            character(len=64) :: module_name = ''
+            integer, allocatable :: derived_type_indices(:)
+            integer :: derived_type_count = 0
+            integer, allocatable :: parameter_indices(:)
+            integer :: parameter_count = 0
+            ! Non-parameter variable declarations exported from the module (#249 B7a).
+            integer, allocatable :: variable_indices(:)
+            integer :: variable_count = 0
+            ! enum_node definitions exported from the module so a module procedure
+            ! can host-associate the enumerators (#1826).
+            integer, allocatable :: enum_indices(:)
+            integer :: enum_count = 0
+        end type module_exports_t
 
-    integer, parameter, public :: MAX_PROC_ARGS = 16
-    integer, parameter, public :: MAX_GENERIC_SPECIFICS = 8
+        integer, parameter, public :: MAX_PROC_ARGS = 16
+        integer, parameter, public :: MAX_GENERIC_SPECIFICS = 8
 
-    ! A generic interface: maps a generic name to up to MAX_GENERIC_SPECIFICS
-    ! specific procedure names (#249 B7c). At a call site the first specific
-    ! whose first-argument kind matches the actual is selected.
-    type, public :: generic_interface_t
-        character(len=64) :: generic_name = ''
-        integer :: specific_count = 0
-        character(len=64) :: specific_names(MAX_GENERIC_SPECIFICS) = ''
-        ! Value kind of the first dummy of each specific (used for dispatch).
-        integer :: first_arg_kinds(MAX_GENERIC_SPECIFICS) = VALUE_I32
-        ! Return value kind of each specific.
-        integer :: return_kinds(MAX_GENERIC_SPECIFICS) = VALUE_I32
-    end type generic_interface_t
+        ! A generic interface: maps a generic name to up to MAX_GENERIC_SPECIFICS
+        ! specific procedure names (#249 B7c). At a call site the first specific
+        ! whose first-argument kind matches the actual is selected.
+        type, public :: generic_interface_t
+            character(len=64) :: generic_name = ''
+            integer :: specific_count = 0
+            character(len=64) :: specific_names(MAX_GENERIC_SPECIFICS) = ''
+            ! Value kind of the first dummy of each specific (used for dispatch).
+            integer :: first_arg_kinds(MAX_GENERIC_SPECIFICS) = VALUE_I32
+            ! Return value kind of each specific.
+            integer :: return_kinds(MAX_GENERIC_SPECIFICS) = VALUE_I32
+        end type generic_interface_t
 
-    ! A user-defined operator or assignment overload. interface operator(+)
-    ! / operator(.dot.) / assignment(=) maps an operator token to specific
-    ! procedures; a binary-op or assignment whose operand kinds match dispatches
-    ! to the matching specific instead of the builtin path. Dispatch keys on the
-    ! pair of operand value kinds so distinct overloads of the same token (e.g.
-    ! integer .myop. integer vs real .myop. real) stay separate.
-    type, public :: operator_interface_t
-        character(len=64) :: operator_name = ''
-        logical :: is_assignment = .false.
-        integer :: specific_count = 0
-        character(len=64) :: specific_names(MAX_GENERIC_SPECIFICS) = ''
-        integer :: first_arg_kinds(MAX_GENERIC_SPECIFICS) = VALUE_I32
-        integer :: second_arg_kinds(MAX_GENERIC_SPECIFICS) = VALUE_I32
-        integer :: return_kinds(MAX_GENERIC_SPECIFICS) = VALUE_I32
-    end type operator_interface_t
+        ! A user-defined operator or assignment overload. interface operator(+)
+        ! / operator(.dot.) / assignment(=) maps an operator token to specific
+        ! procedures; a binary-op or assignment whose operand kinds match dispatches
+        ! to the matching specific instead of the builtin path. Dispatch keys on the
+        ! pair of operand value kinds so distinct overloads of the same token (e.g.
+        ! integer .myop. integer vs real .myop. real) stay separate.
+        type, public :: operator_interface_t
+            character(len=64) :: operator_name = ''
+            logical :: is_assignment = .false.
+            integer :: specific_count = 0
+            character(len=64) :: specific_names(MAX_GENERIC_SPECIFICS) = ''
+            integer :: first_arg_kinds(MAX_GENERIC_SPECIFICS) = VALUE_I32
+            integer :: second_arg_kinds(MAX_GENERIC_SPECIFICS) = VALUE_I32
+            integer :: return_kinds(MAX_GENERIC_SPECIFICS) = VALUE_I32
+        end type operator_interface_t
 
-    type, public :: external_procedure_t
-        character(len=64) :: fortran_name = ''
-        character(len=64) :: c_name = ''
-        integer :: return_value_kind = VALUE_I32
-        integer :: arg_value_kinds(MAX_PROC_ARGS) = VALUE_I32
-        integer :: arg_count = 0
-    end type external_procedure_t
+        type, public :: external_procedure_t
+            character(len=64) :: fortran_name = ''
+            character(len=64) :: c_name = ''
+            integer :: return_value_kind = VALUE_I32
+            integer :: arg_value_kinds(MAX_PROC_ARGS) = VALUE_I32
+            integer :: arg_count = 0
+        end type external_procedure_t
 
-    integer, parameter, public :: MAX_NAMELIST_MEMBERS = 32
+        integer, parameter, public :: MAX_NAMELIST_MEMBERS = 32
 
-    ! A NAMELIST group: maps a group name to its ordered member names so a
-    ! WRITE(unit, nml=group) can emit the group banner plus each member's
-    ! current value (#247 namelist I/O).
-    type, public :: namelist_group_t
-        character(len=64) :: group_name = ''
-        integer :: member_count = 0
-        character(len=64) :: member_names(MAX_NAMELIST_MEMBERS) = ''
-    end type namelist_group_t
+        ! A NAMELIST group: maps a group name to its ordered member names so a
+        ! WRITE(unit, nml=group) can emit the group banner plus each member's
+        ! current value (#247 namelist I/O).
+        type, public :: namelist_group_t
+            character(len=64) :: group_name = ''
+            integer :: member_count = 0
+            character(len=64) :: member_names(MAX_NAMELIST_MEMBERS) = ''
+        end type namelist_group_t
 
-    ! A statement function definition: name, ordered scalar dummy names, and the
-    ! arena index of the defining expression. Calls inline the body.
-    integer, parameter, public :: MAX_STMT_FN_ARGS = 8
-    type, public :: statement_function_t
-        character(len=64) :: name = ''
-        integer :: arg_count = 0
-        character(len=64) :: arg_names(MAX_STMT_FN_ARGS) = ''
-        integer :: body_expr_index = 0
-    end type statement_function_t
+        ! A statement function definition: name, ordered scalar dummy names, and the
+        ! arena index of the defining expression. Calls inline the body.
+        integer, parameter, public :: MAX_STMT_FN_ARGS = 8
+        type, public :: statement_function_t
+            character(len=64) :: name = ''
+            integer :: arg_count = 0
+            character(len=64) :: arg_names(MAX_STMT_FN_ARGS) = ''
+            integer :: body_expr_index = 0
+        end type statement_function_t
 
-    type, public :: lowering_context_t
-        type(liric_session_t) :: session
-        type(ast_arena_t) :: arena
-        type(symbol_t), allocatable :: symbols(:)
-        integer :: symbol_count = 0
-        ! Symbols at index <= block_scope_floor belong to an enclosing scope. A
-        ! declaration inside a BLOCK whose name matches such a symbol creates a
-        ! fresh shadowing slot instead of reusing the outer storage (#280).
-        integer :: block_scope_floor = 0
-        type(derived_type_info_t), allocatable :: derived_types(:)
-        integer :: derived_type_count = 0
-        type(module_exports_t), allocatable :: module_exports(:)
-        integer :: module_export_count = 0
-        integer(c_int32_t) :: current_block_id = 0_c_int32_t
-        integer(c_int32_t) :: i32_print_format_id = -1_c_int32_t
-        integer(c_int32_t) :: i64_print_format_id = -1_c_int32_t
-        integer(c_int32_t) :: i8_print_format_id = -1_c_int32_t
-        integer(c_int32_t) :: i16_print_format_id = -1_c_int32_t
-        integer(c_int32_t) :: str_print_format_id = -1_c_int32_t
-        integer :: string_literal_count = 0
-        logical :: has_command_args = .false.
-        type(lr_operand_desc_t) :: argc_value
-        type(lr_operand_desc_t) :: argv_value
-        character(len=64), allocatable :: function_names(:)
-        integer, allocatable :: function_value_kinds(:)
-        integer, allocatable :: function_param_counts(:)
-        integer, allocatable :: function_node_indices(:)
-        integer :: function_count = 0
-        ! USE-rename procedure aliases (#274): a call to local name
-        ! proc_alias_locals(k) resolves to the real procedure
-        ! proc_alias_targets(k) before mangling.
-        character(len=64), allocatable :: proc_alias_locals(:)
-        character(len=64), allocatable :: proc_alias_targets(:)
-        integer :: proc_alias_count = 0
-        type(external_procedure_t), allocatable :: external_procedures(:)
-        integer :: external_procedure_count = 0
-        ! Generic interface table (#249 B7c).
-        type(generic_interface_t), allocatable :: generics(:)
-        integer :: generic_count = 0
-        ! Operator/assignment overload table.
-        type(operator_interface_t), allocatable :: operators(:)
-        integer :: operator_count = 0
-        logical :: in_internal_function = .false.
-        logical :: in_internal_subroutine = .false.
-        ! Name of the contained procedure currently being lowered. Lets an
-        ! assumed-shape dummy a(:) recover its extent from the caller's actual.
-        character(len=:), allocatable :: current_proc_name
-        integer :: current_function_result_index = 0
-        logical :: current_block_terminated = .false.
-        integer(c_int32_t) :: current_loop_exit_block = 0_c_int32_t
-        integer(c_int32_t) :: current_loop_latch_block = 0_c_int32_t
-        logical :: in_counted_do = .false.
-        logical :: current_block_exited_loop = .false.
-        ! GOTO label table for a labeled program body (#270). Each labeled
-        ! statement owns a LIRIC block; a `goto N` branches to label_blocks(k)
-        ! where label_names(k) == 'N'. Active only while in_labeled_body.
-        logical :: in_labeled_body = .false.
-        character(len=16), allocatable :: label_names(:)
-        integer(c_int32_t), allocatable :: label_blocks(:)
-        integer :: label_count = 0
-        ! Search paths (-I) for .fmod module artefacts resolved on USE.
-        character(len=:), allocatable :: include_paths(:)
-        integer :: include_path_count = 0
-        ! File I/O unit table (#247 B5c). unit_table_id is the LIRIC global vreg
-        ! for the [256 x ptr] table; -1 means not yet created.
-        integer(c_int32_t) :: unit_table_id = -1_c_int32_t
-        ! Next unit number assigned by newunit=. Start at 10 to avoid 0/1/6.
-        integer(c_int32_t) :: next_file_unit = 10_c_int32_t
-        ! NAMELIST group table (#247 namelist I/O).
-        type(namelist_group_t), allocatable :: namelist_groups(:)
-        integer :: namelist_group_count = 0
-        ! Statement functions (f(x) = x*x + 1). Each entry records the name, its
-        ! scalar dummy names, and the arena index of the defining expression.
-        ! A call to such a name inlines the body with actuals bound to dummies.
-        type(statement_function_t), allocatable :: statement_functions(:)
-        integer :: statement_function_count = 0
-    end type lowering_context_t
+        type, public :: lowering_context_t
+            type(liric_session_t) :: session
+            type(ast_arena_t) :: arena
+            type(symbol_t), allocatable :: symbols(:)
+            integer :: symbol_count = 0
+            ! Symbols at index <= block_scope_floor belong to an enclosing scope. A
+            ! declaration inside a BLOCK whose name matches such a symbol creates a
+            ! fresh shadowing slot instead of reusing the outer storage (#280).
+            integer :: block_scope_floor = 0
+            type(derived_type_info_t), allocatable :: derived_types(:)
+            integer :: derived_type_count = 0
+            type(module_exports_t), allocatable :: module_exports(:)
+            integer :: module_export_count = 0
+            integer(c_int32_t) :: current_block_id = 0_c_int32_t
+            integer(c_int32_t) :: i32_print_format_id = -1_c_int32_t
+            integer(c_int32_t) :: i64_print_format_id = -1_c_int32_t
+            integer(c_int32_t) :: i8_print_format_id = -1_c_int32_t
+            integer(c_int32_t) :: i16_print_format_id = -1_c_int32_t
+            integer(c_int32_t) :: str_print_format_id = -1_c_int32_t
+            integer :: string_literal_count = 0
+            logical :: has_command_args = .false.
+            type(lr_operand_desc_t) :: argc_value
+            type(lr_operand_desc_t) :: argv_value
+            character(len=64), allocatable :: function_names(:)
+            integer, allocatable :: function_value_kinds(:)
+            integer, allocatable :: function_param_counts(:)
+            integer, allocatable :: function_node_indices(:)
+            integer :: function_count = 0
+            ! USE-rename procedure aliases (#274): a call to local name
+            ! proc_alias_locals(k) resolves to the real procedure
+            ! proc_alias_targets(k) before mangling.
+            character(len=64), allocatable :: proc_alias_locals(:)
+            character(len=64), allocatable :: proc_alias_targets(:)
+            integer :: proc_alias_count = 0
+            type(external_procedure_t), allocatable :: external_procedures(:)
+            integer :: external_procedure_count = 0
+            ! Generic interface table (#249 B7c).
+            type(generic_interface_t), allocatable :: generics(:)
+            integer :: generic_count = 0
+            ! Operator/assignment overload table.
+            type(operator_interface_t), allocatable :: operators(:)
+            integer :: operator_count = 0
+            logical :: in_internal_function = .false.
+                logical :: in_internal_subroutine = .false.
+                    ! Name of the contained procedure currently being lowered. Lets an
+                    ! assumed-shape dummy a(:) recover its extent from the caller's actual.
+                    character(len=:), allocatable :: current_proc_name
+                    integer :: current_function_result_index = 0
+                    logical :: current_block_terminated = .false.
+                    integer(c_int32_t) :: current_loop_exit_block = 0_c_int32_t
+                    integer(c_int32_t) :: current_loop_latch_block = 0_c_int32_t
+                    logical :: in_counted_do = .false.
+                    logical :: current_block_exited_loop = .false.
+                    ! GOTO label table for a labeled program body (#270). Each labeled
+                    ! statement owns a LIRIC block; a `goto N` branches to label_blocks(k)
+                    ! where label_names(k) == 'N'. Active only while in_labeled_body.
+                    logical :: in_labeled_body = .false.
+                    character(len=16), allocatable :: label_names(:)
+                    integer(c_int32_t), allocatable :: label_blocks(:)
+                    integer :: label_count = 0
+                    ! Search paths (-I) for .fmod module artefacts resolved on USE.
+                    character(len=:), allocatable :: include_paths(:)
+                    integer :: include_path_count = 0
+                    ! File I/O unit table (#247 B5c). unit_table_id is the LIRIC global vreg
+                    ! for the [256 x ptr] table; -1 means not yet created.
+                    integer(c_int32_t) :: unit_table_id = -1_c_int32_t
+                    ! Next unit number assigned by newunit=. Start at 10 to avoid 0/1/6.
+                    integer(c_int32_t) :: next_file_unit = 10_c_int32_t
+                    ! NAMELIST group table (#247 namelist I/O).
+                    type(namelist_group_t), allocatable :: namelist_groups(:)
+                    integer :: namelist_group_count = 0
+                    ! Statement functions (f(x) = x*x + 1). Each entry records the name, its
+                    ! scalar dummy names, and the arena index of the defining expression.
+                    ! A call to such a name inlines the body with actuals bound to dummies.
+                    type(statement_function_t), allocatable :: statement_functions(:)
+                    integer :: statement_function_count = 0
+                end type lowering_context_t
 
-    type, public :: branch_result_t
-        type(symbol_t), allocatable :: symbols(:)
-        integer :: symbol_count = 0
-        integer(c_int32_t) :: predecessor_block_id = 0_c_int32_t
-        logical :: terminated = .false.
-    end type branch_result_t
+                type, public :: branch_result_t
+                    type(symbol_t), allocatable :: symbols(:)
+                    integer :: symbol_count = 0
+                    integer(c_int32_t) :: predecessor_block_id = 0_c_int32_t
+                    logical :: terminated = .false.
+                end type branch_result_t
 
-end module session_program_lowering_types
+            end module session_program_lowering_types

--- a/test/test_conformance_gauntlet_smoke.f90
+++ b/test/test_conformance_gauntlet_smoke.f90
@@ -20,8 +20,8 @@ program test_conformance_gauntlet_smoke
 
     ! Build the command string at runtime
     cmd = 'timeout 120 bash ' // SCRIPT // &
-          ' --suite fortfront-f90 --max-files 20' // &
-          ' --report ' // REPORT
+        ' --suite fortfront-f90 --max-files 20' // &
+        ' --report ' // REPORT
 
     call execute_command_line(cmd, exitstat=exit_stat)
 
@@ -44,7 +44,7 @@ program test_conformance_gauntlet_smoke
     has_summary = .false.
     has_zero_fail_summary = .false.
     open(newunit=unit, file=REPORT, status='old', action='read', &
-         iostat=io_stat)
+        iostat=io_stat)
     if (io_stat /= 0) then
         print *, 'FAIL: cannot open report ', trim(adjustl(REPORT))
         stop 1

--- a/test/test_counted_do_compiler.f90
+++ b/test/test_counted_do_compiler.f90
@@ -5,18 +5,18 @@ program test_counted_do_compiler
     print *, '=== counted do compiler test ==='
 
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         '  integer :: i'//new_line('a')// &
-         '  integer :: n'//new_line('a')// &
-         '  integer :: total'//new_line('a')// &
-         '  n = 1 + 2'//new_line('a')// &
-         '  total = 0'//new_line('a')// &
-         '  do i = 1, n'//new_line('a')// &
-         '    total = total + i'//new_line('a')// &
-         '  end do'//new_line('a')// &
-         '  stop total'//new_line('a')// &
-         'end program main', 6, &
-         '/tmp/ffc_counted_do_test')) stop 1
+        'program main'//new_line('a')// &
+        '  integer :: i'//new_line('a')// &
+        '  integer :: n'//new_line('a')// &
+        '  integer :: total'//new_line('a')// &
+        '  n = 1 + 2'//new_line('a')// &
+        '  total = 0'//new_line('a')// &
+        '  do i = 1, n'//new_line('a')// &
+        '    total = total + i'//new_line('a')// &
+        '  end do'//new_line('a')// &
+        '  stop total'//new_line('a')// &
+        'end program main', 6, &
+        '/tmp/ffc_counted_do_test')) stop 1
 
     if (.not. test_runtime_positive_step()) stop 1
     if (.not. test_runtime_negative_step()) stop 1
@@ -27,42 +27,42 @@ contains
 
     logical function test_runtime_positive_step()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: i'//new_line('a')// &
-                                       '  integer :: s'//new_line('a')// &
-                                       '  integer :: total'//new_line('a')// &
-                                       '  s = 2'//new_line('a')// &
-                                       '  total = 0'//new_line('a')// &
-                                       '  do i = 1, 10, s'//new_line('a')// &
-                                       '    total = total + i'//new_line('a')// &
-                                       '  end do'//new_line('a')// &
-                                       '  stop total'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  integer :: s'//new_line('a')// &
+            '  integer :: total'//new_line('a')// &
+            '  s = 2'//new_line('a')// &
+            '  total = 0'//new_line('a')// &
+            '  do i = 1, 10, s'//new_line('a')// &
+            '    total = total + i'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            '  stop total'//new_line('a')// &
+            'end program main'
 
         ! 1 + 3 + 5 + 7 + 9 = 25
         test_runtime_positive_step = expect_exit_status( &
-                                  source, 25, &
-                                  '/tmp/ffc_counted_do_runtime_pos_test')
+            source, 25, &
+            '/tmp/ffc_counted_do_runtime_pos_test')
     end function test_runtime_positive_step
 
     logical function test_runtime_negative_step()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: i'//new_line('a')// &
-                                       '  integer :: s'//new_line('a')// &
-                                       '  integer :: total'//new_line('a')// &
-                                       '  s = -1'//new_line('a')// &
-                                       '  total = 0'//new_line('a')// &
-                                       '  do i = 5, 1, s'//new_line('a')// &
-                                       '    total = total + i'//new_line('a')// &
-                                       '  end do'//new_line('a')// &
-                                       '  stop total'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  integer :: s'//new_line('a')// &
+            '  integer :: total'//new_line('a')// &
+            '  s = -1'//new_line('a')// &
+            '  total = 0'//new_line('a')// &
+            '  do i = 5, 1, s'//new_line('a')// &
+            '    total = total + i'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            '  stop total'//new_line('a')// &
+            'end program main'
 
         ! 5 + 4 + 3 + 2 + 1 = 15
         test_runtime_negative_step = expect_exit_status( &
-                                  source, 15, &
-                                  '/tmp/ffc_counted_do_runtime_neg_test')
+            source, 15, &
+            '/tmp/ffc_counted_do_runtime_neg_test')
     end function test_runtime_negative_step
 
 end program test_counted_do_compiler

--- a/test/test_docs_no_drift_claims.f90
+++ b/test/test_docs_no_drift_claims.f90
@@ -1,144 +1,144 @@
 program test_docs_no_drift_claims
-  implicit none
+    implicit none
 
-  character(len=256), parameter :: readme_path = "README.md"
-  character(len=256), parameter :: api_path = "docs/API_REFERENCE.md"
-  character(len=256), parameter :: dev_path = "docs/DEVELOPER_GUIDE.md"
+    character(len=256), parameter :: readme_path = "README.md"
+    character(len=256), parameter :: api_path = "docs/API_REFERENCE.md"
+    character(len=256), parameter :: dev_path = "docs/DEVELOPER_GUIDE.md"
 
-  integer :: unit, iostat
-  character(len=4096) :: line
-  character(len=1024) :: content
-  logical :: found_readme, found_api, found_dev
-  logical :: found_support_contract, found_fpm_build, found_fpm_test
-  logical :: fail
+    integer :: unit, iostat
+    character(len=4096) :: line
+    character(len=1024) :: content
+    logical :: found_readme, found_api, found_dev
+    logical :: found_support_contract, found_fpm_build, found_fpm_test
+    logical :: fail
 
-  ! Forbidden phrases that must not appear
-  character(len=1024), parameter :: forbidden_1 = "currently 40 programs"
-  character(len=1024), parameter :: forbidden_2 = "Stored but not yet consumed by lowering"
-  character(len=1024), parameter :: forbidden_3 = "CI runs the same workflow"
+    ! Forbidden phrases that must not appear
+    character(len=1024), parameter :: forbidden_1 = "currently 40 programs"
+    character(len=1024), parameter :: forbidden_2 = "Stored but not yet consumed by lowering"
+    character(len=1024), parameter :: forbidden_3 = "CI runs the same workflow"
 
-  ! Required content
-  character(len=1024), parameter :: required_1 = "SUPPORT_CONTRACT.md"
-  character(len=1024), parameter :: required_2 = "fpm build"
-  character(len=1024), parameter :: required_3 = "fpm test"
+    ! Required content
+    character(len=1024), parameter :: required_1 = "SUPPORT_CONTRACT.md"
+    character(len=1024), parameter :: required_2 = "fpm build"
+    character(len=1024), parameter :: required_3 = "fpm test"
 
-  fail = .false.
-  found_readme = .false.
-  found_api = .false.
-  found_dev = .false.
-  found_support_contract = .false.
-  found_fpm_build = .false.
-  found_fpm_test = .false.
+    fail = .false.
+    found_readme = .false.
+    found_api = .false.
+    found_dev = .false.
+    found_support_contract = .false.
+    found_fpm_build = .false.
+    found_fpm_test = .false.
 
-  ! Check README.md
-  unit = 10
-  open(unit=unit, file=readme_path, status="old", iostat=iostat)
-  if (iostat == 0) then
-    found_readme = .true.
-    do
-      read(unit, '(a)', iostat=iostat) line
-      if (iostat /= 0) exit
-      if (index(line, trim(forbidden_1)) > 0) then
-        write(*, '(a)') "FAIL: README.md contains forbidden phrase: " // trim(forbidden_1)
+    ! Check README.md
+    unit = 10
+    open(unit=unit, file=readme_path, status="old", iostat=iostat)
+    if (iostat == 0) then
+        found_readme = .true.
+        do
+            read(unit, '(a)', iostat=iostat) line
+            if (iostat /= 0) exit
+            if (index(line, trim(forbidden_1)) > 0) then
+                write(*, '(a)') "FAIL: README.md contains forbidden phrase: " // trim(forbidden_1)
+                fail = .true.
+            end if
+            if (index(line, trim(forbidden_2)) > 0) then
+                write(*, '(a)') "FAIL: README.md contains forbidden phrase: " // trim(forbidden_2)
+                fail = .true.
+            end if
+            if (index(line, trim(forbidden_3)) > 0) then
+                write(*, '(a)') "FAIL: README.md contains forbidden phrase: " // trim(forbidden_3)
+                fail = .true.
+            end if
+            if (index(line, trim(required_1)) > 0) found_support_contract = .true.
+            if (index(line, trim(required_2)) > 0) found_fpm_build = .true.
+            if (index(line, trim(required_3)) > 0) found_fpm_test = .true.
+        end do
+        close(unit)
+    else
+        write(*, '(a)') "FAIL: Cannot open " // trim(readme_path)
         fail = .true.
-      end if
-      if (index(line, trim(forbidden_2)) > 0) then
-        write(*, '(a)') "FAIL: README.md contains forbidden phrase: " // trim(forbidden_2)
-        fail = .true.
-      end if
-      if (index(line, trim(forbidden_3)) > 0) then
-        write(*, '(a)') "FAIL: README.md contains forbidden phrase: " // trim(forbidden_3)
-        fail = .true.
-      end if
-      if (index(line, trim(required_1)) > 0) found_support_contract = .true.
-      if (index(line, trim(required_2)) > 0) found_fpm_build = .true.
-      if (index(line, trim(required_3)) > 0) found_fpm_test = .true.
-    end do
-    close(unit)
-  else
-    write(*, '(a)') "FAIL: Cannot open " // trim(readme_path)
-    fail = .true.
-  end if
+    end if
 
-  ! Check docs/API_REFERENCE.md
-  unit = 20
-  open(unit=unit, file=api_path, status="old", iostat=iostat)
-  if (iostat == 0) then
-    found_api = .true.
-    do
-      read(unit, '(a)', iostat=iostat) line
-      if (iostat /= 0) exit
-      if (index(line, trim(forbidden_1)) > 0) then
-        write(*, '(a)') "FAIL: API_REFERENCE.md contains forbidden phrase: " // trim(forbidden_1)
+    ! Check docs/API_REFERENCE.md
+    unit = 20
+    open(unit=unit, file=api_path, status="old", iostat=iostat)
+    if (iostat == 0) then
+        found_api = .true.
+        do
+            read(unit, '(a)', iostat=iostat) line
+            if (iostat /= 0) exit
+            if (index(line, trim(forbidden_1)) > 0) then
+                write(*, '(a)') "FAIL: API_REFERENCE.md contains forbidden phrase: " // trim(forbidden_1)
+                fail = .true.
+            end if
+            if (index(line, trim(forbidden_2)) > 0) then
+                write(*, '(a)') "FAIL: API_REFERENCE.md contains forbidden phrase: " // trim(forbidden_2)
+                fail = .true.
+            end if
+            if (index(line, trim(forbidden_3)) > 0) then
+                write(*, '(a)') "FAIL: API_REFERENCE.md contains forbidden phrase: " // trim(forbidden_3)
+                fail = .true.
+            end if
+            if (index(line, trim(required_1)) > 0) found_support_contract = .true.
+        end do
+        close(unit)
+    else
+        write(*, '(a)') "FAIL: Cannot open " // trim(api_path)
         fail = .true.
-      end if
-      if (index(line, trim(forbidden_2)) > 0) then
-        write(*, '(a)') "FAIL: API_REFERENCE.md contains forbidden phrase: " // trim(forbidden_2)
-        fail = .true.
-      end if
-      if (index(line, trim(forbidden_3)) > 0) then
-        write(*, '(a)') "FAIL: API_REFERENCE.md contains forbidden phrase: " // trim(forbidden_3)
-        fail = .true.
-      end if
-      if (index(line, trim(required_1)) > 0) found_support_contract = .true.
-    end do
-    close(unit)
-  else
-    write(*, '(a)') "FAIL: Cannot open " // trim(api_path)
-    fail = .true.
-  end if
+    end if
 
-  ! Check docs/DEVELOPER_GUIDE.md
-  unit = 30
-  open(unit=unit, file=dev_path, status="old", iostat=iostat)
-  if (iostat == 0) then
-    found_dev = .true.
-    do
-      read(unit, '(a)', iostat=iostat) line
-      if (iostat /= 0) exit
-      if (index(line, trim(forbidden_1)) > 0) then
-        write(*, '(a)') "FAIL: DEVELOPER_GUIDE.md contains forbidden phrase: " // trim(forbidden_1)
+    ! Check docs/DEVELOPER_GUIDE.md
+    unit = 30
+    open(unit=unit, file=dev_path, status="old", iostat=iostat)
+    if (iostat == 0) then
+        found_dev = .true.
+        do
+            read(unit, '(a)', iostat=iostat) line
+            if (iostat /= 0) exit
+            if (index(line, trim(forbidden_1)) > 0) then
+                write(*, '(a)') "FAIL: DEVELOPER_GUIDE.md contains forbidden phrase: " // trim(forbidden_1)
+                fail = .true.
+            end if
+            if (index(line, trim(forbidden_2)) > 0) then
+                write(*, '(a)') "FAIL: DEVELOPER_GUIDE.md contains forbidden phrase: " // trim(forbidden_2)
+                fail = .true.
+            end if
+            if (index(line, trim(forbidden_3)) > 0) then
+                write(*, '(a)') "FAIL: DEVELOPER_GUIDE.md contains forbidden phrase: " // trim(forbidden_3)
+                fail = .true.
+            end if
+            if (index(line, trim(required_1)) > 0) found_support_contract = .true.
+            if (index(line, trim(required_2)) > 0) found_fpm_build = .true.
+            if (index(line, trim(required_3)) > 0) found_fpm_test = .true.
+        end do
+        close(unit)
+    else
+        write(*, '(a)') "FAIL: Cannot open " // trim(dev_path)
         fail = .true.
-      end if
-      if (index(line, trim(forbidden_2)) > 0) then
-        write(*, '(a)') "FAIL: DEVELOPER_GUIDE.md contains forbidden phrase: " // trim(forbidden_2)
+    end if
+
+    ! Check required content presence
+    if (.not. found_support_contract) then
+        write(*, '(a)') "FAIL: No doc mentions SUPPORT_CONTRACT.md"
         fail = .true.
-      end if
-      if (index(line, trim(forbidden_3)) > 0) then
-        write(*, '(a)') "FAIL: DEVELOPER_GUIDE.md contains forbidden phrase: " // trim(forbidden_3)
+    end if
+
+    if (.not. found_fpm_build) then
+        write(*, '(a)') "FAIL: No doc mentions fpm build"
         fail = .true.
-      end if
-      if (index(line, trim(required_1)) > 0) found_support_contract = .true.
-      if (index(line, trim(required_2)) > 0) found_fpm_build = .true.
-      if (index(line, trim(required_3)) > 0) found_fpm_test = .true.
-    end do
-    close(unit)
-  else
-    write(*, '(a)') "FAIL: Cannot open " // trim(dev_path)
-    fail = .true.
-  end if
+    end if
 
-  ! Check required content presence
-  if (.not. found_support_contract) then
-    write(*, '(a)') "FAIL: No doc mentions SUPPORT_CONTRACT.md"
-    fail = .true.
-  end if
+    if (.not. found_fpm_test) then
+        write(*, '(a)') "FAIL: No doc mentions fpm test"
+        fail = .true.
+    end if
 
-  if (.not. found_fpm_build) then
-    write(*, '(a)') "FAIL: No doc mentions fpm build"
-    fail = .true.
-  end if
-
-  if (.not. found_fpm_test) then
-    write(*, '(a)') "FAIL: No doc mentions fpm test"
-    fail = .true.
-  end if
-
-  if (fail) then
-    stop 1
-  else
-    write(*, '(a)') "PASS: No drift-prone claims found"
-    stop 0
-  end if
+    if (fail) then
+        stop 1
+    else
+        write(*, '(a)') "PASS: No drift-prone claims found"
+        stop 0
+    end if
 
 end program test_docs_no_drift_claims

--- a/test/test_fortfront_corpus_conformance.f90
+++ b/test/test_fortfront_corpus_conformance.f90
@@ -44,8 +44,8 @@ contains
         ! Generous per-file timeout so a single slow compile under full-suite
         ! load is not a false failure (idle compiles are well under a second).
         cmd = 'timeout '//trim(timeout_text)//' bash '//SCRIPT// &
-              ' --suite '//suite//' --report '//report// &
-              ' --timeout 30 > '//log_path//' 2>&1'
+            ' --suite '//suite//' --report '//report// &
+            ' --timeout 30 > '//log_path//' 2>&1'
         call execute_command_line(cmd, exitstat=exit_stat)
 
         if (exit_stat /= 0) then
@@ -89,7 +89,7 @@ contains
         summary = ''
 
         open (newunit=unit, file=report, status='old', action='read', &
-              iostat=io_stat)
+            iostat=io_stat)
         if (io_stat /= 0) return
 
         do

--- a/test/test_liric_session_bindings.f90
+++ b/test/test_liric_session_bindings.f90
@@ -43,7 +43,7 @@ program test_liric_session_bindings
     end if
 
     call execute_command_line(exe_path, exitstat=exit_stat, &
-                              cmdstat=cmd_stat)
+        cmdstat=cmd_stat)
     if (cmd_stat /= 0) then
         print *, 'FAIL: could not run emitted executable'
         call destroy(session)
@@ -119,7 +119,7 @@ program test_liric_session_bindings
     call destroy(session)
 
     call execute_command_line(exe_path2, exitstat=exit_stat, &
-                              cmdstat=cmd_stat)
+        cmdstat=cmd_stat)
     if (cmd_stat /= 0) then
         print *, 'FAIL: could not run mem test executable'
         call execute_command_line('rm -f '//exe_path2)

--- a/test/test_minimal_ext1.f90
+++ b/test/test_minimal_ext1.f90
@@ -2,7 +2,7 @@ program test_minimal_ext1
     use ffc_test_support, only: expect_exit_status
     implicit none
     logical :: ok
-    
+
     ! Test 1: a(1,1)=4, a(1,2)=5, stop a(1,1) - should be 4 if extent1=2, 5 if extent1=0
     ok = expect_exit_status(&
         'program main'//new_line('a')// &
@@ -18,7 +18,7 @@ program test_minimal_ext1
         print *, 'FAIL: extent1 may be 0 (a(1,2) overwrote a(1,1))'
         stop 1
     end if
-    
+
     ! Test 2: a(2,1)=7, a(2,2)=8, stop a(2,1) - should be 7 if extent1=2, 8 if extent1=0
     ok = expect_exit_status(&
         'program main'//new_line('a')// &
@@ -33,5 +33,5 @@ program test_minimal_ext1
     else
         print *, 'FAIL: a(2,2) overwrote a(2,1), extent1 may be 0'
     end if
-    
+
 end program test_minimal_ext1

--- a/test/test_rank2_loop_debug.f90
+++ b/test/test_rank2_loop_debug.f90
@@ -1,10 +1,10 @@
 program test_rank2_loop_debug
     use ffc_test_support, only: expect_exit_status
     implicit none
-    
+
     ! First: manual writes, no loops, sum all 6 elements
     logical :: ok
-    
+
     ! test: a(1,1)=4,a(2,1)=7,a(1,2)=5,a(2,2)=8,a(1,3)=6,a(2,3)=9 -> sum=39
     ok = expect_exit_status(&
         'program main'//new_line('a')// &
@@ -26,5 +26,5 @@ program test_rank2_loop_debug
         print *, 'FAIL: manual writes'
         stop 1
     end if
-    
+
 end program test_rank2_loop_debug

--- a/test/test_runtime_mn.f90
+++ b/test/test_runtime_mn.f90
@@ -2,7 +2,7 @@ program test_runtime_mn
     use ffc_test_support, only: expect_exit_status
     implicit none
     logical :: ok
-    
+
     ! Use runtime M and N (passed from command-line or computed)
     ! Actually allocate(a(m,n)) where m,n are variables
     ok = expect_exit_status(&

--- a/test/test_session_array_constructor_compiler.f90
+++ b/test/test_session_array_constructor_compiler.f90
@@ -1,7 +1,7 @@
 program test_session_array_constructor_compiler
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                  compiler_frontend_result_t, &
-                                  compile_frontend_from_string, INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, INPUT_MODE_STANDARD
     use session_program_lowering, only: lower_program_to_liric_exe
     implicit none
 
@@ -87,7 +87,7 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, error_msg)
+            frontend_result%root_index, exe, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', stem, ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -97,7 +97,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', stem, ']: gfortran rejected source'
             return
@@ -106,7 +106,7 @@ contains
         call execute_command_line(exe//' > '//ffc_out, exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out, exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', stem, ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
@@ -114,7 +114,7 @@ contains
             matches_gfortran = .true.
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref//' '// &
-                                  ffc_out//' '//ref_out)
+            ffc_out//' '//ref_out)
     end function matches_gfortran
 
 end program test_session_array_constructor_compiler

--- a/test/test_session_array_function_result_compiler.f90
+++ b/test/test_session_array_function_result_compiler.f90
@@ -5,9 +5,9 @@ program test_session_array_function_result_compiler
     ! gfortran byte-for-byte.
     use session_program_lowering, only: lower_program_to_liric_exe
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                   compiler_frontend_result_t, &
-                                   compile_frontend_from_string, &
-                                   INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
     implicit none
 
     logical :: all_passed
@@ -144,7 +144,7 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, error_msg)
+            frontend_result%root_index, exe, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', trim(stem), ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -154,7 +154,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', trim(stem), ']: gfortran rejected source'
             return
@@ -163,14 +163,14 @@ contains
         call execute_command_line(exe//' > '//ffc_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', trim(stem), ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
             return
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref// &
-                                  ' '//ffc_out//' '//ref_out)
+            ' '//ffc_out//' '//ref_out)
         matches_gfortran = .true.
     end function matches_gfortran
 

--- a/test/test_session_array_intrinsics_compiler.f90
+++ b/test/test_session_array_intrinsics_compiler.f90
@@ -29,38 +29,38 @@ contains
 
     logical function test_rank2_array_intrinsics()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(1:2, 1:2)'//new_line('a')// &
-                                       '  integer :: r(1:4)'//new_line('a')// &
-                                       '  integer :: w(1:4)'//new_line('a')// &
-                                       '  integer :: s'//new_line('a')// &
-                                       '  integer :: dims(2)'//new_line('a')// &
-                                       '  a = [1, 2, 3, 4]'//new_line('a')// &
-                                       '  w = [1, 1, 1, 1]'//new_line('a')// &
-                                       '  dims = shape(a)'//new_line('a')// &
-                                       '  print *, dims(1)'//new_line('a')// &
-                                       '  print *, dims(2)'//new_line('a')// &
-                                       '  print *, size(a)'//new_line('a')// &
-                                       '  print *, sum(a)'//new_line('a')// &
-                                       '  print *, maxval(a)'//new_line('a')// &
-                                       '  print *, minval(a)'//new_line('a')// &
-                                       '  r = reshape(a, [4])'//new_line('a')// &
-                                       '  s = dot_product(r, w)'//new_line('a')// &
-                                       '  print *, r(1)'//new_line('a')// &
-                                       '  print *, r(4)'//new_line('a')// &
-                                       '  print *, s'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(1:2, 1:2)'//new_line('a')// &
+            '  integer :: r(1:4)'//new_line('a')// &
+            '  integer :: w(1:4)'//new_line('a')// &
+            '  integer :: s'//new_line('a')// &
+            '  integer :: dims(2)'//new_line('a')// &
+            '  a = [1, 2, 3, 4]'//new_line('a')// &
+            '  w = [1, 1, 1, 1]'//new_line('a')// &
+            '  dims = shape(a)'//new_line('a')// &
+            '  print *, dims(1)'//new_line('a')// &
+            '  print *, dims(2)'//new_line('a')// &
+            '  print *, size(a)'//new_line('a')// &
+            '  print *, sum(a)'//new_line('a')// &
+            '  print *, maxval(a)'//new_line('a')// &
+            '  print *, minval(a)'//new_line('a')// &
+            '  r = reshape(a, [4])'//new_line('a')// &
+            '  s = dot_product(r, w)'//new_line('a')// &
+            '  print *, r(1)'//new_line('a')// &
+            '  print *, r(4)'//new_line('a')// &
+            '  print *, s'//new_line('a')// &
+            'end program main'
 
         test_rank2_array_intrinsics = expect_output( &
             source, '           2'//new_line('a')// &
-                    '           2'//new_line('a')// &
-                    '           4'//new_line('a')// &
-                    '          10'//new_line('a')// &
-                    '           4'//new_line('a')// &
-                    '           1'//new_line('a')// &
-                    '           1'//new_line('a')// &
-                    '           4'//new_line('a')// &
-                    '          10'//new_line('a'), &
+            '           2'//new_line('a')// &
+            '           4'//new_line('a')// &
+            '          10'//new_line('a')// &
+            '           4'//new_line('a')// &
+            '           1'//new_line('a')// &
+            '           1'//new_line('a')// &
+            '           4'//new_line('a')// &
+            '          10'//new_line('a'), &
             '/tmp/ffc_session_array_intrinsics_test')
     end function test_rank2_array_intrinsics
 

--- a/test/test_session_array_product_compiler.f90
+++ b/test/test_session_array_product_compiler.f90
@@ -17,11 +17,11 @@ contains
 
     logical function test_rank1_product()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(1:4)'//new_line('a')// &
-                                       '  a = [2, 3, 4, 5]'//new_line('a')// &
-                                       '  print *, product(a)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(1:4)'//new_line('a')// &
+            '  a = [2, 3, 4, 5]'//new_line('a')// &
+            '  print *, product(a)'//new_line('a')// &
+            'end program main'
 
         test_rank1_product = expect_output( &
             source, '         120'//new_line('a'), &
@@ -30,11 +30,11 @@ contains
 
     logical function test_rank2_product()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(1:2, 1:2)'//new_line('a')// &
-                                       '  a = [1, 2, 3, 4]'//new_line('a')// &
-                                       '  print *, product(a)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(1:2, 1:2)'//new_line('a')// &
+            '  a = [1, 2, 3, 4]'//new_line('a')// &
+            '  print *, product(a)'//new_line('a')// &
+            'end program main'
 
         test_rank2_product = expect_output( &
             source, '          24'//new_line('a'), &

--- a/test/test_session_array_section_compiler.f90
+++ b/test/test_session_array_section_compiler.f90
@@ -22,51 +22,51 @@ contains
 
     logical function test_print_section()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(1:4)'//new_line('a')// &
-                                       '  integer :: b(0:1, 2:3)'//new_line('a')// &
-                                       '  a = [1, 2, 3, 4]'//new_line('a')// &
-                                       '  b = [5, 6, 7, 8]'//new_line('a')// &
-                                       '  print *, a(2:3)'//new_line('a')// &
-                                       '  print *, b(0:1, 3:3)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(1:4)'//new_line('a')// &
+            '  integer :: b(0:1, 2:3)'//new_line('a')// &
+            '  a = [1, 2, 3, 4]'//new_line('a')// &
+            '  b = [5, 6, 7, 8]'//new_line('a')// &
+            '  print *, a(2:3)'//new_line('a')// &
+            '  print *, b(0:1, 3:3)'//new_line('a')// &
+            'end program main'
 
         test_print_section = expect_output( &
             source, '           2           3'//new_line('a')// &
-                    '           7           8'//new_line('a'), &
+            '           7           8'//new_line('a'), &
             '/tmp/ffc_session_array_section_print_test')
     end function test_print_section
 
     logical function test_copy_section()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(1:4)'//new_line('a')// &
-                                       '  integer :: c(2)'//new_line('a')// &
-                                       '  integer :: b(0:1, 2:3)'//new_line('a')// &
-                                       '  integer :: d(0:1, 3:3)'//new_line('a')// &
-                                       '  a = [1, 2, 3, 4]'//new_line('a')// &
-                                       '  b = [5, 6, 7, 8]'//new_line('a')// &
-                                       '  c = a(2:3)'//new_line('a')// &
-                                       '  d = b(0:1, 3:3)'//new_line('a')// &
-                                       '  print *, c(1) + c(2)'//new_line('a')// &
-                                       '  print *, d(0, 3) + d(1, 3)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(1:4)'//new_line('a')// &
+            '  integer :: c(2)'//new_line('a')// &
+            '  integer :: b(0:1, 2:3)'//new_line('a')// &
+            '  integer :: d(0:1, 3:3)'//new_line('a')// &
+            '  a = [1, 2, 3, 4]'//new_line('a')// &
+            '  b = [5, 6, 7, 8]'//new_line('a')// &
+            '  c = a(2:3)'//new_line('a')// &
+            '  d = b(0:1, 3:3)'//new_line('a')// &
+            '  print *, c(1) + c(2)'//new_line('a')// &
+            '  print *, d(0, 3) + d(1, 3)'//new_line('a')// &
+            'end program main'
 
         test_copy_section = expect_output( &
             source, '           5'//new_line('a')// &
-                    '          15'//new_line('a'), &
+            '          15'//new_line('a'), &
             '/tmp/ffc_session_array_section_copy_test')
     end function test_copy_section
 
     logical function test_whole_array_copy()
         ! b = a(2:4): whole-array assignment from a rank-1 integer section.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(4), b(3)'//new_line('a')// &
-                                       '  a = [1, 2, 3, 4]'//new_line('a')// &
-                                       '  b = a(2:4)'//new_line('a')// &
-                                       '  print *, b'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(4), b(3)'//new_line('a')// &
+            '  a = [1, 2, 3, 4]'//new_line('a')// &
+            '  b = a(2:4)'//new_line('a')// &
+            '  print *, b'//new_line('a')// &
+            'end program main'
 
         test_whole_array_copy = expect_output( &
             source, '           2           3           4'//new_line('a'), &
@@ -76,13 +76,13 @@ contains
     logical function test_elementwise_sections()
         ! c = a(1:3) + d(2:4): elementwise op between two conformable sections.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(4), d(4), c(3)'//new_line('a')// &
-                                       '  a = [10, 20, 30, 40]'//new_line('a')// &
-                                       '  d = [1, 2, 3, 4]'//new_line('a')// &
-                                       '  c = a(1:3) + d(2:4)'//new_line('a')// &
-                                       '  print *, c'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(4), d(4), c(3)'//new_line('a')// &
+            '  a = [10, 20, 30, 40]'//new_line('a')// &
+            '  d = [1, 2, 3, 4]'//new_line('a')// &
+            '  c = a(1:3) + d(2:4)'//new_line('a')// &
+            '  print *, c'//new_line('a')// &
+            'end program main'
 
         test_elementwise_sections = expect_output( &
             source, '          12          23          34'//new_line('a'), &
@@ -92,11 +92,11 @@ contains
     logical function test_sum_section()
         ! sum(a(lo:hi)) reduces over the section extent only.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(6)'//new_line('a')// &
-                                       '  a = [1, 2, 3, 4, 5, 6]'//new_line('a')// &
-                                       '  print *, sum(a(2:5))'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(6)'//new_line('a')// &
+            '  a = [1, 2, 3, 4, 5, 6]'//new_line('a')// &
+            '  print *, sum(a(2:5))'//new_line('a')// &
+            'end program main'
 
         test_sum_section = expect_output( &
             source, '          14'//new_line('a'), &
@@ -106,11 +106,11 @@ contains
     logical function test_section_after_string()
         ! 'tag', a(lo:hi): a section among other list-directed print items.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(5)'//new_line('a')// &
-                                       '  a = [1, 2, 3, 4, 5]'//new_line('a')// &
-                                       "  print *, 'vals:', a(2:4)"//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(5)'//new_line('a')// &
+            '  a = [1, 2, 3, 4, 5]'//new_line('a')// &
+            "  print *, 'vals:', a(2:4)"//new_line('a')// &
+            'end program main'
 
         test_section_after_string = expect_output( &
             source, ' vals:           2           3           4'//new_line('a'), &

--- a/test/test_session_array_unsupported_diagnostics.f90
+++ b/test/test_session_array_unsupported_diagnostics.f90
@@ -1,7 +1,7 @@
 program test_session_array_unsupported_diagnostics
     use ffc_test_support, only: expect_error_contains, &
-                                expect_cli_error_contains, expect_no_error, &
-                                expect_cli_no_error
+        expect_cli_error_contains, expect_no_error, &
+        expect_cli_no_error
     implicit none
 
     logical :: all_passed
@@ -42,201 +42,201 @@ contains
 
     logical function test_array_rank3_declaration_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(2, 2, 2)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(2, 2, 2)'//new_line('a')// &
+            'end program main'
 
         test_array_rank3_declaration_diagnostic = expect_error_contains( &
-                                            source, 'unsupported array declaration', &
-                                            '/tmp/ffc_session_array_diagnostic_test')
+            source, 'unsupported array declaration', &
+            '/tmp/ffc_session_array_diagnostic_test')
     end function test_array_rank3_declaration_diagnostic
 
     logical function test_array_zero_extent_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(0)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(0)'//new_line('a')// &
+            'end program main'
 
         test_array_zero_extent_diagnostic = expect_error_contains( &
-                                            source, 'non-positive extent', &
-                                            '/tmp/ffc_session_array_zero_test')
+            source, 'non-positive extent', &
+            '/tmp/ffc_session_array_zero_test')
     end function test_array_zero_extent_diagnostic
 
     logical function test_array_reversed_extent_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(2:1)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(2:1)'//new_line('a')// &
+            'end program main'
 
         test_array_reversed_extent_diagnostic = expect_error_contains( &
-                                                source, 'non-positive extent', &
-                                                '/tmp/ffc_session_array_reversed_test')
+            source, 'non-positive extent', &
+            '/tmp/ffc_session_array_reversed_test')
     end function test_array_reversed_extent_diagnostic
 
     logical function test_noninteger_array_declaration_diagnostic()
         ! real(4) arrays are now supported; verify no diagnostic.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  real :: values(3)'//new_line('a')// &
-                                       '  values = 1.0'//new_line('a')// &
-                                       '  print *, values(1)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  real :: values(3)'//new_line('a')// &
+            '  values = 1.0'//new_line('a')// &
+            '  print *, values(1)'//new_line('a')// &
+            'end program main'
 
         test_noninteger_array_declaration_diagnostic = expect_no_error( &
-                                                     source, &
-                                                     '/tmp/ffc_session_real_array_test')
+            source, &
+            '/tmp/ffc_session_real_array_test')
     end function test_noninteger_array_declaration_diagnostic
 
     logical function test_array_assignment_target_diagnostic()
         character(len=*), parameter :: expected = &
-                                       'unsupported array assignment target'
+            'unsupported array assignment target'
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(3)'//new_line('a')// &
-                                       '  values(1, 1) = 1'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            '  values(1, 1) = 1'//new_line('a')// &
+            'end program main'
 
         test_array_assignment_target_diagnostic = &
             expect_error_contains(source, expected, &
-                                  '/tmp/ffc_session_array_target_test')
+            '/tmp/ffc_session_array_target_test')
     end function test_array_assignment_target_diagnostic
 
     logical function test_array_expression_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(3)'//new_line('a')// &
-                                       '  print *, values(1, 1)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            '  print *, values(1, 1)'//new_line('a')// &
+            'end program main'
 
         test_array_expression_diagnostic = expect_error_contains( &
-                                           source, 'array expression', &
-                                           '/tmp/ffc_session_array_expr_test')
+            source, 'array expression', &
+            '/tmp/ffc_session_array_expr_test')
     end function test_array_expression_diagnostic
 
     logical function test_whole_array_expression_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(3)'//new_line('a')// &
-                                       '  print *, values'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            '  print *, values'//new_line('a')// &
+            'end program main'
 
         ! Whole-array list-directed print of an integer array is now supported
         ! (one element print per slot); verify it lowers without a diagnostic.
         test_whole_array_expression_diagnostic = expect_no_error( &
-                                               source, &
-                                               '/tmp/ffc_session_whole_array_expr_test')
+            source, &
+            '/tmp/ffc_session_whole_array_expr_test')
     end function test_whole_array_expression_diagnostic
 
     logical function test_array_rhs_assignment_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(3)'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = values'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = values'//new_line('a')// &
+            'end program main'
 
         test_array_rhs_assignment_diagnostic = expect_error_contains( &
-                                               source, 'unsupported array expression', &
-                                           '/tmp/ffc_session_array_rhs_assignment_test')
+            source, 'unsupported array expression', &
+            '/tmp/ffc_session_array_rhs_assignment_test')
     end function test_array_rhs_assignment_diagnostic
 
     logical function test_array_slice_subscript_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(3)'//new_line('a')// &
-                                       '  print *, values(1:2, 3:4)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            '  print *, values(1:2, 3:4)'//new_line('a')// &
+            'end program main'
 
         test_array_slice_subscript_diagnostic = expect_error_contains( &
-                                                source, 'too many subscripts', &
-                                                '/tmp/ffc_session_array_slice_test')
+            source, 'too many subscripts', &
+            '/tmp/ffc_session_array_slice_test')
     end function test_array_slice_subscript_diagnostic
 
     logical function test_array_real_subscript_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(3)'//new_line('a')// &
-                                       '  print *, values(1.0)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            '  print *, values(1.0)'//new_line('a')// &
+            'end program main'
 
         test_array_real_subscript_diagnostic = expect_error_contains( &
-                                               source, 'unsupported array subscript', &
-                                               '/tmp/ffc_session_array_real_index_test')
+            source, 'unsupported array subscript', &
+            '/tmp/ffc_session_array_real_index_test')
     end function test_array_real_subscript_diagnostic
 
     logical function test_whole_array_assignment_target_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(3)'//new_line('a')// &
-                                       '  values = 4'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            '  values = 4'//new_line('a')// &
+            'end program main'
 
         ! Scalar broadcast to a whole integer array (values = 4) is supported;
         ! verify it lowers without a diagnostic.
         test_whole_array_assignment_target_diagnostic = expect_no_error( &
-                                        source, &
-                                         '/tmp/ffc_session_whole_array_assignment_test')
+            source, &
+            '/tmp/ffc_session_whole_array_assignment_test')
     end function test_whole_array_assignment_target_diagnostic
 
     logical function test_whole_array_argument_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(1)'//new_line('a')// &
-                                       '  values(1) = 1'//new_line('a')// &
-                                       '  call bump(values)'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine bump(x)'//new_line('a')// &
-                                       '    integer :: x'//new_line('a')// &
-                                       '    x = x + 4'//new_line('a')// &
-                                       '  end subroutine bump'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(1)'//new_line('a')// &
+            '  values(1) = 1'//new_line('a')// &
+            '  call bump(values)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine bump(x)'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '    x = x + 4'//new_line('a')// &
+            '  end subroutine bump'//new_line('a')// &
+            'end program main'
 
         test_whole_array_argument_diagnostic = expect_error_contains( &
-                                               source, 'unsupported array argument', &
-                                               '/tmp/ffc_session_array_arg_test')
+            source, 'unsupported array argument', &
+            '/tmp/ffc_session_array_arg_test')
     end function test_whole_array_argument_diagnostic
 
     logical function test_cli_array_rank3_declaration_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(2, 2, 2)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(2, 2, 2)'//new_line('a')// &
+            'end program main'
 
         test_cli_array_rank3_declaration_diagnostic = expect_cli_error_contains( &
-                                              source, 'unsupported array declaration', &
-                                                '/tmp/ffc_cli_array_diagnostic_test')
+            source, 'unsupported array declaration', &
+            '/tmp/ffc_cli_array_diagnostic_test')
     end function test_cli_array_rank3_declaration_diagnostic
 
     logical function test_cli_array_zero_extent_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(0)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(0)'//new_line('a')// &
+            'end program main'
 
         test_cli_array_zero_extent_diagnostic = expect_cli_error_contains( &
-                                                source, 'non-positive extent', &
-                                                '/tmp/ffc_cli_array_zero_test')
+            source, 'non-positive extent', &
+            '/tmp/ffc_cli_array_zero_test')
     end function test_cli_array_zero_extent_diagnostic
 
     logical function test_cli_array_reversed_extent_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(2:1)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(2:1)'//new_line('a')// &
+            'end program main'
 
         test_cli_array_reversed_extent_diagnostic = expect_cli_error_contains( &
-                                                    source, 'non-positive extent', &
-                                                    '/tmp/ffc_cli_array_reversed_test')
+            source, 'non-positive extent', &
+            '/tmp/ffc_cli_array_reversed_test')
     end function test_cli_array_reversed_extent_diagnostic
 
     logical function test_cli_noninteger_array_declaration_diagnostic()
         ! real(4) arrays are now supported; verify no diagnostic.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  real :: values(3)'//new_line('a')// &
-                                       '  values = 1.0'//new_line('a')// &
-                                       '  print *, values(1)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  real :: values(3)'//new_line('a')// &
+            '  values = 1.0'//new_line('a')// &
+            '  print *, values(1)'//new_line('a')// &
+            'end program main'
 
         test_cli_noninteger_array_declaration_diagnostic = &
             expect_cli_no_error(source, '/tmp/ffc_cli_real_array_test')
@@ -244,85 +244,85 @@ contains
 
     logical function test_cli_array_assignment_target_diagnostic()
         character(len=*), parameter :: expected = &
-                                       'unsupported array assignment target'
+            'unsupported array assignment target'
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(3)'//new_line('a')// &
-                                       '  values(1, 1) = 1'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            '  values(1, 1) = 1'//new_line('a')// &
+            'end program main'
 
         test_cli_array_assignment_target_diagnostic = &
             expect_cli_error_contains(source, expected, &
-                                      '/tmp/ffc_cli_array_target_test')
+            '/tmp/ffc_cli_array_target_test')
     end function test_cli_array_assignment_target_diagnostic
 
     logical function test_cli_array_expression_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(3)'//new_line('a')// &
-                                       '  print *, values(1, 1)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            '  print *, values(1, 1)'//new_line('a')// &
+            'end program main'
 
         test_cli_array_expression_diagnostic = expect_cli_error_contains( &
-                                               source, 'array expression', &
-                                               '/tmp/ffc_cli_array_expr_test')
+            source, 'array expression', &
+            '/tmp/ffc_cli_array_expr_test')
     end function test_cli_array_expression_diagnostic
 
 
     logical function test_cli_array_rhs_assignment_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(3)'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = values'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = values'//new_line('a')// &
+            'end program main'
 
         test_cli_array_rhs_assignment_diagnostic = expect_cli_error_contains( &
-                                               source, 'unsupported array expression', &
-                                               '/tmp/ffc_cli_array_rhs_assignment_test')
+            source, 'unsupported array expression', &
+            '/tmp/ffc_cli_array_rhs_assignment_test')
     end function test_cli_array_rhs_assignment_diagnostic
 
     logical function test_cli_array_slice_subscript_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(3)'//new_line('a')// &
-                                       '  print *, values(1:2, 3:4)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            '  print *, values(1:2, 3:4)'//new_line('a')// &
+            'end program main'
 
         test_cli_array_slice_subscript_diagnostic = expect_cli_error_contains( &
-                                                source, 'too many subscripts', &
-                                                    '/tmp/ffc_cli_array_slice_test')
+            source, 'too many subscripts', &
+            '/tmp/ffc_cli_array_slice_test')
     end function test_cli_array_slice_subscript_diagnostic
 
     logical function test_cli_array_real_subscript_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(3)'//new_line('a')// &
-                                       '  print *, values(1.0)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(3)'//new_line('a')// &
+            '  print *, values(1.0)'//new_line('a')// &
+            'end program main'
 
         test_cli_array_real_subscript_diagnostic = expect_cli_error_contains( &
-                                                source, 'unsupported array subscript', &
-                                                   '/tmp/ffc_cli_array_real_index_test')
+            source, 'unsupported array subscript', &
+            '/tmp/ffc_cli_array_real_index_test')
     end function test_cli_array_real_subscript_diagnostic
 
 
     logical function test_cli_whole_array_argument_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(1)'//new_line('a')// &
-                                       '  values(1) = 1'//new_line('a')// &
-                                       '  call bump(values)'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine bump(x)'//new_line('a')// &
-                                       '    integer :: x'//new_line('a')// &
-                                       '    x = x + 4'//new_line('a')// &
-                                       '  end subroutine bump'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(1)'//new_line('a')// &
+            '  values(1) = 1'//new_line('a')// &
+            '  call bump(values)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine bump(x)'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '    x = x + 4'//new_line('a')// &
+            '  end subroutine bump'//new_line('a')// &
+            'end program main'
 
         test_cli_whole_array_argument_diagnostic = expect_cli_error_contains( &
-                                                 source, 'unsupported array argument', &
-                                                   '/tmp/ffc_cli_array_arg_test')
+            source, 'unsupported array argument', &
+            '/tmp/ffc_cli_array_arg_test')
     end function test_cli_whole_array_argument_diagnostic
 
 end program test_session_array_unsupported_diagnostics

--- a/test/test_session_associate_compiler.f90
+++ b/test/test_session_associate_compiler.f90
@@ -21,84 +21,84 @@ contains
 
     logical function test_associate_scalar_alias()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: n'//new_line('a')// &
-                                       'n = 7'//new_line('a')// &
-                                       'associate (x => n)'//new_line('a')// &
-                                       '    stop x'//new_line('a')// &
-                                       'end associate'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: n'//new_line('a')// &
+            'n = 7'//new_line('a')// &
+            'associate (x => n)'//new_line('a')// &
+            '    stop x'//new_line('a')// &
+            'end associate'//new_line('a')// &
+            'end program main'
 
         test_associate_scalar_alias = expect_exit_status( &
-                                  source, 7, &
-                                  '/tmp/ffc_session_associate_scalar')
+            source, 7, &
+            '/tmp/ffc_session_associate_scalar')
     end function test_associate_scalar_alias
 
     logical function test_associate_expression_selector()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: a'//new_line('a')// &
-                                       'integer :: b'//new_line('a')// &
-                                       'a = 3'//new_line('a')// &
-                                       'b = 5'//new_line('a')// &
-                                       'associate (s => a + b)'//new_line('a')// &
-                                       '    stop s'//new_line('a')// &
-                                       'end associate'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: a'//new_line('a')// &
+            'integer :: b'//new_line('a')// &
+            'a = 3'//new_line('a')// &
+            'b = 5'//new_line('a')// &
+            'associate (s => a + b)'//new_line('a')// &
+            '    stop s'//new_line('a')// &
+            'end associate'//new_line('a')// &
+            'end program main'
 
         test_associate_expression_selector = expect_exit_status( &
-                                  source, 8, &
-                                  '/tmp/ffc_session_associate_expr')
+            source, 8, &
+            '/tmp/ffc_session_associate_expr')
     end function test_associate_expression_selector
 
     logical function test_associate_two_names()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: p'//new_line('a')// &
-                                       'integer :: q'//new_line('a')// &
-                                       'p = 4'//new_line('a')// &
-                                       'q = 6'//new_line('a')// &
-                                       'associate (u => p, v => q)'//new_line('a')// &
-                                       '    stop u + v'//new_line('a')// &
-                                       'end associate'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: p'//new_line('a')// &
+            'integer :: q'//new_line('a')// &
+            'p = 4'//new_line('a')// &
+            'q = 6'//new_line('a')// &
+            'associate (u => p, v => q)'//new_line('a')// &
+            '    stop u + v'//new_line('a')// &
+            'end associate'//new_line('a')// &
+            'end program main'
 
         test_associate_two_names = expect_exit_status( &
-                                  source, 10, &
-                                  '/tmp/ffc_session_associate_two')
+            source, 10, &
+            '/tmp/ffc_session_associate_two')
     end function test_associate_two_names
 
     logical function test_associate_scope_drops_binding()
         ! The associate name is scoped to the construct; afterwards the original
         ! variable controls the result. Reuse the same identifier outside.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: n'//new_line('a')// &
-                                       'n = 2'//new_line('a')// &
-                                       'associate (x => n)'//new_line('a')// &
-                                       '    stop x'//new_line('a')// &
-                                       'end associate'//new_line('a')// &
-                                       'stop 99'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: n'//new_line('a')// &
+            'n = 2'//new_line('a')// &
+            'associate (x => n)'//new_line('a')// &
+            '    stop x'//new_line('a')// &
+            'end associate'//new_line('a')// &
+            'stop 99'//new_line('a')// &
+            'end program main'
 
         test_associate_scope_drops_binding = expect_exit_status( &
-                                  source, 2, &
-                                  '/tmp/ffc_session_associate_scope')
+            source, 2, &
+            '/tmp/ffc_session_associate_scope')
     end function test_associate_scope_drops_binding
 
     logical function test_associate_print_value()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: n'//new_line('a')// &
-                                       'n = 42'//new_line('a')// &
-                                       'associate (x => n)'//new_line('a')// &
-                                       '    print *, x'//new_line('a')// &
-                                       'end associate'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: n'//new_line('a')// &
+            'n = 42'//new_line('a')// &
+            'associate (x => n)'//new_line('a')// &
+            '    print *, x'//new_line('a')// &
+            'end associate'//new_line('a')// &
+            'end program main'
 
         test_associate_print_value = expect_output( &
-                                  source, '          42'//new_line('a'), &
-                                  '/tmp/ffc_session_associate_print')
+            source, '          42'//new_line('a'), &
+            '/tmp/ffc_session_associate_print')
     end function test_associate_print_value
 
     logical function test_associate_real_expr_alias()
@@ -106,20 +106,20 @@ contains
         ! be usable in a further real expression, and print correctly. This
         ! guards the f32 selector path (val * 2.0).
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'real :: val'//new_line('a')// &
-                                       'real :: out'//new_line('a')// &
-                                       'val = 3.0'//new_line('a')// &
-                                       'associate (scaled => val * 2.0)'// &
-                                       new_line('a')// &
-                                       '    out = scaled + 1.0'//new_line('a')// &
-                                       '    print *, out'//new_line('a')// &
-                                       'end associate'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'real :: val'//new_line('a')// &
+            'real :: out'//new_line('a')// &
+            'val = 3.0'//new_line('a')// &
+            'associate (scaled => val * 2.0)'// &
+            new_line('a')// &
+            '    out = scaled + 1.0'//new_line('a')// &
+            '    print *, out'//new_line('a')// &
+            'end associate'//new_line('a')// &
+            'end program main'
 
         test_associate_real_expr_alias = expect_output( &
-                                  source, '   7.00000000    '//new_line('a'), &
-                                  '/tmp/ffc_session_associate_real_expr')
+            source, '   7.00000000    '//new_line('a'), &
+            '/tmp/ffc_session_associate_real_expr')
     end function test_associate_real_expr_alias
 
 end program test_session_associate

--- a/test/test_session_block_if_compiler.f90
+++ b/test/test_session_block_if_compiler.f90
@@ -5,14 +5,14 @@ program test_session_block_if_compiler
     print *, '=== direct session block if compiler test ==='
 
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'if (2 < 3) then'//new_line('a')// &
-         '    stop 7'//new_line('a')// &
-         'else'//new_line('a')// &
-         '    stop 1'//new_line('a')// &
-         'end if'//new_line('a')// &
-         'end program main', 7, &
-         '/tmp/ffc_session_block_if_test')) stop 1
+        'program main'//new_line('a')// &
+        'if (2 < 3) then'//new_line('a')// &
+        '    stop 7'//new_line('a')// &
+        'else'//new_line('a')// &
+        '    stop 1'//new_line('a')// &
+        'end if'//new_line('a')// &
+        'end program main', 7, &
+        '/tmp/ffc_session_block_if_test')) stop 1
 
     print *, 'PASS: block IF lowers through direct LIRIC session'
 end program test_session_block_if_compiler

--- a/test/test_session_c_interop_compiler.f90
+++ b/test/test_session_c_interop_compiler.f90
@@ -8,37 +8,37 @@ program test_session_c_interop
     ! pointer; c_f_pointer(cp, p) binds p to that address so a read of p
     ! dereferences it and observes x's value (issue #2820).
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'use, intrinsic :: iso_c_binding, only: c_ptr, c_loc, c_f_pointer, '// &
-         'c_associated, c_int'//new_line('a')// &
-         'integer(c_int), target :: x'//new_line('a')// &
-         'integer(c_int), pointer :: p'//new_line('a')// &
-         'type(c_ptr) :: cp'//new_line('a')// &
-         'x = 5'//new_line('a')// &
-         'cp = c_loc(x)'//new_line('a')// &
-         'if (.not. c_associated(cp)) stop 1'//new_line('a')// &
-         'call c_f_pointer(cp, p)'//new_line('a')// &
-         'stop p'//new_line('a')// &
-         'end program main', 5, &
-         '/tmp/ffc_session_c_interop_status_test')) stop 1
+        'program main'//new_line('a')// &
+        'use, intrinsic :: iso_c_binding, only: c_ptr, c_loc, c_f_pointer, '// &
+        'c_associated, c_int'//new_line('a')// &
+        'integer(c_int), target :: x'//new_line('a')// &
+        'integer(c_int), pointer :: p'//new_line('a')// &
+        'type(c_ptr) :: cp'//new_line('a')// &
+        'x = 5'//new_line('a')// &
+        'cp = c_loc(x)'//new_line('a')// &
+        'if (.not. c_associated(cp)) stop 1'//new_line('a')// &
+        'call c_f_pointer(cp, p)'//new_line('a')// &
+        'stop p'//new_line('a')// &
+        'end program main', 5, &
+        '/tmp/ffc_session_c_interop_status_test')) stop 1
 
     ! The same round-trip prints the dereferenced value.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         'use, intrinsic :: iso_c_binding, only: c_ptr, c_loc, c_f_pointer, '// &
-         'c_associated, c_int'//new_line('a')// &
-         'integer(c_int), target :: x'//new_line('a')// &
-         'integer(c_int), pointer :: p'//new_line('a')// &
-         'type(c_ptr) :: cp'//new_line('a')// &
-         'x = 7'//new_line('a')// &
-         'cp = c_loc(x)'//new_line('a')// &
-         'if (c_associated(cp)) then'//new_line('a')// &
-         'call c_f_pointer(cp, p)'//new_line('a')// &
-         'print *, p'//new_line('a')// &
-         'end if'//new_line('a')// &
-         'end program main', &
-         '           7'//new_line('a'), &
-         '/tmp/ffc_session_c_interop_output_test')) stop 2
+        'program main'//new_line('a')// &
+        'use, intrinsic :: iso_c_binding, only: c_ptr, c_loc, c_f_pointer, '// &
+        'c_associated, c_int'//new_line('a')// &
+        'integer(c_int), target :: x'//new_line('a')// &
+        'integer(c_int), pointer :: p'//new_line('a')// &
+        'type(c_ptr) :: cp'//new_line('a')// &
+        'x = 7'//new_line('a')// &
+        'cp = c_loc(x)'//new_line('a')// &
+        'if (c_associated(cp)) then'//new_line('a')// &
+        'call c_f_pointer(cp, p)'//new_line('a')// &
+        'print *, p'//new_line('a')// &
+        'end if'//new_line('a')// &
+        'end program main', &
+        '           7'//new_line('a'), &
+        '/tmp/ffc_session_c_interop_output_test')) stop 2
 
     print *, 'PASS: c_loc / c_associated / c_f_pointer scalar round-trip'
 end program test_session_c_interop

--- a/test/test_session_character_function_result_compiler.f90
+++ b/test/test_session_character_function_result_compiler.f90
@@ -6,9 +6,9 @@ program test_session_character_function_result_compiler
     ! output must match gfortran byte-for-byte (#1614).
     use session_program_lowering, only: lower_program_to_liric_exe
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                   compiler_frontend_result_t, &
-                                   compile_frontend_from_string, &
-                                   INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
     implicit none
 
     logical :: all_passed
@@ -117,7 +117,7 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, error_msg)
+            frontend_result%root_index, exe, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', trim(stem), ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -127,7 +127,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', trim(stem), ']: gfortran rejected source'
             return
@@ -136,14 +136,14 @@ contains
         call execute_command_line(exe//' > '//ffc_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', trim(stem), ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
             return
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref// &
-                                  ' '//ffc_out//' '//ref_out)
+            ' '//ffc_out//' '//ref_out)
         matches_gfortran = .true.
     end function matches_gfortran
 

--- a/test/test_session_character_literal_print_compiler.f90
+++ b/test/test_session_character_literal_print_compiler.f90
@@ -5,10 +5,10 @@ program test_session_character_literal_print_compiler
     print *, '=== direct session character literal print compiler test ==='
 
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  print *, "hello"'//new_line('a')// &
-         'end program main', ' hello'//new_line('a'), &
-         '/tmp/ffc_session_character_literal_print_test')) stop 1
+        'program main'//new_line('a')// &
+        '  print *, "hello"'//new_line('a')// &
+        'end program main', ' hello'//new_line('a'), &
+        '/tmp/ffc_session_character_literal_print_test')) stop 1
 
     print *, 'PASS: character literal print lowers through direct LIRIC session'
 end program test_session_character_literal_print_compiler

--- a/test/test_session_command_argument_compiler.f90
+++ b/test/test_session_command_argument_compiler.f90
@@ -3,8 +3,8 @@ program test_session_command_argument_compiler
     ! compiled binaries are invoked with arguments to check the runtime
     ! behaviour against gfortran.
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                  compiler_frontend_result_t, &
-                                  compile_frontend_from_string, INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, INPUT_MODE_STANDARD
     use session_program_lowering, only: lower_program_to_liric_exe
     implicit none
 
@@ -41,7 +41,7 @@ contains
             return
         end if
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, error_msg)
+            frontend_result%root_index, exe, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL: ffc lowering failed: ', trim(error_msg)
             return
@@ -134,7 +134,7 @@ contains
 
         file_first_line_is = .false.
         open (newunit=unit, file=path, status='old', action='read', &
-              iostat=io_stat)
+            iostat=io_stat)
         if (io_stat /= 0) return
         read (unit, '(A)', iostat=io_stat) line
         close (unit)

--- a/test/test_session_complex_arith_compiler.f90
+++ b/test/test_session_complex_arith_compiler.f90
@@ -5,9 +5,9 @@ program test_session_complex_arith_compiler
     !   (a+bi)/(c+di) = ((ac+bd) + (bc-ad)i) / (c*c+d*d)
     use session_program_lowering, only: lower_program_to_liric_exe
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                   compiler_frontend_result_t, &
-                                   compile_frontend_from_string, &
-                                   INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
     implicit none
 
     logical :: all_passed
@@ -114,7 +114,7 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, error_msg)
+            frontend_result%root_index, exe, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', trim(stem), ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -124,7 +124,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', trim(stem), ']: gfortran rejected source'
             return
@@ -133,14 +133,14 @@ contains
         call execute_command_line(exe//' > '//ffc_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', trim(stem), ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
             return
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref// &
-                                  ' '//ffc_out//' '//ref_out)
+            ' '//ffc_out//' '//ref_out)
         matches_gfortran = .true.
     end function matches_gfortran
 

--- a/test/test_session_complex_compiler.f90
+++ b/test/test_session_complex_compiler.f90
@@ -3,9 +3,9 @@ program test_session_complex_compiler
     ! list-directed print match gfortran byte-for-byte (#246).
     use session_program_lowering, only: lower_program_to_liric_exe
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                   compiler_frontend_result_t, &
-                                   compile_frontend_from_string, &
-                                   INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
     implicit none
 
     logical :: all_passed
@@ -102,7 +102,7 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, error_msg)
+            frontend_result%root_index, exe, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', trim(stem), ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -112,7 +112,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', trim(stem), ']: gfortran rejected source'
             return
@@ -121,14 +121,14 @@ contains
         call execute_command_line(exe//' > '//ffc_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', trim(stem), ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
             return
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref// &
-                                  ' '//ffc_out//' '//ref_out)
+            ' '//ffc_out//' '//ref_out)
         matches_gfortran = .true.
     end function matches_gfortran
 

--- a/test/test_session_complex_function_result_compiler.f90
+++ b/test/test_session_complex_function_result_compiler.f90
@@ -3,9 +3,9 @@ program test_session_complex_function_result_compiler
     ! the sret result ABI and print byte-for-byte like gfortran (#266 E5).
     use session_program_lowering, only: lower_program_to_liric_exe
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                   compiler_frontend_result_t, &
-                                   compile_frontend_from_string, &
-                                   INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
     implicit none
 
     logical :: all_passed
@@ -84,7 +84,7 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, error_msg)
+            frontend_result%root_index, exe, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', trim(stem), ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -94,7 +94,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', trim(stem), ']: gfortran rejected source'
             return
@@ -103,14 +103,14 @@ contains
         call execute_command_line(exe//' > '//ffc_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', trim(stem), ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
             return
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref// &
-                                  ' '//ffc_out//' '//ref_out)
+            ' '//ffc_out//' '//ref_out)
         matches_gfortran = .true.
     end function matches_gfortran
 

--- a/test/test_session_complex_literal_compiler.f90
+++ b/test/test_session_complex_literal_compiler.f90
@@ -4,9 +4,9 @@ program test_session_complex_literal_compiler
     ! +/- arithmetic, and real(z)/aimag(z) extraction match gfortran exactly.
     use session_program_lowering, only: lower_program_to_liric_exe
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                   compiler_frontend_result_t, &
-                                   compile_frontend_from_string, &
-                                   INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
     implicit none
 
     logical :: all_passed
@@ -87,7 +87,7 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, error_msg)
+            frontend_result%root_index, exe, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', trim(stem), ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -97,7 +97,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', trim(stem), ']: gfortran rejected source'
             return
@@ -106,14 +106,14 @@ contains
         call execute_command_line(exe//' > '//ffc_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', trim(stem), ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
             return
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref// &
-                                  ' '//ffc_out//' '//ref_out)
+            ' '//ffc_out//' '//ref_out)
         matches_gfortran = .true.
     end function matches_gfortran
 

--- a/test/test_session_deferred_char_compiler.f90
+++ b/test/test_session_deferred_char_compiler.f90
@@ -128,7 +128,7 @@ contains
 
         test_two_deferred_characters_get_independent_descriptors = &
             expect_exit_status( &
-                source, 0, '/tmp/ffc_session_deferred_two_decl_test')
+            source, 0, '/tmp/ffc_session_deferred_two_decl_test')
     end function test_two_deferred_characters_get_independent_descriptors
 
     logical function test_deferred_literal_assignment_sets_length()

--- a/test/test_session_derived_type_compiler.f90
+++ b/test/test_session_derived_type_compiler.f90
@@ -1,6 +1,6 @@
 program test_session_derived_type_compiler
     use ffc_test_support, only: expect_exit_status, expect_output, &
-                                expect_error_contains
+        expect_error_contains
     implicit none
 
     logical :: all_passed
@@ -107,78 +107,78 @@ contains
 
     logical function test_component_slots()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: cell_t'//new_line('a')// &
-                                       '    integer :: lo'//new_line('a')// &
-                                       '    integer :: mid'//new_line('a')// &
-                                       '    integer :: hi'//new_line('a')// &
-                                       '  end type cell_t'//new_line('a')// &
-                                       '  type(cell_t) :: node'//new_line('a')// &
-                                       '  node%lo = 4'//new_line('a')// &
-                                       '  node%mid = 6'//new_line('a')// &
-                                     '  node%hi = node%lo + node%mid'//new_line('a')// &
-                                       '  print *, node%lo + node%mid + node%hi'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: cell_t'//new_line('a')// &
+            '    integer :: lo'//new_line('a')// &
+            '    integer :: mid'//new_line('a')// &
+            '    integer :: hi'//new_line('a')// &
+            '  end type cell_t'//new_line('a')// &
+            '  type(cell_t) :: node'//new_line('a')// &
+            '  node%lo = 4'//new_line('a')// &
+            '  node%mid = 6'//new_line('a')// &
+            '  node%hi = node%lo + node%mid'//new_line('a')// &
+            '  print *, node%lo + node%mid + node%hi'// &
+            new_line('a')// &
+            'end program main'
 
         test_component_slots = expect_output(source, '          20'//new_line('a'), &
-                                             '/tmp/ffc_session_derived_slots_test')
+            '/tmp/ffc_session_derived_slots_test')
     end function test_component_slots
 
     logical function test_two_variables_do_not_alias()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: pair_t'//new_line('a')// &
-                                       '    integer :: left'//new_line('a')// &
-                                       '    integer :: right'//new_line('a')// &
-                                       '  end type pair_t'//new_line('a')// &
-                                       '  type(pair_t) :: first'//new_line('a')// &
-                                       '  type(pair_t) :: second'//new_line('a')// &
-                                       '  first%left = 3'//new_line('a')// &
-                                       '  first%right = 8'//new_line('a')// &
-                                       '  second%left = 11'//new_line('a')// &
-                                       '  second%right = 13'//new_line('a')// &
-                                       '  print *, first%left + second%right'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: pair_t'//new_line('a')// &
+            '    integer :: left'//new_line('a')// &
+            '    integer :: right'//new_line('a')// &
+            '  end type pair_t'//new_line('a')// &
+            '  type(pair_t) :: first'//new_line('a')// &
+            '  type(pair_t) :: second'//new_line('a')// &
+            '  first%left = 3'//new_line('a')// &
+            '  first%right = 8'//new_line('a')// &
+            '  second%left = 11'//new_line('a')// &
+            '  second%right = 13'//new_line('a')// &
+            '  print *, first%left + second%right'// &
+            new_line('a')// &
+            'end program main'
 
         test_two_variables_do_not_alias = expect_output( &
-                                          source, '          16'//new_line('a'), &
-                                          '/tmp/ffc_session_derived_alias_test')
+            source, '          16'//new_line('a'), &
+            '/tmp/ffc_session_derived_alias_test')
     end function test_two_variables_do_not_alias
 
     logical function test_component_stop_code()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: status_t'//new_line('a')// &
-                                       '    integer :: code'//new_line('a')// &
-                                       '  end type status_t'//new_line('a')// &
-                                       '  type(status_t) :: result'//new_line('a')// &
-                                       '  result%code = 7'//new_line('a')// &
-                                       '  stop result%code'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: status_t'//new_line('a')// &
+            '    integer :: code'//new_line('a')// &
+            '  end type status_t'//new_line('a')// &
+            '  type(status_t) :: result'//new_line('a')// &
+            '  result%code = 7'//new_line('a')// &
+            '  stop result%code'//new_line('a')// &
+            'end program main'
 
         test_component_stop_code = expect_exit_status( &
-                                   source, 7, &
-                                   '/tmp/ffc_session_derived_stop_test')
+            source, 7, &
+            '/tmp/ffc_session_derived_stop_test')
     end function test_component_stop_code
 
     logical function test_real_component_diagnostic()
         ! Real scalar components round-trip through the i32-slot layout: store a
         ! real value and print it back with the real format.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: sample_t'//new_line('a')// &
-                                       '    real :: value'//new_line('a')// &
-                                       '  end type sample_t'//new_line('a')// &
-                                       '  type(sample_t) :: s'//new_line('a')// &
-                                       '  s%value = 7.0'//new_line('a')// &
-                                       '  print *, s%value'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: sample_t'//new_line('a')// &
+            '    real :: value'//new_line('a')// &
+            '  end type sample_t'//new_line('a')// &
+            '  type(sample_t) :: s'//new_line('a')// &
+            '  s%value = 7.0'//new_line('a')// &
+            '  print *, s%value'//new_line('a')// &
+            'end program main'
 
         test_real_component_diagnostic = expect_output( &
-                                         source, '   7.00000000    '//new_line('a'), &
-                                         '/tmp/ffc_session_derived_real_test')
+            source, '   7.00000000    '//new_line('a'), &
+            '/tmp/ffc_session_derived_real_test')
     end function test_real_component_diagnostic
 
     logical function test_nested_component_access()
@@ -186,99 +186,99 @@ contains
         ! slot layout; x%inner%value reads and writes through the cumulative
         ! slot offset.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: inner_t'//new_line('a')// &
-                                       '    integer :: value'//new_line('a')// &
-                                       '  end type inner_t'//new_line('a')// &
-                                       '  type :: outer_t'//new_line('a')// &
-                                       '    type(inner_t) :: inner'//new_line('a')// &
-                                       '    integer :: tag'//new_line('a')// &
-                                       '  end type outer_t'//new_line('a')// &
-                                       '  type(outer_t) :: obj'//new_line('a')// &
-                                       '  obj%inner%value = 42'//new_line('a')// &
-                                       '  obj%tag = 7'//new_line('a')// &
-                                       '  print *, obj%inner%value + obj%tag'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: inner_t'//new_line('a')// &
+            '    integer :: value'//new_line('a')// &
+            '  end type inner_t'//new_line('a')// &
+            '  type :: outer_t'//new_line('a')// &
+            '    type(inner_t) :: inner'//new_line('a')// &
+            '    integer :: tag'//new_line('a')// &
+            '  end type outer_t'//new_line('a')// &
+            '  type(outer_t) :: obj'//new_line('a')// &
+            '  obj%inner%value = 42'//new_line('a')// &
+            '  obj%tag = 7'//new_line('a')// &
+            '  print *, obj%inner%value + obj%tag'// &
+            new_line('a')// &
+            'end program main'
 
         test_nested_component_access = expect_output( &
-                                       source, '          49'//new_line('a'), &
-                                       '/tmp/ffc_session_derived_nested_test')
+            source, '          49'//new_line('a'), &
+            '/tmp/ffc_session_derived_nested_test')
     end function test_nested_component_access
 
     logical function test_constructor_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: item_t'//new_line('a')// &
-                                       '    integer :: count'//new_line('a')// &
-                                       '  end type item_t'//new_line('a')// &
-                                       '  type(item_t) :: item'//new_line('a')// &
-                                       '  item = item_t(4)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: item_t'//new_line('a')// &
+            '    integer :: count'//new_line('a')// &
+            '  end type item_t'//new_line('a')// &
+            '  type(item_t) :: item'//new_line('a')// &
+            '  item = item_t(4)'//new_line('a')// &
+            'end program main'
 
         test_constructor_diagnostic = expect_error_contains( &
-                                      source, 'unsupported derived type constructor', &
-                                      '/tmp/ffc_session_derived_constructor_test')
+            source, 'unsupported derived type constructor', &
+            '/tmp/ffc_session_derived_constructor_test')
     end function test_constructor_diagnostic
 
     logical function test_inheritance_parent_component()
         ! A child that extends a parent inherits the parent's component; the
         ! parent component is reachable on a child instance (#248 B6a).
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: base_t'//new_line('a')// &
-                                       '    integer :: code'//new_line('a')// &
-                                       '  end type base_t'//new_line('a')// &
-                                       '  type, extends(base_t) :: child_t'// &
-                                       new_line('a')// &
-                                       '    integer :: extra'//new_line('a')// &
-                                       '  end type child_t'//new_line('a')// &
-                                       '  type(child_t) :: c'//new_line('a')// &
-                                       '  c%code = 6'//new_line('a')// &
-                                       '  c%extra = 3'//new_line('a')// &
-                                       '  stop c%code + c%extra'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: base_t'//new_line('a')// &
+            '    integer :: code'//new_line('a')// &
+            '  end type base_t'//new_line('a')// &
+            '  type, extends(base_t) :: child_t'// &
+            new_line('a')// &
+            '    integer :: extra'//new_line('a')// &
+            '  end type child_t'//new_line('a')// &
+            '  type(child_t) :: c'//new_line('a')// &
+            '  c%code = 6'//new_line('a')// &
+            '  c%extra = 3'//new_line('a')// &
+            '  stop c%code + c%extra'//new_line('a')// &
+            'end program main'
 
         test_inheritance_parent_component = expect_exit_status( &
-                                      source, 9, &
-                                      '/tmp/ffc_session_derived_extends_test')
+            source, 9, &
+            '/tmp/ffc_session_derived_extends_test')
     end function test_inheritance_parent_component
 
     logical function test_type_bound_binding_compiles()
         ! A plain procedure binding is recorded (not yet lowered as a call,
         ! #146), so a type carrying one compiles and its data is usable.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: counter_t'//new_line('a')// &
-                                       '    integer :: n'//new_line('a')// &
-                                       '  contains'//new_line('a')// &
-                                       '    procedure :: bump => bump_impl'// &
-                                       new_line('a')// &
-                                       '  end type counter_t'//new_line('a')// &
-                                       '  type(counter_t) :: c'//new_line('a')// &
-                                       '  c%n = 5'//new_line('a')// &
-                                       '  stop c%n'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine bump_impl(x)'//new_line('a')// &
-                                       '    integer :: x'//new_line('a')// &
-                                       '    x = x + 1'//new_line('a')// &
-                                       '  end subroutine bump_impl'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: counter_t'//new_line('a')// &
+            '    integer :: n'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: bump => bump_impl'// &
+            new_line('a')// &
+            '  end type counter_t'//new_line('a')// &
+            '  type(counter_t) :: c'//new_line('a')// &
+            '  c%n = 5'//new_line('a')// &
+            '  stop c%n'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine bump_impl(x)'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '    x = x + 1'//new_line('a')// &
+            '  end subroutine bump_impl'//new_line('a')// &
+            'end program main'
 
         test_type_bound_binding_compiles = expect_exit_status( &
-                                     source, 5, &
-                                     '/tmp/ffc_session_derived_bound_test')
+            source, 5, &
+            '/tmp/ffc_session_derived_bound_test')
     end function test_type_bound_binding_compiles
 
     logical function test_component_default_initialiser()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: t'//new_line('a')// &
-                                       '    integer :: x = 5'//new_line('a')// &
-                                       '  end type t'//new_line('a')// &
-                                       '  type(t) :: a'//new_line('a')// &
-                                       '  stop a%x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: t'//new_line('a')// &
+            '    integer :: x = 5'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            '  type(t) :: a'//new_line('a')// &
+            '  stop a%x'//new_line('a')// &
+            'end program main'
 
         test_component_default_initialiser = expect_exit_status( &
             source, 5, '/tmp/ffc_session_comp_default_test')
@@ -286,15 +286,15 @@ contains
 
     logical function test_component_default_overridden()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: t'//new_line('a')// &
-                                       '    integer :: x = 5'//new_line('a')// &
-                                       '    integer :: y = 10'//new_line('a')// &
-                                       '  end type t'//new_line('a')// &
-                                       '  type(t) :: a'//new_line('a')// &
-                                       '  a%x = 1'//new_line('a')// &
-                                       '  stop a%x + a%y'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: t'//new_line('a')// &
+            '    integer :: x = 5'//new_line('a')// &
+            '    integer :: y = 10'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            '  type(t) :: a'//new_line('a')// &
+            '  a%x = 1'//new_line('a')// &
+            '  stop a%x + a%y'//new_line('a')// &
+            'end program main'
 
         ! x overridden to 1, y keeps its default 10 -> 11
         test_component_default_overridden = expect_exit_status( &
@@ -303,16 +303,16 @@ contains
 
     logical function test_array_component_assignment_and_read()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: t'//new_line('a')// &
-                                       '    integer :: a(3)'//new_line('a')// &
-                                       '  end type t'//new_line('a')// &
-                                       '  type(t) :: x'//new_line('a')// &
-                                       '  x%a(1) = 7'//new_line('a')// &
-                                       '  x%a(2) = 8'//new_line('a')// &
-                                       '  x%a(3) = 9'//new_line('a')// &
-                                       '  stop x%a(2)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: t'//new_line('a')// &
+            '    integer :: a(3)'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            '  type(t) :: x'//new_line('a')// &
+            '  x%a(1) = 7'//new_line('a')// &
+            '  x%a(2) = 8'//new_line('a')// &
+            '  x%a(3) = 9'//new_line('a')// &
+            '  stop x%a(2)'//new_line('a')// &
+            'end program main'
 
         test_array_component_assignment_and_read = expect_exit_status( &
             source, 8, '/tmp/ffc_session_arraycomp_test')
@@ -320,17 +320,17 @@ contains
 
     logical function test_array_component_with_parameter_size()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer, parameter :: n = 3'// &
-                                       new_line('a')// &
-                                       '  type :: t'//new_line('a')// &
-                                       '    integer :: a(n)'//new_line('a')// &
-                                       '  end type t'//new_line('a')// &
-                                       '  type(t) :: x'//new_line('a')// &
-                                       '  x%a(1) = 4'//new_line('a')// &
-                                       '  x%a(3) = 6'//new_line('a')// &
-                                       '  stop x%a(1) + x%a(3)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer, parameter :: n = 3'// &
+            new_line('a')// &
+            '  type :: t'//new_line('a')// &
+            '    integer :: a(n)'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            '  type(t) :: x'//new_line('a')// &
+            '  x%a(1) = 4'//new_line('a')// &
+            '  x%a(3) = 6'//new_line('a')// &
+            '  stop x%a(1) + x%a(3)'//new_line('a')// &
+            'end program main'
 
         test_array_component_with_parameter_size = expect_exit_status( &
             source, 10, '/tmp/ffc_session_arraycomp_param_test')
@@ -338,17 +338,17 @@ contains
 
     logical function test_array_component_mixed_with_scalar()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: t'//new_line('a')// &
-                                       '    integer :: a(2)'//new_line('a')// &
-                                       '    integer :: s'//new_line('a')// &
-                                       '  end type t'//new_line('a')// &
-                                       '  type(t) :: x'//new_line('a')// &
-                                       '  x%a(1) = 1'//new_line('a')// &
-                                       '  x%a(2) = 2'//new_line('a')// &
-                                       '  x%s = 100'//new_line('a')// &
-                                       '  stop x%a(1) + x%a(2) + x%s'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: t'//new_line('a')// &
+            '    integer :: a(2)'//new_line('a')// &
+            '    integer :: s'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            '  type(t) :: x'//new_line('a')// &
+            '  x%a(1) = 1'//new_line('a')// &
+            '  x%a(2) = 2'//new_line('a')// &
+            '  x%s = 100'//new_line('a')// &
+            '  stop x%a(1) + x%a(2) + x%s'//new_line('a')// &
+            'end program main'
 
         test_array_component_mixed_with_scalar = expect_exit_status( &
             source, 103, '/tmp/ffc_session_arraycomp_mixed_test')
@@ -356,22 +356,22 @@ contains
 
     logical function test_function_returns_derived()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: point_t'//new_line('a')// &
-                                       '    integer :: x'//new_line('a')// &
-                                       '    integer :: y'//new_line('a')// &
-                                       '  end type point_t'//new_line('a')// &
-                                       '  type(point_t) :: q'//new_line('a')// &
-                                       '  q = make_point()'//new_line('a')// &
-                                       '  stop q%x + q%y'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  function make_point() result(p)'// &
-                                       new_line('a')// &
-                                       '    type(point_t) :: p'//new_line('a')// &
-                                       '    p%x = 1'//new_line('a')// &
-                                       '    p%y = 2'//new_line('a')// &
-                                       '  end function make_point'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: point_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '    integer :: y'//new_line('a')// &
+            '  end type point_t'//new_line('a')// &
+            '  type(point_t) :: q'//new_line('a')// &
+            '  q = make_point()'//new_line('a')// &
+            '  stop q%x + q%y'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  function make_point() result(p)'// &
+            new_line('a')// &
+            '    type(point_t) :: p'//new_line('a')// &
+            '    p%x = 1'//new_line('a')// &
+            '    p%y = 2'//new_line('a')// &
+            '  end function make_point'//new_line('a')// &
+            'end program main'
 
         test_function_returns_derived = expect_exit_status( &
             source, 3, '/tmp/ffc_session_derived_return_test')
@@ -379,23 +379,23 @@ contains
 
     logical function test_function_returns_derived_with_arg()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: box_t'//new_line('a')// &
-                                       '    integer :: lo'//new_line('a')// &
-                                       '    integer :: hi'//new_line('a')// &
-                                       '  end type box_t'//new_line('a')// &
-                                       '  type(box_t) :: b'//new_line('a')// &
-                                       '  b = make_box(5)'//new_line('a')// &
-                                       '  stop b%lo + b%hi'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  function make_box(n) result(r)'// &
-                                       new_line('a')// &
-                                       '    integer, intent(in) :: n'//new_line('a')// &
-                                       '    type(box_t) :: r'//new_line('a')// &
-                                       '    r%lo = n'//new_line('a')// &
-                                       '    r%hi = n * 2'//new_line('a')// &
-                                       '  end function make_box'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: box_t'//new_line('a')// &
+            '    integer :: lo'//new_line('a')// &
+            '    integer :: hi'//new_line('a')// &
+            '  end type box_t'//new_line('a')// &
+            '  type(box_t) :: b'//new_line('a')// &
+            '  b = make_box(5)'//new_line('a')// &
+            '  stop b%lo + b%hi'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  function make_box(n) result(r)'// &
+            new_line('a')// &
+            '    integer, intent(in) :: n'//new_line('a')// &
+            '    type(box_t) :: r'//new_line('a')// &
+            '    r%lo = n'//new_line('a')// &
+            '    r%hi = n * 2'//new_line('a')// &
+            '  end function make_box'//new_line('a')// &
+            'end program main'
 
         ! 5 + 10 -> 15
         test_function_returns_derived_with_arg = expect_exit_status( &
@@ -404,20 +404,20 @@ contains
 
     logical function test_generic_binding_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: t'//new_line('a')// &
-                                       '    integer :: n'//new_line('a')// &
-                                       '  contains'//new_line('a')// &
-                                       '    generic :: g => f1, f2'//new_line('a')// &
-                                       '  end type t'//new_line('a')// &
-                                       '  type(t) :: x'//new_line('a')// &
-                                       '  x%n = 1'//new_line('a')// &
-                                       '  stop x%n'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: t'//new_line('a')// &
+            '    integer :: n'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    generic :: g => f1, f2'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            '  type(t) :: x'//new_line('a')// &
+            '  x%n = 1'//new_line('a')// &
+            '  stop x%n'//new_line('a')// &
+            'end program main'
 
         test_generic_binding_diagnostic = expect_error_contains( &
-                                     source, 'type-bound procedure', &
-                                     '/tmp/ffc_session_generic_bound_test')
+            source, 'type-bound procedure', &
+            '/tmp/ffc_session_generic_bound_test')
     end function test_generic_binding_diagnostic
 
 end program test_session_derived_type_compiler

--- a/test/test_session_do_while_compiler.f90
+++ b/test/test_session_do_while_compiler.f90
@@ -18,57 +18,57 @@ contains
 
     logical function test_do_while_counts_up_to_threshold()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: counter'//new_line('a')// &
-                                       'counter = 0'//new_line('a')// &
-                                       'do while (counter < 5)'//new_line('a')// &
-                                       '    counter = counter + 1'//new_line('a')// &
-                                       'end do'//new_line('a')// &
-                                       'stop counter'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: counter'//new_line('a')// &
+            'counter = 0'//new_line('a')// &
+            'do while (counter < 5)'//new_line('a')// &
+            '    counter = counter + 1'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'stop counter'//new_line('a')// &
+            'end program main'
 
         test_do_while_counts_up_to_threshold = expect_exit_status( &
-                                  source, 5, &
-                                  '/tmp/ffc_session_do_while_count_test')
+            source, 5, &
+            '/tmp/ffc_session_do_while_count_test')
     end function test_do_while_counts_up_to_threshold
 
     logical function test_do_while_zero_iterations()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: counter'//new_line('a')// &
-                                       'counter = 9'//new_line('a')// &
-                                       'do while (counter < 5)'//new_line('a')// &
-                                       '    counter = counter + 1'//new_line('a')// &
-                                       'end do'//new_line('a')// &
-                                       'stop counter'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: counter'//new_line('a')// &
+            'counter = 9'//new_line('a')// &
+            'do while (counter < 5)'//new_line('a')// &
+            '    counter = counter + 1'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'stop counter'//new_line('a')// &
+            'end program main'
 
         test_do_while_zero_iterations = expect_exit_status( &
-                                  source, 9, &
-                                  '/tmp/ffc_session_do_while_zero_test')
+            source, 9, &
+            '/tmp/ffc_session_do_while_zero_test')
     end function test_do_while_zero_iterations
 
     logical function test_do_while_logical_accumulator()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: counter'//new_line('a')// &
-                                       'logical :: seen'//new_line('a')// &
-                                       'counter = 0'//new_line('a')// &
-                                       'seen = .false.'//new_line('a')// &
-                                       'do while (counter < 3)'//new_line('a')// &
-                                       '    counter = counter + 1'//new_line('a')// &
-                                       '    seen = .true.'//new_line('a')// &
-                                       'end do'//new_line('a')// &
-                                       'if (seen) then'//new_line('a')// &
-                                       '    stop counter'//new_line('a')// &
-                                       'else'//new_line('a')// &
-                                       '    stop 0'//new_line('a')// &
-                                       'end if'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: counter'//new_line('a')// &
+            'logical :: seen'//new_line('a')// &
+            'counter = 0'//new_line('a')// &
+            'seen = .false.'//new_line('a')// &
+            'do while (counter < 3)'//new_line('a')// &
+            '    counter = counter + 1'//new_line('a')// &
+            '    seen = .true.'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'if (seen) then'//new_line('a')// &
+            '    stop counter'//new_line('a')// &
+            'else'//new_line('a')// &
+            '    stop 0'//new_line('a')// &
+            'end if'//new_line('a')// &
+            'end program main'
 
         test_do_while_logical_accumulator = expect_exit_status( &
-                                  source, 3, &
-                                  '/tmp/ffc_session_do_while_logical_test')
+            source, 3, &
+            '/tmp/ffc_session_do_while_logical_test')
     end function test_do_while_logical_accumulator
 
 end program test_session_do_while_compiler

--- a/test/test_session_e_descriptor_compiler.f90
+++ b/test/test_session_e_descriptor_compiler.f90
@@ -30,7 +30,7 @@ contains
             '    -0.1235E+05'//new_line('a')
 
         test_plain_e_descriptors = expect_output(source, expected, &
-                                                 '/tmp/ffc_fmt_e_test')
+            '/tmp/ffc_fmt_e_test')
     end function test_plain_e_descriptors
 
     logical function test_en_descriptors()
@@ -46,7 +46,7 @@ contains
             ' 123.000E-06'//new_line('a')
 
         test_en_descriptors = expect_output(source, expected, &
-                                            '/tmp/ffc_fmt_en_test')
+            '/tmp/ffc_fmt_en_test')
     end function test_en_descriptors
 
 end program test_session_e_descriptor_compiler

--- a/test/test_session_emit_fmod_compiler.f90
+++ b/test/test_session_emit_fmod_compiler.f90
@@ -1,7 +1,7 @@
 program test_session_emit_fmod_compiler
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                  compiler_frontend_result_t, &
-                                  compile_frontend_from_string, INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, INPUT_MODE_STANDARD
     use session_program_lowering, only: lower_program_to_liric_object
     implicit none
 
@@ -32,7 +32,7 @@ contains
         call execute_command_line('mkdir -p /tmp/ffc_fmod_test_consts')
         call execute_command_line('rm -f '//fmod)
         if (.not. compile_module(source, &
-                '/tmp/ffc_fmod_test_consts/consts.o')) return
+            '/tmp/ffc_fmod_test_consts/consts.o')) return
         if (.not. file_contains(fmod, 'name = "width"')) then
             print *, 'FAIL: .fmod missing parameter name'
             return
@@ -59,7 +59,7 @@ contains
         call execute_command_line('mkdir -p /tmp/ffc_fmod_test_shapes')
         call execute_command_line('rm -f '//fmod)
         if (.not. compile_module(source, &
-                '/tmp/ffc_fmod_test_shapes/shapes.o')) return
+            '/tmp/ffc_fmod_test_shapes/shapes.o')) return
         if (.not. file_contains(fmod, 'name = "point_t"')) then
             print *, 'FAIL: .fmod missing derived type name'
             return
@@ -85,7 +85,7 @@ contains
         call execute_command_line('mkdir -p /tmp/ffc_fmod_test_state')
         call execute_command_line('rm -f '//fmod)
         if (.not. compile_module(source, &
-                '/tmp/ffc_fmod_test_state/state.o')) return
+            '/tmp/ffc_fmod_test_state/state.o')) return
         if (.not. file_contains(fmod, '[[variable]]')) then
             print *, 'FAIL: .fmod missing variable section'
             return
@@ -119,8 +119,8 @@ contains
             return
         end if
         call lower_program_to_liric_object(frontend_result%arena, &
-                                           frontend_result%root_index, &
-                                           object_path, error_msg)
+            frontend_result%root_index, &
+            object_path, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL: module object lowering failed: ', trim(error_msg)
             return
@@ -136,7 +136,7 @@ contains
 
         found = .false.
         open (newunit=unit, file=path, status='old', action='read', &
-              iostat=io_stat)
+            iostat=io_stat)
         if (io_stat /= 0) then
             print *, 'FAIL: could not open ', path
             return

--- a/test/test_session_empty_program_compiler.f90
+++ b/test/test_session_empty_program_compiler.f90
@@ -5,9 +5,9 @@ program test_session_empty_program_compiler
     print *, '=== direct session empty program compiler test ==='
 
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'end program main', 0, &
-         '/tmp/ffc_session_empty_program_test')) stop 1
+        'program main'//new_line('a')// &
+        'end program main', 0, &
+        '/tmp/ffc_session_empty_program_test')) stop 1
 
     print *, 'PASS: empty program compiles and runs through direct LIRIC session'
 end program test_session_empty_program_compiler

--- a/test/test_session_empty_program_object_compiler.f90
+++ b/test/test_session_empty_program_object_compiler.f90
@@ -5,9 +5,9 @@ program test_session_empty_program_object_compiler
     print *, '=== direct session empty program object compiler test ==='
 
     if (.not. expect_object_exists( &
-         'program main'//new_line('a')// &
-         'end program main', &
-         '/tmp/ffc_session_empty_program_test.o')) stop 1
+        'program main'//new_line('a')// &
+        'end program main', &
+        '/tmp/ffc_session_empty_program_test.o')) stop 1
 
     print *, 'PASS: empty program emits object through direct LIRIC session'
 end program test_session_empty_program_object_compiler

--- a/test/test_session_enum_compiler.f90
+++ b/test/test_session_enum_compiler.f90
@@ -6,60 +6,60 @@ program test_session_enum_compiler
 
     ! Explicit initializers bind as integer named constants.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '    enum, bind(c)'//new_line('a')// &
-         '        enumerator :: RED = 1'//new_line('a')// &
-         '        enumerator :: GREEN = 2'//new_line('a')// &
-         '    end enum'//new_line('a')// &
-         '    integer :: color'//new_line('a')// &
-         '    color = RED'//new_line('a')// &
-         '    print *, color, GREEN'//new_line('a')// &
-         'end program main', &
-         '           1           2'//new_line('a'), &
-         '/tmp/ffc_session_enum_explicit_test')) stop 1
+        'program main'//new_line('a')// &
+        '    enum, bind(c)'//new_line('a')// &
+        '        enumerator :: RED = 1'//new_line('a')// &
+        '        enumerator :: GREEN = 2'//new_line('a')// &
+        '    end enum'//new_line('a')// &
+        '    integer :: color'//new_line('a')// &
+        '    color = RED'//new_line('a')// &
+        '    print *, color, GREEN'//new_line('a')// &
+        'end program main', &
+        '           1           2'//new_line('a'), &
+        '/tmp/ffc_session_enum_explicit_test')) stop 1
     print *, 'PASS: explicit enumerator values bind as constants'
 
     ! Implicit values start at 0 and increment; multiple names per line.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '    enum, bind(c)'//new_line('a')// &
-         '        enumerator :: a, b, c'//new_line('a')// &
-         '    end enum'//new_line('a')// &
-         '    print *, a, b, c'//new_line('a')// &
-         'end program main', &
-         '           0           1           2'//new_line('a'), &
-         '/tmp/ffc_session_enum_implicit_test')) stop 1
+        'program main'//new_line('a')// &
+        '    enum, bind(c)'//new_line('a')// &
+        '        enumerator :: a, b, c'//new_line('a')// &
+        '    end enum'//new_line('a')// &
+        '    print *, a, b, c'//new_line('a')// &
+        'end program main', &
+        '           0           1           2'//new_line('a'), &
+        '/tmp/ffc_session_enum_implicit_test')) stop 1
     print *, 'PASS: implicit enumerator values count from zero'
 
     ! Mixed explicit and implicit values resume from the last explicit value.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '    enum, bind(c)'//new_line('a')// &
-         '        enumerator :: x = 10, y, z = 20, w'//new_line('a')// &
-         '    end enum'//new_line('a')// &
-         '    print *, x, y, z, w'//new_line('a')// &
-         'end program main', &
-         '          10          11          20          21'//new_line('a'), &
-         '/tmp/ffc_session_enum_mixed_test')) stop 1
+        'program main'//new_line('a')// &
+        '    enum, bind(c)'//new_line('a')// &
+        '        enumerator :: x = 10, y, z = 20, w'//new_line('a')// &
+        '    end enum'//new_line('a')// &
+        '    print *, x, y, z, w'//new_line('a')// &
+        'end program main', &
+        '          10          11          20          21'//new_line('a'), &
+        '/tmp/ffc_session_enum_mixed_test')) stop 1
     print *, 'PASS: mixed enumerator values resume from explicit value'
 
     ! Enumerators work as select case selectors and in expressions.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '    enum, bind(c)'//new_line('a')// &
-         '        enumerator :: mon = 1, tue, wed'//new_line('a')// &
-         '    end enum'//new_line('a')// &
-         '    integer :: d'//new_line('a')// &
-         '    d = tue'//new_line('a')// &
-         '    select case (d)'//new_line('a')// &
-         '    case (tue)'//new_line('a')// &
-         '        print *, wed + mon'//new_line('a')// &
-         '    case default'//new_line('a')// &
-         '        print *, -1'//new_line('a')// &
-         '    end select'//new_line('a')// &
-         'end program main', &
-         '           4'//new_line('a'), &
-         '/tmp/ffc_session_enum_select_test')) stop 1
+        'program main'//new_line('a')// &
+        '    enum, bind(c)'//new_line('a')// &
+        '        enumerator :: mon = 1, tue, wed'//new_line('a')// &
+        '    end enum'//new_line('a')// &
+        '    integer :: d'//new_line('a')// &
+        '    d = tue'//new_line('a')// &
+        '    select case (d)'//new_line('a')// &
+        '    case (tue)'//new_line('a')// &
+        '        print *, wed + mon'//new_line('a')// &
+        '    case default'//new_line('a')// &
+        '        print *, -1'//new_line('a')// &
+        '    end select'//new_line('a')// &
+        'end program main', &
+        '           4'//new_line('a'), &
+        '/tmp/ffc_session_enum_select_test')) stop 1
     print *, 'PASS: enumerators drive select case and expressions'
 
     print *, 'PASS: enum/enumerator lower through direct LIRIC session'

--- a/test/test_session_fixed_size_array_compiler.f90
+++ b/test/test_session_fixed_size_array_compiler.f90
@@ -30,11 +30,11 @@ contains
 
     logical function test_array_constructor_literal()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(3)'//new_line('a')// &
-                                       '  a = [1, 2, 3]'//new_line('a')// &
-                                       '  stop a(2)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(3)'//new_line('a')// &
+            '  a = [1, 2, 3]'//new_line('a')// &
+            '  stop a(2)'//new_line('a')// &
+            'end program main'
 
         test_array_constructor_literal = expect_exit_status( &
             source, 2, '/tmp/ffc_session_array_ctor_lit_test')
@@ -42,16 +42,16 @@ contains
 
     logical function test_array_of_derived_assign_and_read()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: point_t'//new_line('a')// &
-                                       '    integer :: x'//new_line('a')// &
-                                       '    integer :: y'//new_line('a')// &
-                                       '  end type point_t'//new_line('a')// &
-                                       '  type(point_t) :: ps(3)'//new_line('a')// &
-                                       '  ps(1)%x = 7'//new_line('a')// &
-                                       '  ps(2)%y = 8'//new_line('a')// &
-                                       '  stop ps(1)%x + ps(2)%y'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: point_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '    integer :: y'//new_line('a')// &
+            '  end type point_t'//new_line('a')// &
+            '  type(point_t) :: ps(3)'//new_line('a')// &
+            '  ps(1)%x = 7'//new_line('a')// &
+            '  ps(2)%y = 8'//new_line('a')// &
+            '  stop ps(1)%x + ps(2)%y'//new_line('a')// &
+            'end program main'
 
         test_array_of_derived_assign_and_read = expect_exit_status( &
             source, 15, '/tmp/ffc_session_array_of_derived_test')
@@ -59,13 +59,13 @@ contains
 
     logical function test_array_constructor_runtime()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(3)'//new_line('a')// &
-                                       '  integer :: n'//new_line('a')// &
-                                       '  n = 5'//new_line('a')// &
-                                       '  a = [n, n * 2, n + 1]'//new_line('a')// &
-                                       '  stop a(1) + a(2) + a(3)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(3)'//new_line('a')// &
+            '  integer :: n'//new_line('a')// &
+            '  n = 5'//new_line('a')// &
+            '  a = [n, n * 2, n + 1]'//new_line('a')// &
+            '  stop a(1) + a(2) + a(3)'//new_line('a')// &
+            'end program main'
 
         ! [5, 10, 6] -> 21
         test_array_constructor_runtime = expect_exit_status( &
@@ -74,192 +74,192 @@ contains
 
     logical function test_simple_array()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(3)'//new_line('a')// &
-                                       '  a(1) = 4'//new_line('a')// &
-                                       '  a(2) = 5'//new_line('a')// &
-                                       '  print *, a(1) + a(2)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(3)'//new_line('a')// &
+            '  a(1) = 4'//new_line('a')// &
+            '  a(2) = 5'//new_line('a')// &
+            '  print *, a(1) + a(2)'//new_line('a')// &
+            'end program main'
 
         test_simple_array = expect_output(source, '           9'//new_line('a'), &
-                                          '/tmp/ffc_session_array_simple_test')
+            '/tmp/ffc_session_array_simple_test')
     end function test_simple_array
 
     logical function test_array_parameter_bound()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer, parameter :: n = 3'// &
-                                       new_line('a')// &
-                                       '  integer :: a(n)'//new_line('a')// &
-                                       '  a(1) = 2'//new_line('a')// &
-                                       '  a(n) = 7'//new_line('a')// &
-                                       '  print *, a(1) + a(n)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer, parameter :: n = 3'// &
+            new_line('a')// &
+            '  integer :: a(n)'//new_line('a')// &
+            '  a(1) = 2'//new_line('a')// &
+            '  a(n) = 7'//new_line('a')// &
+            '  print *, a(1) + a(n)'//new_line('a')// &
+            'end program main'
 
         test_array_parameter_bound = expect_output( &
-                                     source, '           9'//new_line('a'), &
-                                     '/tmp/ffc_session_array_param_bound_test')
+            source, '           9'//new_line('a'), &
+            '/tmp/ffc_session_array_param_bound_test')
     end function test_array_parameter_bound
 
     logical function test_array_explicit_bounds()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(2:4)'//new_line('a')// &
-                                       '  a(2) = 4'//new_line('a')// &
-                                       '  a(4) = 5'//new_line('a')// &
-                                       '  print *, a(2) + a(4)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(2:4)'//new_line('a')// &
+            '  a(2) = 4'//new_line('a')// &
+            '  a(4) = 5'//new_line('a')// &
+            '  print *, a(2) + a(4)'//new_line('a')// &
+            'end program main'
 
         test_array_explicit_bounds = expect_output( &
-                                     source, '           9'//new_line('a'), &
-                                     '/tmp/ffc_session_array_explicit_bounds_test')
+            source, '           9'//new_line('a'), &
+            '/tmp/ffc_session_array_explicit_bounds_test')
     end function test_array_explicit_bounds
 
     logical function test_array_negative_lower_bound()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: values(-1:1)'//new_line('a')// &
-                                       '  values(-1) = 4'//new_line('a')// &
-                                       '  values(0) = 5'//new_line('a')// &
-                                       '  values(1) = 6'//new_line('a')// &
-                                       '  print *, values(-1) + values(0) '// &
-                                       '+ values(1)'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: values(-1:1)'//new_line('a')// &
+            '  values(-1) = 4'//new_line('a')// &
+            '  values(0) = 5'//new_line('a')// &
+            '  values(1) = 6'//new_line('a')// &
+            '  print *, values(-1) + values(0) '// &
+            '+ values(1)'// &
+            new_line('a')// &
+            'end program main'
 
         test_array_negative_lower_bound = expect_output( &
-                                          source, '          15'//new_line('a'), &
-                                          '/tmp/ffc_session_array_neg_lower_test')
+            source, '          15'//new_line('a'), &
+            '/tmp/ffc_session_array_neg_lower_test')
     end function test_array_negative_lower_bound
 
     logical function test_array_with_loop()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(5)'//new_line('a')// &
-                                       '  integer :: i'//new_line('a')// &
-                                       '  integer :: sum'//new_line('a')// &
-                                       '  sum = 0'//new_line('a')// &
-                                       '  do i = 1, 5'//new_line('a')// &
-                                       '    a(i) = i'//new_line('a')// &
-                                       '    sum = sum + a(i)'//new_line('a')// &
-                                       '  end do'//new_line('a')// &
-                                       '  print *, sum'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(5)'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  integer :: sum'//new_line('a')// &
+            '  sum = 0'//new_line('a')// &
+            '  do i = 1, 5'//new_line('a')// &
+            '    a(i) = i'//new_line('a')// &
+            '    sum = sum + a(i)'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            '  print *, sum'//new_line('a')// &
+            'end program main'
 
         test_array_with_loop = expect_output(source, '          15'//new_line('a'), &
-                                             '/tmp/ffc_session_array_loop_test')
+            '/tmp/ffc_session_array_loop_test')
     end function test_array_with_loop
 
     logical function test_array_variable_subscript()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(4)'//new_line('a')// &
-                                       '  integer :: idx'//new_line('a')// &
-                                       '  a(1) = 10'//new_line('a')// &
-                                       '  a(2) = 20'//new_line('a')// &
-                                       '  a(3) = 30'//new_line('a')// &
-                                       '  idx = 2'//new_line('a')// &
-                                       '  print *, a(idx)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(4)'//new_line('a')// &
+            '  integer :: idx'//new_line('a')// &
+            '  a(1) = 10'//new_line('a')// &
+            '  a(2) = 20'//new_line('a')// &
+            '  a(3) = 30'//new_line('a')// &
+            '  idx = 2'//new_line('a')// &
+            '  print *, a(idx)'//new_line('a')// &
+            'end program main'
 
         test_array_variable_subscript = expect_output(source, '          20'//new_line('a'), &
-                                                      '/tmp/ffc_session_array_var_test')
+            '/tmp/ffc_session_array_var_test')
     end function test_array_variable_subscript
 
     logical function test_array_element_argument()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(1)'//new_line('a')// &
-                                       '  a(1) = 1'//new_line('a')// &
-                                       '  call bump(a(1))'//new_line('a')// &
-                                       '  print *, a(1)'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine bump(x)'//new_line('a')// &
-                                       '    integer :: x'//new_line('a')// &
-                                       '    x = x + 4'//new_line('a')// &
-                                       '  end subroutine bump'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(1)'//new_line('a')// &
+            '  a(1) = 1'//new_line('a')// &
+            '  call bump(a(1))'//new_line('a')// &
+            '  print *, a(1)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine bump(x)'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '    x = x + 4'//new_line('a')// &
+            '  end subroutine bump'//new_line('a')// &
+            'end program main'
 
         test_array_element_argument = expect_output( &
-                                      source, '           5'//new_line('a'), &
-                                      '/tmp/ffc_session_array_element_arg_test')
+            source, '           5'//new_line('a'), &
+            '/tmp/ffc_session_array_element_arg_test')
     end function test_array_element_argument
 
     logical function test_array_stop_code()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(2)'//new_line('a')// &
-                                       '  a(1) = 7'//new_line('a')// &
-                                       '  stop a(1)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(2)'//new_line('a')// &
+            '  a(1) = 7'//new_line('a')// &
+            '  stop a(1)'//new_line('a')// &
+            'end program main'
 
         test_array_stop_code = expect_exit_status(source, 7, &
-                                                  '/tmp/ffc_session_array_stop_test')
+            '/tmp/ffc_session_array_stop_test')
     end function test_array_stop_code
 
     logical function test_array_in_contained_subroutine()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  call fill()'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine fill()'//new_line('a')// &
-                                       '    integer :: a(2)'//new_line('a')// &
-                                       '    a(1) = 4'//new_line('a')// &
-                                       '    a(2) = 5'//new_line('a')// &
-                                       '    print *, a(1) + a(2)'//new_line('a')// &
-                                       '  end subroutine fill'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  call fill()'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine fill()'//new_line('a')// &
+            '    integer :: a(2)'//new_line('a')// &
+            '    a(1) = 4'//new_line('a')// &
+            '    a(2) = 5'//new_line('a')// &
+            '    print *, a(1) + a(2)'//new_line('a')// &
+            '  end subroutine fill'//new_line('a')// &
+            'end program main'
 
         test_array_in_contained_subroutine = expect_output( &
-                                             source, '           9'//new_line('a'), &
-                                             '/tmp/ffc_session_array_subroutine_test')
-    end function test_array_in_contained_subroutine
+                source, '           9'//new_line('a'), &
+                '/tmp/ffc_session_array_subroutine_test')
+        end function test_array_in_contained_subroutine
 
-    logical function test_array_in_contained_function()
-        character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  print *, fill()'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  integer function fill()'//new_line('a')// &
-                                       '    integer :: a(2)'//new_line('a')// &
-                                       '    a(1) = 4'//new_line('a')// &
-                                       '    a(2) = 5'//new_line('a')// &
-                                       '    fill = a(1) + a(2)'//new_line('a')// &
-                                       '  end function fill'//new_line('a')// &
-                                       'end program main'
+        logical function test_array_in_contained_function()
+            character(len=*), parameter :: source = &
+                'program main'//new_line('a')// &
+                '  print *, fill()'//new_line('a')// &
+                'contains'//new_line('a')// &
+                '  integer function fill()'//new_line('a')// &
+                '    integer :: a(2)'//new_line('a')// &
+                '    a(1) = 4'//new_line('a')// &
+                '    a(2) = 5'//new_line('a')// &
+                '    fill = a(1) + a(2)'//new_line('a')// &
+                '  end function fill'//new_line('a')// &
+                'end program main'
 
-        test_array_in_contained_function = expect_output( &
-                                           source, '           9'//new_line('a'), &
-                                           '/tmp/ffc_session_array_function_test')
-    end function test_array_in_contained_function
+            test_array_in_contained_function = expect_output( &
+                    source, '           9'//new_line('a'), &
+                    '/tmp/ffc_session_array_function_test')
+            end function test_array_in_contained_function
 
-    logical function test_array_inline_literal_initializer()
-        ! Inline array-literal initializer must populate storage, so a later
-        ! strided section assignment leaves the untouched elements intact.
-        character(len=*), parameter :: source = &
-                                       'integer :: arr(10) = '// &
-                                       '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]'// &
-                                       new_line('a')// &
-                                       'arr(1:9:2) = 0'//new_line('a')// &
-                                       'print *, arr'//new_line('a')
+            logical function test_array_inline_literal_initializer()
+                ! Inline array-literal initializer must populate storage, so a later
+                ! strided section assignment leaves the untouched elements intact.
+                character(len=*), parameter :: source = &
+                    'integer :: arr(10) = '// &
+                    '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]'// &
+                    new_line('a')// &
+                    'arr(1:9:2) = 0'//new_line('a')// &
+                    'print *, arr'//new_line('a')
 
-        test_array_inline_literal_initializer = expect_output( &
-            source, &
-            '           0           2           0           4           0'// &
-            '           6           0           8           0          10'// &
-            new_line('a'), &
-            '/tmp/ffc_session_array_inline_literal_test')
-    end function test_array_inline_literal_initializer
+                test_array_inline_literal_initializer = expect_output( &
+                    source, &
+                    '           0           2           0           4           0'// &
+                    '           6           0           8           0          10'// &
+                    new_line('a'), &
+                    '/tmp/ffc_session_array_inline_literal_test')
+            end function test_array_inline_literal_initializer
 
-    logical function test_array_inline_scalar_initializer()
-        ! Inline scalar initializer broadcasts to every element.
-        character(len=*), parameter :: source = &
-                                       'integer :: a(4) = 7'//new_line('a')// &
-                                       'print *, a(1) + a(4)'//new_line('a')
+            logical function test_array_inline_scalar_initializer()
+                ! Inline scalar initializer broadcasts to every element.
+                character(len=*), parameter :: source = &
+                    'integer :: a(4) = 7'//new_line('a')// &
+                    'print *, a(1) + a(4)'//new_line('a')
 
-        test_array_inline_scalar_initializer = expect_output( &
-            source, '          14'//new_line('a'), &
-            '/tmp/ffc_session_array_inline_scalar_test')
-    end function test_array_inline_scalar_initializer
+                test_array_inline_scalar_initializer = expect_output( &
+                    source, '          14'//new_line('a'), &
+                    '/tmp/ffc_session_array_inline_scalar_test')
+            end function test_array_inline_scalar_initializer
 
-end program test_session_fixed_size_array_compiler
+        end program test_session_fixed_size_array_compiler

--- a/test/test_session_formatted_output_compiler.f90
+++ b/test/test_session_formatted_output_compiler.f90
@@ -3,8 +3,8 @@ program test_session_formatted_output_compiler
     ! gfortran: the I/F/ES/A/L/X edit descriptors, repeat counts, embedded
     ! string literals, the '/' record terminator, and format reversion.
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                  compiler_frontend_result_t, &
-                                  compile_frontend_from_string, INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, INPUT_MODE_STANDARD
     use session_program_lowering, only: lower_program_to_liric_exe
     implicit none
 
@@ -190,8 +190,8 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, &
-                                        error_msg)
+            frontend_result%root_index, exe, &
+            error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', stem, ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -201,7 +201,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', stem, ']: gfortran rejected source'
             return
@@ -210,7 +210,7 @@ contains
         call execute_command_line(exe//' > '//ffc_out, exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out, exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', stem, ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
@@ -218,7 +218,7 @@ contains
             matches_gfortran = .true.
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref//' '// &
-                                  ffc_out//' '//ref_out)
+            ffc_out//' '//ref_out)
     end function matches_gfortran
 
 end program test_session_formatted_output_compiler

--- a/test/test_session_formatted_print_compiler.f90
+++ b/test/test_session_formatted_print_compiler.f90
@@ -1,7 +1,7 @@
 program test_session_formatted_print_compiler
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                  compiler_frontend_result_t, &
-                                  compile_frontend_from_string, INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, INPUT_MODE_STANDARD
     use ffc_test_support, only: expect_output
     use session_program_lowering, only: lower_program_to_liric_exe
     implicit none
@@ -33,7 +33,7 @@ contains
             'end program main'
 
         test_integer_i0 = expect_output(source, '42'//new_line('a'), &
-                                        '/tmp/ffc_fmt_i0_test')
+            '/tmp/ffc_fmt_i0_test')
     end function test_integer_i0
 
     logical function test_integer_i5()
@@ -45,7 +45,7 @@ contains
             'end program main'
 
         test_integer_i5 = expect_output(source, '   42'//new_line('a'), &
-                                        '/tmp/ffc_fmt_i5_test')
+            '/tmp/ffc_fmt_i5_test')
     end function test_integer_i5
 
     logical function test_string_a_literal()
@@ -55,7 +55,7 @@ contains
             'end program main'
 
         test_string_a_literal = expect_output(source, 'hello'//new_line('a'), &
-                                              '/tmp/ffc_fmt_a_lit_test')
+            '/tmp/ffc_fmt_a_lit_test')
     end function test_string_a_literal
 
     logical function test_string_a_variable()
@@ -137,8 +137,8 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, &
-                                        error_msg)
+            frontend_result%root_index, exe, &
+            error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', stem, ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -148,7 +148,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', stem, ']: gfortran rejected source'
             return
@@ -157,7 +157,7 @@ contains
         call execute_command_line(exe//' > '//ffc_out, exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out, exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', stem, ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
@@ -165,7 +165,7 @@ contains
             matches_gfortran = .true.
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref//' '// &
-                                  ffc_out//' '//ref_out)
+            ffc_out//' '//ref_out)
     end function matches_gfortran
 
 end program test_session_formatted_print_compiler

--- a/test/test_session_generic_interface_compiler.f90
+++ b/test/test_session_generic_interface_compiler.f90
@@ -106,7 +106,7 @@ contains
 
         ! print_val(7, result) -> print_int(7, result) -> result = 7 + 1 = 8
         test_generic_subroutine = expect_exit_status( &
-            source, 8, '/tmp/ffc_session_generic_sub')
-    end function test_generic_subroutine
+                source, 8, '/tmp/ffc_session_generic_sub')
+        end function test_generic_subroutine
 
-end program test_session_generic_interface_compiler
+    end program test_session_generic_interface_compiler

--- a/test/test_session_goto_compiler.f90
+++ b/test/test_session_goto_compiler.f90
@@ -1,87 +1,87 @@
 program test_session_goto_compiler
     use ffc_test_support, only: expect_output, expect_exit_status, &
-                                expect_eof_stderr_and_exit
+        expect_eof_stderr_and_exit
     implicit none
 
     print *, '=== direct session goto/pause compiler test ==='
 
     ! Forward goto skips the dead assignment, lands on the labelled CONTINUE.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '    implicit none'//new_line('a')// &
-         '    integer :: i'//new_line('a')// &
-         '    i = 0'//new_line('a')// &
-         '    goto 100'//new_line('a')// &
-         '    i = 999'//new_line('a')// &
-         '100 continue'//new_line('a')// &
-         '    print *, i'//new_line('a')// &
-         'end program main', &
-         '           0'//new_line('a'), &
-         '/tmp/ffc_session_goto_forward_test')) stop 1
+        'program main'//new_line('a')// &
+        '    implicit none'//new_line('a')// &
+        '    integer :: i'//new_line('a')// &
+        '    i = 0'//new_line('a')// &
+        '    goto 100'//new_line('a')// &
+        '    i = 999'//new_line('a')// &
+        '100 continue'//new_line('a')// &
+        '    print *, i'//new_line('a')// &
+        'end program main', &
+        '           0'//new_line('a'), &
+        '/tmp/ffc_session_goto_forward_test')) stop 1
     print *, 'PASS: forward goto skips statements'
 
     ! Backward goto drives a counting loop to completion.
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         '    implicit none'//new_line('a')// &
-         '    integer :: i'//new_line('a')// &
-         '    i = 0'//new_line('a')// &
-         '10  i = i + 1'//new_line('a')// &
-         '    if (i < 3) goto 10'//new_line('a')// &
-         '    stop i'//new_line('a')// &
-         'end program main', 3, &
-         '/tmp/ffc_session_goto_backward_test')) stop 1
+        'program main'//new_line('a')// &
+        '    implicit none'//new_line('a')// &
+        '    integer :: i'//new_line('a')// &
+        '    i = 0'//new_line('a')// &
+        '10  i = i + 1'//new_line('a')// &
+        '    if (i < 3) goto 10'//new_line('a')// &
+        '    stop i'//new_line('a')// &
+        'end program main', 3, &
+        '/tmp/ffc_session_goto_backward_test')) stop 1
     print *, 'PASS: backward goto loops until the condition fails'
 
     ! Computed goto branches to the selector-th label (1-based).
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '    implicit none'//new_line('a')// &
-         '    integer :: choice'//new_line('a')// &
-         '    choice = 2'//new_line('a')// &
-         '    goto (100, 200, 300), choice'//new_line('a')// &
-         '100 print *, "one"'//new_line('a')// &
-         '    goto 999'//new_line('a')// &
-         '200 print *, "two"'//new_line('a')// &
-         '    goto 999'//new_line('a')// &
-         '300 print *, "three"'//new_line('a')// &
-         '999 continue'//new_line('a')// &
-         'end program main', &
-         ' two'//new_line('a'), &
-         '/tmp/ffc_session_computed_goto_test')) stop 1
+        'program main'//new_line('a')// &
+        '    implicit none'//new_line('a')// &
+        '    integer :: choice'//new_line('a')// &
+        '    choice = 2'//new_line('a')// &
+        '    goto (100, 200, 300), choice'//new_line('a')// &
+        '100 print *, "one"'//new_line('a')// &
+        '    goto 999'//new_line('a')// &
+        '200 print *, "two"'//new_line('a')// &
+        '    goto 999'//new_line('a')// &
+        '300 print *, "three"'//new_line('a')// &
+        '999 continue'//new_line('a')// &
+        'end program main', &
+        ' two'//new_line('a'), &
+        '/tmp/ffc_session_computed_goto_test')) stop 1
     print *, 'PASS: computed goto selects the second label'
 
     ! Out-of-range selector falls through to the next statement.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '    implicit none'//new_line('a')// &
-         '    integer :: choice'//new_line('a')// &
-         '    choice = 5'//new_line('a')// &
-         '    goto (100, 200), choice'//new_line('a')// &
-         '    print *, "fell through"'//new_line('a')// &
-         '    goto 999'//new_line('a')// &
-         '100 print *, "one"'//new_line('a')// &
-         '    goto 999'//new_line('a')// &
-         '200 print *, "two"'//new_line('a')// &
-         '999 continue'//new_line('a')// &
-         'end program main', &
-         ' fell through'//new_line('a'), &
-         '/tmp/ffc_session_computed_goto_oob_test')) stop 1
+        'program main'//new_line('a')// &
+        '    implicit none'//new_line('a')// &
+        '    integer :: choice'//new_line('a')// &
+        '    choice = 5'//new_line('a')// &
+        '    goto (100, 200), choice'//new_line('a')// &
+        '    print *, "fell through"'//new_line('a')// &
+        '    goto 999'//new_line('a')// &
+        '100 print *, "one"'//new_line('a')// &
+        '    goto 999'//new_line('a')// &
+        '200 print *, "two"'//new_line('a')// &
+        '999 continue'//new_line('a')// &
+        'end program main', &
+        ' fell through'//new_line('a'), &
+        '/tmp/ffc_session_computed_goto_oob_test')) stop 1
     print *, 'PASS: out-of-range computed goto falls through'
 
     ! PAUSE writes its banner to stderr and waits on stdin; end-of-input ends
     ! the job after flushing earlier output, so "after" is never printed (#280).
     if (.not. expect_eof_stderr_and_exit( &
-         'program main'//new_line('a')// &
-         '    implicit none'//new_line('a')// &
-         '    print *, "before"'//new_line('a')// &
-         '    pause "halt"'//new_line('a')// &
-         '    print *, "after"'//new_line('a')// &
-         'end program main', &
-         'PAUSE halt'//new_line('a')// &
-         'To resume execution, type go.  Other input will terminate the job.'// &
-         new_line('a')//' before'//new_line('a'), 0, &
-         '/tmp/ffc_session_pause_test')) stop 1
+        'program main'//new_line('a')// &
+        '    implicit none'//new_line('a')// &
+        '    print *, "before"'//new_line('a')// &
+        '    pause "halt"'//new_line('a')// &
+        '    print *, "after"'//new_line('a')// &
+        'end program main', &
+        'PAUSE halt'//new_line('a')// &
+        'To resume execution, type go.  Other input will terminate the job.'// &
+        new_line('a')//' before'//new_line('a'), 0, &
+        '/tmp/ffc_session_pause_test')) stop 1
     print *, 'PASS: pause halts on end-of-input'
 
     print *, 'PASS: goto and pause lower through direct LIRIC session'

--- a/test/test_session_if_merge_compiler.f90
+++ b/test/test_session_if_merge_compiler.f90
@@ -22,30 +22,30 @@ contains
 
     logical function test_integer_if_merge()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: x'//new_line('a')// &
-                                       'if (2 < 3) then'//new_line('a')// &
-                                       '    x = 9'//new_line('a')// &
-                                       'else'//new_line('a')// &
-                                       '    x = 4'//new_line('a')// &
-                                       'end if'//new_line('a')// &
-                                       'stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: x'//new_line('a')// &
+            'if (2 < 3) then'//new_line('a')// &
+            '    x = 9'//new_line('a')// &
+            'else'//new_line('a')// &
+            '    x = 4'//new_line('a')// &
+            'end if'//new_line('a')// &
+            'stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_if_merge = expect_exit_status( &
-                                source, 9, &
-                                '/tmp/ffc_session_if_integer_merge_test')
+            source, 9, &
+            '/tmp/ffc_session_if_integer_merge_test')
     end function test_integer_if_merge
 
     logical function test_if_without_else_taken()
         ! if (cond) stop N with no else: the then branch runs when cond holds.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: x'//new_line('a')// &
-                                       'x = 5'//new_line('a')// &
-                                       'if (x > 3) stop 7'//new_line('a')// &
-                                       'stop 0'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: x'//new_line('a')// &
+            'x = 5'//new_line('a')// &
+            'if (x > 3) stop 7'//new_line('a')// &
+            'stop 0'//new_line('a')// &
+            'end program main'
 
         test_if_without_else_taken = expect_exit_status( &
             source, 7, '/tmp/ffc_if_noelse_taken_test')
@@ -55,14 +55,14 @@ contains
         ! A carried value keeps its pre-IF value when the else-less branch is
         ! skipped (merge phi picks the baseline).
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: x'//new_line('a')// &
-                                       'integer :: y'//new_line('a')// &
-                                       'x = 1'//new_line('a')// &
-                                       'y = 4'//new_line('a')// &
-                                       'if (x > 3) y = 9'//new_line('a')// &
-                                       'stop y'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: x'//new_line('a')// &
+            'integer :: y'//new_line('a')// &
+            'x = 1'//new_line('a')// &
+            'y = 4'//new_line('a')// &
+            'if (x > 3) y = 9'//new_line('a')// &
+            'stop y'//new_line('a')// &
+            'end program main'
 
         test_if_without_else_not_taken = expect_exit_status( &
             source, 4, '/tmp/ffc_if_noelse_skip_test')
@@ -70,98 +70,98 @@ contains
 
     logical function test_real_if_merge()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'real :: x'//new_line('a')// &
-                                       'if (2 < 3) then'//new_line('a')// &
-                                       '    x = 4.5'//new_line('a')// &
-                                       'else'//new_line('a')// &
-                                       '    x = 1.25'//new_line('a')// &
-                                       'end if'//new_line('a')// &
-                                       'print *, x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'real :: x'//new_line('a')// &
+            'if (2 < 3) then'//new_line('a')// &
+            '    x = 4.5'//new_line('a')// &
+            'else'//new_line('a')// &
+            '    x = 1.25'//new_line('a')// &
+            'end if'//new_line('a')// &
+            'print *, x'//new_line('a')// &
+            'end program main'
 
         test_real_if_merge = expect_output( &
-                             source, '   4.50000000    '//new_line('a'), &
-                             '/tmp/ffc_session_if_real_merge_test')
+            source, '   4.50000000    '//new_line('a'), &
+            '/tmp/ffc_session_if_real_merge_test')
     end function test_real_if_merge
 
     logical function test_logical_if_merge()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'logical :: flag'//new_line('a')// &
-                                       'if (2 < 3) then'//new_line('a')// &
-                                       '    flag = .true.'//new_line('a')// &
-                                       'else'//new_line('a')// &
-                                       '    flag = .false.'//new_line('a')// &
-                                       'end if'//new_line('a')// &
-                                       'if (flag) then'//new_line('a')// &
-                                       '    stop 7'//new_line('a')// &
-                                       'else'//new_line('a')// &
-                                       '    stop 3'//new_line('a')// &
-                                       'end if'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'logical :: flag'//new_line('a')// &
+            'if (2 < 3) then'//new_line('a')// &
+            '    flag = .true.'//new_line('a')// &
+            'else'//new_line('a')// &
+            '    flag = .false.'//new_line('a')// &
+            'end if'//new_line('a')// &
+            'if (flag) then'//new_line('a')// &
+            '    stop 7'//new_line('a')// &
+            'else'//new_line('a')// &
+            '    stop 3'//new_line('a')// &
+            'end if'//new_line('a')// &
+            'end program main'
 
         test_logical_if_merge = expect_exit_status( &
-                                source, 7, &
-                                '/tmp/ffc_session_if_logical_merge_test')
+            source, 7, &
+            '/tmp/ffc_session_if_logical_merge_test')
     end function test_logical_if_merge
 
     logical function test_nested_if_in_do_merge()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: i'//new_line('a')// &
-                                       'integer :: total'//new_line('a')// &
-                                       'logical :: found'//new_line('a')// &
-                                       'total = 0'//new_line('a')// &
-                                       'found = .false.'//new_line('a')// &
-                                       'do i = 1, 3'//new_line('a')// &
-                                       '    if (i < 3) then'//new_line('a')// &
-                                       '        total = total + i'//new_line('a')// &
-                                       '        found = .true.'//new_line('a')// &
-                                       '    else'//new_line('a')// &
-                                       '        total = total + 4'//new_line('a')// &
-                                       '        found = found'//new_line('a')// &
-                                       '    end if'//new_line('a')// &
-                                       'end do'//new_line('a')// &
-                                       'if (found) then'//new_line('a')// &
-                                       '    stop total'//new_line('a')// &
-                                       'else'//new_line('a')// &
-                                       '    stop 1'//new_line('a')// &
-                                       'end if'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: i'//new_line('a')// &
+            'integer :: total'//new_line('a')// &
+            'logical :: found'//new_line('a')// &
+            'total = 0'//new_line('a')// &
+            'found = .false.'//new_line('a')// &
+            'do i = 1, 3'//new_line('a')// &
+            '    if (i < 3) then'//new_line('a')// &
+            '        total = total + i'//new_line('a')// &
+            '        found = .true.'//new_line('a')// &
+            '    else'//new_line('a')// &
+            '        total = total + 4'//new_line('a')// &
+            '        found = found'//new_line('a')// &
+            '    end if'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'if (found) then'//new_line('a')// &
+            '    stop total'//new_line('a')// &
+            'else'//new_line('a')// &
+            '    stop 1'//new_line('a')// &
+            'end if'//new_line('a')// &
+            'end program main'
 
         test_nested_if_in_do_merge = expect_exit_status( &
-                                     source, 7, &
-                                     '/tmp/ffc_session_nested_if_do_test')
+            source, 7, &
+            '/tmp/ffc_session_nested_if_do_test')
     end function test_nested_if_in_do_merge
 
     logical function test_do_in_if_merge()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: i'//new_line('a')// &
-                                       'integer :: total'//new_line('a')// &
-                                       'logical :: flag'//new_line('a')// &
-                                       'total = 0'//new_line('a')// &
-                                       'flag = .false.'//new_line('a')// &
-                                       'if (2 < 3) then'//new_line('a')// &
-                                       '    do i = 1, 2'//new_line('a')// &
-                                       '        total = total + i'//new_line('a')// &
-                                       '        flag = .true.'//new_line('a')// &
-                                       '    end do'//new_line('a')// &
-                                       'else'//new_line('a')// &
-                                       '    total = 9'//new_line('a')// &
-                                       '    flag = .false.'//new_line('a')// &
-                                       'end if'//new_line('a')// &
-                                       'if (flag) then'//new_line('a')// &
-                                       '    stop total'//new_line('a')// &
-                                       'else'//new_line('a')// &
-                                       '    stop 8'//new_line('a')// &
-                                       'end if'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: i'//new_line('a')// &
+            'integer :: total'//new_line('a')// &
+            'logical :: flag'//new_line('a')// &
+            'total = 0'//new_line('a')// &
+            'flag = .false.'//new_line('a')// &
+            'if (2 < 3) then'//new_line('a')// &
+            '    do i = 1, 2'//new_line('a')// &
+            '        total = total + i'//new_line('a')// &
+            '        flag = .true.'//new_line('a')// &
+            '    end do'//new_line('a')// &
+            'else'//new_line('a')// &
+            '    total = 9'//new_line('a')// &
+            '    flag = .false.'//new_line('a')// &
+            'end if'//new_line('a')// &
+            'if (flag) then'//new_line('a')// &
+            '    stop total'//new_line('a')// &
+            'else'//new_line('a')// &
+            '    stop 8'//new_line('a')// &
+            'end if'//new_line('a')// &
+            'end program main'
 
         test_do_in_if_merge = expect_exit_status( &
-                              source, 3, &
-                              '/tmp/ffc_session_do_if_test')
+            source, 3, &
+            '/tmp/ffc_session_do_if_test')
     end function test_do_in_if_merge
 
 end program test_session_if_merge_compiler

--- a/test/test_session_inquiry_fold_compiler.f90
+++ b/test/test_session_inquiry_fold_compiler.f90
@@ -24,11 +24,11 @@ contains
     ! kind(1.0d0) folds to 8; the classic dp = kind(1.0d0) idiom.
     logical function test_kind_of_double_literal()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer, parameter :: dp = '// &
-                                       'kind(1.0d0)'//new_line('a')// &
-                                       '  print *, dp'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer, parameter :: dp = '// &
+            'kind(1.0d0)'//new_line('a')// &
+            '  print *, dp'//new_line('a')// &
+            'end program main'
 
         test_kind_of_double_literal = expect_output( &
             source, '           8'//new_line('a'), &
@@ -38,17 +38,17 @@ contains
     ! Default real/integer/logical literals fold to kind 4; character kind 1.
     logical function test_kind_of_default_literals()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer, parameter :: kr = kind(1.0)'// &
-                                       new_line('a')// &
-                                       '  integer, parameter :: ki = kind(1)'// &
-                                       new_line('a')// &
-                                       '  integer, parameter :: kl = kind(.true.)'// &
-                                       new_line('a')// &
-                                       "  integer, parameter :: kc = kind('a')"// &
-                                       new_line('a')// &
-                                       '  print *, kr, ki, kl, kc'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer, parameter :: kr = kind(1.0)'// &
+            new_line('a')// &
+            '  integer, parameter :: ki = kind(1)'// &
+            new_line('a')// &
+            '  integer, parameter :: kl = kind(.true.)'// &
+            new_line('a')// &
+            "  integer, parameter :: kc = kind('a')"// &
+            new_line('a')// &
+            '  print *, kr, ki, kl, kc'//new_line('a')// &
+            'end program main'
 
         test_kind_of_default_literals = expect_output( &
             source, &
@@ -59,12 +59,12 @@ contains
     ! kind(x) of a declared double variable folds to its declared kind.
     logical function test_kind_of_variable()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  real(8) :: x'//new_line('a')// &
-                                       '  integer, parameter :: k = kind(x)'// &
-                                       new_line('a')// &
-                                       '  print *, k'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  real(8) :: x'//new_line('a')// &
+            '  integer, parameter :: k = kind(x)'// &
+            new_line('a')// &
+            '  print *, k'//new_line('a')// &
+            'end program main'
 
         test_kind_of_variable = expect_output( &
             source, '           8'//new_line('a'), &
@@ -74,12 +74,12 @@ contains
     ! size(arr) folds to the total element count of a fixed-size array.
     logical function test_size_whole_array()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(3, 4)'//new_line('a')// &
-                                       '  integer, parameter :: n = size(a)'// &
-                                       new_line('a')// &
-                                       '  print *, n'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(3, 4)'//new_line('a')// &
+            '  integer, parameter :: n = size(a)'// &
+            new_line('a')// &
+            '  print *, n'//new_line('a')// &
+            'end program main'
 
         test_size_whole_array = expect_output( &
             source, '          12'//new_line('a'), &
@@ -89,14 +89,14 @@ contains
     ! size(arr, dim) folds to the extent of one dimension.
     logical function test_size_with_dim()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(3, 4)'//new_line('a')// &
-                                       '  integer, parameter :: n1 = size(a, 1)'// &
-                                       new_line('a')// &
-                                       '  integer, parameter :: n2 = size(a, 2)'// &
-                                       new_line('a')// &
-                                       '  print *, n1, n2'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(3, 4)'//new_line('a')// &
+            '  integer, parameter :: n1 = size(a, 1)'// &
+            new_line('a')// &
+            '  integer, parameter :: n2 = size(a, 2)'// &
+            new_line('a')// &
+            '  print *, n1, n2'//new_line('a')// &
+            'end program main'
 
         test_size_with_dim = expect_output( &
             source, '           3           4'//new_line('a'), &
@@ -106,12 +106,12 @@ contains
     ! A folded size is usable as an array bound.
     logical function test_size_as_array_bound()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(5)'//new_line('a')// &
-                                       '  integer :: b(size(a))'//new_line('a')// &
-                                       '  b = 7'//new_line('a')// &
-                                       '  print *, size(b), b(5)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(5)'//new_line('a')// &
+            '  integer :: b(size(a))'//new_line('a')// &
+            '  b = 7'//new_line('a')// &
+            '  print *, size(b), b(5)'//new_line('a')// &
+            'end program main'
 
         test_size_as_array_bound = expect_output( &
             source, '           5           7'//new_line('a'), &
@@ -121,12 +121,12 @@ contains
     ! len(s) folds to the declared length of a fixed-length character.
     logical function test_len_fixed_character()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  character(len=5) :: s'//new_line('a')// &
-                                       '  integer, parameter :: l = len(s)'// &
-                                       new_line('a')// &
-                                       '  print *, l'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  character(len=5) :: s'//new_line('a')// &
+            '  integer, parameter :: l = len(s)'// &
+            new_line('a')// &
+            '  print *, l'//new_line('a')// &
+            'end program main'
 
         test_len_fixed_character = expect_output( &
             source, '           5'//new_line('a'), &
@@ -136,15 +136,15 @@ contains
     ! A non-default-kind integer parameter is a compile-time array bound.
     logical function test_nondefault_int_parameter_bound()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  use iso_fortran_env, only: int64'// &
-                                       new_line('a')// &
-                                       '  integer(int64), parameter :: n = 5'// &
-                                       new_line('a')// &
-                                       '  integer :: a(n)'//new_line('a')// &
-                                       '  a = 1'//new_line('a')// &
-                                       '  print *, size(a)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  use iso_fortran_env, only: int64'// &
+            new_line('a')// &
+            '  integer(int64), parameter :: n = 5'// &
+            new_line('a')// &
+            '  integer :: a(n)'//new_line('a')// &
+            '  a = 1'//new_line('a')// &
+            '  print *, size(a)'//new_line('a')// &
+            'end program main'
 
         test_nondefault_int_parameter_bound = expect_output( &
             source, '           5'//new_line('a'), &

--- a/test/test_session_integer_function_compiler.f90
+++ b/test/test_session_integer_function_compiler.f90
@@ -5,16 +5,16 @@ program test_session_integer_function_compiler
     print *, '=== direct session integer function compiler test ==='
 
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         '  integer :: x'//new_line('a')// &
-         '  x = add(2, 3)'//new_line('a')// &
-         '  stop x'//new_line('a')// &
-         'contains'//new_line('a')// &
-         '  integer function add(a, b)'//new_line('a')// &
-         '    add = a + b'//new_line('a')// &
-         '  end function add'//new_line('a')// &
-         'end program main', 5, &
-         '/tmp/ffc_session_integer_fn_test')) stop 1
+        'program main'//new_line('a')// &
+        '  integer :: x'//new_line('a')// &
+        '  x = add(2, 3)'//new_line('a')// &
+        '  stop x'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  integer function add(a, b)'//new_line('a')// &
+        '    add = a + b'//new_line('a')// &
+        '  end function add'//new_line('a')// &
+        'end program main', 5, &
+        '/tmp/ffc_session_integer_fn_test')) stop 1
 
     print *, 'PASS: integer function calls lower through direct LIRIC session'
 end program test_session_integer_function_compiler

--- a/test/test_session_integer_intrinsic_compiler.f90
+++ b/test/test_session_integer_intrinsic_compiler.f90
@@ -1,6 +1,6 @@
 program test_session_integer_intrinsic_compiler
     use ffc_test_support, only: expect_exit_status, expect_output, &
-                                expect_error_contains
+        expect_error_contains
     implicit none
 
     logical :: all_passed
@@ -41,260 +41,260 @@ contains
 
     logical function test_integer_intrinsic_values()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  integer :: y'//new_line('a')// &
-                                       '  x = abs(0 - 7)'//new_line('a')// &
-                                  '  y = min(x, 9, 4) + max(1, 2, 3)'//new_line('a')// &
-                                       '  stop y'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  integer :: y'//new_line('a')// &
+            '  x = abs(0 - 7)'//new_line('a')// &
+            '  y = min(x, 9, 4) + max(1, 2, 3)'//new_line('a')// &
+            '  stop y'//new_line('a')// &
+            'end program main'
 
         test_integer_intrinsic_values = expect_exit_status( &
-                                   source, 7, &
-                                   '/tmp/ffc_session_integer_intrinsic_test')
+            source, 7, &
+            '/tmp/ffc_session_integer_intrinsic_test')
     end function test_integer_intrinsic_values
 
     logical function test_integer_mod_intrinsic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a'//new_line('a')// &
-                                       '  integer :: b'//new_line('a')// &
-                                       '  a = 17'//new_line('a')// &
-                                       '  b = 5'//new_line('a')// &
-                                       '  stop mod(a, b) + mod(-7, 3)'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a'//new_line('a')// &
+            '  integer :: b'//new_line('a')// &
+            '  a = 17'//new_line('a')// &
+            '  b = 5'//new_line('a')// &
+            '  stop mod(a, b) + mod(-7, 3)'// &
+            new_line('a')// &
+            'end program main'
 
         test_integer_mod_intrinsic = expect_exit_status( &
-                                     source, 1, &
-                                     '/tmp/ffc_session_integer_mod_test')
+            source, 1, &
+            '/tmp/ffc_session_integer_mod_test')
     end function test_integer_mod_intrinsic
 
     logical function test_integer_iand_intrinsic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = iand(12, 10)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = iand(12, 10)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_iand_intrinsic = expect_exit_status( &
-                                      source, 8, &
-                                      '/tmp/ffc_session_integer_iand_test')
+            source, 8, &
+            '/tmp/ffc_session_integer_iand_test')
     end function test_integer_iand_intrinsic
 
     logical function test_integer_ior_intrinsic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = ior(12, 10)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = ior(12, 10)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_ior_intrinsic = expect_exit_status( &
-                                     source, 14, &
-                                     '/tmp/ffc_session_integer_ior_test')
+            source, 14, &
+            '/tmp/ffc_session_integer_ior_test')
     end function test_integer_ior_intrinsic
 
     logical function test_integer_ieor_intrinsic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = ieor(12, 10)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = ieor(12, 10)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_ieor_intrinsic = expect_exit_status( &
-                                      source, 6, &
-                                      '/tmp/ffc_session_integer_ieor_test')
+            source, 6, &
+            '/tmp/ffc_session_integer_ieor_test')
     end function test_integer_ieor_intrinsic
 
     logical function test_integer_not_intrinsic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = abs(not(0))'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = abs(not(0))'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         ! not(0) == -1, abs(-1) == 1
         test_integer_not_intrinsic = expect_exit_status( &
-                                     source, 1, &
-                                     '/tmp/ffc_session_integer_not_test')
+            source, 1, &
+            '/tmp/ffc_session_integer_not_test')
     end function test_integer_not_intrinsic
 
     logical function test_integer_ishft_left_literal()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = ishft(1, 4)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = ishft(1, 4)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_ishft_left_literal = expect_exit_status( &
-                                      source, 16, &
-                                      '/tmp/ffc_session_integer_ishft_left_test')
+            source, 16, &
+            '/tmp/ffc_session_integer_ishft_left_test')
     end function test_integer_ishft_left_literal
 
     logical function test_integer_ishft_right_literal()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = ishft(16, -4)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = ishft(16, -4)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_ishft_right_literal = expect_exit_status( &
-                                      source, 1, &
-                                      '/tmp/ffc_session_integer_ishft_right_test')
+            source, 1, &
+            '/tmp/ffc_session_integer_ishft_right_test')
     end function test_integer_ishft_right_literal
 
     logical function test_integer_ishftc_rotates()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = ishftc(3, 2)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = ishftc(3, 2)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         ! 3 (0b11) rotated left by 2 within 32 bits == 12 (0b1100)
         test_integer_ishftc_rotates = expect_exit_status( &
-                                      source, 12, &
-                                      '/tmp/ffc_session_integer_ishftc_test')
+            source, 12, &
+            '/tmp/ffc_session_integer_ishftc_test')
     end function test_integer_ishftc_rotates
 
     logical function test_integer_sign_positive()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = sign(7, 3)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = sign(7, 3)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_sign_positive = expect_exit_status( &
-                                     source, 7, &
-                                     '/tmp/ffc_session_integer_sign_pos_test')
+            source, 7, &
+            '/tmp/ffc_session_integer_sign_pos_test')
     end function test_integer_sign_positive
 
     logical function test_integer_sign_negative()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = sign(7, -3)'//new_line('a')// &
-                                       '  stop abs(x)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = sign(7, -3)'//new_line('a')// &
+            '  stop abs(x)'//new_line('a')// &
+            'end program main'
 
         ! sign(7, -3) == -7; abs gives 7 (stop needs a non-negative code)
         test_integer_sign_negative = expect_exit_status( &
-                                     source, 7, &
-                                     '/tmp/ffc_session_integer_sign_neg_test')
+            source, 7, &
+            '/tmp/ffc_session_integer_sign_neg_test')
     end function test_integer_sign_negative
 
     logical function test_integer_sign_zero_sign()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = sign(7, 0)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = sign(7, 0)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         ! Fortran: a zero second argument is treated as a positive sign
         test_integer_sign_zero_sign = expect_exit_status( &
-                                     source, 7, &
-                                     '/tmp/ffc_session_integer_sign_zero_test')
+            source, 7, &
+            '/tmp/ffc_session_integer_sign_zero_test')
     end function test_integer_sign_zero_sign
 
     logical function test_int_truncates_toward_zero()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = int(5.7) - int(-5.7)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = int(5.7) - int(-5.7)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         ! int(5.7) == 5, int(-5.7) == -5, difference == 10
         test_int_truncates_toward_zero = expect_exit_status( &
-                                     source, 10, &
-                                     '/tmp/ffc_session_int_trunc_test')
+            source, 10, &
+            '/tmp/ffc_session_int_trunc_test')
     end function test_int_truncates_toward_zero
 
     logical function test_nint_rounds_half_away()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = nint(2.5) - nint(-2.5)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = nint(2.5) - nint(-2.5)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         ! nint(2.5) == 3, nint(-2.5) == -3, difference == 6
         test_nint_rounds_half_away = expect_exit_status( &
-                                     source, 6, &
-                                     '/tmp/ffc_session_nint_test')
+            source, 6, &
+            '/tmp/ffc_session_nint_test')
     end function test_nint_rounds_half_away
 
     logical function test_floor_negative()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = abs(floor(-1.5))'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = abs(floor(-1.5))'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         ! floor(-1.5) == -2, abs == 2
         test_floor_negative = expect_exit_status( &
-                                     source, 2, &
-                                     '/tmp/ffc_session_floor_test')
+            source, 2, &
+            '/tmp/ffc_session_floor_test')
     end function test_floor_negative
 
     logical function test_ceiling_positive()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = ceiling(1.5)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = ceiling(1.5)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         test_ceiling_positive = expect_exit_status( &
-                                     source, 2, &
-                                     '/tmp/ffc_session_ceiling_test')
+            source, 2, &
+            '/tmp/ffc_session_ceiling_test')
     end function test_ceiling_positive
 
     logical function test_real_intrinsic_values()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  real :: x'//new_line('a')// &
-                                       '  x = abs(0.0 - 2.5) '// &
-                                       '+ min(3.5, 1.25, 2.0) '// &
-                                       '+ max(0.5, 4.25)'//new_line('a')// &
-                                       '  print *, x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  real :: x'//new_line('a')// &
+            '  x = abs(0.0 - 2.5) '// &
+            '+ min(3.5, 1.25, 2.0) '// &
+            '+ max(0.5, 4.25)'//new_line('a')// &
+            '  print *, x'//new_line('a')// &
+            'end program main'
 
         test_real_intrinsic_values = expect_output( &
-                              source, '   8.00000000    '//new_line('a'), &
-                                     '/tmp/ffc_session_real_intrinsic_test')
+            source, '   8.00000000    '//new_line('a'), &
+            '/tmp/ffc_session_real_intrinsic_test')
     end function test_real_intrinsic_values
 
     logical function test_real_conversion_intrinsic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: i'//new_line('a')// &
-                                       '  real :: x'//new_line('a')// &
-                                       '  i = 4'//new_line('a')// &
-                                       '  x = real(i) + 1.5'//new_line('a')// &
-                                       '  print *, x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  real :: x'//new_line('a')// &
+            '  i = 4'//new_line('a')// &
+            '  x = real(i) + 1.5'//new_line('a')// &
+            '  print *, x'//new_line('a')// &
+            'end program main'
 
         test_real_conversion_intrinsic = expect_output( &
-                              source, '   5.50000000    '//new_line('a'), &
-                                        '/tmp/ffc_session_real_conversion_test')
+            source, '   5.50000000    '//new_line('a'), &
+            '/tmp/ffc_session_real_conversion_test')
     end function test_real_conversion_intrinsic
 
     logical function test_unsupported_intrinsic_diagnostic()
         ! verify that a genuinely unsupported integer intrinsic still errors
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  stop ibset(0, 1)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  stop ibset(0, 1)'//new_line('a')// &
+            'end program main'
 
         test_unsupported_intrinsic_diagnostic = expect_error_contains( &
             source, 'unsupported', &
@@ -303,10 +303,10 @@ contains
 
     logical function test_unsupported_real_intrinsic_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  real :: x'//new_line('a')// &
-                                       '  x = modulo(5.5, 2.0)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  real :: x'//new_line('a')// &
+            '  x = modulo(5.5, 2.0)'//new_line('a')// &
+            'end program main'
 
         ! modulo is now in the f64 lookup table so the error comes from the
         ! intrinsic dispatcher rather than the generic "unsupported function call"
@@ -318,29 +318,29 @@ contains
 
     logical function test_user_function_shadowing()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = min(2, 3)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  integer function min(a, b)'//new_line('a')// &
-                                       '    min = a + b'//new_line('a')// &
-                                       '  end function min'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = min(2, 3)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  integer function min(a, b)'//new_line('a')// &
+            '    min = a + b'//new_line('a')// &
+            '  end function min'//new_line('a')// &
+            'end program main'
 
         test_user_function_shadowing = expect_exit_status( &
-                                      source, 5, &
-                                      '/tmp/ffc_session_intrinsic_shadow_test')
+            source, 5, &
+            '/tmp/ffc_session_intrinsic_shadow_test')
     end function test_user_function_shadowing
 
     logical function test_integer_modulo_positive()
         ! modulo(7, 3) == 1  (same as mod when both positive)
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = modulo(7, 3)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = modulo(7, 3)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_modulo_positive = expect_exit_status( &
             source, 1, '/tmp/ffc_session_integer_modulo_pos_test')
@@ -349,11 +349,11 @@ contains
     logical function test_integer_modulo_negative_divisor()
         ! modulo(-7, 3) == 2  (result has sign of divisor, unlike mod)
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = modulo(-7, 3)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = modulo(-7, 3)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_modulo_negative_divisor = expect_exit_status( &
             source, 2, '/tmp/ffc_session_integer_modulo_neg_test')
@@ -362,11 +362,11 @@ contains
     logical function test_integer_dim_positive()
         ! dim(5, 2) == 3
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = dim(5, 2)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = dim(5, 2)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_dim_positive = expect_exit_status( &
             source, 3, '/tmp/ffc_session_integer_dim_pos_test')
@@ -375,11 +375,11 @@ contains
     logical function test_integer_dim_zero()
         ! dim(2, 5) == 0  (negative difference clamped to zero)
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = dim(2, 5)'//new_line('a')// &
-                                       '  stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = dim(2, 5)'//new_line('a')// &
+            '  stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_dim_zero = expect_exit_status( &
             source, 0, '/tmp/ffc_session_integer_dim_zero_test')

--- a/test/test_session_integer_kind64_compiler.f90
+++ b/test/test_session_integer_kind64_compiler.f90
@@ -4,9 +4,9 @@ program test_session_integer_kind64_compiler
     use ffc_test_support, only: expect_output
     use session_program_lowering, only: lower_program_to_liric_exe
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                   compiler_frontend_result_t, &
-                                   compile_frontend_from_string, &
-                                   INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
     implicit none
 
     logical :: all_passed
@@ -83,7 +83,7 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, error_msg)
+            frontend_result%root_index, exe, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', trim(stem), ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -93,7 +93,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', trim(stem), ']: gfortran rejected source'
             return
@@ -102,14 +102,14 @@ contains
         call execute_command_line(exe//' > '//ffc_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', trim(stem), ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
             return
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref// &
-                                  ' '//ffc_out//' '//ref_out)
+            ' '//ffc_out//' '//ref_out)
         matches_gfortran = .true.
     end function matches_gfortran
 

--- a/test/test_session_integer_kind_i8_i16_compiler.f90
+++ b/test/test_session_integer_kind_i8_i16_compiler.f90
@@ -3,9 +3,9 @@ program test_session_integer_kind_i8_i16_compiler
     ! arithmetic, and list-directed print match gfortran byte-for-byte (#246).
     use session_program_lowering, only: lower_program_to_liric_exe
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                   compiler_frontend_result_t, &
-                                   compile_frontend_from_string, &
-                                   INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
     implicit none
 
     logical :: all_passed
@@ -106,7 +106,7 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, error_msg)
+            frontend_result%root_index, exe, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', trim(stem), ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -116,7 +116,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', trim(stem), ']: gfortran rejected source'
             return
@@ -125,14 +125,14 @@ contains
         call execute_command_line(exe//' > '//ffc_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out//' 2>&1', exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', trim(stem), ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
             return
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref// &
-                                  ' '//ffc_out//' '//ref_out)
+            ' '//ffc_out//' '//ref_out)
         matches_gfortran = .true.
     end function matches_gfortran
 

--- a/test/test_session_integer_pow_compiler.f90
+++ b/test/test_session_integer_pow_compiler.f90
@@ -19,56 +19,56 @@ contains
 
     logical function test_integer_pow_zero_is_one()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: x'//new_line('a')// &
-                                       'x = 5 ** 0'//new_line('a')// &
-                                       'stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: x'//new_line('a')// &
+            'x = 5 ** 0'//new_line('a')// &
+            'stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_pow_zero_is_one = expect_exit_status( &
-                                       source, 1, &
-                                       '/tmp/ffc_session_pow_zero_test')
+            source, 1, &
+            '/tmp/ffc_session_pow_zero_test')
     end function test_integer_pow_zero_is_one
 
     logical function test_integer_pow_one_is_identity()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: x'//new_line('a')// &
-                                       'x = 7 ** 1'//new_line('a')// &
-                                       'stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: x'//new_line('a')// &
+            'x = 7 ** 1'//new_line('a')// &
+            'stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_pow_one_is_identity = expect_exit_status( &
-                                       source, 7, &
-                                       '/tmp/ffc_session_pow_one_test')
+            source, 7, &
+            '/tmp/ffc_session_pow_one_test')
     end function test_integer_pow_one_is_identity
 
     logical function test_integer_pow_small()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: x'//new_line('a')// &
-                                       'x = 2 ** 5'//new_line('a')// &
-                                       'stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: x'//new_line('a')// &
+            'x = 2 ** 5'//new_line('a')// &
+            'stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_pow_small = expect_exit_status( &
-                                 source, 32, &
-                                 '/tmp/ffc_session_pow_small_test')
+            source, 32, &
+            '/tmp/ffc_session_pow_small_test')
     end function test_integer_pow_small
 
     logical function test_integer_pow_variable_base()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: b'//new_line('a')// &
-                                       'integer :: x'//new_line('a')// &
-                                       'b = 3'//new_line('a')// &
-                                       'x = b ** 3'//new_line('a')// &
-                                       'stop x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: b'//new_line('a')// &
+            'integer :: x'//new_line('a')// &
+            'b = 3'//new_line('a')// &
+            'x = b ** 3'//new_line('a')// &
+            'stop x'//new_line('a')// &
+            'end program main'
 
         test_integer_pow_variable_base = expect_exit_status( &
-                                         source, 27, &
-                                         '/tmp/ffc_session_pow_varbase_test')
+            source, 27, &
+            '/tmp/ffc_session_pow_varbase_test')
     end function test_integer_pow_variable_base
 
 end program test_session_integer_pow_compiler

--- a/test/test_session_integer_subroutine_compiler.f90
+++ b/test/test_session_integer_subroutine_compiler.f90
@@ -5,18 +5,18 @@ program test_session_integer_subroutine_compiler
     print *, '=== direct session integer subroutine compiler test ==='
 
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  integer :: x'//new_line('a')// &
-         '  x = 5'//new_line('a')// &
-         '  call bump(x)'//new_line('a')// &
-         '  print *, x'//new_line('a')// &
-         'contains'//new_line('a')// &
-         '  subroutine bump(x)'//new_line('a')// &
-         '    integer, intent(inout) :: x'//new_line('a')// &
-         '    x = x + 2'//new_line('a')// &
-         '  end subroutine bump'//new_line('a')// &
-         'end program main', '           7'//new_line('a'), &
-         '/tmp/ffc_session_integer_sub_test')) stop 1
+        'program main'//new_line('a')// &
+        '  integer :: x'//new_line('a')// &
+        '  x = 5'//new_line('a')// &
+        '  call bump(x)'//new_line('a')// &
+        '  print *, x'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  subroutine bump(x)'//new_line('a')// &
+        '    integer, intent(inout) :: x'//new_line('a')// &
+        '    x = x + 2'//new_line('a')// &
+        '  end subroutine bump'//new_line('a')// &
+        'end program main', '           7'//new_line('a'), &
+        '/tmp/ffc_session_integer_sub_test')) stop 1
 
     print *, 'PASS: integer subroutine reference args lower through direct LIRIC session'
 end program test_session_integer_subroutine_compiler

--- a/test/test_session_integer_variable_compiler.f90
+++ b/test/test_session_integer_variable_compiler.f90
@@ -5,12 +5,12 @@ program test_session_integer_variable_compiler
     print *, '=== direct session integer variable compiler test ==='
 
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'integer :: x'//new_line('a')// &
-         'x = 40 + 2'//new_line('a')// &
-         'stop x'//new_line('a')// &
-         'end program main', 42, &
-         '/tmp/ffc_session_integer_var_test')) stop 1
+        'program main'//new_line('a')// &
+        'integer :: x'//new_line('a')// &
+        'x = 40 + 2'//new_line('a')// &
+        'stop x'//new_line('a')// &
+        'end program main', 42, &
+        '/tmp/ffc_session_integer_var_test')) stop 1
 
     print *, 'PASS: integer variable lowers through direct LIRIC session'
 end program test_session_integer_variable_compiler

--- a/test/test_session_iso_c_binding_compiler.f90
+++ b/test/test_session_iso_c_binding_compiler.f90
@@ -1,6 +1,6 @@
 program test_session_iso_c_binding_compiler
     use ffc_test_support, only: expect_exit_status, expect_error_contains, &
-                                expect_exe_has_symbol
+        expect_exe_has_symbol
     implicit none
 
     logical :: all_passed
@@ -193,149 +193,149 @@ contains
 
         ! abs(-3) + abs(10) = 13
         test_call_bind_c_integer_function = expect_exit_status( &
-            source, 13, '/tmp/ffc_session_call_bindc_test')
-    end function test_call_bind_c_integer_function
+                source, 13, '/tmp/ffc_session_call_bindc_test')
+        end function test_call_bind_c_integer_function
 
-    logical function test_call_external_void_subroutine_with_c_ptr()
-        ! Void bind(c) subroutine with a c_ptr argument; passing c_null_ptr
-        ! sends a null pointer (free(NULL) is a no-op), exits 0.
-        character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  use iso_c_binding'//new_line('a')// &
-            '  interface'//new_line('a')// &
-            '    subroutine free_c(p) bind(c, name="free")'//new_line('a')// &
-            '      import :: c_ptr'//new_line('a')// &
-            '      type(c_ptr), value :: p'//new_line('a')// &
-            '    end subroutine free_c'//new_line('a')// &
-            '  end interface'//new_line('a')// &
-            '  call free_c(c_null_ptr)'//new_line('a')// &
-            '  stop 0'//new_line('a')// &
-            'end program main'
+        logical function test_call_external_void_subroutine_with_c_ptr()
+            ! Void bind(c) subroutine with a c_ptr argument; passing c_null_ptr
+            ! sends a null pointer (free(NULL) is a no-op), exits 0.
+            character(len=*), parameter :: source = &
+                'program main'//new_line('a')// &
+                '  use iso_c_binding'//new_line('a')// &
+                '  interface'//new_line('a')// &
+                '    subroutine free_c(p) bind(c, name="free")'//new_line('a')// &
+                '      import :: c_ptr'//new_line('a')// &
+                '      type(c_ptr), value :: p'//new_line('a')// &
+                '    end subroutine free_c'//new_line('a')// &
+                '  end interface'//new_line('a')// &
+                '  call free_c(c_null_ptr)'//new_line('a')// &
+                '  stop 0'//new_line('a')// &
+                'end program main'
 
-        test_call_external_void_subroutine_with_c_ptr = expect_exit_status( &
-            source, 0, '/tmp/ffc_session_extern_void_test')
-    end function test_call_external_void_subroutine_with_c_ptr
+            test_call_external_void_subroutine_with_c_ptr = expect_exit_status( &
+                source, 0, '/tmp/ffc_session_extern_void_test')
+        end function test_call_external_void_subroutine_with_c_ptr
 
-    logical function test_internal_function_bind_c_emits_named_symbol()
-        ! A contained function with bind(c, name="...") is emitted under the
-        ! unmangled C symbol so other languages can link against it.
-        character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  integer :: r'//new_line('a')// &
-            '  r = my_add(2, 3)'//new_line('a')// &
-            '  stop r'//new_line('a')// &
-            'contains'//new_line('a')// &
-            '  integer function my_add(a, b) bind(c, name="my_add")'// &
-            new_line('a')// &
-            '    integer, intent(in) :: a, b'//new_line('a')// &
-            '    my_add = a + b'//new_line('a')// &
-            '  end function my_add'//new_line('a')// &
-            'end program main'
+        logical function test_internal_function_bind_c_emits_named_symbol()
+            ! A contained function with bind(c, name="...") is emitted under the
+            ! unmangled C symbol so other languages can link against it.
+            character(len=*), parameter :: source = &
+                'program main'//new_line('a')// &
+                '  integer :: r'//new_line('a')// &
+                '  r = my_add(2, 3)'//new_line('a')// &
+                '  stop r'//new_line('a')// &
+                'contains'//new_line('a')// &
+                '  integer function my_add(a, b) bind(c, name="my_add")'// &
+                new_line('a')// &
+                '    integer, intent(in) :: a, b'//new_line('a')// &
+                '    my_add = a + b'//new_line('a')// &
+                '  end function my_add'//new_line('a')// &
+                'end program main'
 
-        test_internal_function_bind_c_emits_named_symbol = &
-            expect_exe_has_symbol(source, '/tmp/ffc_session_bindc_sym_test', &
-                                  'my_add')
-    end function test_internal_function_bind_c_emits_named_symbol
+            test_internal_function_bind_c_emits_named_symbol = &
+                expect_exe_has_symbol(source, '/tmp/ffc_session_bindc_sym_test', &
+                'my_add')
+        end function test_internal_function_bind_c_emits_named_symbol
 
-    logical function test_internal_bind_c_function_is_callable()
-        ! The bind(c) function is still callable internally under its C name.
-        character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  integer :: r'//new_line('a')// &
-            '  r = my_add(2, 3)'//new_line('a')// &
-            '  stop r'//new_line('a')// &
-            'contains'//new_line('a')// &
-            '  integer function my_add(a, b) bind(c, name="my_add")'// &
-            new_line('a')// &
-            '    integer, intent(in) :: a, b'//new_line('a')// &
-            '    my_add = a + b'//new_line('a')// &
-            '  end function my_add'//new_line('a')// &
-            'end program main'
+        logical function test_internal_bind_c_function_is_callable()
+            ! The bind(c) function is still callable internally under its C name.
+            character(len=*), parameter :: source = &
+                'program main'//new_line('a')// &
+                '  integer :: r'//new_line('a')// &
+                '  r = my_add(2, 3)'//new_line('a')// &
+                '  stop r'//new_line('a')// &
+                'contains'//new_line('a')// &
+                '  integer function my_add(a, b) bind(c, name="my_add")'// &
+                new_line('a')// &
+                '    integer, intent(in) :: a, b'//new_line('a')// &
+                '    my_add = a + b'//new_line('a')// &
+                '  end function my_add'//new_line('a')// &
+                'end program main'
 
-        test_internal_bind_c_function_is_callable = expect_exit_status( &
-            source, 5, '/tmp/ffc_session_bindc_call_test')
-    end function test_internal_bind_c_function_is_callable
+            test_internal_bind_c_function_is_callable = expect_exit_status( &
+                source, 5, '/tmp/ffc_session_bindc_call_test')
+        end function test_internal_bind_c_function_is_callable
 
-    logical function test_c_loc_of_integer_round_trip_with_c_associated()
-        ! c_loc(x) returns a non-null pointer; c_associated reports it true.
-        character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  use iso_c_binding'//new_line('a')// &
-            '  integer, target :: x'//new_line('a')// &
-            '  type(c_ptr) :: p'//new_line('a')// &
-            '  x = 42'//new_line('a')// &
-            '  p = c_loc(x)'//new_line('a')// &
-            '  if (c_associated(p)) then'//new_line('a')// &
-            '    stop 1'//new_line('a')// &
-            '  else'//new_line('a')// &
-            '    stop 2'//new_line('a')// &
-            '  end if'//new_line('a')// &
-            'end program main'
+        logical function test_c_loc_of_integer_round_trip_with_c_associated()
+            ! c_loc(x) returns a non-null pointer; c_associated reports it true.
+            character(len=*), parameter :: source = &
+                'program main'//new_line('a')// &
+                '  use iso_c_binding'//new_line('a')// &
+                '  integer, target :: x'//new_line('a')// &
+                '  type(c_ptr) :: p'//new_line('a')// &
+                '  x = 42'//new_line('a')// &
+                '  p = c_loc(x)'//new_line('a')// &
+                '  if (c_associated(p)) then'//new_line('a')// &
+                '    stop 1'//new_line('a')// &
+                '  else'//new_line('a')// &
+                '    stop 2'//new_line('a')// &
+                '  end if'//new_line('a')// &
+                'end program main'
 
-        test_c_loc_of_integer_round_trip_with_c_associated = &
-            expect_exit_status(source, 1, '/tmp/ffc_session_c_loc_test')
-    end function test_c_loc_of_integer_round_trip_with_c_associated
+            test_c_loc_of_integer_round_trip_with_c_associated = &
+                expect_exit_status(source, 1, '/tmp/ffc_session_c_loc_test')
+        end function test_c_loc_of_integer_round_trip_with_c_associated
 
-    logical function test_c_associated_on_null_returns_false()
-        ! c_associated(c_null_ptr) is false.
-        character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  use iso_c_binding'//new_line('a')// &
-            '  type(c_ptr) :: p'//new_line('a')// &
-            '  p = c_null_ptr'//new_line('a')// &
-            '  if (c_associated(p)) then'//new_line('a')// &
-            '    stop 1'//new_line('a')// &
-            '  else'//new_line('a')// &
-            '    stop 2'//new_line('a')// &
-            '  end if'//new_line('a')// &
-            'end program main'
+        logical function test_c_associated_on_null_returns_false()
+            ! c_associated(c_null_ptr) is false.
+            character(len=*), parameter :: source = &
+                'program main'//new_line('a')// &
+                '  use iso_c_binding'//new_line('a')// &
+                '  type(c_ptr) :: p'//new_line('a')// &
+                '  p = c_null_ptr'//new_line('a')// &
+                '  if (c_associated(p)) then'//new_line('a')// &
+                '    stop 1'//new_line('a')// &
+                '  else'//new_line('a')// &
+                '    stop 2'//new_line('a')// &
+                '  end if'//new_line('a')// &
+                'end program main'
 
-        test_c_associated_on_null_returns_false = &
-            expect_exit_status(source, 2, '/tmp/ffc_session_c_assoc_null_test')
-    end function test_c_associated_on_null_returns_false
+            test_c_associated_on_null_returns_false = &
+                expect_exit_status(source, 2, '/tmp/ffc_session_c_assoc_null_test')
+        end function test_c_associated_on_null_returns_false
 
-    logical function test_c_f_pointer_assigns_storage()
-        ! c_f_pointer(p, q) crosses p into q; q then reports associated.
-        character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  use iso_c_binding'//new_line('a')// &
-            '  integer, target :: x'//new_line('a')// &
-            '  type(c_ptr) :: p, q'//new_line('a')// &
-            '  x = 7'//new_line('a')// &
-            '  p = c_loc(x)'//new_line('a')// &
-            '  call c_f_pointer(p, q)'//new_line('a')// &
-            '  if (c_associated(q)) then'//new_line('a')// &
-            '    stop 3'//new_line('a')// &
-            '  else'//new_line('a')// &
-            '    stop 4'//new_line('a')// &
-            '  end if'//new_line('a')// &
-            'end program main'
+        logical function test_c_f_pointer_assigns_storage()
+            ! c_f_pointer(p, q) crosses p into q; q then reports associated.
+            character(len=*), parameter :: source = &
+                'program main'//new_line('a')// &
+                '  use iso_c_binding'//new_line('a')// &
+                '  integer, target :: x'//new_line('a')// &
+                '  type(c_ptr) :: p, q'//new_line('a')// &
+                '  x = 7'//new_line('a')// &
+                '  p = c_loc(x)'//new_line('a')// &
+                '  call c_f_pointer(p, q)'//new_line('a')// &
+                '  if (c_associated(q)) then'//new_line('a')// &
+                '    stop 3'//new_line('a')// &
+                '  else'//new_line('a')// &
+                '    stop 4'//new_line('a')// &
+                '  end if'//new_line('a')// &
+                'end program main'
 
-        test_c_f_pointer_assigns_storage = &
-            expect_exit_status(source, 3, '/tmp/ffc_session_c_f_pointer_test')
-    end function test_c_f_pointer_assigns_storage
+            test_c_f_pointer_assigns_storage = &
+                expect_exit_status(source, 3, '/tmp/ffc_session_c_f_pointer_test')
+        end function test_c_f_pointer_assigns_storage
 
-    logical function test_interface_bind_c_with_import_compiles()
-        ! An interface body may carry import :: of a host-scope type used as a
-        ! value argument; it parses and registers without error.
-        character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  use iso_c_binding'//new_line('a')// &
-            '  type, bind(c) :: my_type'//new_line('a')// &
-            '    integer(c_int) :: a'//new_line('a')// &
-            '  end type my_type'//new_line('a')// &
-            '  interface'//new_line('a')// &
-            '    integer(c_int) function use_it(v) bind(c, name="use_it")'// &
-            new_line('a')// &
-            '      import :: my_type, c_int'//new_line('a')// &
-            '      type(my_type), value :: v'//new_line('a')// &
-            '    end function use_it'//new_line('a')// &
-            '  end interface'//new_line('a')// &
-            '  stop 0'//new_line('a')// &
-            'end program main'
+        logical function test_interface_bind_c_with_import_compiles()
+            ! An interface body may carry import :: of a host-scope type used as a
+            ! value argument; it parses and registers without error.
+            character(len=*), parameter :: source = &
+                'program main'//new_line('a')// &
+                '  use iso_c_binding'//new_line('a')// &
+                '  type, bind(c) :: my_type'//new_line('a')// &
+                '    integer(c_int) :: a'//new_line('a')// &
+                '  end type my_type'//new_line('a')// &
+                '  interface'//new_line('a')// &
+                '    integer(c_int) function use_it(v) bind(c, name="use_it")'// &
+                new_line('a')// &
+                '      import :: my_type, c_int'//new_line('a')// &
+                '      type(my_type), value :: v'//new_line('a')// &
+                '    end function use_it'//new_line('a')// &
+                '  end interface'//new_line('a')// &
+                '  stop 0'//new_line('a')// &
+                'end program main'
 
-        test_interface_bind_c_with_import_compiles = expect_exit_status( &
-            source, 0, '/tmp/ffc_session_iface_import_test')
-    end function test_interface_bind_c_with_import_compiles
+            test_interface_bind_c_with_import_compiles = expect_exit_status( &
+                source, 0, '/tmp/ffc_session_iface_import_test')
+        end function test_interface_bind_c_with_import_compiles
 
-end program test_session_iso_c_binding_compiler
+    end program test_session_iso_c_binding_compiler

--- a/test/test_session_lazy_toplevel_function_compiler.f90
+++ b/test/test_session_lazy_toplevel_function_compiler.f90
@@ -16,22 +16,22 @@ program test_session_lazy_toplevel_function_compiler
     ! The issue_2812 corpus case: a function with inferred argument and result
     ! types, called with first-assignment inference at top level.
     if (.not. lazy_runs( &
-            'function add(a, b)'//new_line('a')// &
-            '    add = a + b'//new_line('a')// &
-            'end function'//new_line('a')// &
-            ''//new_line('a')// &
-            'x = add(5, 3)'//new_line('a')// &
-            'print *, x'//new_line('a'), &
-            '           8', 'ffc_lazy_toplevel_add')) ok = .false.
+        'function add(a, b)'//new_line('a')// &
+        '    add = a + b'//new_line('a')// &
+        'end function'//new_line('a')// &
+        ''//new_line('a')// &
+        'x = add(5, 3)'//new_line('a')// &
+        'print *, x'//new_line('a'), &
+        '           8', 'ffc_lazy_toplevel_add')) ok = .false.
 
     ! A top-level subroutine through the same standardization path.
     if (.not. lazy_runs( &
-            'subroutine show(n)'//new_line('a')// &
-            '    print *, n'//new_line('a')// &
-            'end subroutine'//new_line('a')// &
-            ''//new_line('a')// &
-            'call show(7)'//new_line('a'), &
-            '           7', 'ffc_lazy_toplevel_show')) ok = .false.
+        'subroutine show(n)'//new_line('a')// &
+        '    print *, n'//new_line('a')// &
+        'end subroutine'//new_line('a')// &
+        ''//new_line('a')// &
+        'call show(7)'//new_line('a'), &
+        '           7', 'ffc_lazy_toplevel_show')) ok = .false.
 
     ! A top-level subroutine with an explicit local declaration plus bare main
     ! statements parses to a mixed_construct_container root rather than a
@@ -39,25 +39,25 @@ program test_session_lazy_toplevel_function_compiler
     ! the subroutine becomes a contained procedure, the bare statements the
     ! main body (#266, #275). Mirrors monomorphization_scale_subroutine.lf.
     if (.not. lazy_runs( &
-            'subroutine bump(v)'//new_line('a')// &
-            '    integer :: v'//new_line('a')// &
-            '    v = v + 1'//new_line('a')// &
-            '    print *, v'//new_line('a')// &
-            'end subroutine'//new_line('a')// &
-            ''//new_line('a')// &
-            'integer :: k'//new_line('a')// &
-            'k = 41'//new_line('a')// &
-            'call bump(k)'//new_line('a'), &
-            '          42', 'ffc_mixed_container_subroutine')) ok = .false.
+        'subroutine bump(v)'//new_line('a')// &
+        '    integer :: v'//new_line('a')// &
+        '    v = v + 1'//new_line('a')// &
+        '    print *, v'//new_line('a')// &
+        'end subroutine'//new_line('a')// &
+        ''//new_line('a')// &
+        'integer :: k'//new_line('a')// &
+        'k = 41'//new_line('a')// &
+        'call bump(k)'//new_line('a'), &
+        '          42', 'ffc_mixed_container_subroutine')) ok = .false.
 
     ! A declaration-only unit (no executable statements) parses to a
     ! mixed_construct_container whose body holds only specification nodes. It
     ! must lower to a runnable empty main rather than a blanket "unsupported
     ! program unit" rejection (#266, #275). Mirrors the header-only corpus case.
     if (.not. lazy_runs_empty( &
-            'integer :: x'//new_line('a')// &
-            'real :: y'//new_line('a'), &
-            'ffc_mixed_container_decls_only')) ok = .false.
+        'integer :: x'//new_line('a')// &
+        'real :: y'//new_line('a'), &
+        'ffc_mixed_container_decls_only')) ok = .false.
 
     if (.not. ok) stop 1
     print *, 'PASS: top-level lazy function and subroutine lower and run'
@@ -87,7 +87,7 @@ contains
         close (unit)
 
         command = "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | head -n 1); "// &
-                  "test -n ""$exe"" && ""$exe"" "//src_path//' -o '//exe_path//"'"
+            "test -n ""$exe"" && ""$exe"" "//src_path//' -o '//exe_path//"'"
         call execute_command_line(command, exitstat=exit_stat, cmdstat=cmd_stat)
         if (cmd_stat /= 0 .or. exit_stat /= 0) then
             print *, 'FAIL: ffc rejected lazy source ', stem, ' exit=', exit_stat
@@ -95,7 +95,7 @@ contains
         end if
 
         call execute_command_line(exe_path//' > '//out_path, &
-                                  exitstat=exit_stat, cmdstat=cmd_stat)
+            exitstat=exit_stat, cmdstat=cmd_stat)
         if (cmd_stat /= 0 .or. exit_stat /= 0) then
             print *, 'FAIL: lazy executable did not run cleanly: ', stem
             return
@@ -130,7 +130,7 @@ contains
         close (unit)
 
         command = "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | head -n 1); "// &
-                  "test -n ""$exe"" && ""$exe"" "//src_path//' -o '//exe_path//"'"
+            "test -n ""$exe"" && ""$exe"" "//src_path//' -o '//exe_path//"'"
         call execute_command_line(command, exitstat=exit_stat, cmdstat=cmd_stat)
         if (cmd_stat /= 0 .or. exit_stat /= 0) then
             print *, 'FAIL: ffc rejected declaration-only source ', stem, &

--- a/test/test_session_libm_extra_compiler.f90
+++ b/test/test_session_libm_extra_compiler.f90
@@ -33,86 +33,86 @@ contains
         character(len=*), intent(in) :: stem
 
         check = expect_output( &
-                'program main'//new_line('a')// &
-                'real :: x'//new_line('a')// &
-                'x = '//expr//new_line('a')// &
-                'print *, x'//new_line('a')// &
-                'end program main', expected//new_line('a'), stem)
+            'program main'//new_line('a')// &
+            'real :: x'//new_line('a')// &
+            'x = '//expr//new_line('a')// &
+            'print *, x'//new_line('a')// &
+            'end program main', expected//new_line('a'), stem)
     end function check
 
     logical function test_sinh_zero()
         test_sinh_zero = check('sinh(0.0)', '   0.00000000    ', &
-                               '/tmp/ffc_session_sinh_test')
+            '/tmp/ffc_session_sinh_test')
     end function test_sinh_zero
 
     logical function test_cosh_zero()
         test_cosh_zero = check('cosh(0.0)', '   1.00000000    ', &
-                               '/tmp/ffc_session_cosh_test')
+            '/tmp/ffc_session_cosh_test')
     end function test_cosh_zero
 
     logical function test_tanh_zero()
         test_tanh_zero = check('tanh(0.0)', '   0.00000000    ', &
-                               '/tmp/ffc_session_tanh_test')
+            '/tmp/ffc_session_tanh_test')
     end function test_tanh_zero
 
     logical function test_asin_one()
         ! asin of a default real lowers to asinf and matches gfortran at runtime
         test_asin_one = check('asin(1.0)', '   1.57079637    ', &
-                              '/tmp/ffc_session_asin_test')
+            '/tmp/ffc_session_asin_test')
     end function test_asin_one
 
     logical function test_acos_one()
         test_acos_one = check('acos(1.0)', '   0.00000000    ', &
-                              '/tmp/ffc_session_acos_test')
+            '/tmp/ffc_session_acos_test')
     end function test_acos_one
 
     logical function test_asinh_zero()
         test_asinh_zero = check('asinh(0.0)', '   0.00000000    ', &
-                                '/tmp/ffc_session_asinh_test')
+            '/tmp/ffc_session_asinh_test')
     end function test_asinh_zero
 
     logical function test_acosh_one()
         test_acosh_one = check('acosh(1.0)', '   0.00000000    ', &
-                               '/tmp/ffc_session_acosh_test')
+            '/tmp/ffc_session_acosh_test')
     end function test_acosh_one
 
     logical function test_atanh_zero()
         test_atanh_zero = check('atanh(0.0)', '   0.00000000    ', &
-                                '/tmp/ffc_session_atanh_test')
+            '/tmp/ffc_session_atanh_test')
     end function test_atanh_zero
 
     logical function test_log10_thousand()
         test_log10_thousand = check('log10(1000.0)', &
-                                    '   3.00000000    ', &
-                                    '/tmp/ffc_session_log10_test')
+            '   3.00000000    ', &
+            '/tmp/ffc_session_log10_test')
     end function test_log10_thousand
 
     logical function test_erf_zero()
         test_erf_zero = check('erf(0.0)', '   0.00000000    ', &
-                              '/tmp/ffc_session_erf_test')
+            '/tmp/ffc_session_erf_test')
     end function test_erf_zero
 
     logical function test_erfc_zero()
         test_erfc_zero = check('erfc(0.0)', '   1.00000000    ', &
-                               '/tmp/ffc_session_erfc_test')
+            '/tmp/ffc_session_erfc_test')
     end function test_erfc_zero
 
     logical function test_gamma_five()
         ! gamma(5.0) == 4! == 24, printed in gfortran real(4) list-directed form
         test_gamma_five = check('gamma(5.0)', '   24.0000000    ', &
-                                '/tmp/ffc_session_gamma_test')
+            '/tmp/ffc_session_gamma_test')
     end function test_gamma_five
 
     logical function test_log_gamma_one()
         test_log_gamma_one = check('log_gamma(1.0)', &
-                                   '   0.00000000    ', &
-                                   '/tmp/ffc_session_log_gamma_test')
+            '   0.00000000    ', &
+            '/tmp/ffc_session_log_gamma_test')
     end function test_log_gamma_one
 
     logical function test_hypot_three_four()
         test_hypot_three_four = check('hypot(3.0, 4.0)', &
-                                      '   5.00000000    ', &
-                                      '/tmp/ffc_session_hypot_test')
+            '   5.00000000    ', &
+            '/tmp/ffc_session_hypot_test')
     end function test_hypot_three_four
 
 end program test_session_libm_extra

--- a/test/test_session_logical_literal_print_compiler.f90
+++ b/test/test_session_logical_literal_print_compiler.f90
@@ -5,10 +5,10 @@ program test_session_logical_literal_print_compiler
     print *, '=== direct session logical literal print compiler test ==='
 
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  print *, .true.'//new_line('a')// &
-         'end program main', ' T'//new_line('a'), &
-         '/tmp/ffc_session_logical_literal_print_test')) stop 1
+        'program main'//new_line('a')// &
+        '  print *, .true.'//new_line('a')// &
+        'end program main', ' T'//new_line('a'), &
+        '/tmp/ffc_session_logical_literal_print_test')) stop 1
 
     print *, 'PASS: logical literal print lowers through direct LIRIC session'
 end program test_session_logical_literal_print_compiler

--- a/test/test_session_logical_variable_compiler.f90
+++ b/test/test_session_logical_variable_compiler.f90
@@ -5,16 +5,16 @@ program test_session_logical_variable_compiler
     print *, '=== direct session logical variable compiler test ==='
 
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  logical :: flag'//new_line('a')// &
-         '  flag = .true.'//new_line('a')// &
-         '  if (flag) then'//new_line('a')// &
-         '    print *, flag'//new_line('a')// &
-         '  else'//new_line('a')// &
-         '    print *, .false.'//new_line('a')// &
-         '  end if'//new_line('a')// &
-         'end program main', ' T'//new_line('a'), &
-         '/tmp/ffc_session_logical_var_test')) stop 1
+        'program main'//new_line('a')// &
+        '  logical :: flag'//new_line('a')// &
+        '  flag = .true.'//new_line('a')// &
+        '  if (flag) then'//new_line('a')// &
+        '    print *, flag'//new_line('a')// &
+        '  else'//new_line('a')// &
+        '    print *, .false.'//new_line('a')// &
+        '  end if'//new_line('a')// &
+        'end program main', ' T'//new_line('a'), &
+        '/tmp/ffc_session_logical_var_test')) stop 1
 
     print *, 'PASS: logical variables lower through direct LIRIC session'
 end program test_session_logical_variable_compiler

--- a/test/test_session_loop_cycle_compiler.f90
+++ b/test/test_session_loop_cycle_compiler.f90
@@ -17,44 +17,44 @@ contains
 
     logical function test_cycle_skips_remainder_of_body()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: i'//new_line('a')// &
-                                       'integer :: total'//new_line('a')// &
-                                       'total = 0'//new_line('a')// &
-                                       'do i = 1, 5'//new_line('a')// &
-                                       '    if (i == 3) then'//new_line('a')// &
-                                       '        cycle'//new_line('a')// &
-                                       '    else'//new_line('a')// &
-                                       '    end if'//new_line('a')// &
-                                       '    total = total + i'//new_line('a')// &
-                                       'end do'//new_line('a')// &
-                                       'stop total'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: i'//new_line('a')// &
+            'integer :: total'//new_line('a')// &
+            'total = 0'//new_line('a')// &
+            'do i = 1, 5'//new_line('a')// &
+            '    if (i == 3) then'//new_line('a')// &
+            '        cycle'//new_line('a')// &
+            '    else'//new_line('a')// &
+            '    end if'//new_line('a')// &
+            '    total = total + i'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'stop total'//new_line('a')// &
+            'end program main'
 
         test_cycle_skips_remainder_of_body = expect_exit_status( &
-                                  source, 12, &
-                                  '/tmp/ffc_session_cycle_skip_test')
+            source, 12, &
+            '/tmp/ffc_session_cycle_skip_test')
     end function test_cycle_skips_remainder_of_body
 
     logical function test_cycle_does_not_skip_latch()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: i'//new_line('a')// &
-                                       'integer :: visits'//new_line('a')// &
-                                       'visits = 0'//new_line('a')// &
-                                       'do i = 1, 5'//new_line('a')// &
-                                       '    visits = visits + 1'//new_line('a')// &
-                                       '    if (i == 3) then'//new_line('a')// &
-                                       '        cycle'//new_line('a')// &
-                                       '    else'//new_line('a')// &
-                                       '    end if'//new_line('a')// &
-                                       'end do'//new_line('a')// &
-                                       'stop visits'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: i'//new_line('a')// &
+            'integer :: visits'//new_line('a')// &
+            'visits = 0'//new_line('a')// &
+            'do i = 1, 5'//new_line('a')// &
+            '    visits = visits + 1'//new_line('a')// &
+            '    if (i == 3) then'//new_line('a')// &
+            '        cycle'//new_line('a')// &
+            '    else'//new_line('a')// &
+            '    end if'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'stop visits'//new_line('a')// &
+            'end program main'
 
         test_cycle_does_not_skip_latch = expect_exit_status( &
-                                  source, 5, &
-                                  '/tmp/ffc_session_cycle_latch_test')
+            source, 5, &
+            '/tmp/ffc_session_cycle_latch_test')
     end function test_cycle_does_not_skip_latch
 
 end program test_session_loop_cycle_compiler

--- a/test/test_session_loop_exit_compiler.f90
+++ b/test/test_session_loop_exit_compiler.f90
@@ -18,65 +18,65 @@ contains
 
     logical function test_exit_terminates_simple_loop()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: i'//new_line('a')// &
-                                       'do i = 1, 10'//new_line('a')// &
-                                       '    if (i == 5) then'//new_line('a')// &
-                                       '        exit'//new_line('a')// &
-                                       '    else'//new_line('a')// &
-                                       '    end if'//new_line('a')// &
-                                       'end do'//new_line('a')// &
-                                       'stop i'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: i'//new_line('a')// &
+            'do i = 1, 10'//new_line('a')// &
+            '    if (i == 5) then'//new_line('a')// &
+            '        exit'//new_line('a')// &
+            '    else'//new_line('a')// &
+            '    end if'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'stop i'//new_line('a')// &
+            'end program main'
 
         test_exit_terminates_simple_loop = expect_exit_status( &
-                                           source, 5, &
-                                           '/tmp/ffc_session_exit_simple_test')
+            source, 5, &
+            '/tmp/ffc_session_exit_simple_test')
     end function test_exit_terminates_simple_loop
 
     logical function test_exit_carries_accumulator()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: i'//new_line('a')// &
-                                       'integer :: total'//new_line('a')// &
-                                       'total = 0'//new_line('a')// &
-                                       'do i = 1, 10'//new_line('a')// &
-                                       '    if (i == 5) then'//new_line('a')// &
-                                       '        exit'//new_line('a')// &
-                                       '    else'//new_line('a')// &
-                                       '        total = total + i'//new_line('a')// &
-                                       '    end if'//new_line('a')// &
-                                       'end do'//new_line('a')// &
-                                       'stop total'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: i'//new_line('a')// &
+            'integer :: total'//new_line('a')// &
+            'total = 0'//new_line('a')// &
+            'do i = 1, 10'//new_line('a')// &
+            '    if (i == 5) then'//new_line('a')// &
+            '        exit'//new_line('a')// &
+            '    else'//new_line('a')// &
+            '        total = total + i'//new_line('a')// &
+            '    end if'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'stop total'//new_line('a')// &
+            'end program main'
 
         test_exit_carries_accumulator = expect_exit_status( &
-                                        source, 10, &
-                                        '/tmp/ffc_session_exit_accum_test')
+            source, 10, &
+            '/tmp/ffc_session_exit_accum_test')
     end function test_exit_carries_accumulator
 
     logical function test_exit_inside_nested_loops_targets_inner()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'integer :: i'//new_line('a')// &
-                                       'integer :: j'//new_line('a')// &
-                                       'integer :: total'//new_line('a')// &
-                                       'total = 0'//new_line('a')// &
-                                       'do i = 1, 3'//new_line('a')// &
-                                       '    do j = 1, 10'//new_line('a')// &
-                                       '        if (j == 3) then'//new_line('a')// &
-                                       '            exit'//new_line('a')// &
-                                       '        else'//new_line('a')// &
-                                       '        total = total + 1'//new_line('a')// &
-                                       '        end if'//new_line('a')// &
-                                       '    end do'//new_line('a')// &
-                                       'end do'//new_line('a')// &
-                                       'stop total'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'integer :: i'//new_line('a')// &
+            'integer :: j'//new_line('a')// &
+            'integer :: total'//new_line('a')// &
+            'total = 0'//new_line('a')// &
+            'do i = 1, 3'//new_line('a')// &
+            '    do j = 1, 10'//new_line('a')// &
+            '        if (j == 3) then'//new_line('a')// &
+            '            exit'//new_line('a')// &
+            '        else'//new_line('a')// &
+            '        total = total + 1'//new_line('a')// &
+            '        end if'//new_line('a')// &
+            '    end do'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'stop total'//new_line('a')// &
+            'end program main'
 
         test_exit_inside_nested_loops_targets_inner = expect_exit_status( &
-                          source, 6, &
-                          '/tmp/ffc_session_exit_nested_test')
+            source, 6, &
+            '/tmp/ffc_session_exit_nested_test')
     end function test_exit_inside_nested_loops_targets_inner
 
 end program test_session_loop_exit_compiler

--- a/test/test_session_module_constant_scope_compiler.f90
+++ b/test/test_session_module_constant_scope_compiler.f90
@@ -7,54 +7,54 @@ program test_session_module_constant_scope_compiler
     ! A module integer parameter is visible inside a module procedure (#1826),
     ! run end to end through a using program.
     if (.not. expect_output( &
-         'module m'//new_line('a')// &
-         '    integer, parameter :: LIMIT = 7'//new_line('a')// &
-         'contains'//new_line('a')// &
-         '    subroutine show()'//new_line('a')// &
-         '        print *, LIMIT'//new_line('a')// &
-         '    end subroutine show'//new_line('a')// &
-         'end module m'//new_line('a')// &
-         'program main'//new_line('a')// &
-         '    use m'//new_line('a')// &
-         '    call show()'//new_line('a')// &
-         'end program main', &
-         '           7'//new_line('a'), &
-         '/tmp/ffc_modconst_int_test')) stop 1
+        'module m'//new_line('a')// &
+        '    integer, parameter :: LIMIT = 7'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '    subroutine show()'//new_line('a')// &
+        '        print *, LIMIT'//new_line('a')// &
+        '    end subroutine show'//new_line('a')// &
+        'end module m'//new_line('a')// &
+        'program main'//new_line('a')// &
+        '    use m'//new_line('a')// &
+        '    call show()'//new_line('a')// &
+        'end program main', &
+        '           7'//new_line('a'), &
+        '/tmp/ffc_modconst_int_test')) stop 1
     print *, 'PASS: module integer parameter visible in module procedure'
 
     ! A module enumerator is visible inside a module procedure (#1826).
     if (.not. expect_output( &
-         'module colors'//new_line('a')// &
-         '    enum, bind(c)'//new_line('a')// &
-         '        enumerator :: RED = 1, GREEN = 2, BLUE = 3'//new_line('a')// &
-         '    end enum'//new_line('a')// &
-         'contains'//new_line('a')// &
-         '    subroutine report()'//new_line('a')// &
-         '        print *, RED, BLUE'//new_line('a')// &
-         '    end subroutine report'//new_line('a')// &
-         'end module colors'//new_line('a')// &
-         'program main'//new_line('a')// &
-         '    use colors'//new_line('a')// &
-         '    call report()'//new_line('a')// &
-         'end program main', &
-         '           1           3'//new_line('a'), &
-         '/tmp/ffc_modconst_enum_test')) stop 1
+        'module colors'//new_line('a')// &
+        '    enum, bind(c)'//new_line('a')// &
+        '        enumerator :: RED = 1, GREEN = 2, BLUE = 3'//new_line('a')// &
+        '    end enum'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '    subroutine report()'//new_line('a')// &
+        '        print *, RED, BLUE'//new_line('a')// &
+        '    end subroutine report'//new_line('a')// &
+        'end module colors'//new_line('a')// &
+        'program main'//new_line('a')// &
+        '    use colors'//new_line('a')// &
+        '    call report()'//new_line('a')// &
+        'end program main', &
+        '           1           3'//new_line('a'), &
+        '/tmp/ffc_modconst_enum_test')) stop 1
     print *, 'PASS: module enumerator visible in module procedure'
 
     ! Real, logical, and character module parameters bind inside a module
     ! procedure body. The using-program import path for non-integer constants
     ! is a separate boundary, so lower the module on its own to an object.
     if (.not. expect_object_exists( &
-         'module m'//new_line('a')// &
-         '    real, parameter :: SCALE = 2.5'//new_line('a')// &
-         '    logical, parameter :: FLAG = .true.'//new_line('a')// &
-         '    character(len=*), parameter :: TAG = "hi"'//new_line('a')// &
-         'contains'//new_line('a')// &
-         '    subroutine doit()'//new_line('a')// &
-         '        if (FLAG) print *, SCALE, TAG'//new_line('a')// &
-         '    end subroutine doit'//new_line('a')// &
-         'end module m', &
-         '/tmp/ffc_modconst_mixed_test.o')) stop 1
+        'module m'//new_line('a')// &
+        '    real, parameter :: SCALE = 2.5'//new_line('a')// &
+        '    logical, parameter :: FLAG = .true.'//new_line('a')// &
+        '    character(len=*), parameter :: TAG = "hi"'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '    subroutine doit()'//new_line('a')// &
+        '        if (FLAG) print *, SCALE, TAG'//new_line('a')// &
+        '    end subroutine doit'//new_line('a')// &
+        'end module m', &
+        '/tmp/ffc_modconst_mixed_test.o')) stop 1
     print *, 'PASS: real/logical/character parameters bind in module procedure'
 
     print *, 'PASS: module named constants host-associate into procedures'

--- a/test/test_session_module_derived_arg_compiler.f90
+++ b/test/test_session_module_derived_arg_compiler.f90
@@ -16,107 +16,107 @@ contains
     ! and writing component results back through the out dummy.
     logical function test_subroutine_derived_args()
         character(len=*), parameter :: source = &
-           'module vecmod'//new_line('a')// &
-           '  implicit none'//new_line('a')// &
-           '  type :: vector'//new_line('a')// &
-           '    integer :: x'//new_line('a')// &
-           '    integer :: y'//new_line('a')// &
-           '  end type vector'//new_line('a')// &
-           'contains'//new_line('a')// &
-           '  subroutine addvec(a, b, c)'//new_line('a')// &
-           '    type(vector), intent(in) :: a'//new_line('a')// &
-           '    type(vector), intent(in) :: b'//new_line('a')// &
-           '    type(vector), intent(out) :: c'//new_line('a')// &
-           '    c%x = a%x + b%x'//new_line('a')// &
-           '    c%y = a%y + b%y'//new_line('a')// &
-           '  end subroutine addvec'//new_line('a')// &
-           'end module vecmod'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  use vecmod'//new_line('a')// &
-           '  implicit none'//new_line('a')// &
-           '  type(vector) :: p, q, r'//new_line('a')// &
-           '  p%x = 1'//new_line('a')// &
-           '  p%y = 2'//new_line('a')// &
-           '  q%x = 10'//new_line('a')// &
-           '  q%y = 20'//new_line('a')// &
-           '  call addvec(p, q, r)'//new_line('a')// &
-           '  stop r%x + r%y'//new_line('a')// &
-           'end program main'
+            'module vecmod'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: vector'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '    integer :: y'//new_line('a')// &
+            '  end type vector'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine addvec(a, b, c)'//new_line('a')// &
+            '    type(vector), intent(in) :: a'//new_line('a')// &
+            '    type(vector), intent(in) :: b'//new_line('a')// &
+            '    type(vector), intent(out) :: c'//new_line('a')// &
+            '    c%x = a%x + b%x'//new_line('a')// &
+            '    c%y = a%y + b%y'//new_line('a')// &
+            '  end subroutine addvec'//new_line('a')// &
+            'end module vecmod'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use vecmod'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(vector) :: p, q, r'//new_line('a')// &
+            '  p%x = 1'//new_line('a')// &
+            '  p%y = 2'//new_line('a')// &
+            '  q%x = 10'//new_line('a')// &
+            '  q%y = 20'//new_line('a')// &
+            '  call addvec(p, q, r)'//new_line('a')// &
+            '  stop r%x + r%y'//new_line('a')// &
+            'end program main'
 
         ! 11 + 22 = 33.
         test_subroutine_derived_args = expect_exit_status( &
-           source, 33, '/tmp/ffc_module_derived_arg_sub_test')
+            source, 33, '/tmp/ffc_module_derived_arg_sub_test')
     end function test_subroutine_derived_args
 
     ! A module function returning a module-defined derived type, called and its
     ! components read back in the program.
     logical function test_function_derived_result()
         character(len=*), parameter :: source = &
-           'module vecmod'//new_line('a')// &
-           '  implicit none'//new_line('a')// &
-           '  type :: vector'//new_line('a')// &
-           '    integer :: x'//new_line('a')// &
-           '    integer :: y'//new_line('a')// &
-           '  end type vector'//new_line('a')// &
-           'contains'//new_line('a')// &
-           '  function addvec(a, b) result(c)'//new_line('a')// &
-           '    type(vector), intent(in) :: a'//new_line('a')// &
-           '    type(vector), intent(in) :: b'//new_line('a')// &
-           '    type(vector) :: c'//new_line('a')// &
-           '    c%x = a%x + b%x'//new_line('a')// &
-           '    c%y = a%y + b%y'//new_line('a')// &
-           '  end function addvec'//new_line('a')// &
-           'end module vecmod'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  use vecmod'//new_line('a')// &
-           '  implicit none'//new_line('a')// &
-           '  type(vector) :: p, q, r'//new_line('a')// &
-           '  p%x = 3'//new_line('a')// &
-           '  p%y = 4'//new_line('a')// &
-           '  q%x = 30'//new_line('a')// &
-           '  q%y = 40'//new_line('a')// &
-           '  r = addvec(p, q)'//new_line('a')// &
-           '  stop r%x + r%y'//new_line('a')// &
-           'end program main'
+            'module vecmod'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: vector'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '    integer :: y'//new_line('a')// &
+            '  end type vector'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  function addvec(a, b) result(c)'//new_line('a')// &
+            '    type(vector), intent(in) :: a'//new_line('a')// &
+            '    type(vector), intent(in) :: b'//new_line('a')// &
+            '    type(vector) :: c'//new_line('a')// &
+            '    c%x = a%x + b%x'//new_line('a')// &
+            '    c%y = a%y + b%y'//new_line('a')// &
+            '  end function addvec'//new_line('a')// &
+            'end module vecmod'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use vecmod'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(vector) :: p, q, r'//new_line('a')// &
+            '  p%x = 3'//new_line('a')// &
+            '  p%y = 4'//new_line('a')// &
+            '  q%x = 30'//new_line('a')// &
+            '  q%y = 40'//new_line('a')// &
+            '  r = addvec(p, q)'//new_line('a')// &
+            '  stop r%x + r%y'//new_line('a')// &
+            'end program main'
 
         ! 33 + 44 = 77.
         test_function_derived_result = expect_exit_status( &
-           source, 77, '/tmp/ffc_module_derived_arg_fn_test')
+            source, 77, '/tmp/ffc_module_derived_arg_fn_test')
     end function test_function_derived_result
 
     ! Confirm the stdout of a module subroutine that prints a derived result.
     logical function test_derived_arg_output()
         character(len=*), parameter :: source = &
-           'module vecmod'//new_line('a')// &
-           '  implicit none'//new_line('a')// &
-           '  type :: vector'//new_line('a')// &
-           '    integer :: x'//new_line('a')// &
-           '    integer :: y'//new_line('a')// &
-           '  end type vector'//new_line('a')// &
-           'contains'//new_line('a')// &
-           '  subroutine addvec(a, b, c)'//new_line('a')// &
-           '    type(vector), intent(in) :: a'//new_line('a')// &
-           '    type(vector), intent(in) :: b'//new_line('a')// &
-           '    type(vector), intent(out) :: c'//new_line('a')// &
-           '    c%x = a%x + b%x'//new_line('a')// &
-           '    c%y = a%y + b%y'//new_line('a')// &
-           '  end subroutine addvec'//new_line('a')// &
-           'end module vecmod'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  use vecmod'//new_line('a')// &
-           '  implicit none'//new_line('a')// &
-           '  type(vector) :: p, q, r'//new_line('a')// &
-           '  p%x = 1'//new_line('a')// &
-           '  p%y = 2'//new_line('a')// &
-           '  q%x = 10'//new_line('a')// &
-           '  q%y = 20'//new_line('a')// &
-           '  call addvec(p, q, r)'//new_line('a')// &
-           '  print *, r%x, r%y'//new_line('a')// &
-           'end program main'
+            'module vecmod'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: vector'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '    integer :: y'//new_line('a')// &
+            '  end type vector'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine addvec(a, b, c)'//new_line('a')// &
+            '    type(vector), intent(in) :: a'//new_line('a')// &
+            '    type(vector), intent(in) :: b'//new_line('a')// &
+            '    type(vector), intent(out) :: c'//new_line('a')// &
+            '    c%x = a%x + b%x'//new_line('a')// &
+            '    c%y = a%y + b%y'//new_line('a')// &
+            '  end subroutine addvec'//new_line('a')// &
+            'end module vecmod'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use vecmod'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(vector) :: p, q, r'//new_line('a')// &
+            '  p%x = 1'//new_line('a')// &
+            '  p%y = 2'//new_line('a')// &
+            '  q%x = 10'//new_line('a')// &
+            '  q%y = 20'//new_line('a')// &
+            '  call addvec(p, q, r)'//new_line('a')// &
+            '  print *, r%x, r%y'//new_line('a')// &
+            'end program main'
 
         test_derived_arg_output = expect_output( &
-           source, '          11          22'//new_line('a'), &
-           '/tmp/ffc_module_derived_arg_out_test')
+            source, '          11          22'//new_line('a'), &
+            '/tmp/ffc_module_derived_arg_out_test')
     end function test_derived_arg_output
 
 end program test_session_module_derived_arg_compiler

--- a/test/test_session_module_exports_derived_type_compiler.f90
+++ b/test/test_session_module_exports_derived_type_compiler.f90
@@ -20,213 +20,213 @@ contains
 
     logical function test_module_with_single_derived_type()
         character(len=*), parameter :: source = &
-           'module point_mod'//new_line('a')// &
-           '  type :: point_t'//new_line('a')// &
-           '    integer :: x'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           'end module point_mod'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  stop 0'//new_line('a')// &
-           'end program main'
+            'module point_mod'//new_line('a')// &
+            '  type :: point_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            'end module point_mod'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
 
         test_module_with_single_derived_type = expect_exit_status( &
-           source, 0, &
-           '/tmp/ffc_module_exports_single_test')
+            source, 0, &
+            '/tmp/ffc_module_exports_single_test')
     end function test_module_with_single_derived_type
 
     logical function test_module_with_multiple_derived_types()
         character(len=*), parameter :: source = &
-           'module shapes_mod'//new_line('a')// &
-           '  type :: circle_t'//new_line('a')// &
-           '    integer :: radius'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: rectangle_t'//new_line('a')// &
-           '    integer :: width'//new_line('a')// &
-           '    integer :: height'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           'end module shapes_mod'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  stop 0'//new_line('a')// &
-           'end program main'
+            'module shapes_mod'//new_line('a')// &
+            '  type :: circle_t'//new_line('a')// &
+            '    integer :: radius'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: rectangle_t'//new_line('a')// &
+            '    integer :: width'//new_line('a')// &
+            '    integer :: height'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            'end module shapes_mod'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
 
         test_module_with_multiple_derived_types = expect_exit_status( &
-           source, 0, &
-           '/tmp/ffc_module_exports_multi_test')
+            source, 0, &
+            '/tmp/ffc_module_exports_multi_test')
     end function test_module_with_multiple_derived_types
 
     logical function test_empty_module_compiles()
         character(len=*), parameter :: source = &
-           'module empty_mod'//new_line('a')// &
-           'end module empty_mod'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  stop 0'//new_line('a')// &
-           'end program main'
+            'module empty_mod'//new_line('a')// &
+            'end module empty_mod'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
 
         test_empty_module_compiles = expect_exit_status( &
-           source, 0, &
-           '/tmp/ffc_module_exports_empty_test')
+            source, 0, &
+            '/tmp/ffc_module_exports_empty_test')
     end function test_empty_module_compiles
 
     logical function test_module_derived_type_with_component_assignment()
         character(len=*), parameter :: source = &
-           'module vec_mod'//new_line('a')// &
-           '  type :: vec3_t'//new_line('a')// &
-           '    integer :: x, y, z'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           'end module vec_mod'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  use vec_mod'//new_line('a')// &
-           '  type(vec3_t) :: v'//new_line('a')// &
-           '  v%x = 1'//new_line('a')// &
-           '  v%y = 2'//new_line('a')// &
-           '  v%z = 3'//new_line('a')// &
-           '  print *, v%x + v%y + v%z'//new_line('a')// &
-           'end program main'
+            'module vec_mod'//new_line('a')// &
+            '  type :: vec3_t'//new_line('a')// &
+            '    integer :: x, y, z'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            'end module vec_mod'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use vec_mod'//new_line('a')// &
+            '  type(vec3_t) :: v'//new_line('a')// &
+            '  v%x = 1'//new_line('a')// &
+            '  v%y = 2'//new_line('a')// &
+            '  v%z = 3'//new_line('a')// &
+            '  print *, v%x + v%y + v%z'//new_line('a')// &
+            'end program main'
 
         test_module_derived_type_with_component_assignment = expect_output( &
-           source, '           6'//new_line('a'), '/tmp/ffc_module_exports_component_test')
+            source, '           6'//new_line('a'), '/tmp/ffc_module_exports_component_test')
     end function test_module_derived_type_with_component_assignment
 
     logical function test_module_with_many_derived_types()
         character(len=*), parameter :: source = &
-           'module big_mod'//new_line('a')// &
-           '  type :: a1_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a2_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a3_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a4_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a5_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a6_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a7_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a8_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a9_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a10_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a11_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a12_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a13_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a14_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a15_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           '  type :: a16_t'//new_line('a')// &
-           '    integer :: v'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           'end module big_mod'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  stop 0'//new_line('a')// &
-           'end program main'
+            'module big_mod'//new_line('a')// &
+            '  type :: a1_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a2_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a3_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a4_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a5_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a6_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a7_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a8_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a9_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a10_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a11_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a12_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a13_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a14_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a15_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            '  type :: a16_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            'end module big_mod'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
 
         test_module_with_many_derived_types = expect_exit_status( &
-           source, 0, &
-           '/tmp/ffc_module_exports_many_test')
+            source, 0, &
+            '/tmp/ffc_module_exports_many_test')
     end function test_module_with_many_derived_types
 
     logical function test_two_modules_with_derived_types()
         character(len=*), parameter :: source = &
-           'module mod_a'//new_line('a')// &
-           '  type :: type_a_t'//new_line('a')// &
-           '    integer :: a'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           'end module mod_a'//new_line('a')// &
-           'module mod_b'//new_line('a')// &
-           '  type :: type_b_t'//new_line('a')// &
-           '    integer :: b'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           'end module mod_b'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  stop 0'//new_line('a')// &
-           'end program main'
+            'module mod_a'//new_line('a')// &
+            '  type :: type_a_t'//new_line('a')// &
+            '    integer :: a'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            'end module mod_a'//new_line('a')// &
+            'module mod_b'//new_line('a')// &
+            '  type :: type_b_t'//new_line('a')// &
+            '    integer :: b'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            'end module mod_b'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
 
         test_two_modules_with_derived_types = expect_exit_status( &
-           source, 0, &
-           '/tmp/ffc_module_exports_two_mods_test')
+            source, 0, &
+            '/tmp/ffc_module_exports_two_mods_test')
     end function test_two_modules_with_derived_types
 
     logical function test_module_with_only_integer_params()
         character(len=*), parameter :: source = &
-           'module params_mod'//new_line('a')// &
-           '  integer, parameter :: p = 42'//new_line('a')// &
-           'end module params_mod'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  stop 0'//new_line('a')// &
-           'end program main'
+            'module params_mod'//new_line('a')// &
+            '  integer, parameter :: p = 42'//new_line('a')// &
+            'end module params_mod'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
 
         test_module_with_only_integer_params = expect_exit_status( &
-           source, 0, &
-           '/tmp/ffc_module_exports_params_test')
+            source, 0, &
+            '/tmp/ffc_module_exports_params_test')
     end function test_module_with_only_integer_params
 
     logical function test_derived_type_with_single_component()
         character(len=*), parameter :: source = &
-           'module single_comp_mod'//new_line('a')// &
-           '  type :: single_t'//new_line('a')// &
-           '    integer :: only'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           'end module single_comp_mod'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  use single_comp_mod'//new_line('a')// &
-           '  type(single_t) :: s'//new_line('a')// &
-           '  s%only = 99'//new_line('a')// &
-           '  print *, s%only'//new_line('a')// &
-           'end program main'
+            'module single_comp_mod'//new_line('a')// &
+            '  type :: single_t'//new_line('a')// &
+            '    integer :: only'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            'end module single_comp_mod'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use single_comp_mod'//new_line('a')// &
+            '  type(single_t) :: s'//new_line('a')// &
+            '  s%only = 99'//new_line('a')// &
+            '  print *, s%only'//new_line('a')// &
+            'end program main'
 
         test_derived_type_with_single_component = expect_output( &
-           source, '          99'//new_line('a'), '/tmp/ffc_module_exports_single_comp_test')
+            source, '          99'//new_line('a'), '/tmp/ffc_module_exports_single_comp_test')
     end function test_derived_type_with_single_component
 
     logical function test_derived_type_with_many_components()
         character(len=*), parameter :: source = &
-           'module many_comp_mod'//new_line('a')// &
-           '  type :: many_t'//new_line('a')// &
-           '    integer :: c1, c2, c3, c4, c5'//new_line('a')// &
-           '    integer :: c6, c7, c8, c9, c10'//new_line('a')// &
-           '  end type'//new_line('a')// &
-           'end module many_comp_mod'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  use many_comp_mod'//new_line('a')// &
-           '  type(many_t) :: m'//new_line('a')// &
-           '  m%c1 = 1'//new_line('a')// &
-           '  m%c2 = 2'//new_line('a')// &
-           '  m%c3 = 3'//new_line('a')// &
-           '  m%c4 = 4'//new_line('a')// &
-           '  m%c5 = 5'//new_line('a')// &
-           '  m%c6 = 6'//new_line('a')// &
-           '  m%c7 = 7'//new_line('a')// &
-           '  m%c8 = 8'//new_line('a')// &
-           '  m%c9 = 9'//new_line('a')// &
-           '  m%c10 = 10'//new_line('a')// &
-           '  print *, m%c1+m%c2+m%c3+m%c4+m%c5+m%c6+m%c7+m%c8+m%c9+m%c10'//new_line('a')// &
-           'end program main'
+            'module many_comp_mod'//new_line('a')// &
+            '  type :: many_t'//new_line('a')// &
+            '    integer :: c1, c2, c3, c4, c5'//new_line('a')// &
+            '    integer :: c6, c7, c8, c9, c10'//new_line('a')// &
+            '  end type'//new_line('a')// &
+            'end module many_comp_mod'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use many_comp_mod'//new_line('a')// &
+            '  type(many_t) :: m'//new_line('a')// &
+            '  m%c1 = 1'//new_line('a')// &
+            '  m%c2 = 2'//new_line('a')// &
+            '  m%c3 = 3'//new_line('a')// &
+            '  m%c4 = 4'//new_line('a')// &
+            '  m%c5 = 5'//new_line('a')// &
+            '  m%c6 = 6'//new_line('a')// &
+            '  m%c7 = 7'//new_line('a')// &
+            '  m%c8 = 8'//new_line('a')// &
+            '  m%c9 = 9'//new_line('a')// &
+            '  m%c10 = 10'//new_line('a')// &
+            '  print *, m%c1+m%c2+m%c3+m%c4+m%c5+m%c6+m%c7+m%c8+m%c9+m%c10'//new_line('a')// &
+            'end program main'
 
         test_derived_type_with_many_components = expect_output( &
-           source, '          55'//new_line('a'), '/tmp/ffc_module_exports_many_comp_test')
+            source, '          55'//new_line('a'), '/tmp/ffc_module_exports_many_comp_test')
     end function test_derived_type_with_many_components
 
 end program test_session_module_exports_derived_type_compiler

--- a/test/test_session_module_internal_proc_compiler.f90
+++ b/test/test_session_module_internal_proc_compiler.f90
@@ -67,33 +67,33 @@ contains
             'end program main'
 
         test_module_sub_with_internal_function = expect_exit_status( &
-            source, 12, '/tmp/ffc_session_mod_internal_fn_test')
-    end function test_module_sub_with_internal_function
+                source, 12, '/tmp/ffc_session_mod_internal_fn_test')
+        end function test_module_sub_with_internal_function
 
-    logical function test_module_function_with_internal_function()
-        ! A module integer function that contains an internal integer function;
-        ! the program reports the outer function's result.
-        character(len=*), parameter :: source = &
-            'module m'//new_line('a')// &
-            '  implicit none'//new_line('a')// &
-            'contains'//new_line('a')// &
-            '  integer function compute(n)'//new_line('a')// &
-            '    integer, intent(in) :: n'//new_line('a')// &
-            '    compute = bump(n) + 1'//new_line('a')// &
-            '  contains'//new_line('a')// &
-            '    integer function bump(x)'//new_line('a')// &
-            '      integer, intent(in) :: x'//new_line('a')// &
-            '      bump = x * 2'//new_line('a')// &
-            '    end function bump'//new_line('a')// &
-            '  end function compute'//new_line('a')// &
-            'end module m'//new_line('a')// &
-            'program main'//new_line('a')// &
-            '  use m'//new_line('a')// &
-            '  stop compute(5)'//new_line('a')// &
-            'end program main'
+        logical function test_module_function_with_internal_function()
+            ! A module integer function that contains an internal integer function;
+            ! the program reports the outer function's result.
+            character(len=*), parameter :: source = &
+                'module m'//new_line('a')// &
+                '  implicit none'//new_line('a')// &
+                'contains'//new_line('a')// &
+                '  integer function compute(n)'//new_line('a')// &
+                '    integer, intent(in) :: n'//new_line('a')// &
+                '    compute = bump(n) + 1'//new_line('a')// &
+                '  contains'//new_line('a')// &
+                '    integer function bump(x)'//new_line('a')// &
+                '      integer, intent(in) :: x'//new_line('a')// &
+                '      bump = x * 2'//new_line('a')// &
+                '    end function bump'//new_line('a')// &
+                '  end function compute'//new_line('a')// &
+                'end module m'//new_line('a')// &
+                'program main'//new_line('a')// &
+                '  use m'//new_line('a')// &
+                '  stop compute(5)'//new_line('a')// &
+                'end program main'
 
-        test_module_function_with_internal_function = expect_exit_status( &
-            source, 11, '/tmp/ffc_session_mod_fn_internal_fn_test')
-    end function test_module_function_with_internal_function
+            test_module_function_with_internal_function = expect_exit_status( &
+                    source, 11, '/tmp/ffc_session_mod_fn_internal_fn_test')
+            end function test_module_function_with_internal_function
 
-end program test_session_module_internal_proc
+        end program test_session_module_internal_proc

--- a/test/test_session_multi_value_print_compiler.f90
+++ b/test/test_session_multi_value_print_compiler.f90
@@ -1,7 +1,7 @@
 program test_session_multi_value_print_compiler
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                  compiler_frontend_result_t, &
-                                  compile_frontend_from_string, INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, INPUT_MODE_STANDARD
     use session_program_lowering, only: lower_program_to_liric_exe
     implicit none
 
@@ -46,8 +46,8 @@ program test_session_multi_value_print_compiler
     close (unit)
 
     call lower_program_to_liric_exe(frontend_result%arena, &
-                                    frontend_result%root_index, exe_path, &
-                                    error_msg)
+        frontend_result%root_index, exe_path, &
+        error_msg)
     if (len_trim(error_msg) > 0) then
         print *, 'FAIL: direct LIRIC lowering failed: ', trim(error_msg)
         stop 1
@@ -61,7 +61,7 @@ program test_session_multi_value_print_compiler
     end if
 
     call execute_command_line('gfortran -w '//src_path//' -o '//ref_path, &
-                              exitstat=exit_stat)
+        exitstat=exit_stat)
     if (exit_stat /= 0) then
         print *, 'FAIL: gfortran failed to compile ffc output'
         call execute_command_line('rm -f '//exe_path//' '//out_path//' '//ref_path//' '//src_path)
@@ -92,7 +92,7 @@ contains
         integer :: status
 
         call execute_command_line('diff -q '//left//' '//right// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         files_equal = status == 0
     end function files_equal
 
@@ -109,7 +109,7 @@ contains
         call normalize_file(right, norm_right, .false.)
 
         call execute_command_line('diff -q '//norm_left//' '//norm_right// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         outputs_match = status == 0
 
         call execute_command_line('rm -f '//norm_left//' '//norm_right)
@@ -130,7 +130,7 @@ contains
         end if
 
         cmd = 'sed "s/^[[:space:]]*//;s/[[:space:]]*$//;s/[[:space:]]\{1,\}/ /g" '// &
-              in_path//' > '//norm_path//' 2>/dev/null'
+            in_path//' > '//norm_path//' 2>/dev/null'
         call execute_command_line(cmd, exitstat=io_stat)
         allocate (character(len=len_trim(norm_path)) :: out_path)
         out_path = trim(norm_path)
@@ -141,7 +141,7 @@ contains
         integer :: unit, io_stat
 
         open (newunit=unit, file=path, status='old', action='read', &
-              iostat=io_stat)
+            iostat=io_stat)
         if (io_stat /= 0) return
         do
             read (unit, '(A)', iostat=io_stat) output_line

--- a/test/test_session_non_integer_procedure_compiler.f90
+++ b/test/test_session_non_integer_procedure_compiler.f90
@@ -20,118 +20,118 @@ contains
 
     logical function test_real_subroutine()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  real :: x'//new_line('a')// &
-                                       '  x = 1.5'//new_line('a')// &
-                                       '  call bump(x)'//new_line('a')// &
-                                       '  print *, x'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine bump(value)'//new_line('a')// &
-                                   '    real, intent(inout) :: value'//new_line('a')// &
-                                       '    value = value + 1.0'//new_line('a')// &
-                                       '  end subroutine bump'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  real :: x'//new_line('a')// &
+            '  x = 1.5'//new_line('a')// &
+            '  call bump(x)'//new_line('a')// &
+            '  print *, x'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine bump(value)'//new_line('a')// &
+            '    real, intent(inout) :: value'//new_line('a')// &
+            '    value = value + 1.0'//new_line('a')// &
+            '  end subroutine bump'//new_line('a')// &
+            'end program main'
 
         test_real_subroutine = expect_output(source, &
-                                  '   2.50000000    '//new_line('a'), &
-                                              '/tmp/ffc_session_real_sub_test')
-    end function test_real_subroutine
+                '   2.50000000    '//new_line('a'), &
+                '/tmp/ffc_session_real_sub_test')
+        end function test_real_subroutine
 
-    logical function test_logical_subroutine()
-        character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  logical :: flag'//new_line('a')// &
-                                       '  flag = .false.'//new_line('a')// &
-                                       '  call enable(flag)'//new_line('a')// &
-                                       '  if (flag) then'//new_line('a')// &
-                                       '    print *, 1'//new_line('a')// &
-                                       '  else'//new_line('a')// &
-                                       '    print *, 0'//new_line('a')// &
-                                       '  end if'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine enable(value)'//new_line('a')// &
-                                '    logical, intent(inout) :: value'//new_line('a')// &
-                                       '    value = .true.'//new_line('a')// &
-                                       '  end subroutine enable'//new_line('a')// &
-                                       'end program main'
+        logical function test_logical_subroutine()
+            character(len=*), parameter :: source = &
+                'program main'//new_line('a')// &
+                '  logical :: flag'//new_line('a')// &
+                '  flag = .false.'//new_line('a')// &
+                '  call enable(flag)'//new_line('a')// &
+                '  if (flag) then'//new_line('a')// &
+                '    print *, 1'//new_line('a')// &
+                '  else'//new_line('a')// &
+                '    print *, 0'//new_line('a')// &
+                '  end if'//new_line('a')// &
+                'contains'//new_line('a')// &
+                '  subroutine enable(value)'//new_line('a')// &
+                '    logical, intent(inout) :: value'//new_line('a')// &
+                '    value = .true.'//new_line('a')// &
+                '  end subroutine enable'//new_line('a')// &
+                'end program main'
 
-        test_logical_subroutine = expect_output(source, '           1'//new_line('a'), &
-                                                 '/tmp/ffc_session_logical_sub_test')
-    end function test_logical_subroutine
+            test_logical_subroutine = expect_output(source, '           1'//new_line('a'), &
+                    '/tmp/ffc_session_logical_sub_test')
+            end function test_logical_subroutine
 
-    logical function test_real_function()
-        character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  real :: x'//new_line('a')// &
-                                       '  x = add(1.5, 3.0)'//new_line('a')// &
-                                       '  print *, x'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  real function add(a, b)'//new_line('a')// &
-                                       '    real, intent(in) :: a'//new_line('a')// &
-                                       '    real, intent(in) :: b'//new_line('a')// &
-                                       '    add = a + b'//new_line('a')// &
-                                       '  end function add'//new_line('a')// &
-                                       'end program main'
+            logical function test_real_function()
+                character(len=*), parameter :: source = &
+                    'program main'//new_line('a')// &
+                    '  real :: x'//new_line('a')// &
+                    '  x = add(1.5, 3.0)'//new_line('a')// &
+                    '  print *, x'//new_line('a')// &
+                    'contains'//new_line('a')// &
+                    '  real function add(a, b)'//new_line('a')// &
+                    '    real, intent(in) :: a'//new_line('a')// &
+                    '    real, intent(in) :: b'//new_line('a')// &
+                    '    add = a + b'//new_line('a')// &
+                    '  end function add'//new_line('a')// &
+                    'end program main'
 
-        test_real_function = expect_output(source, &
-                                  '   4.50000000    '//new_line('a'), &
-                                            '/tmp/ffc_session_real_fn_test')
-    end function test_real_function
+                test_real_function = expect_output(source, &
+                        '   4.50000000    '//new_line('a'), &
+                        '/tmp/ffc_session_real_fn_test')
+                end function test_real_function
 
-    logical function test_mixed_real_logical_function()
-        character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  real :: x'//new_line('a')// &
-                                       '  logical :: enabled'//new_line('a')// &
-                                       '  x = 1.25'//new_line('a')// &
-                                       '  enabled = .true.'//new_line('a')// &
-                                       '  print *, choose(x, enabled)'// &
-                                       new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  real function choose(value, flag)'// &
-                                       new_line('a')// &
-                                       '    real, intent(in) :: value'// &
-                                       new_line('a')// &
-                                       '    logical, intent(in) :: flag'// &
-                                       new_line('a')// &
-                                       '    if (flag) then'//new_line('a')// &
-                                       '      choose = value + 0.75'//new_line('a')// &
-                                       '    else'//new_line('a')// &
-                                       '      choose = value'//new_line('a')// &
-                                       '    end if'//new_line('a')// &
-                                       '  end function choose'//new_line('a')// &
-                                       'end program main'
+                logical function test_mixed_real_logical_function()
+                    character(len=*), parameter :: source = &
+                        'program main'//new_line('a')// &
+                        '  real :: x'//new_line('a')// &
+                        '  logical :: enabled'//new_line('a')// &
+                        '  x = 1.25'//new_line('a')// &
+                        '  enabled = .true.'//new_line('a')// &
+                        '  print *, choose(x, enabled)'// &
+                        new_line('a')// &
+                        'contains'//new_line('a')// &
+                        '  real function choose(value, flag)'// &
+                        new_line('a')// &
+                        '    real, intent(in) :: value'// &
+                        new_line('a')// &
+                        '    logical, intent(in) :: flag'// &
+                        new_line('a')// &
+                        '    if (flag) then'//new_line('a')// &
+                        '      choose = value + 0.75'//new_line('a')// &
+                        '    else'//new_line('a')// &
+                        '      choose = value'//new_line('a')// &
+                        '    end if'//new_line('a')// &
+                        '  end function choose'//new_line('a')// &
+                        'end program main'
 
-        test_mixed_real_logical_function = expect_output( &
-                              source, '   2.00000000    '//new_line('a'), &
-                                            '/tmp/ffc_session_mixed_fn_test')
-    end function test_mixed_real_logical_function
+                    test_mixed_real_logical_function = expect_output( &
+                            source, '   2.00000000    '//new_line('a'), &
+                            '/tmp/ffc_session_mixed_fn_test')
+                    end function test_mixed_real_logical_function
 
-    logical function test_logical_function()
-        character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  logical :: flag'//new_line('a')// &
-                                       '  logical :: ok'//new_line('a')// &
-                                       '  flag = .false.'//new_line('a')// &
-                                       '  ok = enabled(flag)'//new_line('a')// &
-                                       '  if (ok) then'//new_line('a')// &
-                                       '    print *, 1'//new_line('a')// &
-                                       '  else'//new_line('a')// &
-                                       '    print *, 0'//new_line('a')// &
-                                       '  end if'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                   '  logical function enabled(flag)'//new_line('a')// &
-                                    '    logical, intent(in) :: flag'//new_line('a')// &
-                                       '    if (flag) then'//new_line('a')// &
-                                       '      enabled = .false.'//new_line('a')// &
-                                       '    else'//new_line('a')// &
-                                       '      enabled = .true.'//new_line('a')// &
-                                       '    end if'//new_line('a')// &
-                                       '  end function enabled'//new_line('a')// &
-                                       'end program main'
+                    logical function test_logical_function()
+                        character(len=*), parameter :: source = &
+                            'program main'//new_line('a')// &
+                            '  logical :: flag'//new_line('a')// &
+                            '  logical :: ok'//new_line('a')// &
+                            '  flag = .false.'//new_line('a')// &
+                            '  ok = enabled(flag)'//new_line('a')// &
+                            '  if (ok) then'//new_line('a')// &
+                            '    print *, 1'//new_line('a')// &
+                            '  else'//new_line('a')// &
+                            '    print *, 0'//new_line('a')// &
+                            '  end if'//new_line('a')// &
+                            'contains'//new_line('a')// &
+                            '  logical function enabled(flag)'//new_line('a')// &
+                            '    logical, intent(in) :: flag'//new_line('a')// &
+                            '    if (flag) then'//new_line('a')// &
+                            '      enabled = .false.'//new_line('a')// &
+                            '    else'//new_line('a')// &
+                            '      enabled = .true.'//new_line('a')// &
+                            '    end if'//new_line('a')// &
+                            '  end function enabled'//new_line('a')// &
+                            'end program main'
 
-        test_logical_function = expect_output(source, '           1'//new_line('a'), &
-                                               '/tmp/ffc_session_logical_fn_test')
-    end function test_logical_function
+                        test_logical_function = expect_output(source, '           1'//new_line('a'), &
+                                '/tmp/ffc_session_logical_fn_test')
+                        end function test_logical_function
 
-end program test_session_non_integer_procedure_compiler
+                    end program test_session_non_integer_procedure_compiler

--- a/test/test_session_pointer_array_compiler.f90
+++ b/test/test_session_pointer_array_compiler.f90
@@ -8,53 +8,53 @@ program test_session_pointer_array
     ! t(i), and size(p) reports the target extent. stop returns t(2), set to 99
     ! through the pointer.
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'integer, target :: t(3)'//new_line('a')// &
-         'integer, pointer :: p(:)'//new_line('a')// &
-         't = [10, 20, 30]'//new_line('a')// &
-         'p => t'//new_line('a')// &
-         'if (size(p) /= 3) stop 1'//new_line('a')// &
-         'p(2) = 99'//new_line('a')// &
-         'if (t(2) /= 99) stop 2'//new_line('a')// &
-         'stop t(2)'//new_line('a')// &
-         'end program main', 99, &
-         '/tmp/ffc_session_pointer_array_alias')) stop 1
+        'program main'//new_line('a')// &
+        'integer, target :: t(3)'//new_line('a')// &
+        'integer, pointer :: p(:)'//new_line('a')// &
+        't = [10, 20, 30]'//new_line('a')// &
+        'p => t'//new_line('a')// &
+        'if (size(p) /= 3) stop 1'//new_line('a')// &
+        'p(2) = 99'//new_line('a')// &
+        'if (t(2) /= 99) stop 2'//new_line('a')// &
+        'stop t(2)'//new_line('a')// &
+        'end program main', 99, &
+        '/tmp/ffc_session_pointer_array_alias')) stop 1
 
     ! A read through the pointer observes a later write to the target element.
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'integer, target :: t(4)'//new_line('a')// &
-         'integer, pointer :: p(:)'//new_line('a')// &
-         'p => t'//new_line('a')// &
-         't(3) = 7'//new_line('a')// &
-         'stop p(3)'//new_line('a')// &
-         'end program main', 7, &
-         '/tmp/ffc_session_pointer_array_read')) stop 2
+        'program main'//new_line('a')// &
+        'integer, target :: t(4)'//new_line('a')// &
+        'integer, pointer :: p(:)'//new_line('a')// &
+        'p => t'//new_line('a')// &
+        't(3) = 7'//new_line('a')// &
+        'stop p(3)'//new_line('a')// &
+        'end program main', 7, &
+        '/tmp/ffc_session_pointer_array_read')) stop 2
 
     ! A real target array: pointer element arithmetic flows back to the target.
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'real, target :: r(3)'//new_line('a')// &
-         'real, pointer :: q(:)'//new_line('a')// &
-         'r = [1.0, 2.0, 3.0]'//new_line('a')// &
-         'q => r'//new_line('a')// &
-         'q(1) = q(1) + q(3)'//new_line('a')// &
-         'if (abs(r(1) - 4.0) > 1.0e-6) stop 3'//new_line('a')// &
-         'stop 0'//new_line('a')// &
-         'end program main', 0, &
-         '/tmp/ffc_session_pointer_array_real')) stop 3
+        'program main'//new_line('a')// &
+        'real, target :: r(3)'//new_line('a')// &
+        'real, pointer :: q(:)'//new_line('a')// &
+        'r = [1.0, 2.0, 3.0]'//new_line('a')// &
+        'q => r'//new_line('a')// &
+        'q(1) = q(1) + q(3)'//new_line('a')// &
+        'if (abs(r(1) - 4.0) > 1.0e-6) stop 3'//new_line('a')// &
+        'stop 0'//new_line('a')// &
+        'end program main', 0, &
+        '/tmp/ffc_session_pointer_array_real')) stop 3
 
     ! Whole-array print through the pointer prints the target's elements.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         'integer, target :: t(3)'//new_line('a')// &
-         'integer, pointer :: p(:)'//new_line('a')// &
-         't = [4, 5, 6]'//new_line('a')// &
-         'p => t'//new_line('a')// &
-         'print *, p'//new_line('a')// &
-         'end program main', &
-         '           4           5           6'//new_line('a'), &
-         '/tmp/ffc_session_pointer_array_print')) stop 4
+        'program main'//new_line('a')// &
+        'integer, target :: t(3)'//new_line('a')// &
+        'integer, pointer :: p(:)'//new_line('a')// &
+        't = [4, 5, 6]'//new_line('a')// &
+        'p => t'//new_line('a')// &
+        'print *, p'//new_line('a')// &
+        'end program main', &
+        '           4           5           6'//new_line('a'), &
+        '/tmp/ffc_session_pointer_array_print')) stop 4
 
     print *, 'PASS: rank-1 integer/real pointer/target array, => , element access'
 end program test_session_pointer_array

--- a/test/test_session_pointer_associated2_compiler.f90
+++ b/test/test_session_pointer_associated2_compiler.f90
@@ -6,19 +6,19 @@ program test_session_pointer_associated2
 
     ! B3c: associated(p, t) is true when p => t in straight-line code.
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'implicit none'//new_line('a')// &
-         'integer, target :: t'//new_line('a')// &
-         'integer, target :: u'//new_line('a')// &
-         'integer, pointer :: p'//new_line('a')// &
-         't = 5'//new_line('a')// &
-         'u = 7'//new_line('a')// &
-         'p => t'//new_line('a')// &
-         'if (.not. associated(p, t)) stop 1'//new_line('a')// &
-         'if (associated(p, u)) stop 2'//new_line('a')// &
-         'stop 0'//new_line('a')// &
-         'end program main', 0, &
-         '/tmp/ffc_associated2_test')) stop 1
+        'program main'//new_line('a')// &
+        'implicit none'//new_line('a')// &
+        'integer, target :: t'//new_line('a')// &
+        'integer, target :: u'//new_line('a')// &
+        'integer, pointer :: p'//new_line('a')// &
+        't = 5'//new_line('a')// &
+        'u = 7'//new_line('a')// &
+        'p => t'//new_line('a')// &
+        'if (.not. associated(p, t)) stop 1'//new_line('a')// &
+        'if (associated(p, u)) stop 2'//new_line('a')// &
+        'stop 0'//new_line('a')// &
+        'end program main', 0, &
+        '/tmp/ffc_associated2_test')) stop 1
 
     print *, 'PASS: two-argument associated(p, t)'
 end program test_session_pointer_associated2

--- a/test/test_session_pointer_proc_compiler.f90
+++ b/test/test_session_pointer_proc_compiler.f90
@@ -7,36 +7,36 @@ program test_session_pointer_proc
     ! B3d: procedure pointer to a contained integer function; call through it
     ! and verify the result via stop code.
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'implicit none'//new_line('a')// &
-         'procedure(), pointer :: fp'//new_line('a')// &
-         'fp => double_it'//new_line('a')// &
-         'stop fp(21)'//new_line('a')// &
-         'contains'//new_line('a')// &
-         'integer function double_it(x)'//new_line('a')// &
-         'integer, intent(in) :: x'//new_line('a')// &
-         'double_it = x * 2'//new_line('a')// &
-         'end function double_it'//new_line('a')// &
-         'end program main', 42, &
-         '/tmp/ffc_proc_ptr_func_test')) stop 1
+        'program main'//new_line('a')// &
+        'implicit none'//new_line('a')// &
+        'procedure(), pointer :: fp'//new_line('a')// &
+        'fp => double_it'//new_line('a')// &
+        'stop fp(21)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        'integer function double_it(x)'//new_line('a')// &
+        'integer, intent(in) :: x'//new_line('a')// &
+        'double_it = x * 2'//new_line('a')// &
+        'end function double_it'//new_line('a')// &
+        'end program main', 42, &
+        '/tmp/ffc_proc_ptr_func_test')) stop 1
 
     ! B3d: procedure pointer to a contained subroutine; call mutates a variable.
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'implicit none'//new_line('a')// &
-         'integer :: result'//new_line('a')// &
-         'procedure(), pointer :: sp'//new_line('a')// &
-         'result = 0'//new_line('a')// &
-         'sp => add_ten'//new_line('a')// &
-         'call sp(result)'//new_line('a')// &
-         'stop result'//new_line('a')// &
-         'contains'//new_line('a')// &
-         'subroutine add_ten(x)'//new_line('a')// &
-         'integer, intent(inout) :: x'//new_line('a')// &
-         'x = x + 10'//new_line('a')// &
-         'end subroutine add_ten'//new_line('a')// &
-         'end program main', 10, &
-         '/tmp/ffc_proc_ptr_sub_test')) stop 1
+        'program main'//new_line('a')// &
+        'implicit none'//new_line('a')// &
+        'integer :: result'//new_line('a')// &
+        'procedure(), pointer :: sp'//new_line('a')// &
+        'result = 0'//new_line('a')// &
+        'sp => add_ten'//new_line('a')// &
+        'call sp(result)'//new_line('a')// &
+        'stop result'//new_line('a')// &
+        'contains'//new_line('a')// &
+        'subroutine add_ten(x)'//new_line('a')// &
+        'integer, intent(inout) :: x'//new_line('a')// &
+        'x = x + 10'//new_line('a')// &
+        'end subroutine add_ten'//new_line('a')// &
+        'end program main', 10, &
+        '/tmp/ffc_proc_ptr_sub_test')) stop 1
 
     print *, 'PASS: procedure pointer to function and subroutine'
 end program test_session_pointer_proc

--- a/test/test_session_pointer_scalar_compiler.f90
+++ b/test/test_session_pointer_scalar_compiler.f90
@@ -7,29 +7,29 @@ program test_session_pointer_scalar
     ! p => t then a write through p mutates t; associated(p) is true until
     ! nullify(p). Final stop returns t, which the pointer write set to 42.
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'integer, target :: t'//new_line('a')// &
-         'integer, pointer :: p'//new_line('a')// &
-         't = 5'//new_line('a')// &
-         'p => t'//new_line('a')// &
-         'p = 42'//new_line('a')// &
-         'if (.not. associated(p)) stop 1'//new_line('a')// &
-         'nullify(p)'//new_line('a')// &
-         'if (associated(p)) stop 2'//new_line('a')// &
-         'stop t'//new_line('a')// &
-         'end program main', 42, &
-         '/tmp/ffc_session_pointer_scalar_test')) stop 1
+        'program main'//new_line('a')// &
+        'integer, target :: t'//new_line('a')// &
+        'integer, pointer :: p'//new_line('a')// &
+        't = 5'//new_line('a')// &
+        'p => t'//new_line('a')// &
+        'p = 42'//new_line('a')// &
+        'if (.not. associated(p)) stop 1'//new_line('a')// &
+        'nullify(p)'//new_line('a')// &
+        'if (associated(p)) stop 2'//new_line('a')// &
+        'stop t'//new_line('a')// &
+        'end program main', 42, &
+        '/tmp/ffc_session_pointer_scalar_test')) stop 1
 
     ! A read through the pointer observes a later write to the target.
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'integer, target :: t'//new_line('a')// &
-         'integer, pointer :: p'//new_line('a')// &
-         'p => t'//new_line('a')// &
-         't = 9'//new_line('a')// &
-         'stop p'//new_line('a')// &
-         'end program main', 9, &
-         '/tmp/ffc_session_pointer_read_test')) stop 1
+        'program main'//new_line('a')// &
+        'integer, target :: t'//new_line('a')// &
+        'integer, pointer :: p'//new_line('a')// &
+        'p => t'//new_line('a')// &
+        't = 9'//new_line('a')// &
+        'stop p'//new_line('a')// &
+        'end program main', 9, &
+        '/tmp/ffc_session_pointer_read_test')) stop 1
 
     print *, 'PASS: scalar integer pointer/target, => , associated, nullify'
 end program test_session_pointer_scalar

--- a/test/test_session_pointer_scalar_kinds_compiler.f90
+++ b/test/test_session_pointer_scalar_kinds_compiler.f90
@@ -8,38 +8,38 @@ program test_session_pointer_scalar_kinds
     ! observed when the pointer is dereferenced in an expression. int(p + 0.5)
     ! folds the read value to an exit code (matches gfortran).
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'real, target :: t'//new_line('a')// &
-         'real, pointer :: p'//new_line('a')// &
-         't = 4.0'//new_line('a')// &
-         'p => t'//new_line('a')// &
-         't = 7.0'//new_line('a')// &
-         'if (.not. associated(p)) stop 1'//new_line('a')// &
-         'stop int(p + 0.5)'//new_line('a')// &
-         'end program main', 7, &
-         '/tmp/ffc_session_pointer_real_test')) stop 1
+        'program main'//new_line('a')// &
+        'real, target :: t'//new_line('a')// &
+        'real, pointer :: p'//new_line('a')// &
+        't = 4.0'//new_line('a')// &
+        'p => t'//new_line('a')// &
+        't = 7.0'//new_line('a')// &
+        'if (.not. associated(p)) stop 1'//new_line('a')// &
+        'stop int(p + 0.5)'//new_line('a')// &
+        'end program main', 7, &
+        '/tmp/ffc_session_pointer_real_test')) stop 1
 
     ! A write through a real pointer mutates the target slot.
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'real, target :: t'//new_line('a')// &
-         'real, pointer :: p'//new_line('a')// &
-         'p => t'//new_line('a')// &
-         'p = 9.0'//new_line('a')// &
-         'stop int(t)'//new_line('a')// &
-         'end program main', 9, &
-         '/tmp/ffc_session_pointer_real_write_test')) stop 2
+        'program main'//new_line('a')// &
+        'real, target :: t'//new_line('a')// &
+        'real, pointer :: p'//new_line('a')// &
+        'p => t'//new_line('a')// &
+        'p = 9.0'//new_line('a')// &
+        'stop int(t)'//new_line('a')// &
+        'end program main', 9, &
+        '/tmp/ffc_session_pointer_real_write_test')) stop 2
 
     ! A logical pointer dereferenced in print observes the target value.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         'logical, target :: b'//new_line('a')// &
-         'logical, pointer :: lp'//new_line('a')// &
-         'b = .true.'//new_line('a')// &
-         'lp => b'//new_line('a')// &
-         'print *, lp'//new_line('a')// &
-         'end program main', ' T'//new_line('a'), &
-         '/tmp/ffc_session_pointer_logical_test')) stop 3
+        'program main'//new_line('a')// &
+        'logical, target :: b'//new_line('a')// &
+        'logical, pointer :: lp'//new_line('a')// &
+        'b = .true.'//new_line('a')// &
+        'lp => b'//new_line('a')// &
+        'print *, lp'//new_line('a')// &
+        'end program main', ' T'//new_line('a'), &
+        '/tmp/ffc_session_pointer_logical_test')) stop 3
 
     print *, 'PASS: real and logical scalar pointer => , deref, associated'
 end program test_session_pointer_scalar_kinds

--- a/test/test_session_rank2_array_compiler.f90
+++ b/test/test_session_rank2_array_compiler.f90
@@ -10,18 +10,18 @@ contains
 
     logical function test_rank2_array_with_explicit_bounds()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(0:1, 2:4)'//new_line('a')// &
-                                       '  a(0, 2) = 4'//new_line('a')// &
-                                       '  a(1, 4) = 5'//new_line('a')// &
-                                       '  call bump(a(1, 4))'//new_line('a')// &
-                                       '  stop a(0, 2) + a(1, 4)'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine bump(x)'//new_line('a')// &
-                                       '    integer :: x'//new_line('a')// &
-                                       '    x = x + 1'//new_line('a')// &
-                                       '  end subroutine bump'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(0:1, 2:4)'//new_line('a')// &
+            '  a(0, 2) = 4'//new_line('a')// &
+            '  a(1, 4) = 5'//new_line('a')// &
+            '  call bump(a(1, 4))'//new_line('a')// &
+            '  stop a(0, 2) + a(1, 4)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine bump(x)'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '    x = x + 1'//new_line('a')// &
+            '  end subroutine bump'//new_line('a')// &
+            'end program main'
 
         test_rank2_array_with_explicit_bounds = expect_exit_status( &
             source, 10, '/tmp/ffc_session_rank2_array_test')

--- a/test/test_session_read_fmod_compiler.f90
+++ b/test/test_session_read_fmod_compiler.f90
@@ -1,12 +1,12 @@
 program test_session_read_fmod_compiler
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                  compiler_frontend_result_t, &
-                                  compile_frontend_from_string, INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, INPUT_MODE_STANDARD
     use session_program_lowering, only: lower_program_to_liric_exe, &
-                                        lower_program_to_liric_object
+        lower_program_to_liric_object
     use ffc_module_artefact, only: module_info_t, fmod_parameter_t, &
-                                   fmod_derived_type_t, fmod_variable_t, &
-                                   write_fmod
+        fmod_derived_type_t, fmod_variable_t, &
+        write_fmod
     implicit none
 
     logical :: all_passed
@@ -49,13 +49,13 @@ contains
         end if
 
         call compile_with_include(source, '/tmp/ffc_read_fmod_use', dir, &
-                                  error_msg)
+            error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL: lowering through .fmod failed: ', trim(error_msg)
             return
         end if
         call execute_command_line('/tmp/ffc_read_fmod_use', exitstat=exit_stat, &
-                                  cmdstat=cmd_stat)
+            cmdstat=cmd_stat)
         call execute_command_line('rm -f /tmp/ffc_read_fmod_use')
         if (cmd_stat /= 0) then
             print *, 'FAIL: could not run binary'
@@ -78,7 +78,7 @@ contains
 
         ok = .false.
         call compile_with_include(source, '/tmp/ffc_read_fmod_missing', &
-                                  '/tmp/ffc_read_fmod_empty', error_msg)
+            '/tmp/ffc_read_fmod_empty', error_msg)
         call execute_command_line('rm -f /tmp/ffc_read_fmod_missing')
         if (len_trim(error_msg) == 0) then
             print *, 'FAIL: expected a module-not-found diagnostic'
@@ -135,9 +135,9 @@ contains
         paths(1) = dir
         call execute_command_line('rm -f /tmp/ffc_read_fmod_var.o')
         call lower_program_to_liric_object(frontend_result%arena, &
-                                           frontend_result%root_index, &
-                                           '/tmp/ffc_read_fmod_var.o', &
-                                           error_msg, paths)
+            frontend_result%root_index, &
+            '/tmp/ffc_read_fmod_var.o', &
+            error_msg, paths)
         call execute_command_line('rm -f /tmp/ffc_read_fmod_var.o')
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL: USE of .fmod variable did not resolve: ', &
@@ -162,14 +162,14 @@ contains
         call compile_frontend_from_string(source, frontend_result, options)
         if (.not. frontend_result%success()) then
             error_msg = 'FortFront rejected source: '// &
-                        trim(frontend_result%diagnostic_text)
+                trim(frontend_result%diagnostic_text)
             return
         end if
         paths(1) = include_dir
         call execute_command_line('rm -f '//exe_path)
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe_path, &
-                                        error_msg, paths)
+            frontend_result%root_index, exe_path, &
+            error_msg, paths)
     end subroutine compile_with_include
 
 end program test_session_read_fmod_compiler

--- a/test/test_session_real_array_b1f_compiler.f90
+++ b/test/test_session_real_array_b1f_compiler.f90
@@ -1,7 +1,7 @@
 program test_session_real_array_b1f_compiler
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                  compiler_frontend_result_t, &
-                                  compile_frontend_from_string, INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, INPUT_MODE_STANDARD
     use session_program_lowering, only: lower_program_to_liric_exe
     implicit none
 
@@ -214,7 +214,7 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, error_msg)
+            frontend_result%root_index, exe, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', stem, ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -224,7 +224,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', stem, ']: gfortran rejected source'
             return
@@ -233,7 +233,7 @@ contains
         call execute_command_line(exe//' > '//ffc_out, exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out, exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', stem, ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
@@ -241,7 +241,7 @@ contains
             matches_gfortran = .true.
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref//' '// &
-                                  ffc_out//' '//ref_out)
+            ffc_out//' '//ref_out)
     end function matches_gfortran
 
 end program test_session_real_array_b1f_compiler

--- a/test/test_session_real_array_compiler.f90
+++ b/test/test_session_real_array_compiler.f90
@@ -1,7 +1,7 @@
 program test_session_real_array_compiler
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                  compiler_frontend_result_t, &
-                                  compile_frontend_from_string, INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, INPUT_MODE_STANDARD
     use session_program_lowering, only: lower_program_to_liric_exe
     implicit none
 
@@ -146,7 +146,7 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, error_msg)
+            frontend_result%root_index, exe, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', stem, ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -156,7 +156,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', stem, ']: gfortran rejected source'
             return
@@ -165,7 +165,7 @@ contains
         call execute_command_line(exe//' > '//ffc_out, exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out, exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', stem, ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
@@ -173,7 +173,7 @@ contains
             matches_gfortran = .true.
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref//' '// &
-                                  ffc_out//' '//ref_out)
+            ffc_out//' '//ref_out)
     end function matches_gfortran
 
 end program test_session_real_array_compiler

--- a/test/test_session_real_kind_expr_compiler.f90
+++ b/test/test_session_real_kind_expr_compiler.f90
@@ -6,66 +6,66 @@ program test_session_real_kind_expr_compiler
 
     ! Mixed int/real arithmetic: the integer operand coerces to f64.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  use, intrinsic :: iso_fortran_env, only: dp => real64'// &
-         new_line('a')// &
-         '  integer :: i'//new_line('a')// &
-         '  real(dp) :: y'//new_line('a')// &
-         '  i = 7'//new_line('a')// &
-         '  y = i / 2.0_dp'//new_line('a')// &
-         '  print *, y'//new_line('a')// &
-         'end program main', '   3.5000000000000000     '//new_line('a'), &
-         '/tmp/ffc_real_kind_mixed_f64')) stop 1
+        'program main'//new_line('a')// &
+        '  use, intrinsic :: iso_fortran_env, only: dp => real64'// &
+        new_line('a')// &
+        '  integer :: i'//new_line('a')// &
+        '  real(dp) :: y'//new_line('a')// &
+        '  i = 7'//new_line('a')// &
+        '  y = i / 2.0_dp'//new_line('a')// &
+        '  print *, y'//new_line('a')// &
+        'end program main', '   3.5000000000000000     '//new_line('a'), &
+        '/tmp/ffc_real_kind_mixed_f64')) stop 1
 
     ! real(x, kind=dp) two-argument conversion yields f64.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  use, intrinsic :: iso_fortran_env, only: dp => real64'// &
-         new_line('a')// &
-         '  integer :: i'//new_line('a')// &
-         '  real(dp) :: y'//new_line('a')// &
-         '  i = 7'//new_line('a')// &
-         '  y = real(i, kind=dp)'//new_line('a')// &
-         '  print *, y'//new_line('a')// &
-         'end program main', '   7.0000000000000000     '//new_line('a'), &
-         '/tmp/ffc_real_kind_2arg_kw')) stop 1
+        'program main'//new_line('a')// &
+        '  use, intrinsic :: iso_fortran_env, only: dp => real64'// &
+        new_line('a')// &
+        '  integer :: i'//new_line('a')// &
+        '  real(dp) :: y'//new_line('a')// &
+        '  i = 7'//new_line('a')// &
+        '  y = real(i, kind=dp)'//new_line('a')// &
+        '  print *, y'//new_line('a')// &
+        'end program main', '   7.0000000000000000     '//new_line('a'), &
+        '/tmp/ffc_real_kind_2arg_kw')) stop 1
 
     ! real(x, 8) two-argument conversion yields f64.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  use, intrinsic :: iso_fortran_env, only: dp => real64'// &
-         new_line('a')// &
-         '  integer :: i'//new_line('a')// &
-         '  real(dp) :: y'//new_line('a')// &
-         '  i = 7'//new_line('a')// &
-         '  y = real(i, 8)'//new_line('a')// &
-         '  print *, y'//new_line('a')// &
-         'end program main', '   7.0000000000000000     '//new_line('a'), &
-         '/tmp/ffc_real_kind_2arg_pos')) stop 1
+        'program main'//new_line('a')// &
+        '  use, intrinsic :: iso_fortran_env, only: dp => real64'// &
+        new_line('a')// &
+        '  integer :: i'//new_line('a')// &
+        '  real(dp) :: y'//new_line('a')// &
+        '  i = 7'//new_line('a')// &
+        '  y = real(i, 8)'//new_line('a')// &
+        '  print *, y'//new_line('a')// &
+        'end program main', '   7.0000000000000000     '//new_line('a'), &
+        '/tmp/ffc_real_kind_2arg_pos')) stop 1
 
     ! real(dp) scalar prints with f64 formatting matching gfortran.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  use, intrinsic :: iso_fortran_env, only: dp => real64'// &
-         new_line('a')// &
-         '  integer :: i'//new_line('a')// &
-         '  real(dp) :: y'//new_line('a')// &
-         '  i = 7'//new_line('a')// &
-         '  y = i * 1.0_dp + 3'//new_line('a')// &
-         '  print *, y'//new_line('a')// &
-         'end program main', '   10.000000000000000     '//new_line('a'), &
-         '/tmp/ffc_real_kind_mixed_add')) stop 1
+        'program main'//new_line('a')// &
+        '  use, intrinsic :: iso_fortran_env, only: dp => real64'// &
+        new_line('a')// &
+        '  integer :: i'//new_line('a')// &
+        '  real(dp) :: y'//new_line('a')// &
+        '  i = 7'//new_line('a')// &
+        '  y = i * 1.0_dp + 3'//new_line('a')// &
+        '  print *, y'//new_line('a')// &
+        'end program main', '   10.000000000000000     '//new_line('a'), &
+        '/tmp/ffc_real_kind_mixed_add')) stop 1
 
     ! Mixed int/real arithmetic in default real (f32) coerces correctly.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  integer :: i'//new_line('a')// &
-         '  real :: y'//new_line('a')// &
-         '  i = 7'//new_line('a')// &
-         '  y = i / 2.0'//new_line('a')// &
-         '  print *, y'//new_line('a')// &
-         'end program main', '   3.50000000    '//new_line('a'), &
-         '/tmp/ffc_real_kind_mixed_f32')) stop 1
+        'program main'//new_line('a')// &
+        '  integer :: i'//new_line('a')// &
+        '  real :: y'//new_line('a')// &
+        '  i = 7'//new_line('a')// &
+        '  y = i / 2.0'//new_line('a')// &
+        '  print *, y'//new_line('a')// &
+        'end program main', '   3.50000000    '//new_line('a'), &
+        '/tmp/ffc_real_kind_mixed_f32')) stop 1
 
     print *, 'PASS: mixed int/real arithmetic and real(x,kind) lower correctly'
 end program test_session_real_kind_expr_compiler

--- a/test/test_session_real_list_directed_compiler.f90
+++ b/test/test_session_real_list_directed_compiler.f90
@@ -4,8 +4,8 @@ program test_session_real_list_directed_compiler
     ! Each program is compiled by ffc and by gfortran and the stdout is
     ! compared byte-for-byte (no whitespace normalisation).
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                                  compiler_frontend_result_t, &
-                                  compile_frontend_from_string, INPUT_MODE_STANDARD
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, INPUT_MODE_STANDARD
     use session_program_lowering, only: lower_program_to_liric_exe
     implicit none
 
@@ -81,7 +81,7 @@ contains
         end if
 
         call lower_program_to_liric_exe(frontend_result%arena, &
-                                        frontend_result%root_index, exe, error_msg)
+            frontend_result%root_index, exe, error_msg)
         if (len_trim(error_msg) > 0) then
             print *, 'FAIL[', stem, ']: ffc lowering failed: ', trim(error_msg)
             return
@@ -91,7 +91,7 @@ contains
         write (unit, '(A)') source
         close (unit)
         call execute_command_line('gfortran -w '//src//' -o '//ref, &
-                                  exitstat=exit_stat)
+            exitstat=exit_stat)
         if (exit_stat /= 0) then
             print *, 'FAIL[', stem, ']: gfortran rejected source'
             return
@@ -100,7 +100,7 @@ contains
         call execute_command_line(exe//' > '//ffc_out, exitstat=exit_stat)
         call execute_command_line(ref//' > '//ref_out, exitstat=exit_stat)
         call execute_command_line('diff '//ffc_out//' '//ref_out// &
-                                  ' > /dev/null 2>&1', exitstat=status)
+            ' > /dev/null 2>&1', exitstat=status)
         if (status /= 0) then
             print *, 'FAIL[', stem, ']: ffc output differs from gfortran'
             call execute_command_line('diff '//ffc_out//' '//ref_out)
@@ -108,7 +108,7 @@ contains
             matches_gfortran = .true.
         end if
         call execute_command_line('rm -f '//src//' '//exe//' '//ref//' '// &
-                                  ffc_out//' '//ref_out)
+            ffc_out//' '//ref_out)
     end function matches_gfortran
 
 end program test_session_real_list_directed_compiler

--- a/test/test_session_real_literal_print_compiler.f90
+++ b/test/test_session_real_literal_print_compiler.f90
@@ -6,17 +6,17 @@ program test_session_real_literal_print_compiler
 
     ! Default real literal is f32: 9 significant digits, %12s    field.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  print *, 2.5'//new_line('a')// &
-         'end program main', '   2.50000000    '//new_line('a'), &
-         '/tmp/ffc_session_real_literal_print_test')) stop 1
+        'program main'//new_line('a')// &
+        '  print *, 2.5'//new_line('a')// &
+        'end program main', '   2.50000000    '//new_line('a'), &
+        '/tmp/ffc_session_real_literal_print_test')) stop 1
 
     ! Explicit real(8) literal retains f64: 17 significant digits.
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  print *, 2.5d0'//new_line('a')// &
-         'end program main', '   2.5000000000000000     '//new_line('a'), &
-         '/tmp/ffc_session_real_literal_f64_print_test')) stop 1
+        'program main'//new_line('a')// &
+        '  print *, 2.5d0'//new_line('a')// &
+        'end program main', '   2.5000000000000000     '//new_line('a'), &
+        '/tmp/ffc_session_real_literal_f64_print_test')) stop 1
 
     print *, 'PASS: real literal print lowers through direct LIRIC session'
 end program test_session_real_literal_print_compiler

--- a/test/test_session_real_parameter_compiler.f90
+++ b/test/test_session_real_parameter_compiler.f90
@@ -6,27 +6,27 @@ program test_session_real_parameter_compiler
     print *, '=== direct session real/logical/character parameter test ==='
 
     if (.not. expect_output( &
-         'program main'//nl// &
-         '  real, parameter :: half = 0.5'//nl// &
-         '  real(8), parameter :: two = 2.0d0'//nl// &
-         '  logical, parameter :: yes = .true.'//nl// &
-         '  character(len=*), parameter :: tag = "ok"'//nl// &
-         '  real :: r'//nl// &
-         '  r = half + 1.0'//nl// &
-         '  print *, half'//nl// &
-         '  print *, two'//nl// &
-         '  print *, yes'//nl// &
-         '  print *, tag'//nl// &
-         '  print *, r'//nl// &
-         '  if (yes) print *, "branch"'//nl// &
-         'end program main', &
-         '  0.500000000    '//nl// &
-         '   2.0000000000000000     '//nl// &
-         ' T'//nl// &
-         ' ok'//nl// &
-         '   1.50000000    '//nl// &
-         ' branch'//nl, &
-         '/tmp/ffc_session_real_parameter_test')) stop 1
+        'program main'//nl// &
+        '  real, parameter :: half = 0.5'//nl// &
+        '  real(8), parameter :: two = 2.0d0'//nl// &
+        '  logical, parameter :: yes = .true.'//nl// &
+        '  character(len=*), parameter :: tag = "ok"'//nl// &
+        '  real :: r'//nl// &
+        '  r = half + 1.0'//nl// &
+        '  print *, half'//nl// &
+        '  print *, two'//nl// &
+        '  print *, yes'//nl// &
+        '  print *, tag'//nl// &
+        '  print *, r'//nl// &
+        '  if (yes) print *, "branch"'//nl// &
+        'end program main', &
+        '  0.500000000    '//nl// &
+        '   2.0000000000000000     '//nl// &
+        ' T'//nl// &
+        ' ok'//nl// &
+        '   1.50000000    '//nl// &
+        ' branch'//nl, &
+        '/tmp/ffc_session_real_parameter_test')) stop 1
 
     print *, 'PASS: real/logical/character parameters lower through LIRIC'
 end program test_session_real_parameter_compiler

--- a/test/test_session_real_pow_compiler.f90
+++ b/test/test_session_real_pow_compiler.f90
@@ -18,45 +18,45 @@ contains
 
     logical function test_real_pow_two_three()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'real :: x'//new_line('a')// &
-                                       'x = 2.0 ** 3.0'//new_line('a')// &
-                                       'print *, x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'real :: x'//new_line('a')// &
+            'x = 2.0 ** 3.0'//new_line('a')// &
+            'print *, x'//new_line('a')// &
+            'end program main'
 
         test_real_pow_two_three = expect_output( &
-                                  source, '   8.00000000    '//new_line('a'), &
-                                  '/tmp/ffc_session_real_pow_two_three_test')
+            source, '   8.00000000    '//new_line('a'), &
+            '/tmp/ffc_session_real_pow_two_three_test')
     end function test_real_pow_two_three
 
     logical function test_real_pow_half()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'real :: x'//new_line('a')// &
-                                       'x = 4.0 ** 0.5'//new_line('a')// &
-                                       'print *, x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'real :: x'//new_line('a')// &
+            'x = 4.0 ** 0.5'//new_line('a')// &
+            'print *, x'//new_line('a')// &
+            'end program main'
 
         test_real_pow_half = expect_output( &
-                             source, '   2.00000000    '//new_line('a'), &
-                             '/tmp/ffc_session_real_pow_half_test')
+            source, '   2.00000000    '//new_line('a'), &
+            '/tmp/ffc_session_real_pow_half_test')
     end function test_real_pow_half
 
     logical function test_real_pow_variable()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       'real :: b'//new_line('a')// &
-                                       'real :: e'//new_line('a')// &
-                                       'real :: x'//new_line('a')// &
-                                       'b = 3.0'//new_line('a')// &
-                                       'e = 2.0'//new_line('a')// &
-                                       'x = b ** e'//new_line('a')// &
-                                       'print *, x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            'real :: b'//new_line('a')// &
+            'real :: e'//new_line('a')// &
+            'real :: x'//new_line('a')// &
+            'b = 3.0'//new_line('a')// &
+            'e = 2.0'//new_line('a')// &
+            'x = b ** e'//new_line('a')// &
+            'print *, x'//new_line('a')// &
+            'end program main'
 
         test_real_pow_variable = expect_output( &
-                                 source, '   9.00000000    '//new_line('a'), &
-                                 '/tmp/ffc_session_real_pow_variable_test')
+            source, '   9.00000000    '//new_line('a'), &
+            '/tmp/ffc_session_real_pow_variable_test')
     end function test_real_pow_variable
 
 end program test_session_real_pow_compiler

--- a/test/test_session_real_transcendental_compiler.f90
+++ b/test/test_session_real_transcendental_compiler.f90
@@ -25,43 +25,43 @@ contains
         character(len=*), intent(in) :: stem
 
         check = expect_output( &
-                'program main'//new_line('a')// &
-                'real :: x'//new_line('a')// &
-                'x = '//expr//new_line('a')// &
-                'print *, x'//new_line('a')// &
-                'end program main', expected//new_line('a'), stem)
+            'program main'//new_line('a')// &
+            'real :: x'//new_line('a')// &
+            'x = '//expr//new_line('a')// &
+            'print *, x'//new_line('a')// &
+            'end program main', expected//new_line('a'), stem)
     end function check
 
     logical function test_sqrt_four()
         test_sqrt_four = check('sqrt(4.0)', '   2.00000000    ', &
-                               '/tmp/ffc_session_sqrt_test')
+            '/tmp/ffc_session_sqrt_test')
     end function test_sqrt_four
 
     logical function test_sin_zero()
         test_sin_zero = check('sin(0.0)', '   0.00000000    ', &
-                              '/tmp/ffc_session_sin_test')
+            '/tmp/ffc_session_sin_test')
     end function test_sin_zero
 
     logical function test_cos_zero()
         test_cos_zero = check('cos(0.0)', '   1.00000000    ', &
-                              '/tmp/ffc_session_cos_test')
+            '/tmp/ffc_session_cos_test')
     end function test_cos_zero
 
     logical function test_exp_zero()
         test_exp_zero = check('exp(0.0)', '   1.00000000    ', &
-                              '/tmp/ffc_session_exp_test')
+            '/tmp/ffc_session_exp_test')
     end function test_exp_zero
 
     logical function test_log_one()
         test_log_one = check('log(1.0)', '   0.00000000    ', &
-                             '/tmp/ffc_session_log_test')
+            '/tmp/ffc_session_log_test')
     end function test_log_one
 
     logical function test_atan2_one_one()
         ! atan2(1.0, 1.0) == pi/4, printed in gfortran real(4) list-directed form
         test_atan2_one_one = check('atan2(1.0, 1.0)', &
-                                   '  0.785398185    ', &
-                                   '/tmp/ffc_session_atan2_test')
+            '  0.785398185    ', &
+            '/tmp/ffc_session_atan2_test')
     end function test_atan2_one_one
 
 end program test_session_real_transcendental_compiler

--- a/test/test_session_real_variable_compiler.f90
+++ b/test/test_session_real_variable_compiler.f90
@@ -5,22 +5,22 @@ program test_session_real_variable_compiler
     print *, '=== direct session real variable compiler test ==='
 
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  real :: x'//new_line('a')// &
-         '  real :: y'//new_line('a')// &
-         '  x = 2.0'//new_line('a')// &
-         '  y = x + 1.5'//new_line('a')// &
-         '  print *, y'//new_line('a')// &
-         'end program main', '   3.50000000    '//new_line('a'), &
-         '/tmp/ffc_session_real_var_test')) stop 1
+        'program main'//new_line('a')// &
+        '  real :: x'//new_line('a')// &
+        '  real :: y'//new_line('a')// &
+        '  x = 2.0'//new_line('a')// &
+        '  y = x + 1.5'//new_line('a')// &
+        '  print *, y'//new_line('a')// &
+        'end program main', '   3.50000000    '//new_line('a'), &
+        '/tmp/ffc_session_real_var_test')) stop 1
 
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  real :: x'//new_line('a')// &
-         '  x = sign(2.5, -4.0)'//new_line('a')// &
-         '  print *, x'//new_line('a')// &
-         'end program main', '  -2.50000000    '//new_line('a'), &
-         '/tmp/ffc_session_real_sign_test')) stop 1
+        'program main'//new_line('a')// &
+        '  real :: x'//new_line('a')// &
+        '  x = sign(2.5, -4.0)'//new_line('a')// &
+        '  print *, x'//new_line('a')// &
+        'end program main', '  -2.50000000    '//new_line('a'), &
+        '/tmp/ffc_session_real_sign_test')) stop 1
 
     print *, 'PASS: real variables and arithmetic lower through direct LIRIC'
 end program test_session_real_variable_compiler

--- a/test/test_session_recursive_function_compiler.f90
+++ b/test/test_session_recursive_function_compiler.f90
@@ -65,7 +65,7 @@ contains
         ! A bare module lowers but has no entry point; a successful compile is the
         ! pass condition, so reuse expect_exit_status with the no-main exit code 0.
         test_recursive_module_function = expect_exit_status( &
-            source, 0, '/tmp/ffc_session_recursive_module_test')
-    end function test_recursive_module_function
+                source, 0, '/tmp/ffc_session_recursive_module_test')
+        end function test_recursive_module_function
 
-end program test_session_recursive_function_compiler
+    end program test_session_recursive_function_compiler

--- a/test/test_session_reshape_compiler.f90
+++ b/test/test_session_reshape_compiler.f90
@@ -34,11 +34,11 @@ contains
             'end program main'
         test_identifier_source_rank2 = expect_output( &
             source, '           1'//new_line('a')// &
-                    '           3'//new_line('a')// &
-                    '           5'//new_line('a')// &
-                    '           2'//new_line('a')// &
-                    '           4'//new_line('a')// &
-                    '           6'//new_line('a'), &
+            '           3'//new_line('a')// &
+            '           5'//new_line('a')// &
+            '           2'//new_line('a')// &
+            '           4'//new_line('a')// &
+            '           6'//new_line('a'), &
             '/tmp/ffc_session_reshape_ident_test')
     end function test_identifier_source_rank2
 
@@ -55,9 +55,9 @@ contains
             'end program main'
         test_literal_source_rank2 = expect_output( &
             source, '          10'//new_line('a')// &
-                    '          20'//new_line('a')// &
-                    '          30'//new_line('a')// &
-                    '          40'//new_line('a'), &
+            '          20'//new_line('a')// &
+            '          30'//new_line('a')// &
+            '          40'//new_line('a'), &
             '/tmp/ffc_session_reshape_literal_test')
     end function test_literal_source_rank2
 
@@ -72,7 +72,7 @@ contains
             'end program main'
         test_real_literal_source_rank2 = expect_output( &
             source, '   1.50000000    '//new_line('a')// &
-                    '   4.50000000    '//new_line('a'), &
+            '   4.50000000    '//new_line('a'), &
             '/tmp/ffc_session_reshape_real_test')
     end function test_real_literal_source_rank2
 

--- a/test/test_session_scalar_print_compiler.f90
+++ b/test/test_session_scalar_print_compiler.f90
@@ -5,12 +5,12 @@ program test_session_scalar_print_compiler
     print *, '=== direct session scalar print compiler test ==='
 
     if (.not. expect_output( &
-         'program main'//new_line('a')// &
-         '  integer :: x'//new_line('a')// &
-         '  x = 2 + 3'//new_line('a')// &
-         '  print *, x'//new_line('a')// &
-         'end program main', '           5'//new_line('a'), &
-         '/tmp/ffc_session_scalar_print_test')) stop 1
+        'program main'//new_line('a')// &
+        '  integer :: x'//new_line('a')// &
+        '  x = 2 + 3'//new_line('a')// &
+        '  print *, x'//new_line('a')// &
+        'end program main', '           5'//new_line('a'), &
+        '/tmp/ffc_session_scalar_print_test')) stop 1
 
     print *, 'PASS: integer print lowers through direct LIRIC session'
 end program test_session_scalar_print_compiler

--- a/test/test_session_selected_kind_compiler.f90
+++ b/test/test_session_selected_kind_compiler.f90
@@ -1,6 +1,6 @@
 program test_session_selected_kind
     use ffc_test_support, only: expect_exit_status, expect_output, &
-                                expect_error_contains
+        expect_error_contains
     implicit none
 
     logical :: all_passed
@@ -26,14 +26,14 @@ contains
     ! decimal range: r<=2 -> 1, r<=4 -> 2, r<=9 -> 4, r<=18 -> 8, r<=38 -> 16.
     logical function test_selected_int_kind_print()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  print *, selected_int_kind(2)'// &
-                                       new_line('a')// &
-                                       '  print *, selected_int_kind(9)'// &
-                                       new_line('a')// &
-                                       '  print *, selected_int_kind(18)'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  print *, selected_int_kind(2)'// &
+            new_line('a')// &
+            '  print *, selected_int_kind(9)'// &
+            new_line('a')// &
+            '  print *, selected_int_kind(18)'// &
+            new_line('a')// &
+            'end program main'
 
         test_selected_int_kind_print = expect_output( &
             source, &
@@ -46,10 +46,10 @@ contains
     ! No available integer kind reaches 39 decimal digits: result is -1.
     logical function test_selected_int_kind_unavailable()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  print *, selected_int_kind(39)'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  print *, selected_int_kind(39)'// &
+            new_line('a')// &
+            'end program main'
 
         test_selected_int_kind_unavailable = expect_output( &
             source, '          -1'//new_line('a'), &
@@ -59,12 +59,12 @@ contains
     ! selected_real_kind(p): smallest real kind with >= p decimal digits.
     logical function test_selected_real_kind_one_arg()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  print *, selected_real_kind(6)'// &
-                                       new_line('a')// &
-                                       '  print *, selected_real_kind(15)'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  print *, selected_real_kind(6)'// &
+            new_line('a')// &
+            '  print *, selected_real_kind(15)'// &
+            new_line('a')// &
+            'end program main'
 
         test_selected_real_kind_one_arg = expect_output( &
             source, &
@@ -76,12 +76,12 @@ contains
     ! selected_real_kind(p, r) requires both precision and range to be met.
     logical function test_selected_real_kind_two_args()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  print *, selected_real_kind(6, 30)'// &
-                                       new_line('a')// &
-                                       '  print *, selected_real_kind(15, 307)'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  print *, selected_real_kind(6, 30)'// &
+            new_line('a')// &
+            '  print *, selected_real_kind(15, 307)'// &
+            new_line('a')// &
+            'end program main'
 
         test_selected_real_kind_two_args = expect_output( &
             source, &
@@ -93,14 +93,14 @@ contains
     ! Standard error codes: -1 precision unmet, -2 range unmet, -3 both unmet.
     logical function test_selected_real_kind_error_codes()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  print *, selected_real_kind(40)'// &
-                                       new_line('a')// &
-                                       '  print *, selected_real_kind(0, 5000)'// &
-                                       new_line('a')// &
-                                       '  print *, selected_real_kind(40, 5000)'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  print *, selected_real_kind(40)'// &
+            new_line('a')// &
+            '  print *, selected_real_kind(0, 5000)'// &
+            new_line('a')// &
+            '  print *, selected_real_kind(40, 5000)'// &
+            new_line('a')// &
+            'end program main'
 
         test_selected_real_kind_error_codes = expect_output( &
             source, &
@@ -113,11 +113,11 @@ contains
     ! The fold result is usable as a compile-time integer parameter value.
     logical function test_selected_int_kind_in_parameter()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer, parameter :: ik = '// &
-                                       'selected_int_kind(9)'//new_line('a')// &
-                                       '  stop ik'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer, parameter :: ik = '// &
+            'selected_int_kind(9)'//new_line('a')// &
+            '  stop ik'//new_line('a')// &
+            'end program main'
 
         test_selected_int_kind_in_parameter = expect_exit_status( &
             source, 4, '/tmp/ffc_session_selected_int_kind_param')
@@ -126,10 +126,10 @@ contains
     ! The argument may itself be a compile-time integer expression.
     logical function test_selected_int_kind_constant_expr()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  print *, selected_int_kind(4 + 5)'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  print *, selected_int_kind(4 + 5)'// &
+            new_line('a')// &
+            'end program main'
 
         test_selected_int_kind_constant_expr = expect_output( &
             source, '           4'//new_line('a'), &
@@ -139,12 +139,12 @@ contains
     ! A runtime variable argument is not a constant expression and is rejected.
     logical function test_selected_int_kind_nonconstant_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: n'//new_line('a')// &
-                                       '  n = 9'//new_line('a')// &
-                                       '  print *, selected_int_kind(n)'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: n'//new_line('a')// &
+            '  n = 9'//new_line('a')// &
+            '  print *, selected_int_kind(n)'// &
+            new_line('a')// &
+            'end program main'
 
         test_selected_int_kind_nonconstant_diagnostic = expect_error_contains( &
             source, &

--- a/test/test_session_separate_compilation_compiler.f90
+++ b/test/test_session_separate_compilation_compiler.f90
@@ -22,18 +22,18 @@ contains
 
         ok = .false.
         if (.not. write_file(m_src, &
-                'module ffc_sep_mod'//new_line('a')// &
-                '  implicit none'//new_line('a')// &
-                '  integer, parameter :: answer = 42'//new_line('a')// &
-                'end module ffc_sep_mod')) return
+            'module ffc_sep_mod'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer, parameter :: answer = 42'//new_line('a')// &
+            'end module ffc_sep_mod')) return
         if (.not. write_file(main_src, &
-                'program main'//new_line('a')// &
-                '  use ffc_sep_mod'//new_line('a')// &
-                '  stop answer'//new_line('a')// &
-                'end program main')) return
+            'program main'//new_line('a')// &
+            '  use ffc_sep_mod'//new_line('a')// &
+            '  stop answer'//new_line('a')// &
+            'end program main')) return
 
         call execute_command_line('rm -f '//m_obj//' /tmp/ffc_sep_mod.fmod '// &
-                                  main_exe)
+            main_exe)
 
         ! Compile the module (emits the object and its .fmod), then compile the
         ! program naming the object; the .fmod is found beside it.
@@ -54,7 +54,7 @@ contains
 
         call execute_command_line(main_exe, exitstat=exit_stat, cmdstat=cmd_stat)
         call execute_command_line('rm -f '//m_src//' '//main_src//' '//m_obj// &
-                                  ' /tmp/ffc_sep_mod.fmod '//main_exe)
+            ' /tmp/ffc_sep_mod.fmod '//main_exe)
         if (cmd_stat /= 0) then
             print *, 'FAIL: could not run the linked program'
             return
@@ -74,7 +74,7 @@ contains
 
         ok = .false.
         open (newunit=unit, file=path, status='replace', action='write', &
-              iostat=io_stat)
+            iostat=io_stat)
         if (io_stat /= 0) then
             print *, 'FAIL: could not write ', path
             return

--- a/test/test_session_shift_merge_compiler.f90
+++ b/test/test_session_shift_merge_compiler.f90
@@ -34,9 +34,9 @@ contains
             'end program main'
         test_cshift_positive = expect_output( &
             source, '           2'//new_line('a')// &
-                    '           3'//new_line('a')// &
-                    '           4'//new_line('a')// &
-                    '           1'//new_line('a'), &
+            '           3'//new_line('a')// &
+            '           4'//new_line('a')// &
+            '           1'//new_line('a'), &
             '/tmp/ffc_session_cshift_pos_test')
     end function test_cshift_positive
 
@@ -55,9 +55,9 @@ contains
             'end program main'
         test_cshift_negative = expect_output( &
             source, '           4'//new_line('a')// &
-                    '           1'//new_line('a')// &
-                    '           2'//new_line('a')// &
-                    '           3'//new_line('a'), &
+            '           1'//new_line('a')// &
+            '           2'//new_line('a')// &
+            '           3'//new_line('a'), &
             '/tmp/ffc_session_cshift_neg_test')
     end function test_cshift_negative
 
@@ -76,9 +76,9 @@ contains
             'end program main'
         test_eoshift_fills_zero = expect_output( &
             source, '           2'//new_line('a')// &
-                    '           3'//new_line('a')// &
-                    '           4'//new_line('a')// &
-                    '           0'//new_line('a'), &
+            '           3'//new_line('a')// &
+            '           4'//new_line('a')// &
+            '           0'//new_line('a'), &
             '/tmp/ffc_session_eoshift_zero_test')
     end function test_eoshift_fills_zero
 
@@ -101,8 +101,8 @@ contains
             'end program main'
         test_merge_integer = expect_output( &
             source, '           1'//new_line('a')// &
-                    '           5'//new_line('a')// &
-                    '           3'//new_line('a'), &
+            '           5'//new_line('a')// &
+            '           3'//new_line('a'), &
             '/tmp/ffc_session_merge_int_test')
     end function test_merge_integer
 
@@ -123,7 +123,7 @@ contains
             'end program main'
         test_merge_real = expect_output( &
             source, '   3.50000000    '//new_line('a')// &
-                    '   2.50000000    '//new_line('a'), &
+            '   2.50000000    '//new_line('a'), &
             '/tmp/ffc_session_merge_real_test')
     end function test_merge_real
 

--- a/test/test_session_spread_compiler.f90
+++ b/test/test_session_spread_compiler.f90
@@ -34,11 +34,11 @@ contains
             'end program main'
         test_spread_dim2 = expect_output( &
             source, '           1'//new_line('a')// &
-                    '           2'//new_line('a')// &
-                    '           3'//new_line('a')// &
-                    '           1'//new_line('a')// &
-                    '           2'//new_line('a')// &
-                    '           3'//new_line('a'), &
+            '           2'//new_line('a')// &
+            '           3'//new_line('a')// &
+            '           1'//new_line('a')// &
+            '           2'//new_line('a')// &
+            '           3'//new_line('a'), &
             '/tmp/ffc_session_spread_dim2_test')
     end function test_spread_dim2
 
@@ -60,11 +60,11 @@ contains
             'end program main'
         test_spread_dim1 = expect_output( &
             source, '           1'//new_line('a')// &
-                    '           1'//new_line('a')// &
-                    '           2'//new_line('a')// &
-                    '           2'//new_line('a')// &
-                    '           3'//new_line('a')// &
-                    '           3'//new_line('a'), &
+            '           1'//new_line('a')// &
+            '           2'//new_line('a')// &
+            '           2'//new_line('a')// &
+            '           3'//new_line('a')// &
+            '           3'//new_line('a'), &
             '/tmp/ffc_session_spread_dim1_test')
     end function test_spread_dim1
 
@@ -85,9 +85,9 @@ contains
             'end program main'
         test_spread_real = expect_output( &
             source, '   1.50000000    '//new_line('a')// &
-                    '   2.50000000    '//new_line('a')// &
-                    '   1.50000000    '//new_line('a')// &
-                    '   2.50000000    '//new_line('a'), &
+            '   2.50000000    '//new_line('a')// &
+            '   1.50000000    '//new_line('a')// &
+            '   2.50000000    '//new_line('a'), &
             '/tmp/ffc_session_spread_real_test')
     end function test_spread_real
 

--- a/test/test_session_statement_function_compiler.f90
+++ b/test/test_session_statement_function_compiler.f90
@@ -31,24 +31,24 @@ contains
             'end program main'
 
         test_integer_statement_function = expect_output( &
-            source, '          17'//new_line('a'), &
-            '/tmp/ffc_stmt_fn_int')
-    end function test_integer_statement_function
+                source, '          17'//new_line('a'), &
+                '/tmp/ffc_stmt_fn_int')
+        end function test_integer_statement_function
 
-    logical function test_real_statement_function()
-        ! area(r) = pi*r*r called with 2.0 yields 12.5663605 (single precision).
-        character(len=*), parameter :: source = &
-            'program main'//new_line('a')// &
-            '  real :: r, a'//new_line('a')// &
-            '  real, parameter :: pi = 3.14159'//new_line('a')// &
-            '  area(r) = pi * r * r'//new_line('a')// &
-            '  a = area(2.0)'//new_line('a')// &
-            '  print *, a'//new_line('a')// &
-            'end program main'
+        logical function test_real_statement_function()
+            ! area(r) = pi*r*r called with 2.0 yields 12.5663605 (single precision).
+            character(len=*), parameter :: source = &
+                'program main'//new_line('a')// &
+                '  real :: r, a'//new_line('a')// &
+                '  real, parameter :: pi = 3.14159'//new_line('a')// &
+                '  area(r) = pi * r * r'//new_line('a')// &
+                '  a = area(2.0)'//new_line('a')// &
+                '  print *, a'//new_line('a')// &
+                'end program main'
 
-        test_real_statement_function = expect_output( &
-            source, '   12.5663605    '//new_line('a'), &
-            '/tmp/ffc_stmt_fn_real')
-    end function test_real_statement_function
+            test_real_statement_function = expect_output( &
+                    source, '   12.5663605    '//new_line('a'), &
+                    '/tmp/ffc_stmt_fn_real')
+            end function test_real_statement_function
 
-end program test_session_statement_function
+        end program test_session_statement_function

--- a/test/test_session_stop_code_compiler.f90
+++ b/test/test_session_stop_code_compiler.f90
@@ -5,10 +5,10 @@ program test_session_stop_code_compiler
     print *, '=== direct session stop code compiler test ==='
 
     if (.not. expect_exit_status( &
-         'program main'//new_line('a')// &
-         'stop 2 + 3 * 4'//new_line('a')// &
-         'end program main', 14, &
-         '/tmp/ffc_session_stop_code_test')) stop 1
+        'program main'//new_line('a')// &
+        'stop 2 + 3 * 4'//new_line('a')// &
+        'end program main', 14, &
+        '/tmp/ffc_session_stop_code_test')) stop 1
 
     print *, 'PASS: integer stop expression lowers through direct LIRIC session'
 end program test_session_stop_code_compiler

--- a/test/test_session_type_bound_compiler.f90
+++ b/test/test_session_type_bound_compiler.f90
@@ -18,96 +18,96 @@ contains
     ! concrete-type object the dispatch is static (by reference).
     logical function test_bound_sub_and_fn()
         character(len=*), parameter :: source = &
-           'module m'//new_line('a')// &
-           '  implicit none'//new_line('a')// &
-           '  type :: counter'//new_line('a')// &
-           '    integer :: n'//new_line('a')// &
-           '  contains'//new_line('a')// &
-           '    procedure :: set => counter_set'//new_line('a')// &
-           '    procedure :: get => counter_get'//new_line('a')// &
-           '  end type counter'//new_line('a')// &
-           'contains'//new_line('a')// &
-           '  subroutine counter_set(this, v)'//new_line('a')// &
-           '    class(counter), intent(inout) :: this'//new_line('a')// &
-           '    integer, intent(in) :: v'//new_line('a')// &
-           '    this%n = v'//new_line('a')// &
-           '  end subroutine counter_set'//new_line('a')// &
-           '  integer function counter_get(this)'//new_line('a')// &
-           '    class(counter), intent(in) :: this'//new_line('a')// &
-           '    counter_get = this%n'//new_line('a')// &
-           '  end function counter_get'//new_line('a')// &
-           'end module m'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  use m'//new_line('a')// &
-           '  implicit none'//new_line('a')// &
-           '  type(counter) :: c'//new_line('a')// &
-           '  call c%set(42)'//new_line('a')// &
-           '  stop c%get()'//new_line('a')// &
-           'end program main'
+            'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: counter'//new_line('a')// &
+            '    integer :: n'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: set => counter_set'//new_line('a')// &
+            '    procedure :: get => counter_get'//new_line('a')// &
+            '  end type counter'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine counter_set(this, v)'//new_line('a')// &
+            '    class(counter), intent(inout) :: this'//new_line('a')// &
+            '    integer, intent(in) :: v'//new_line('a')// &
+            '    this%n = v'//new_line('a')// &
+            '  end subroutine counter_set'//new_line('a')// &
+            '  integer function counter_get(this)'//new_line('a')// &
+            '    class(counter), intent(in) :: this'//new_line('a')// &
+            '    counter_get = this%n'//new_line('a')// &
+            '  end function counter_get'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(counter) :: c'//new_line('a')// &
+            '  call c%set(42)'//new_line('a')// &
+            '  stop c%get()'//new_line('a')// &
+            'end program main'
 
         test_bound_sub_and_fn = expect_exit_status( &
-           source, 42, '/tmp/ffc_type_bound_sub_fn_test')
+            source, 42, '/tmp/ffc_type_bound_sub_fn_test')
     end function test_bound_sub_and_fn
 
     ! Bound function with an explicit argument, result combined and printed.
     logical function test_bound_call_output()
         character(len=*), parameter :: source = &
-           'module m'//new_line('a')// &
-           '  implicit none'//new_line('a')// &
-           '  type :: box'//new_line('a')// &
-           '    integer :: base'//new_line('a')// &
-           '  contains'//new_line('a')// &
-           '    procedure :: plus => box_plus'//new_line('a')// &
-           '  end type box'//new_line('a')// &
-           'contains'//new_line('a')// &
-           '  integer function box_plus(this, k)'//new_line('a')// &
-           '    class(box), intent(in) :: this'//new_line('a')// &
-           '    integer, intent(in) :: k'//new_line('a')// &
-           '    box_plus = this%base + k'//new_line('a')// &
-           '  end function box_plus'//new_line('a')// &
-           'end module m'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  use m'//new_line('a')// &
-           '  implicit none'//new_line('a')// &
-           '  type(box) :: b'//new_line('a')// &
-           '  b%base = 100'//new_line('a')// &
-           '  print *, b%plus(23)'//new_line('a')// &
-           'end program main'
+            'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: box'//new_line('a')// &
+            '    integer :: base'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: plus => box_plus'//new_line('a')// &
+            '  end type box'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  integer function box_plus(this, k)'//new_line('a')// &
+            '    class(box), intent(in) :: this'//new_line('a')// &
+            '    integer, intent(in) :: k'//new_line('a')// &
+            '    box_plus = this%base + k'//new_line('a')// &
+            '  end function box_plus'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(box) :: b'//new_line('a')// &
+            '  b%base = 100'//new_line('a')// &
+            '  print *, b%plus(23)'//new_line('a')// &
+            'end program main'
 
         test_bound_call_output = expect_output( &
-           source, '         123'//new_line('a'), &
-           '/tmp/ffc_type_bound_out_test')
+            source, '         123'//new_line('a'), &
+            '/tmp/ffc_type_bound_out_test')
     end function test_bound_call_output
 
     ! A pass(self) renamed passed-object dummy: the bound subroutine receives
     ! the object in the position named by pass, not necessarily the first.
     logical function test_bound_pass_rename()
         character(len=*), parameter :: source = &
-           'module m'//new_line('a')// &
-           '  implicit none'//new_line('a')// &
-           '  type :: acc'//new_line('a')// &
-           '    integer :: total'//new_line('a')// &
-           '  contains'//new_line('a')// &
-           '    procedure, pass(self) :: add => acc_add'//new_line('a')// &
-           '  end type acc'//new_line('a')// &
-           'contains'//new_line('a')// &
-           '  subroutine acc_add(self, v)'//new_line('a')// &
-           '    class(acc), intent(inout) :: self'//new_line('a')// &
-           '    integer, intent(in) :: v'//new_line('a')// &
-           '    self%total = self%total + v'//new_line('a')// &
-           '  end subroutine acc_add'//new_line('a')// &
-           'end module m'//new_line('a')// &
-           'program main'//new_line('a')// &
-           '  use m'//new_line('a')// &
-           '  implicit none'//new_line('a')// &
-           '  type(acc) :: a'//new_line('a')// &
-           '  a%total = 5'//new_line('a')// &
-           '  call a%add(7)'//new_line('a')// &
-           '  stop a%total'//new_line('a')// &
-           'end program main'
+            'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: acc'//new_line('a')// &
+            '    integer :: total'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure, pass(self) :: add => acc_add'//new_line('a')// &
+            '  end type acc'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine acc_add(self, v)'//new_line('a')// &
+            '    class(acc), intent(inout) :: self'//new_line('a')// &
+            '    integer, intent(in) :: v'//new_line('a')// &
+            '    self%total = self%total + v'//new_line('a')// &
+            '  end subroutine acc_add'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(acc) :: a'//new_line('a')// &
+            '  a%total = 5'//new_line('a')// &
+            '  call a%add(7)'//new_line('a')// &
+            '  stop a%total'//new_line('a')// &
+            'end program main'
 
         test_bound_pass_rename = expect_exit_status( &
-           source, 12, '/tmp/ffc_type_bound_pass_test')
+            source, 12, '/tmp/ffc_type_bound_pass_test')
     end function test_bound_pass_rename
 
 end program test_session_type_bound_compiler

--- a/test/test_session_type_info_compiler.f90
+++ b/test/test_session_type_info_compiler.f90
@@ -34,10 +34,10 @@ contains
 
         test_each_derived_type_definition_emits_type_info = .true.
         if (.not. expect_exe_has_symbol(source, &
-                '/tmp/ffc_type_info_point.o', '__ffc_type_info_point_t')) &
+            '/tmp/ffc_type_info_point.o', '__ffc_type_info_point_t')) &
             test_each_derived_type_definition_emits_type_info = .false.
         if (.not. expect_exe_has_symbol(source, &
-                '/tmp/ffc_type_info_pair.o', '__ffc_type_info_pair_t')) &
+            '/tmp/ffc_type_info_pair.o', '__ffc_type_info_pair_t')) &
             test_each_derived_type_definition_emits_type_info = .false.
     end function test_each_derived_type_definition_emits_type_info
 

--- a/test/test_session_unit_boundary_diagnostics.f90
+++ b/test/test_session_unit_boundary_diagnostics.f90
@@ -1,7 +1,7 @@
 program test_session_unit_boundary_diagnostics
     use ffc_test_support, only: expect_exit_status, &
-                                expect_cli_no_error, &
-                                expect_no_error
+        expect_cli_no_error, &
+        expect_no_error
     implicit none
 
     logical :: all_passed
@@ -20,9 +20,9 @@ contains
 
     logical function test_use_intrinsic_module_no_error()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  use iso_fortran_env'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  use iso_fortran_env'//new_line('a')// &
+            'end program main'
 
         ! USE of intrinsic module should be silently ignored (no error)
         test_use_intrinsic_module_no_error = expect_no_error( &

--- a/test/test_session_unsupported_diagnostics.f90
+++ b/test/test_session_unsupported_diagnostics.f90
@@ -1,7 +1,7 @@
 program test_session_unsupported_diagnostics
     use ffc_test_support, only: expect_error_contains, &
-                                expect_cli_error_contains, &
-                                expect_output, expect_cli_no_error
+        expect_cli_error_contains, &
+        expect_output, expect_cli_no_error
     implicit none
 
     logical :: all_passed
@@ -66,73 +66,73 @@ contains
         ! A substring target keeps the unsupported diagnostic; // concatenation
         ! into a fixed-length scalar is now lowered (see the fixed-concat test).
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  character(len=5) :: name'//new_line('a')// &
-                                       '  name = "ab"'//new_line('a')// &
-                                       '  name = name(1:2)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  character(len=5) :: name'//new_line('a')// &
+            '  name = "ab"'//new_line('a')// &
+            '  name = name(1:2)'//new_line('a')// &
+            'end program main'
 
         test_character_expression_diagnostic = expect_error_contains( &
-                                           source, 'unsupported character assignment', &
-                                           '/tmp/ffc_session_character_diagnostic_test')
+            source, 'unsupported character assignment', &
+            '/tmp/ffc_session_character_diagnostic_test')
     end function test_character_expression_diagnostic
 
     logical function test_unassigned_character_print_diagnostic()
         character(len=*), parameter :: expected = &
-                                       'unsupported character variable print'
+            'unsupported character variable print'
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  character(len=5) :: name'//new_line('a')// &
-                                       '  print *, name'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  character(len=5) :: name'//new_line('a')// &
+            '  print *, name'//new_line('a')// &
+            'end program main'
 
         test_unassigned_character_print_diagnostic = &
             expect_error_contains(source, expected, &
-                                  '/tmp/ffc_session_unassigned_character_test')
+            '/tmp/ffc_session_unassigned_character_test')
     end function test_unassigned_character_print_diagnostic
 
     logical function test_module_diagnostic()
         ! Scalar module variables lower since #263; a module ARRAY variable still
         ! needs storage that is not yet emitted, so it stays a clean diagnostic.
         character(len=*), parameter :: source = &
-                                       'module m'//new_line('a')// &
-                                       '  integer :: counter(3)'//new_line('a')// &
-                                       'end module m'
+            'module m'//new_line('a')// &
+            '  integer :: counter(3)'//new_line('a')// &
+            'end module m'
 
         test_module_diagnostic = expect_error_contains( &
-                                 source, 'unsupported module variable', &
-                                 '/tmp/ffc_session_module_diagnostic_test')
+            source, 'unsupported module variable', &
+            '/tmp/ffc_session_module_diagnostic_test')
     end function test_module_diagnostic
 
     logical function test_character_parameter_diagnostic()
         character(len=*), parameter :: expected = &
-                                       'unsupported character parameter '// &
-                                       'declaration'
+            'unsupported character parameter '// &
+            'declaration'
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  call show("hi")'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine show(s)'//new_line('a')// &
-                                       '    character(len=2), intent(in) :: '// &
-                                       's'// &
-                                       new_line('a')// &
-                                       '    print *, s'//new_line('a')// &
-                                       '  end subroutine show'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  call show("hi")'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine show(s)'//new_line('a')// &
+            '    character(len=2), intent(in) :: '// &
+            's'// &
+            new_line('a')// &
+            '    print *, s'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end program main'
 
         test_character_parameter_diagnostic = expect_error_contains( &
-                                              source, expected, &
-                                              '/tmp/ffc_session_char_param_test')
+            source, expected, &
+            '/tmp/ffc_session_char_param_test')
     end function test_character_parameter_diagnostic
 
     ! complex scalars are supported now; verify they lower and match gfortran.
     logical function test_complex_scalar_lowers()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  complex :: z'//new_line('a')// &
-                                       '  z = (1.0, 2.0)'//new_line('a')// &
-                                       '  print *, z'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  complex :: z'//new_line('a')// &
+            '  z = (1.0, 2.0)'//new_line('a')// &
+            '  print *, z'//new_line('a')// &
+            'end program main'
 
         test_complex_scalar_lowers = expect_output( &
             source, '             (1.00000000,2.00000000)'//new_line('a'), &
@@ -143,45 +143,45 @@ contains
         ! SELECT CASE without a CASE DEFAULT arm now lowers; the matching arm
         ! runs and a non-matching selector simply falls through.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = 1'//new_line('a')// &
-                                       '  select case (x)'//new_line('a')// &
-                                       '  case (1)'//new_line('a')// &
-                                       '    print *, 1'//new_line('a')// &
-                                       '  end select'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = 1'//new_line('a')// &
+            '  select case (x)'//new_line('a')// &
+            '  case (1)'//new_line('a')// &
+            '    print *, 1'//new_line('a')// &
+            '  end select'//new_line('a')// &
+            'end program main'
 
         test_select_case_no_default_lowers = expect_output( &
-                                      source, '           1'//new_line('a'), &
-                                      '/tmp/ffc_session_select_case_test')
+            source, '           1'//new_line('a'), &
+            '/tmp/ffc_session_select_case_test')
     end function test_select_case_no_default_lowers
 
     logical function test_do_zero_step_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: i'//new_line('a')// &
-                                       '  do i = 1, 3, 0'//new_line('a')// &
-                                       '    print *, i'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  do i = 1, 3, 0'//new_line('a')// &
+            '    print *, i'//new_line('a')// &
+            'end program main'
 
         test_do_zero_step_diagnostic = expect_error_contains( &
-                                       source, 'nonzero literal step', &
-                                       '/tmp/ffc_session_do_zero_step_test')
+            source, 'nonzero literal step', &
+            '/tmp/ffc_session_do_zero_step_test')
     end function test_do_zero_step_diagnostic
 
     logical function test_do_terminating_body_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: i'//new_line('a')// &
-                                       '  do i = 1, 3'//new_line('a')// &
-                                       '    stop 1'//new_line('a')// &
-                                       '  end do'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  do i = 1, 3'//new_line('a')// &
+            '    stop 1'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            'end program main'
 
         test_do_terminating_body_diagnostic = expect_error_contains( &
-                                       source, 'unsupported terminating do loop body', &
-                                            '/tmp/ffc_session_do_terminating_body_test')
+            source, 'unsupported terminating do loop body', &
+            '/tmp/ffc_session_do_terminating_body_test')
     end function test_do_terminating_body_diagnostic
 
     logical function test_derived_type_diagnostic()
@@ -189,216 +189,216 @@ contains
         ! the type lowers; reading or writing it through obj%comp is not yet
         ! supported and must report a clear diagnostic.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: point'//new_line('a')// &
-                                       '    character(len=4) :: name'//new_line('a')// &
-                                       '  end type point'//new_line('a')// &
-                                       '  type(point) :: p'//new_line('a')// &
-                                       '  p%name = "abcd"'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: point'//new_line('a')// &
+            '    character(len=4) :: name'//new_line('a')// &
+            '  end type point'//new_line('a')// &
+            '  type(point) :: p'//new_line('a')// &
+            '  p%name = "abcd"'//new_line('a')// &
+            'end program main'
 
         test_derived_type_diagnostic = expect_error_contains( &
-                                       source, &
-                                       'character component access', &
-                                       '/tmp/ffc_session_derived_type_test')
+            source, &
+            'character component access', &
+            '/tmp/ffc_session_derived_type_test')
     end function test_derived_type_diagnostic
 
     logical function test_component_assignment_target_diagnostic()
         character(len=*), parameter :: expected = &
-                                       'unsupported derived type component '// &
-                                       'assignment target'
+            'unsupported derived type component '// &
+            'assignment target'
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  p%x = 1'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  p%x = 1'//new_line('a')// &
+            'end program main'
 
         test_component_assignment_target_diagnostic = expect_error_contains( &
-                                                      source, expected, &
-                                               '/tmp/ffc_session_component_target_test')
+            source, expected, &
+            '/tmp/ffc_session_component_target_test')
     end function test_component_assignment_target_diagnostic
 
     logical function test_component_expression_diagnostic()
         character(len=*), parameter :: expected = &
-                                       'unsupported derived type component '// &
-                                       'expression'
+            'unsupported derived type component '// &
+            'expression'
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  print *, p%x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  print *, p%x'//new_line('a')// &
+            'end program main'
 
         test_component_expression_diagnostic = expect_error_contains( &
-                                               source, expected, &
-                                               '/tmp/ffc_session_component_expr_test')
+            source, expected, &
+            '/tmp/ffc_session_component_expr_test')
     end function test_component_expression_diagnostic
 
     logical function test_unsupported_intrinsic_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  print *, sqrt(4)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  print *, sqrt(4)'//new_line('a')// &
+            'end program main'
 
         test_unsupported_intrinsic_diagnostic = expect_error_contains( &
-                                          source, 'unsupported scalar intrinsic: sqrt', &
-                                            '/tmp/ffc_session_intrinsic_diagnostic_test')
+            source, 'unsupported scalar intrinsic: sqrt', &
+            '/tmp/ffc_session_intrinsic_diagnostic_test')
     end function test_unsupported_intrinsic_diagnostic
 
     logical function test_external_function_call_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = external_value(1)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = external_value(1)'//new_line('a')// &
+            'end program main'
 
         test_external_function_call_diagnostic = expect_error_contains( &
-                                           source, 'unsupported scalar function call', &
-                                                 '/tmp/ffc_session_external_call_test')
+            source, 'unsupported scalar function call', &
+            '/tmp/ffc_session_external_call_test')
     end function test_external_function_call_diagnostic
 
     logical function test_external_real_function_call_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  real :: x'//new_line('a')// &
-                                       '  x = external_real(1.0)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  real :: x'//new_line('a')// &
+            '  x = external_real(1.0)'//new_line('a')// &
+            'end program main'
 
         test_external_real_function_call_diagnostic = &
             expect_error_contains(source, &
-                                  'unsupported scalar real(4) function call', &
-                                  '/tmp/ffc_session_external_real_call_test')
+            'unsupported scalar real(4) function call', &
+            '/tmp/ffc_session_external_real_call_test')
     end function test_external_real_function_call_diagnostic
 
     logical function test_external_logical_function_call_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  logical :: flag'//new_line('a')// &
-                                       '  flag = external_flag(.true.)'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  logical :: flag'//new_line('a')// &
+            '  flag = external_flag(.true.)'// &
+            new_line('a')// &
+            'end program main'
 
         test_external_logical_function_call_diagnostic = &
             expect_error_contains(source, &
-                                  'unsupported scalar logical function call', &
-                                  '/tmp/ffc_session_external_logical_call_test')
+            'unsupported scalar logical function call', &
+            '/tmp/ffc_session_external_logical_call_test')
     end function test_external_logical_function_call_diagnostic
 
     logical function test_integer_exponent_operator_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = 2 ** (-1)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = 2 ** (-1)'//new_line('a')// &
+            'end program main'
 
         test_integer_exponent_operator_diagnostic = expect_error_contains( &
-                                          source, 'unsupported negative integer exponent', &
-                                      '/tmp/ffc_session_integer_exponent_operator_test')
+            source, 'unsupported negative integer exponent', &
+            '/tmp/ffc_session_integer_exponent_operator_test')
     end function test_integer_exponent_operator_diagnostic
 
     logical function test_allocate_statement_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  allocate(values(3))'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  allocate(values(3))'//new_line('a')// &
+            'end program main'
 
         test_allocate_statement_diagnostic = expect_error_contains( &
-                                             source, &
-                                             'unsupported allocate statement', &
-                                             '/tmp/ffc_session_allocate_test')
+            source, &
+            'unsupported allocate statement', &
+            '/tmp/ffc_session_allocate_test')
     end function test_allocate_statement_diagnostic
 
     logical function test_deallocate_statement_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  deallocate(values)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  deallocate(values)'//new_line('a')// &
+            'end program main'
 
         test_deallocate_statement_diagnostic = expect_error_contains( &
-                                               source, &
-                                               'unsupported deallocate statement', &
-                                               '/tmp/ffc_session_deallocate_test')
+            source, &
+            'unsupported deallocate statement', &
+            '/tmp/ffc_session_deallocate_test')
     end function test_deallocate_statement_diagnostic
 
     logical function test_return_statement_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  return'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  return'//new_line('a')// &
+            'end program main'
 
         test_return_statement_diagnostic = expect_error_contains( &
-                                           source, &
-                                           'unsupported return statement', &
-                                           '/tmp/ffc_session_return_test')
+            source, &
+            'unsupported return statement', &
+            '/tmp/ffc_session_return_test')
     end function test_return_statement_diagnostic
 
     logical function test_cli_character_expression_diagnostic()
         ! A substring target keeps the unsupported diagnostic; // concatenation
         ! into a fixed-length scalar is now lowered (see the fixed-concat test).
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  character(len=5) :: name'//new_line('a')// &
-                                       '  name = "ab"'//new_line('a')// &
-                                       '  name = name(1:2)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  character(len=5) :: name'//new_line('a')// &
+            '  name = "ab"'//new_line('a')// &
+            '  name = name(1:2)'//new_line('a')// &
+            'end program main'
 
         test_cli_character_expression_diagnostic = expect_cli_error_contains( &
-                                           source, 'unsupported character assignment', &
-                                               '/tmp/ffc_cli_character_diagnostic_test')
+            source, 'unsupported character assignment', &
+            '/tmp/ffc_cli_character_diagnostic_test')
     end function test_cli_character_expression_diagnostic
 
     logical function test_cli_unassigned_character_print_diagnostic()
         character(len=*), parameter :: expected = &
-                                       'unsupported character variable print'
+            'unsupported character variable print'
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  character(len=5) :: name'//new_line('a')// &
-                                       '  print *, name'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  character(len=5) :: name'//new_line('a')// &
+            '  print *, name'//new_line('a')// &
+            'end program main'
 
         test_cli_unassigned_character_print_diagnostic = &
             expect_cli_error_contains(source, expected, &
-                                      '/tmp/ffc_cli_unassigned_character_test')
+            '/tmp/ffc_cli_unassigned_character_test')
     end function test_cli_unassigned_character_print_diagnostic
 
     logical function test_cli_module_diagnostic()
         ! Scalar module variables lower since #263; a module ARRAY variable still
         ! needs storage that is not yet emitted, so it stays a clean diagnostic.
         character(len=*), parameter :: source = &
-                                       'module m'//new_line('a')// &
-                                       '  integer :: counter(3)'//new_line('a')// &
-                                       'end module m'
+            'module m'//new_line('a')// &
+            '  integer :: counter(3)'//new_line('a')// &
+            'end module m'
 
         test_cli_module_diagnostic = expect_cli_error_contains( &
-                                     source, 'unsupported module variable', &
-                                     '/tmp/ffc_cli_module_diagnostic_test')
+            source, 'unsupported module variable', &
+            '/tmp/ffc_cli_module_diagnostic_test')
     end function test_cli_module_diagnostic
 
     logical function test_cli_character_parameter_diagnostic()
         character(len=*), parameter :: expected = &
-                                       'unsupported character parameter '// &
-                                       'declaration'
+            'unsupported character parameter '// &
+            'declaration'
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  call show("hi")'//new_line('a')// &
-                                       'contains'//new_line('a')// &
-                                       '  subroutine show(s)'//new_line('a')// &
-                                       '    character(len=2), intent(in) :: '// &
-                                       's'// &
-                                       new_line('a')// &
-                                       '    print *, s'//new_line('a')// &
-                                       '  end subroutine show'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  call show("hi")'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine show(s)'//new_line('a')// &
+            '    character(len=2), intent(in) :: '// &
+            's'// &
+            new_line('a')// &
+            '    print *, s'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end program main'
 
         test_cli_character_parameter_diagnostic = expect_cli_error_contains( &
-                                                  source, expected, &
-                                                  '/tmp/ffc_cli_char_param_test')
+            source, expected, &
+            '/tmp/ffc_cli_char_param_test')
     end function test_cli_character_parameter_diagnostic
 
     logical function test_cli_complex_scalar_lowers()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  complex :: z'//new_line('a')// &
-                                       '  z = (1.0, 2.0)'//new_line('a')// &
-                                       '  print *, z'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  complex :: z'//new_line('a')// &
+            '  z = (1.0, 2.0)'//new_line('a')// &
+            '  print *, z'//new_line('a')// &
+            'end program main'
 
         test_cli_complex_scalar_lowers = expect_cli_no_error( &
             source, '/tmp/ffc_cli_scalar_type_test')
@@ -408,190 +408,190 @@ contains
     logical function test_cli_select_case_no_default_lowers()
         ! Same construct through the CLI: it compiles cleanly with no diagnostic.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = 1'//new_line('a')// &
-                                       '  select case (x)'//new_line('a')// &
-                                       '  case (1)'//new_line('a')// &
-                                       '    print *, 1'//new_line('a')// &
-                                       '  end select'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = 1'//new_line('a')// &
+            '  select case (x)'//new_line('a')// &
+            '  case (1)'//new_line('a')// &
+            '    print *, 1'//new_line('a')// &
+            '  end select'//new_line('a')// &
+            'end program main'
 
         test_cli_select_case_no_default_lowers = expect_cli_no_error( &
-                                          source, '/tmp/ffc_cli_select_case_test')
+            source, '/tmp/ffc_cli_select_case_test')
     end function test_cli_select_case_no_default_lowers
 
     logical function test_cli_do_zero_step_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: i'//new_line('a')// &
-                                       '  do i = 1, 3, 0'//new_line('a')// &
-                                       '    print *, i'//new_line('a')// &
-                                       '  end do'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  do i = 1, 3, 0'//new_line('a')// &
+            '    print *, i'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            'end program main'
 
         test_cli_do_zero_step_diagnostic = expect_cli_error_contains( &
-                                           source, 'nonzero literal step', &
-                                           '/tmp/ffc_cli_do_zero_step_test')
+            source, 'nonzero literal step', &
+            '/tmp/ffc_cli_do_zero_step_test')
     end function test_cli_do_zero_step_diagnostic
 
     logical function test_cli_do_terminating_body_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: i'//new_line('a')// &
-                                       '  do i = 1, 3'//new_line('a')// &
-                                       '    stop 1'//new_line('a')// &
-                                       '  end do'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  do i = 1, 3'//new_line('a')// &
+            '    stop 1'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            'end program main'
 
         test_cli_do_terminating_body_diagnostic = expect_cli_error_contains( &
-                                       source, 'unsupported terminating do loop body', &
-                                                '/tmp/ffc_cli_do_terminating_body_test')
+            source, 'unsupported terminating do loop body', &
+            '/tmp/ffc_cli_do_terminating_body_test')
     end function test_cli_do_terminating_body_diagnostic
 
     logical function test_cli_derived_type_diagnostic()
         ! A fixed-length character component lowers into the slot layout;
         ! accessing it through obj%comp is rejected with a clear diagnostic.
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  type :: point'//new_line('a')// &
-                                       '    character(len=4) :: name'//new_line('a')// &
-                                       '  end type point'//new_line('a')// &
-                                       '  type(point) :: p'//new_line('a')// &
-                                       '  p%name = "abcd"'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  type :: point'//new_line('a')// &
+            '    character(len=4) :: name'//new_line('a')// &
+            '  end type point'//new_line('a')// &
+            '  type(point) :: p'//new_line('a')// &
+            '  p%name = "abcd"'//new_line('a')// &
+            'end program main'
 
         test_cli_derived_type_diagnostic = expect_cli_error_contains( &
-                                           source, &
-                                           'character component access', &
-                                           '/tmp/ffc_cli_derived_type_test')
+            source, &
+            'character component access', &
+            '/tmp/ffc_cli_derived_type_test')
     end function test_cli_derived_type_diagnostic
 
     logical function test_cli_component_assignment_target_diagnostic()
         character(len=*), parameter :: expected = &
-                                       'unsupported derived type component '// &
-                                       'assignment target'
+            'unsupported derived type component '// &
+            'assignment target'
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  p%x = 1'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  p%x = 1'//new_line('a')// &
+            'end program main'
 
         test_cli_component_assignment_target_diagnostic = &
             expect_cli_error_contains(source, expected, &
-                                      '/tmp/ffc_cli_component_target_test')
+            '/tmp/ffc_cli_component_target_test')
     end function test_cli_component_assignment_target_diagnostic
 
     logical function test_cli_component_expression_diagnostic()
         character(len=*), parameter :: expected = &
-                                       'unsupported derived type component '// &
-                                       'expression'
+            'unsupported derived type component '// &
+            'expression'
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  print *, p%x'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  print *, p%x'//new_line('a')// &
+            'end program main'
 
         test_cli_component_expression_diagnostic = expect_cli_error_contains( &
-                                                   source, expected, &
-                                                   '/tmp/ffc_cli_component_expr_test')
+            source, expected, &
+            '/tmp/ffc_cli_component_expr_test')
     end function test_cli_component_expression_diagnostic
 
     logical function test_cli_unsupported_intrinsic_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  print *, sqrt(4)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  print *, sqrt(4)'//new_line('a')// &
+            'end program main'
 
         test_cli_unsupported_intrinsic_diagnostic = expect_cli_error_contains( &
-                                          source, 'unsupported scalar intrinsic: sqrt', &
-                                                '/tmp/ffc_cli_intrinsic_diagnostic_test')
+            source, 'unsupported scalar intrinsic: sqrt', &
+            '/tmp/ffc_cli_intrinsic_diagnostic_test')
     end function test_cli_unsupported_intrinsic_diagnostic
 
     logical function test_cli_external_function_call_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = external_value(1)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = external_value(1)'//new_line('a')// &
+            'end program main'
 
         test_cli_external_function_call_diagnostic = expect_cli_error_contains( &
-                                           source, 'unsupported scalar function call', &
-                                                     '/tmp/ffc_cli_external_call_test')
+            source, 'unsupported scalar function call', &
+            '/tmp/ffc_cli_external_call_test')
     end function test_cli_external_function_call_diagnostic
 
     logical function test_cli_external_real_function_call_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  real :: x'//new_line('a')// &
-                                       '  x = external_real(1.0)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  real :: x'//new_line('a')// &
+            '  x = external_real(1.0)'//new_line('a')// &
+            'end program main'
 
         test_cli_external_real_function_call_diagnostic = &
             expect_cli_error_contains(source, &
-                                      'unsupported scalar real(4) function call', &
-                                      '/tmp/ffc_cli_external_real_call_test')
+            'unsupported scalar real(4) function call', &
+            '/tmp/ffc_cli_external_real_call_test')
     end function test_cli_external_real_function_call_diagnostic
 
     logical function test_cli_external_logical_function_call_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  logical :: flag'//new_line('a')// &
-                                       '  flag = external_flag(.true.)'// &
-                                       new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  logical :: flag'//new_line('a')// &
+            '  flag = external_flag(.true.)'// &
+            new_line('a')// &
+            'end program main'
 
         test_cli_external_logical_function_call_diagnostic = &
             expect_cli_error_contains(source, &
-                                      'unsupported scalar logical function call', &
-                                      '/tmp/ffc_cli_external_logical_call_test')
+            'unsupported scalar logical function call', &
+            '/tmp/ffc_cli_external_logical_call_test')
     end function test_cli_external_logical_function_call_diagnostic
 
     logical function test_cli_integer_exponent_operator_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: x'//new_line('a')// &
-                                       '  x = 2 ** (-1)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            '  x = 2 ** (-1)'//new_line('a')// &
+            'end program main'
 
         test_cli_integer_exponent_operator_diagnostic = &
             expect_cli_error_contains(source, &
-                                      'unsupported negative integer exponent', &
-                                      '/tmp/ffc_cli_integer_exponent_operator_test')
+            'unsupported negative integer exponent', &
+            '/tmp/ffc_cli_integer_exponent_operator_test')
     end function test_cli_integer_exponent_operator_diagnostic
 
     logical function test_cli_allocate_statement_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  allocate(values(3))'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  allocate(values(3))'//new_line('a')// &
+            'end program main'
 
         test_cli_allocate_statement_diagnostic = expect_cli_error_contains( &
-                                                 source, &
-                                                 'unsupported allocate statement', &
-                                                 '/tmp/ffc_cli_allocate_test')
+            source, &
+            'unsupported allocate statement', &
+            '/tmp/ffc_cli_allocate_test')
     end function test_cli_allocate_statement_diagnostic
 
     logical function test_cli_deallocate_statement_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  deallocate(values)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  deallocate(values)'//new_line('a')// &
+            'end program main'
 
         test_cli_deallocate_statement_diagnostic = expect_cli_error_contains( &
-                                                   source, &
-                                                   'unsupported deallocate statement', &
-                                                   '/tmp/ffc_cli_deallocate_test')
+            source, &
+            'unsupported deallocate statement', &
+            '/tmp/ffc_cli_deallocate_test')
     end function test_cli_deallocate_statement_diagnostic
 
     logical function test_cli_return_statement_diagnostic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  return'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  return'//new_line('a')// &
+            'end program main'
 
         test_cli_return_statement_diagnostic = expect_cli_error_contains( &
-                                               source, &
-                                               'unsupported return statement', &
-                                               '/tmp/ffc_cli_return_test')
+            source, &
+            'unsupported return statement', &
+            '/tmp/ffc_cli_return_test')
     end function test_cli_return_statement_diagnostic
 
 end program test_session_unsupported_diagnostics

--- a/test/test_session_use_module_derived_type_compiler.f90
+++ b/test/test_session_use_module_derived_type_compiler.f90
@@ -5,18 +5,18 @@ program test_session_use_module_derived_type_compiler
     print *, '=== direct session use module derived type compiler test ==='
 
     if (.not. expect_exit_status( &
-         'module point_mod'//new_line('a')// &
-         '  type :: point_t'//new_line('a')// &
-         '    integer :: x, y'//new_line('a')// &
-         '  end type'//new_line('a')// &
-         'end module point_mod'//new_line('a')// &
-         'program main'//new_line('a')// &
-         '  use point_mod'//new_line('a')// &
-         '  type(point_t) :: p'//new_line('a')// &
-         '  p%x = 7'//new_line('a')// &
-         '  stop p%x'//new_line('a')// &
-         'end program main', 7, &
-         '/tmp/ffc_session_use_module_derived_type_test')) stop 1
+        'module point_mod'//new_line('a')// &
+        '  type :: point_t'//new_line('a')// &
+        '    integer :: x, y'//new_line('a')// &
+        '  end type'//new_line('a')// &
+        'end module point_mod'//new_line('a')// &
+        'program main'//new_line('a')// &
+        '  use point_mod'//new_line('a')// &
+        '  type(point_t) :: p'//new_line('a')// &
+        '  p%x = 7'//new_line('a')// &
+        '  stop p%x'//new_line('a')// &
+        'end program main', 7, &
+        '/tmp/ffc_session_use_module_derived_type_test')) stop 1
 
     print *, 'PASS: USE module derived type lowers through direct LIRIC session'
 end program test_session_use_module_derived_type_compiler

--- a/test/test_session_use_only_compiler.f90
+++ b/test/test_session_use_only_compiler.f90
@@ -115,85 +115,85 @@ contains
             'end program main'
 
         test_use_only_admits_module_function = expect_exit_status( &
-            source, 25, '/tmp/ffc_session_use_only_function_test')
-    end function test_use_only_admits_module_function
+                source, 25, '/tmp/ffc_session_use_only_function_test')
+        end function test_use_only_admits_module_function
 
-    logical function test_use_only_admits_module_subroutine()
-        ! A module subroutine named in only: is a valid export (#263).
-        character(len=*), parameter :: source = &
-            'module m'//new_line('a')// &
-            '  implicit none'//new_line('a')// &
-            'contains'//new_line('a')// &
-            '  subroutine no_op()'//new_line('a')// &
-            '  end subroutine no_op'//new_line('a')// &
-            'end module m'//new_line('a')// &
-            'program main'//new_line('a')// &
-            '  use m, only: no_op'//new_line('a')// &
-            '  call no_op()'//new_line('a')// &
-            '  stop 7'//new_line('a')// &
-            'end program main'
+        logical function test_use_only_admits_module_subroutine()
+            ! A module subroutine named in only: is a valid export (#263).
+            character(len=*), parameter :: source = &
+                'module m'//new_line('a')// &
+                '  implicit none'//new_line('a')// &
+                'contains'//new_line('a')// &
+                '  subroutine no_op()'//new_line('a')// &
+                '  end subroutine no_op'//new_line('a')// &
+                'end module m'//new_line('a')// &
+                'program main'//new_line('a')// &
+                '  use m, only: no_op'//new_line('a')// &
+                '  call no_op()'//new_line('a')// &
+                '  stop 7'//new_line('a')// &
+                'end program main'
 
-        test_use_only_admits_module_subroutine = expect_exit_status( &
-            source, 7, '/tmp/ffc_session_use_only_subroutine_test')
-    end function test_use_only_admits_module_subroutine
+            test_use_only_admits_module_subroutine = expect_exit_status( &
+                    source, 7, '/tmp/ffc_session_use_only_subroutine_test')
+            end function test_use_only_admits_module_subroutine
 
-    logical function test_use_rename_module_variable()
-        ! Renaming a module variable binds the local name to the shared
-        ! global (#274).
-        character(len=*), parameter :: source = &
-            'module m'//new_line('a')// &
-            '  implicit none'//new_line('a')// &
-            '  integer :: counter = 42'//new_line('a')// &
-            'end module m'//new_line('a')// &
-            'program main'//new_line('a')// &
-            '  use m, only: local_counter => counter'//new_line('a')// &
-            '  implicit none'//new_line('a')// &
-            '  stop local_counter'//new_line('a')// &
-            'end program main'
+            logical function test_use_rename_module_variable()
+                ! Renaming a module variable binds the local name to the shared
+                ! global (#274).
+                character(len=*), parameter :: source = &
+                    'module m'//new_line('a')// &
+                    '  implicit none'//new_line('a')// &
+                    '  integer :: counter = 42'//new_line('a')// &
+                    'end module m'//new_line('a')// &
+                    'program main'//new_line('a')// &
+                    '  use m, only: local_counter => counter'//new_line('a')// &
+                    '  implicit none'//new_line('a')// &
+                    '  stop local_counter'//new_line('a')// &
+                    'end program main'
 
-        test_use_rename_module_variable = expect_exit_status( &
-            source, 42, '/tmp/ffc_session_use_rename_var_test')
-    end function test_use_rename_module_variable
+                test_use_rename_module_variable = expect_exit_status( &
+                    source, 42, '/tmp/ffc_session_use_rename_var_test')
+            end function test_use_rename_module_variable
 
-    logical function test_use_rename_module_function()
-        ! Renaming a module function aliases the call site (#274).
-        character(len=*), parameter :: source = &
-            'module m'//new_line('a')// &
-            '  implicit none'//new_line('a')// &
-            'contains'//new_line('a')// &
-            '  integer function square(x) result(res)'//new_line('a')// &
-            '    integer, intent(in) :: x'//new_line('a')// &
-            '    res = x * x'//new_line('a')// &
-            '  end function square'//new_line('a')// &
-            'end module m'//new_line('a')// &
-            'program main'//new_line('a')// &
-            '  use m, only: sq => square'//new_line('a')// &
-            '  implicit none'//new_line('a')// &
-            '  stop sq(6)'//new_line('a')// &
-            'end program main'
+            logical function test_use_rename_module_function()
+                ! Renaming a module function aliases the call site (#274).
+                character(len=*), parameter :: source = &
+                    'module m'//new_line('a')// &
+                    '  implicit none'//new_line('a')// &
+                    'contains'//new_line('a')// &
+                    '  integer function square(x) result(res)'//new_line('a')// &
+                    '    integer, intent(in) :: x'//new_line('a')// &
+                    '    res = x * x'//new_line('a')// &
+                    '  end function square'//new_line('a')// &
+                    'end module m'//new_line('a')// &
+                    'program main'//new_line('a')// &
+                    '  use m, only: sq => square'//new_line('a')// &
+                    '  implicit none'//new_line('a')// &
+                    '  stop sq(6)'//new_line('a')// &
+                    'end program main'
 
-        test_use_rename_module_function = expect_exit_status( &
-            source, 36, '/tmp/ffc_session_use_rename_fn_test')
-    end function test_use_rename_module_function
+                test_use_rename_module_function = expect_exit_status( &
+                        source, 36, '/tmp/ffc_session_use_rename_fn_test')
+                end function test_use_rename_module_function
 
-    logical function test_use_rename_module_subroutine()
-        ! Renaming a module subroutine aliases the call site (#274).
-        character(len=*), parameter :: source = &
-            'module m'//new_line('a')// &
-            '  implicit none'//new_line('a')// &
-            'contains'//new_line('a')// &
-            '  subroutine no_op()'//new_line('a')// &
-            '  end subroutine no_op'//new_line('a')// &
-            'end module m'//new_line('a')// &
-            'program main'//new_line('a')// &
-            '  use m, only: run => no_op'//new_line('a')// &
-            '  implicit none'//new_line('a')// &
-            '  call run()'//new_line('a')// &
-            '  stop 9'//new_line('a')// &
-            'end program main'
+                logical function test_use_rename_module_subroutine()
+                    ! Renaming a module subroutine aliases the call site (#274).
+                    character(len=*), parameter :: source = &
+                        'module m'//new_line('a')// &
+                        '  implicit none'//new_line('a')// &
+                        'contains'//new_line('a')// &
+                        '  subroutine no_op()'//new_line('a')// &
+                        '  end subroutine no_op'//new_line('a')// &
+                        'end module m'//new_line('a')// &
+                        'program main'//new_line('a')// &
+                        '  use m, only: run => no_op'//new_line('a')// &
+                        '  implicit none'//new_line('a')// &
+                        '  call run()'//new_line('a')// &
+                        '  stop 9'//new_line('a')// &
+                        'end program main'
 
-        test_use_rename_module_subroutine = expect_exit_status( &
-            source, 9, '/tmp/ffc_session_use_rename_sub_test')
-    end function test_use_rename_module_subroutine
+                    test_use_rename_module_subroutine = expect_exit_status( &
+                            source, 9, '/tmp/ffc_session_use_rename_sub_test')
+                    end function test_use_rename_module_subroutine
 
-end program test_session_use_only_compiler
+                end program test_session_use_only_compiler

--- a/test/test_session_where_compiler.f90
+++ b/test/test_session_where_compiler.f90
@@ -47,7 +47,7 @@ contains
             'end program main'
 
         ok = expect_output(source, i12([10, 0, 30, 0, 50]), &
-                           '/tmp/ffc_where_masked_test')
+            '/tmp/ffc_where_masked_test')
     end function test_where_masked_assignment
 
     logical function test_where_elsewhere() result(ok)
@@ -67,7 +67,7 @@ contains
             'end program main'
 
         ok = expect_output(source, i12([1, 2, 30, 40]), &
-                           '/tmp/ffc_where_elsewhere_test')
+            '/tmp/ffc_where_elsewhere_test')
     end function test_where_elsewhere
 
 end program test_session_where_compiler

--- a/test/test_session_whole_array_arithmetic_compiler.f90
+++ b/test/test_session_whole_array_arithmetic_compiler.f90
@@ -10,24 +10,24 @@ contains
 
     logical function test_rank2_whole_array_arithmetic()
         character(len=*), parameter :: source = &
-                                       'program main'//new_line('a')// &
-                                       '  integer :: a(0:1, 2:3)'//new_line('a')// &
-                                       '  integer :: b(0:1, 2:3)'//new_line('a')// &
-                                       '  integer :: c(0:1, 2:3)'//new_line('a')// &
-                                       '  integer :: d(0:1, 2:3)'//new_line('a')// &
-                                       '  integer :: e(0:1, 2:3)'//new_line('a')// &
-                                       '  integer :: f(0:1, 2:3)'//new_line('a')// &
-                                       '  a = [1, 2, 3, 4]'//new_line('a')// &
-                                       '  b = [5, 6, 7, 8]'//new_line('a')// &
-                                       '  c = a + b'//new_line('a')// &
-                                       '  d = a - b'//new_line('a')// &
-                                       '  e = a * b'//new_line('a')// &
-                                       '  f = c'//new_line('a')// &
-                                       '  print *, c(0, 2) + c(1, 2) + c(0, 3) + c(1, 3) + &'//new_line('a')// &
-                                       '            d(0, 2) + d(1, 2) + d(0, 3) + d(1, 3) + &'//new_line('a')// &
-                                       '            e(0, 2) + e(1, 2) + e(0, 3) + e(1, 3) + &'//new_line('a')// &
-                                       '            f(0, 2) + f(1, 2) + f(0, 3) + f(1, 3)'//new_line('a')// &
-                                       'end program main'
+            'program main'//new_line('a')// &
+            '  integer :: a(0:1, 2:3)'//new_line('a')// &
+            '  integer :: b(0:1, 2:3)'//new_line('a')// &
+            '  integer :: c(0:1, 2:3)'//new_line('a')// &
+            '  integer :: d(0:1, 2:3)'//new_line('a')// &
+            '  integer :: e(0:1, 2:3)'//new_line('a')// &
+            '  integer :: f(0:1, 2:3)'//new_line('a')// &
+            '  a = [1, 2, 3, 4]'//new_line('a')// &
+            '  b = [5, 6, 7, 8]'//new_line('a')// &
+            '  c = a + b'//new_line('a')// &
+            '  d = a - b'//new_line('a')// &
+            '  e = a * b'//new_line('a')// &
+            '  f = c'//new_line('a')// &
+            '  print *, c(0, 2) + c(1, 2) + c(0, 3) + c(1, 3) + &'//new_line('a')// &
+            '            d(0, 2) + d(1, 2) + d(0, 3) + d(1, 3) + &'//new_line('a')// &
+            '            e(0, 2) + e(1, 2) + e(0, 3) + e(1, 3) + &'//new_line('a')// &
+            '            f(0, 2) + f(1, 2) + f(0, 3) + f(1, 3)'//new_line('a')// &
+            'end program main'
 
         test_rank2_whole_array_arithmetic = expect_output( &
             source, '         126'//new_line('a'), &


### PR DESCRIPTION
Format all Fortran sources with `fo fmt` native style (88 col, 4 space indent). Pure reformatting: `git diff -w` is empty (5468/5468 balanced). The `liric` link failure under `fo build` is pre-existing on main (reproduces unmodified), unrelated to formatting. Closes #288.