### PR TITLE
Use FortFront compiler node queries

### DIFF
--- a/src/ffc_fortfront_queries.f90
+++ b/src/ffc_fortfront_queries.f90
@@ -6,13 +6,16 @@ module ffc_fortfront_queries
         get_select_case_info, get_case_block_info, &
         get_case_default_body, get_case_range_info, &
         get_select_type_info, get_type_guard_info
-    use fortfront_utils, only: node_exists, get_node_type_at, &
-        get_type_for_node
-    use fortfront, only: is_derived_type_node, derived_type_node, &
-        is_declaration_node, declaration_node
-    use type_system_unified, only: mono_type_t, &
-        TINT, TREAL, TCHAR, TLOGICAL, TARRAY, TCOMPLEX, TDOUBLE, TDERIVED
-    use ast_nodes_control, only: goto_node
+    use fortfront_compiler, only: node_exists, get_node_type_at, &
+        get_type_for_node, mono_type_t, &
+        TINT, TREAL, TCHAR, TLOGICAL, TARRAY, TCOMPLEX, TDOUBLE, TDERIVED, &
+        is_derived_type_node, is_declaration_node, &
+        get_derived_type_name, get_derived_type_components, &
+        get_declaration_var_name, get_declaration_type_name, &
+        get_declaration_has_initializer, &
+        get_declaration_initializer_index, &
+        get_node_stmt_label, get_goto_label, goto_is_computed, &
+        get_goto_label_list, get_goto_selector_index
     implicit none
     private
     public :: ast_arena_t, node_exists, get_node_type_at
@@ -33,200 +36,5 @@ module ffc_fortfront_queries
     public :: get_declaration_type_name
     public :: get_declaration_has_initializer
     public :: get_declaration_initializer_index
