### PR TITLE
docs: record #303 rank tracking resolution in parity plan (refs #303)

### DIFF
--- a/docs/PARITY_PLAN.md
+++ b/docs/PARITY_PLAN.md
@@ -64,6 +64,8 @@ Feature gaps (each a bucket of xfailed files):
 - **#284** separate compilation: duplicate runtime-helper symbols.
 - **#286** file:line:col diagnostics on stderr plus `--json`.
 - **#294** mixed-kind generic dispatch per call-site argument kinds.
+- **#303** generic dispatch rank tracking: same-kind specifics distinguished by
+  argument rank (scalar vs array), resolved in PR #312.
 - **#297** separate-file submodules from `.fmod`.
 
 Correctness bugs:


### PR DESCRIPTION
## Requirements

| ID | Requirement | Status |
|----|-------------|--------|
| REQ-001 | Add \`specific_arg_ranks\` to \`generic_interface_t\` (types.f90); default 0 | satisfied (merged PR #312) |
| REQ-002 | Populate ranks in \`add_generic_specific\` from declaration metadata | satisfied (merged PR #312) |
| REQ-003 | Thread caller per-arg rank into resolve path; extend \`resolve_generic\` to match on (kind, rank) | satisfied (merged PR #312) |
| REQ-004 | Add intent/purity dimension if a corpus case needs it | satisfied — no corpus case requires it |
| REQ-005 | Test extends \`test_session_generic_interface_compiler.f90\` with scalar-vs-array same-kind overload | satisfied (merged PR #312) |
| REQ-006 | Update \`docs/PARITY_PLAN.md\` to record resolution | satisfied (this PR) |

## File-set enumeration

- \`docs/PARITY_PLAN.md\` — added #303 resolution entry to feature gaps list

Implementation files (\`src/session_program_lowering_types.f90\`, \`src/session_program_lowering_interface.inc\`, \`src/session_program_lowering_arguments.inc\`, \`src/session_program_lowering_derived_module_ops.inc\`, \`src/session_program_lowering_expr_lowering.inc\`, \`src/session_program_lowering_integer.inc\`, \`src/session_program_lowering.f90\`) were edited and merged in PR #312.

Test file (\`test/test_session_generic_interface_compiler.f90\`) was extended and merged in PR #312.

## Verification

\`\`\`
$ fo test test_session_generic_interface_compiler
test_session_generic_interface_compiler    PASS       0.04s
Summary: 1 passed, 0 failed, 0 skipped (  0.04s)

$ fo test
Tests: 256 passed (  70.1s)
\`\`\`

CI shows 3 pre-existing failures on \`main\` (character function result, integer8 ABI, fortfront corpus conformance) caused by gcc version mismatch between CI (gcc-14) and local (gcc-16). These tests pass locally and are unrelated to this change.

(ref #303)

<!-- orchestrate: fully-resolved -->