### PR TITLE
fix: track generic dispatch metadata beyond scalar VALUE_* kinds (refs #303)

### DIFF
--- a/docs/PARITY_PLAN.md
+++ b/docs/PARITY_PLAN.md
@@ -64,6 +64,8 @@ Feature gaps (each a bucket of xfailed files):
 - **#284** separate compilation: duplicate runtime-helper symbols.
 - **#286** file:line:col diagnostics on stderr plus `--json`.
 - **#294** mixed-kind generic dispatch per call-site argument kinds.
+- **#303** generic dispatch rank tracking: same-kind specifics distinguished by
+  argument rank (scalar vs array), resolved in PR #312.
 - **#297** separate-file submodules from `.fmod`.
 
 Correctness bugs:


### PR DESCRIPTION
## Requirements

| ID | Requirement | Status |
|---|---|---|
| REQ-001 | Add `specific_arg_ranks` to `generic_interface_t` | satisfied (types.f90:370, PR #312) |
| REQ-002 | Populate ranks in `add_generic_specific` from declaration metadata | satisfied (interface.inc:140-146, PR #312) |
| REQ-003 | Thread caller per-arg rank into resolve path | satisfied (all call sites compute `call_arg_ranks`, PR #312) |
| REQ-004 | Extend `resolve_generic` to match on (kind, rank) tuple | satisfied (interface.inc:525-605, PR #312) |
| REQ-005 | Add intent/purity dimension if a corpus case needs it | satisfied — no corpus case requires intent/purity for Fortran generic dispatch (F2018 does not use INTENT/PURE in generic resolution) |
| REQ-006 | Test with scalar-vs-array same-kind overload | satisfied (`test_generic_rank_dispatch`, test_session_generic_interface_compiler.f90:150-183, PR #312) |

## File-set enumeration

**Edited in this PR:**
- `docs/PARITY_PLAN.md` — records #303 resolution

**Edited in PR #312 (merged to main before this branch):**
- `src/session_program_lowering_types.f90` — `specific_arg_ranks` field in `generic_interface_t`
- `src/session_program_lowering_interface.inc` — rank population, `specific_arg_rank`, `generic_signature_matches`, `resolve_generic`, `degeneric_call_name`, `generic_return_kind`
- `src/session_program_lowering_arguments.inc` — `call_argument_ranks`, `expression_value_rank`
- `src/session_program_lowering.f90` — subroutine call rank computation
- `src/session_program_lowering_integer.inc` — integer call site rank computation
- `src/session_program_lowering_expr_lowering.inc` — expression call site rank computation
- `src/session_program_lowering_derived_module_ops.inc` — .fmod import rank default (0 for scalar)
- `test/test_session_generic_interface_compiler.f90` — `test_generic_rank_dispatch`

**Intentionally not edited:**
- `src/session_program_lowering_fmod.inc` — .fmod export carries only scalar procedures (`params_all_supported_scalar` rejects array dummies), so rank metadata is not needed for cross-compilation generics yet. Documented in `session_program_lowering_derived_module_ops.inc:330`.

## Verification evidence

```
$ fo test test_session_generic_interface_compiler
test_session_generic_interface_compiler    PASS       0.05s
Summary: 1 passed, 0 failed, 0 skipped (  0.05s)

$ fo test
Tests: 280 passed (  81.6s)
```

All 280 tests green. Generic rank dispatch test (`test_generic_rank_dispatch`) verifies scalar-vs-array same-kind overload resolves correctly: `proc(5)` dispatches to `proc_scalar` (returns 50), `proc([1,2,3])` dispatches to `proc_array` (returns 6), exit code 44.

(ref #303)

<!-- orchestrate: fully-resolved -->

## CI note

Three tests fail on CI (`test_session_character_function_result_compiler`, `test_session_integer8_function_compiler`, `test_fortfront_corpus_conformance`) with the same failures seen on every main CI run since 2026-07-05. These are pre-existing LIRIC/gcc-14 ABI mismatches on ubuntu-latest, unrelated to this PR. The branch passes all 280 tests locally (gcc 16). This PR contains only a documentation change to `docs/PARITY_PLAN.md`.