-
-contains
-
-    subroutine get_derived_type_name(arena, type_index, name, error_msg)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: type_index
-        character(len=:), allocatable, intent(out) :: name
-        character(len=:), allocatable, intent(out) :: error_msg
-
-        call set_empty(name)
-        if (.not. node_exists(arena, type_index)) then
-            error_msg = 'derived type index does not reference an AST node'
-            return
-        end if
-        select type (node => arena%entries(type_index)%node)
-            type is (derived_type_node)
-            if (allocated(node%name)) name = node%name
-            call set_empty(error_msg)
-        class default
-            error_msg = 'AST node is not a derived type definition'
-        end select
-    end subroutine get_derived_type_name
-
-    subroutine get_derived_type_components(arena, type_index, components)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: type_index
-        integer, allocatable, intent(out) :: components(:)
-
-        if (.not. node_exists(arena, type_index)) then
-            allocate (components(0))
-            return
-        end if
-        select type (node => arena%entries(type_index)%node)
-            type is (derived_type_node)
-            if (allocated(node%component_indices)) then
-                components = node%component_indices
-            else
-                allocate (components(0))
-            end if
-        class default
-            allocate (components(0))
-        end select
-    end subroutine get_derived_type_components
-
-    subroutine get_declaration_var_name(arena, decl_index, var_name, &
-            error_msg)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: decl_index
-        character(len=:), allocatable, intent(out) :: var_name
-        character(len=:), allocatable, intent(out) :: error_msg
-
-        call set_empty(var_name)
-        if (.not. node_exists(arena, decl_index)) then
-            error_msg = 'declaration index does not reference an AST node'
-            return
-        end if
-        select type (node => arena%entries(decl_index)%node)
-            type is (declaration_node)
-            if (allocated(node%var_name)) var_name = node%var_name
-            if (len_trim(var_name) == 0 .and. node%is_multi_declaration .and. &
-                allocated(node%var_names)) then
-                if (size(node%var_names) == 1) var_name = node%var_names(1)
-            end if
-            call set_empty(error_msg)
-        class default
-            error_msg = 'AST node is not a declaration'
-        end select
-    end subroutine get_declaration_var_name
-
-    subroutine get_declaration_type_name(arena, decl_index, type_name, &
-            error_msg)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: decl_index
-        character(len=:), allocatable, intent(out) :: type_name
-        character(len=:), allocatable, intent(out) :: error_msg
-
-        call set_empty(type_name)
-        if (.not. node_exists(arena, decl_index)) then
-            error_msg = 'declaration index does not reference an AST node'
-            return
-        end if
-        select type (node => arena%entries(decl_index)%node)
-            type is (declaration_node)
-            if (allocated(node%type_name)) type_name = node%type_name
-            call set_empty(error_msg)
-        class default
-            error_msg = 'AST node is not a declaration'
-        end select
-    end subroutine get_declaration_type_name
-
-    logical function get_declaration_has_initializer(arena, decl_index) &
-            result(has_init)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: decl_index
-
-        has_init = .false.
-        if (.not. node_exists(arena, decl_index)) return
-        select type (node => arena%entries(decl_index)%node)
-            type is (declaration_node)
-            has_init = node%has_initializer
-        end select
-    end function get_declaration_has_initializer
-
-    function get_declaration_initializer_index(arena, decl_index) &
-            result(init_index)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: decl_index
-        integer :: init_index
-
-        init_index = 0
-        if (.not. node_exists(arena, decl_index)) return
-        select type (node => arena%entries(decl_index)%node)
-            type is (declaration_node)
-            if (node%has_initializer .and. node%initializer_index > 0) then
-                init_index = node%initializer_index
-            end if
-        end select
-    end function get_declaration_initializer_index
-
-    ! Statement label attached to any node (e.g. the 100 in `100 continue`).
-    ! Empty string when the statement carries no label.
-    function get_node_stmt_label(arena, node_index) result(label)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: node_index
-        character(len=:), allocatable :: label
-
-        call set_empty(label)
-        if (.not. node_exists(arena, node_index)) return
-        if (allocated(arena%entries(node_index)%node%stmt_label)) then
-            label = arena%entries(node_index)%node%stmt_label
-        end if
-    end function get_node_stmt_label
-
-    ! Target label of a simple `goto N`. Empty string for a non-goto node or a
-    ! computed goto (which carries label_list instead).
-    function get_goto_label(arena, node_index) result(label)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: node_index
-        character(len=:), allocatable :: label
-
-        call set_empty(label)
-        if (.not. node_exists(arena, node_index)) return
-        select type (node => arena%entries(node_index)%node)
-            type is (goto_node)
-            if (allocated(node%label)) label = node%label
-        end select
-    end function get_goto_label
-
-    ! A computed goto carries a comma-separated label_list and a selector;
-    ! it is out of scope for the simple branch lowering.
-    logical function goto_is_computed(arena, node_index) result(is_computed)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: node_index
-
-        is_computed = .false.
-        if (.not. node_exists(arena, node_index)) return
-        select type (node => arena%entries(node_index)%node)
-            type is (goto_node)
-            is_computed = node%selector_index /= 0 .or. &
-                allocated(node%label_list)
-        end select
-    end function goto_is_computed
-
-    ! Comma-separated target labels of a computed `goto (L1, L2, ...), expr`.
-    ! Empty string for a non-computed goto.
-    function get_goto_label_list(arena, node_index) result(label_list)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: node_index
-        character(len=:), allocatable :: label_list
-
-        call set_empty(label_list)
-        if (.not. node_exists(arena, node_index)) return
-        select type (node => arena%entries(node_index)%node)
-            type is (goto_node)
-            if (allocated(node%label_list)) label_list = node%label_list
-        end select
-    end function get_goto_label_list
-
-    ! Arena index of the selector expression of a computed goto; 0 otherwise.
-    integer function get_goto_selector_index(arena, node_index) result(idx)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: node_index
-
-        idx = 0
-        if (.not. node_exists(arena, node_index)) return
-        select type (node => arena%entries(node_index)%node)
-            type is (goto_node)
-            idx = node%selector_index
-        end select
-    end function get_goto_selector_index
-
-    subroutine set_empty(value)
-        character(len=:), allocatable, intent(out) :: value
-        allocate (character(len=0) :: value)
-    end subroutine set_empty
 
 end module ffc_fortfront_queries

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -43,7 +43,7 @@ module session_program_lowering
         is_binary_op, get_binary_op_info, &
         is_literal, get_literal_info, &
         is_identifier, get_identifier_name, &
-        is_declaration_node, is_module_node, is_program_node, &
+        is_module_node, is_program_node, &
         declaration_binding_t, resolve_name_at_node, &
         resolve_identifier_binding, BINDING_NAMED_CONSTANT, &
         ASSOCIATION_DIRECT


### PR DESCRIPTION
## Summary
- switch ffc_fortfront_queries to re-export the public FortFront compiler node query API
- remove local duplicate declaration, derived-type, label, and GOTO query implementations
- drop the old duplicate declaration-query import in session lowering

## Verification
### Test fails on main
```bash
bash -lc '! rg -n "use (fortfront_utils|type_system_unified|ast_nodes_control)|use fortfront, only: is_derived_type_node|is_declaration_node, declaration_node" src/ffc_fortfront_queries.f90'
```
```text
9:    use fortfront_utils, only: node_exists, get_node_type_at, &
11:    use fortfront, only: is_derived_type_node, derived_type_node, &
12:        is_declaration_node, declaration_node
13:    use type_system_unified, only: mono_type_t, &
15:    use ast_nodes_control, only: goto_node
```

### Test passes after fix
```bash
bash -lc '! rg -n "use (fortfront_utils|type_system_unified|ast_nodes_control)|use fortfront, only: is_derived_type_node|is_declaration_node, declaration_node" src/ffc_fortfront_queries.f90'
```
```text
# no output
```

```bash
fo
```
```text
Static: OK (308 modules, 288 changed, 288 affected)
Build: OK
Tests: OK
Lint: OK
All stages passed (21.8s)
```
