### PR TITLE
Promote DATA implied-do conformance case

### DIFF
--- a/test/conformance/xfail_fortfront_f90.txt
+++ b/test/conformance/xfail_fortfront_f90.txt
@@ -125,6 +125,3 @@ issue_2848_dimension_statement.f90  # ff#2848 DIMENSION statement -> unsupported
 issue_2850_bare_function_interface.f90  # ff#2850 bare interface: duplicate decl
 issue_2850_bare_subroutine_interface.f90  # ff#2850 bare interface
 issue_2855_external_intrinsic_conflict.f90  # ff#2855 external/intrinsic conflict
-# DATA with implied-DO: ffc output matches gfortran-16 but mismatches gfortran-14
-# (CI runner). Kept in xfail so CI does not FAIL; produces XPASS locally on gfortran-16+.
-issue_2349_data_implied_do.f90


### PR DESCRIPTION
## Summary

- remove the stale xfail entry for the DATA implied-DO corpus case
- keep the existing behavioral test, which fully initializes an array and checks implied-DO storage order

## Verification

- Before: `scripts/conformance_gauntlet.sh --suite fortfront-f90` reported `PASS=334 XFAIL=104 XPASS=1 FAIL=0 NOREF=94`; `issue_2349_data_implied_do.f90` was the sole XPASS with `ffc_exit=0` and `ref_exit=0`.
- Reference check: GCC 14.2.0, GCC 14.4.0, and GCC 16.1.1 all compiled the case and produced stdout byte-identical to ffc. The current CI runner reports Ubuntu GCC 14.2.0. This is an output comparison, not missing reference availability.
- History check: `43ea8cc` recorded a GCC 14/16 formatting difference, `4f14a07` promoted the case after reporting a match on both, and `cad1f50` restored the entry shortly afterward. The fresh three-version comparison does not reproduce the recorded difference.
- `fo test test_fortfront_corpus_conformance`: `1 passed, 0 failed, 0 skipped`
- Fresh gauntlet: `PASS=335 XFAIL=104 XPASS=0 FAIL=0 NOREF=94 SKIP=0 TOTAL=439`; the case is `PASS` with `ffc_exit=0` and `ref_exit=0`.
- `fo`: static analysis OK; build OK; `246/246` tests passed; lint OK.
