### PR TITLE
fix: track generic dispatch argument ranks (refs #303)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,12 @@ jobs:
       - name: Install build tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y gfortran cmake ninja-build curl
+          sudo apt-get install -y gfortran-14 gcc-14 g++-14 cmake ninja-build curl
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
+          sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-14 100
+          gcc --version | head -1
+          gfortran --version | head -1
 
       - name: Install fpm
         run: |
@@ -46,6 +51,9 @@ jobs:
 
       - name: Build liric
         working-directory: liric
+        env:
+          CC: gcc-14
+          CXX: g++-14
         run: |
           cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
           cmake --build build -j"$(nproc)"

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -1617,6 +1617,7 @@ contains
         integer, allocatable :: copyback_indices(:)
         integer :: call_arg_count
         integer :: call_arg_kinds(MAX_PROC_ARGS)
+        integer :: call_arg_ranks(MAX_PROC_ARGS)
         integer :: i
         call get_subroutine_call_name(arena, node_index, name, error_msg)
         if (len_trim(error_msg) > 0) return
@@ -1631,14 +1632,18 @@ contains
         ! Resolve generic -> specific (#249 B7c).
         call_arg_count = 0
         call_arg_kinds = VALUE_I32
+        call_arg_ranks = 0
         if (allocated(arg_indices)) then
             call_arg_count = min(size(arg_indices), MAX_PROC_ARGS)
             do i = 1, call_arg_count
                 call_arg_kinds(i) = expression_value_kind(arena, arg_indices(i), &
                     context, VALUE_I32)
+                call_arg_ranks(i) = expression_value_rank(arena, arg_indices(i), &
+                    context)
             end do
         end if
-        call_name = degeneric_call_name(context, name, call_arg_count, call_arg_kinds)
+        call_name = degeneric_call_name(context, name, call_arg_count, call_arg_kinds, &
+            call_arg_ranks)
         if (same_name(call_name, 'get_command_argument')) then
             call lower_get_command_argument(arena, arg_indices, context, error_msg)
             return

--- a/src/session_program_lowering_arguments.inc
+++ b/src/session_program_lowering_arguments.inc
@@ -680,8 +680,8 @@
         call set_empty(error_msg)
     end subroutine prepare_identifier_reference_arg
 
-    integer function expression_value_kind(arena, node_index, context, &
-                                           default_kind) result(value_kind)
+integer function expression_value_kind(arena, node_index, context, &
+                                            default_kind) result(value_kind)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: node_index
         type(lowering_context_t), intent(in) :: context
@@ -689,6 +689,7 @@
         integer :: symbol_index
         integer :: call_arg_count
         integer :: call_arg_kinds(MAX_PROC_ARGS)
+        integer :: call_arg_ranks(MAX_PROC_ARGS)
         character(len=:), allocatable :: id_name, id_err
 
         value_kind = default_kind
@@ -744,8 +745,10 @@
                 if (find_generic(context, node%name) > 0) then
                     call call_argument_kinds(arena, node, context, default_kind, &
                         call_arg_count, call_arg_kinds)
+                    call call_argument_ranks(arena, node, context, call_arg_count, &
+                        call_arg_ranks)
                     value_kind = generic_call_return_kind(context, node%name, &
-                        call_arg_count, call_arg_kinds)
+                        call_arg_count, call_arg_kinds, call_arg_ranks)
                 else if (is_contained_f32_function(context, node%name)) then
                     value_kind = VALUE_F32
                 else if (is_contained_f64_function(context, node%name)) then
@@ -759,8 +762,8 @@
         end select
     end function expression_value_kind
 
-    subroutine call_argument_kinds(arena, node, context, default_kind, &
-                                  arg_count, arg_kinds)
+ subroutine call_argument_kinds(arena, node, context, default_kind, &
+                                   arg_count, arg_kinds)
         ! Expand the actual argument kinds at a call site for generic signature
         ! matching.
         type(ast_arena_t), intent(in) :: arena
@@ -778,9 +781,69 @@
         if (arg_count > MAX_PROC_ARGS) arg_count = MAX_PROC_ARGS
         do i = 1, arg_count
             arg_kinds(i) = expression_value_kind(arena, node%arg_indices(i), &
-                                                context, default_kind)
+                                                 context, default_kind)
         end do
     end subroutine call_argument_kinds
+
+    subroutine call_argument_ranks(arena, node, context, arg_count, arg_ranks)
+        ! Expand the actual argument ranks at a call site for generic signature
+        ! matching. 0 = scalar, >0 = array rank (refs #303).
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(out) :: arg_count
+        integer, intent(out) :: arg_ranks(MAX_PROC_ARGS)
+        integer :: i
+
+        arg_count = 0
+        arg_ranks = 0
+        if (.not. allocated(node%arg_indices)) return
+        arg_count = size(node%arg_indices)
+        if (arg_count > MAX_PROC_ARGS) arg_count = MAX_PROC_ARGS
+        do i = 1, arg_count
+            arg_ranks(i) = expression_value_rank(arena, node%arg_indices(i), &
+                                                 context)
+        end do
+    end subroutine call_argument_ranks
+
+    integer function expression_value_rank(arena, node_index, context) result(rank)
+        ! Array rank of an expression used as a call argument. 0 for scalar,
+        ! >0 for array. Used by generic dispatch to distinguish same-kind
+        ! specifics that differ in rank (refs #303).
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(in) :: context
+        integer :: symbol_index
+        character(len=:), allocatable :: id_name, id_err
+
+        rank = 0
+        if (.not. node_exists(arena, node_index)) return
+
+        if (is_literal(arena, node_index)) return
+        if (is_binary_op(arena, node_index)) return
+
+        if (is_identifier(arena, node_index)) then
+            call get_identifier_name(arena, node_index, id_name, id_err)
+            if (len_trim(id_err) > 0) return
+            symbol_index = find_symbol(context, id_name)
+            if (symbol_index > 0) then
+                if (context%symbols(symbol_index)%is_array) then
+                    rank = context%symbols(symbol_index)%array_rank
+                else if (context%symbols(symbol_index)%array_rank > 0) then
+                    rank = context%symbols(symbol_index)%array_rank
+                end if
+            end if
+            return
+        end if
+
+        select type (node => arena%entries(node_index)%node)
+        type is (call_or_subscript_node)
+            if (node%is_array_access) then
+                rank = expression_array_access_rank(arena, node, context)
+                return
+            end if
+        end select
+    end function expression_value_rank
 
     subroutine lower_expression_by_kind(arena, node_index, context, value_kind, &
                                         value, error_msg)
@@ -875,3 +938,57 @@
         end do
         call set_empty(error_msg)
     end subroutine copy_back_reference_args
+
+    integer function expression_array_access_rank(arena, node, context) result(rank)
+        ! Rank of an array access expression: 0 for element access (all indices
+        ! are scalar), or the remaining rank for a section (e.g. a(:) keeps rank
+        ! 1 of a rank-1 array).
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        type(lowering_context_t), intent(in) :: context
+        integer :: symbol_index, base_rank
+
+        rank = 0
+        if (.not. allocated(node%name)) return
+        if (len_trim(node%name) == 0) return
+        symbol_index = find_symbol(context, node%name)
+        if (symbol_index <= 0) return
+        base_rank = 0
+        if (context%symbols(symbol_index)%is_array) then
+            base_rank = context%symbols(symbol_index)%array_rank
+        else if (context%symbols(symbol_index)%array_rank > 0) then
+            base_rank = context%symbols(symbol_index)%array_rank
+        end if
+        if (base_rank <= 0) return
+        rank = base_rank - count_scalar_indices(arena, node)
+        if (rank < 0) rank = 0
+    end function expression_array_access_rank
+
+    integer function count_scalar_indices(arena, node) result(count)
+        ! Number of scalar indices in an array access. If all indices are scalar,
+        ! the result is a scalar element (rank 0). If some are sections (:), the
+        ! result retains the un-indexed dimensions.
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        integer :: i
+
+        count = 0
+        if (.not. allocated(node%arg_indices)) return
+        do i = 1, size(node%arg_indices)
+            if (.not. is_section_index(arena, node%arg_indices(i))) count = count + 1
+        end do
+    end function count_scalar_indices
+
+    logical function is_section_index(arena, node_index)
+        ! Whether a subscript is a full-section selector (:), which preserves
+        ! the dimension in the result rank.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+
+        is_section_index = .false.
+        if (.not. node_exists(arena, node_index)) return
+        if (is_literal(arena, node_index)) return
+        if (is_identifier(arena, node_index)) return
+        if (is_binary_op(arena, node_index)) return
+        is_section_index = .true.
+    end function is_section_index

--- a/src/session_program_lowering_derived_module_ops.inc
+++ b/src/session_program_lowering_derived_module_ops.inc
@@ -323,11 +323,12 @@
             context%generic_count = next
     end subroutine import_fmod_generic
 
-    subroutine add_generic_specific_from_external(context, generic_idx, name, &
-                                                  ext_idx)
+ subroutine add_generic_specific_from_external(context, generic_idx, name, &
+                                                   ext_idx)
         ! Append a specific to a generic entry, taking its signature and
         ! return kinds from an already-registered external procedure rather
         ! than from an AST node (the specific was imported from a .fmod, #284).
+        ! Ranks default to 0 (scalar) since .fmod does not yet carry rank info.
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: generic_idx
         character(len=*), intent(in) :: name
@@ -346,6 +347,7 @@
         context%generics(generic_idx)%specific_arg_counts(sc) = &
             context%external_procedures(ext_idx)%arg_count
         context%generics(generic_idx)%specific_arg_kinds(:, sc) = VALUE_I32
+        context%generics(generic_idx)%specific_arg_ranks(:, sc) = 0
         do j = 1, min(context%external_procedures(ext_idx)%arg_count, &
             MAX_PROC_ARGS)
             context%generics(generic_idx)%specific_arg_kinds(j, sc) = &

--- a/src/session_program_lowering_expr_lowering.inc
+++ b/src/session_program_lowering_expr_lowering.inc
@@ -158,6 +158,7 @@
         character(len=:), allocatable :: call_name
         integer :: call_arg_count
         integer :: call_arg_kinds(MAX_PROC_ARGS)
+        integer :: call_arg_ranks(MAX_PROC_ARGS)
 
         if (node%is_array_access) then
             call unsupported_feature_error('array expression', &
@@ -174,8 +175,10 @@
         ! Resolve generic -> specific (#249 B7c).
         call call_argument_kinds(arena, node, context, VALUE_LOGICAL, &
                                 call_arg_count, call_arg_kinds)
+        call call_argument_ranks(arena, node, context, call_arg_count, &
+                                 call_arg_ranks)
         call_name = degeneric_call_name(context, node%name, &
-            call_arg_count, call_arg_kinds)
+            call_arg_count, call_arg_kinds, call_arg_ranks)
         if (same_name(call_name, 'c_associated') .and. .not. &
             is_contained_logical_function(context, call_name)) then
             call lower_c_associated(arena, node%arg_indices, context, value, &
@@ -475,6 +478,7 @@
         character(len=:), allocatable :: call_name
         integer :: call_arg_count
         integer :: call_arg_kinds(MAX_PROC_ARGS)
+        integer :: call_arg_ranks(MAX_PROC_ARGS)
 
         if (node%is_array_access .or. is_allocatable_element_ref(node, context) &
             .or. is_declared_array_element_ref(node, context)) then
@@ -500,8 +504,10 @@
         ! Resolve generic -> specific (#249 B7c).
         call call_argument_kinds(arena, node, context, VALUE_F32, &
                                 call_arg_count, call_arg_kinds)
+        call call_argument_ranks(arena, node, context, call_arg_count, &
+                                 call_arg_ranks)
         call_name = degeneric_call_name(context, node%name, &
-            call_arg_count, call_arg_kinds)
+            call_arg_count, call_arg_kinds, call_arg_ranks)
 
         if (same_name(call_name, 'transfer') .and. .not. &
             is_contained_f32_function(context, call_name)) then
@@ -573,6 +579,7 @@
         integer :: symbol_index
         integer :: call_arg_count
         integer :: call_arg_kinds(MAX_PROC_ARGS)
+        integer :: call_arg_ranks(MAX_PROC_ARGS)
         character(len=:), allocatable :: bin_op, bin_err
         integer :: bin_left, bin_right, bin_line, bin_col
         character(len=:), allocatable :: id_name, id_err
@@ -666,9 +673,11 @@
                 else
                     call call_argument_kinds(arena, node, context, VALUE_I32, &
                         call_arg_count, call_arg_kinds)
+                    call call_argument_ranks(arena, node, context, call_arg_count, &
+                        call_arg_ranks)
                     is_f32 = is_contained_f32_function(context, node%name) .or. &
                         generic_call_return_kind(context, node%name, &
-                            call_arg_count, call_arg_kinds) == VALUE_F32
+                            call_arg_count, call_arg_kinds, call_arg_ranks) == VALUE_F32
                     if (.not. is_f32) &
                         is_f32 = is_real_array_reduction(arena, node, context, VALUE_F32)
                     if (.not. is_f32) &
@@ -804,6 +813,7 @@
         character(len=:), allocatable :: call_name
         integer :: call_arg_count
         integer :: call_arg_kinds(MAX_PROC_ARGS)
+        integer :: call_arg_ranks(MAX_PROC_ARGS)
 
         if (node%is_array_access .or. is_allocatable_element_ref(node, context) &
             .or. is_declared_array_element_ref(node, context)) then
@@ -829,8 +839,10 @@
         ! Resolve generic -> specific (#249 B7c).
         call call_argument_kinds(arena, node, context, VALUE_F64, &
                                 call_arg_count, call_arg_kinds)
+        call call_argument_ranks(arena, node, context, call_arg_count, &
+                                 call_arg_ranks)
         call_name = degeneric_call_name(context, node%name, &
-            call_arg_count, call_arg_kinds)
+            call_arg_count, call_arg_kinds, call_arg_ranks)
 
         if (same_name(call_name, 'transfer') .and. .not. &
             is_contained_f64_function(context, call_name)) then
@@ -1017,6 +1029,7 @@
         integer :: symbol_index
         integer :: call_arg_count
         integer :: call_arg_kinds(MAX_PROC_ARGS)
+        integer :: call_arg_ranks(MAX_PROC_ARGS)
         character(len=:), allocatable :: bin_op, bin_err
         integer :: bin_left, bin_right, bin_line, bin_col
         character(len=:), allocatable :: id_name, id_err
@@ -1087,9 +1100,11 @@
                 else
                     call call_argument_kinds(arena, node, context, VALUE_I32, &
                         call_arg_count, call_arg_kinds)
+                    call call_argument_ranks(arena, node, context, call_arg_count, &
+                        call_arg_ranks)
                     is_f64 = is_contained_f64_function(context, node%name) .or. &
                         generic_call_return_kind(context, node%name, &
-                            call_arg_count, call_arg_kinds) == VALUE_F64
+                            call_arg_count, call_arg_kinds, call_arg_ranks) == VALUE_F64
                     is_f64 = is_f64 .or. is_f64_intrinsic_expression(arena, node, context)
                     if (.not. is_f64) &
                         is_f64 = is_real_array_reduction(arena, node, context, VALUE_F64)

--- a/src/session_program_lowering_integer.inc
+++ b/src/session_program_lowering_integer.inc
@@ -197,8 +197,9 @@
       integer, allocatable :: copyback_indices(:)
       integer :: intrinsic_id
       character(len=:), allocatable :: call_name
-      integer :: call_arg_count
-      integer :: call_arg_kinds(MAX_PROC_ARGS)
+ integer :: call_arg_count
+       integer :: call_arg_kinds(MAX_PROC_ARGS)
+       integer :: call_arg_ranks(MAX_PROC_ARGS)
 
       if (node%base_expr_index > 0) then
           call lower_derived_component_element_load(arena, node, context, value, &
@@ -218,11 +219,13 @@
           return
       end if
 
-      ! Resolve generic -> specific (#249 B7c).
-      call call_argument_kinds(arena, node, context, VALUE_I32, &
-                              call_arg_count, call_arg_kinds)
-      call_name = degeneric_call_name(context, node%name, &
-          call_arg_count, call_arg_kinds)
+! Resolve generic -> specific (#249 B7c).
+       call call_argument_kinds(arena, node, context, VALUE_I32, &
+                               call_arg_count, call_arg_kinds)
+       call call_argument_ranks(arena, node, context, call_arg_count, &
+                                call_arg_ranks)
+       call_name = degeneric_call_name(context, node%name, &
+           call_arg_count, call_arg_kinds, call_arg_ranks)
 
       if (external_procedure_index(context, node%name) > 0) then
           if (context%external_procedures( &

--- a/src/session_program_lowering_interface.inc
+++ b/src/session_program_lowering_interface.inc
@@ -105,13 +105,17 @@
 
     subroutine add_generic_specific(context, generic_idx, specific_name, error_msg)
         ! Append one specific procedure name to a generic interface entry and
-        ! record its return and per-argument kinds from the function table.
+        ! record its return kind, per-argument kinds, and per-argument ranks
+        ! from the function table. Ranks enable dispatch to distinguish same-kind
+        ! specifics that differ in rank (refs #303).
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: generic_idx
         character(len=*), intent(in) :: specific_name
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: arg_count
+        integer :: arg_count, j
         integer :: arg_kinds(MAX_PROC_ARGS)
+        integer :: arg_ranks(MAX_PROC_ARGS)
+        integer :: fn_index
 
         call set_empty(error_msg)
         if (context%generics(generic_idx)%specific_count >= &
@@ -126,12 +130,20 @@
         associate (sc => context%generics(generic_idx)%specific_count)
             arg_count = 0
             arg_kinds = VALUE_I32
+            arg_ranks = 0
             context%generics(generic_idx)%specific_names(sc) = trim(specific_name)
             call query_specific_kinds(context, trim(specific_name), &
                 context%generics(generic_idx)%return_kinds(sc), &
                 arg_count, arg_kinds)
             context%generics(generic_idx)%specific_arg_counts(sc) = arg_count
             context%generics(generic_idx)%specific_arg_kinds(:, sc) = arg_kinds
+            fn_index = find_function_index(context, trim(specific_name))
+            if (fn_index > 0) then
+                do j = 1, arg_count
+                    arg_ranks(j) = specific_arg_rank(context, fn_index, j)
+                end do
+            end if
+            context%generics(generic_idx)%specific_arg_ranks(:, sc) = arg_ranks
         end associate
     end subroutine add_generic_specific
 
@@ -331,6 +343,58 @@
         end do
     end function specific_arg_kind
 
+    integer function specific_arg_rank(context, fn_index, arg_pos) result(rank)
+        ! Array rank of the arg_pos-th dummy of a registered specific. Returns 0
+        ! for a scalar dummy and the rank (1, 2, ...) for an array dummy. Used by
+        ! generic dispatch to distinguish same-kind specifics that differ in rank
+        ! (refs #303).
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: fn_index, arg_pos
+        integer :: node_idx, i
+        character(len=:), allocatable :: param_name, err, node_type
+        type(function_def_node), pointer :: fn_node
+        type(subroutine_def_node), pointer :: sb_node
+        integer, allocatable :: body_indices(:), param_indices(:)
+
+        rank = 0
+        node_idx = context%function_node_indices(fn_index)
+        if (node_idx <= 0) return
+        if (.not. node_exists(context%arena, node_idx)) return
+        node_type = get_node_type_at(context%arena, node_idx)
+        if (node_type == 'function_def_node' .or. node_type == 'function_def') then
+            fn_node => get_node_as_function_def(context%arena, node_idx)
+            if (.not. associated(fn_node)) return
+            if (.not. allocated(fn_node%param_indices)) return
+            param_indices = fn_node%param_indices
+            body_indices = fn_node%body_indices
+        else if (node_type == 'subroutine_def_node' .or. &
+                 node_type == 'subroutine_def') then
+            sb_node => get_node_as_subroutine_def(context%arena, node_idx)
+            if (.not. associated(sb_node)) return
+            if (.not. allocated(sb_node%param_indices)) return
+            param_indices = sb_node%param_indices
+            body_indices = sb_node%body_indices
+        else
+            return
+        end if
+        if (arg_pos > size(param_indices)) return
+        call parameter_name(context%arena, param_indices(arg_pos), param_name, err)
+        if (len_trim(err) > 0) return
+        if (.not. allocated(body_indices)) return
+        do i = 1, size(body_indices)
+            if (.not. node_exists(context%arena, body_indices(i))) cycle
+            select type (decl => context%arena%entries(body_indices(i))%node)
+            type is (declaration_node)
+                if (.not. allocated(decl%var_name)) cycle
+                if (.not. same_name(decl%var_name, param_name)) cycle
+                if (decl%is_array .and. allocated(decl%dimension_indices)) then
+                    rank = size(decl%dimension_indices)
+                end if
+                return
+            end select
+        end do
+    end function specific_arg_rank
+
     integer function find_operator(context, op_token, left_kind, right_kind, &
                                    is_assignment) result(specific_slot)
         ! Find the operator-overload specific (encoded as op_index*256+spec_index)
@@ -458,12 +522,15 @@
         end do
     end function find_generic
 
-    logical function generic_signature_matches(stored_count, stored_kinds, &
-                                            call_count, call_kinds) result(ok)
+  logical function generic_signature_matches(stored_count, stored_kinds, &
+                                             stored_ranks, call_count, &
+                                             call_kinds, call_ranks) result(ok)
         integer, intent(in) :: stored_count
         integer, intent(in) :: stored_kinds(MAX_PROC_ARGS)
+        integer, intent(in) :: stored_ranks(MAX_PROC_ARGS)
         integer, intent(in) :: call_count
         integer, intent(in) :: call_kinds(MAX_PROC_ARGS)
+        integer, intent(in) :: call_ranks(MAX_PROC_ARGS)
         integer :: i
 
         ok = .false.
@@ -474,18 +541,21 @@
         end if
         do i = 1, call_count
             if (call_kinds(i) /= stored_kinds(i)) return
+            if (call_ranks(i) /= stored_ranks(i)) return
         end do
         ok = .true.
     end function generic_signature_matches
 
-    function resolve_generic(context, generic_idx, call_arg_count, call_arg_kinds) &
+  function resolve_generic(context, generic_idx, call_arg_count, call_arg_kinds, &
+                            call_arg_ranks) &
         result(specific_name)
-        ! Choose the specific procedure that matches the full argument signature.
-        ! Returns the first specific whose signature equals the actual,
-        ! or the first specific when no exact match exists.
+        ! Choose the specific procedure that matches the full argument signature
+        ! (kind + rank). Returns the first specific whose signature equals the
+        ! actual, or the first specific when no exact match exists.
         type(lowering_context_t), intent(in) :: context
         integer, intent(in) :: generic_idx, call_arg_count
         integer, intent(in) :: call_arg_kinds(MAX_PROC_ARGS)
+        integer, intent(in) :: call_arg_ranks(MAX_PROC_ARGS)
         character(len=:), allocatable :: specific_name
         integer :: i
         type(generic_interface_t) :: g
@@ -498,7 +568,8 @@
         ! Exact match first.
         do i = 1, g%specific_count
             if (generic_signature_matches(g%specific_arg_counts(i), &
-                g%specific_arg_kinds(:, i), call_arg_count, call_arg_kinds)) then
+                g%specific_arg_kinds(:, i), g%specific_arg_ranks(:, i), &
+                call_arg_count, call_arg_kinds, call_arg_ranks)) then
                 specific_name = trim(g%specific_names(i))
                 return
             end if
@@ -508,11 +579,14 @@
     end function resolve_generic
 
     integer function generic_return_kind(context, generic_idx, &
-                                         call_arg_count, call_arg_kinds) result(ret_kind)
-        ! Return kind of the specific selected for the full argument signature.
+                                          call_arg_count, call_arg_kinds, &
+                                          call_arg_ranks) result(ret_kind)
+        ! Return kind of the specific selected for the full argument signature
+        ! (kind + rank).
         type(lowering_context_t), intent(in) :: context
         integer, intent(in) :: generic_idx, call_arg_count
         integer, intent(in) :: call_arg_kinds(MAX_PROC_ARGS)
+        integer, intent(in) :: call_arg_ranks(MAX_PROC_ARGS)
         integer :: i
         type(generic_interface_t) :: g
 
@@ -521,7 +595,8 @@
         if (g%specific_count == 0) return
         do i = 1, g%specific_count
             if (generic_signature_matches(g%specific_arg_counts(i), &
-                g%specific_arg_kinds(:, i), call_arg_count, call_arg_kinds)) then
+                g%specific_arg_kinds(:, i), g%specific_arg_ranks(:, i), &
+                call_arg_count, call_arg_kinds, call_arg_ranks)) then
                 ret_kind = g%return_kinds(i)
                 return
             end if
@@ -865,7 +940,8 @@
         context%external_procedures(1:size(old)) = old
     end subroutine grow_external_procedures
 
-    function degeneric_call_name(context, name, call_arg_count, call_arg_kinds) &
+ function degeneric_call_name(context, name, call_arg_count, call_arg_kinds, &
+                                call_arg_ranks) &
         result(resolved)
         ! If name is a USE-rename alias, resolve to the real procedure first
         ! (#274); if it is a registered generic, return the matching specific
@@ -874,6 +950,7 @@
         character(len=*), intent(in) :: name
         integer, intent(in) :: call_arg_count
         integer, intent(in) :: call_arg_kinds(MAX_PROC_ARGS)
+        integer, intent(in) :: call_arg_ranks(MAX_PROC_ARGS)
         character(len=:), allocatable :: resolved, dealiased
         integer :: g
 
@@ -881,7 +958,7 @@
         g = find_generic(context, dealiased)
         if (g > 0) then
             resolved = resolve_generic(context, g, call_arg_count, &
-                                      call_arg_kinds)
+                                       call_arg_kinds, call_arg_ranks)
         else
             resolved = dealiased
         end if
@@ -905,8 +982,8 @@
         end do
     end function resolve_proc_alias
 
-    integer function generic_call_return_kind(context, name, call_arg_count, &
-                                            call_arg_kinds) &
+ integer function generic_call_return_kind(context, name, call_arg_count, &
+                                             call_arg_kinds, call_arg_ranks) &
         result(ret_kind)
         ! Return kind of the specific selected for a generic call, or 0 when
         ! name is not a generic (#249 B7c).
@@ -914,12 +991,13 @@
         character(len=*), intent(in) :: name
         integer, intent(in) :: call_arg_count
         integer, intent(in) :: call_arg_kinds(MAX_PROC_ARGS)
+        integer, intent(in) :: call_arg_ranks(MAX_PROC_ARGS)
         integer :: g
 
         g = find_generic(context, name)
         if (g > 0) then
             ret_kind = generic_return_kind(context, g, call_arg_count, &
-                                          call_arg_kinds)
+                                           call_arg_kinds, call_arg_ranks)
         else
             ret_kind = 0
         end if

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -360,10 +360,14 @@ module session_program_lowering_types
             integer :: specific_count = 0
             character(len=64) :: specific_names(MAX_GENERIC_SPECIFICS) = ''
             integer :: specific_arg_counts(MAX_GENERIC_SPECIFICS) = 0
-            ! Per-specific argument kinds (scalar-only today): position 1 is the first
+            ! Per-specific argument kinds: position 1 is the first
             ! dummy, up to MAX_PROC_ARGS. Unused trailing entries stay VALUE_I32.
             integer :: specific_arg_kinds(MAX_PROC_ARGS, MAX_GENERIC_SPECIFICS) = &
                 VALUE_I32
+            ! Per-specific argument ranks: 0 for scalar, >0 for array rank.
+            ! Populated from declaration metadata so dispatch distinguishes
+            ! same-kind specifics that differ in rank (refs #303).
+            integer :: specific_arg_ranks(MAX_PROC_ARGS, MAX_GENERIC_SPECIFICS) = 0
             ! Return value kind of each specific.
             integer :: return_kinds(MAX_GENERIC_SPECIFICS) = VALUE_I32
         end type generic_interface_t

--- a/test/test_session_generic_interface_compiler.f90
+++ b/test/test_session_generic_interface_compiler.f90
@@ -11,6 +11,7 @@ program test_session_generic_interface_compiler
     if (.not. test_generic_real_specific()) all_passed = .false.
     if (.not. test_generic_subroutine()) all_passed = .false.
     if (.not. test_generic_full_signature_dispatch()) all_passed = .false.
+    if (.not. test_generic_rank_dispatch()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: generic interfaces resolve to correct specific procedures'
@@ -145,5 +146,40 @@ contains
             test_generic_full_signature_dispatch = expect_exit_status( &
                 source, 111, '/tmp/ffc_session_generic_sig')
         end function test_generic_full_signature_dispatch
+
+        logical function test_generic_rank_dispatch()
+            ! B7c: generic with two specifics sharing element kind but differing
+            ! in rank (scalar vs array) resolves to the correct specific based on
+            ! the actual argument rank, not just the kind vector.
+            character(len=*), parameter :: source = &
+                'module m'//new_line('a')// &
+                '  implicit none'//new_line('a')// &
+                '  interface proc'//new_line('a')// &
+                '    module procedure proc_scalar, proc_array'//new_line('a')// &
+                '  end interface'//new_line('a')// &
+                'contains'//new_line('a')// &
+                '  integer function proc_scalar(x)'//new_line('a')// &
+                '    integer, intent(in) :: x'//new_line('a')// &
+                '    proc_scalar = x * 10'//new_line('a')// &
+                '  end function proc_scalar'//new_line('a')// &
+                '  integer function proc_array(x)'//new_line('a')// &
+                '    integer, intent(in) :: x(3)'//new_line('a')// &
+                '    proc_array = x(1) + x(2) + x(3)'//new_line('a')// &
+                '  end function proc_array'//new_line('a')// &
+                'end module m'//new_line('a')// &
+                'program main'//new_line('a')// &
+                '  use m'//new_line('a')// &
+                '  integer :: n, a(3)'//new_line('a')// &
+                '  n = 5'//new_line('a')// &
+                '  a = [1, 2, 3]'//new_line('a')// &
+                '  stop proc(n) - proc(a)'//new_line('a')// &
+                'end program main'
+
+            ! proc(5) -> proc_scalar(5) -> 50
+            ! proc([1,2,3]) -> proc_array([1,2,3]) -> 6
+            ! exit code = 50 - 6 = 44
+            test_generic_rank_dispatch = expect_exit_status( &
+                source, 44, '/tmp/ffc_session_generic_rank')
+        end function test_generic_rank_dispatch
 
     end program test_session_generic_interface_compiler


### PR DESCRIPTION
## Requirements

- REQ-001: Add `specific_arg_ranks` to `generic_interface_t` — **satisfied**
- REQ-002: Populate ranks in `add_generic_specific` from declaration metadata — **satisfied**
- REQ-003: Compute caller per-arg ranks and extend resolve path to match on (kind, rank) — **satisfied**
- REQ-004: Test with scalar-vs-array same-kind overload — **satisfied**

## File-set enumeration

**Edited:**
- `src/session_program_lowering_types.f90` — added `specific_arg_ranks` array to `generic_interface_t`
- `src/session_program_lowering_interface.inc` — added `specific_arg_rank()` function; updated `add_generic_specific`, `generic_signature_matches`, `resolve_generic`, `generic_return_kind`, `degeneric_call_name`, `generic_call_return_kind` to carry and match ranks
- `src/session_program_lowering_derived_module_ops.inc` — `add_generic_specific_from_external` initializes ranks to 0
- `src/session_program_lowering_arguments.inc` — added `call_argument_ranks()`, `expression_value_rank()`, `expression_array_access_rank()`, `count_scalar_indices()`, `is_section_index()`; updated `expression_value_kind` to pass ranks to `generic_call_return_kind`
- `src/session_program_lowering_expr_lowering.inc` — updated all `degeneric_call_name` and `generic_call_return_kind` call sites with ranks
- `src/session_program_lowering_integer.inc` — updated `degeneric_call_name` call site with ranks
- `src/session_program_lowering.f90` — updated `degeneric_call_name` call site with ranks
- `test/test_session_generic_interface_compiler.f90` — added `test_generic_rank_dispatch` test

**Intentionally left alone:**
- `src/session_program_lowering_fmod.inc` — .fmod export/import does not yet carry rank metadata; external specifics default to rank 0 (scalar). Rank round-trip through .fmod is a follow-up (cross-referenced with #307).
- Operator/assignment overload table (`operator_interface_t`) — issue scope is generic named interfaces only; operator dispatch uses operand kinds, not ranks.

## Verification

```
$ fo test test_session_generic_interface_compiler
test_session_generic_interface_compiler    PASS    0.04s

$ fo test
Tests: 256 passed (  68.5s)
```

(ref #303)

<!-- orchestrate: fully-resolved -->