### PR TITLE
Fix generic resolution for real literals

### DIFF
--- a/src/session_program_lowering_arguments.inc
+++ b/src/session_program_lowering_arguments.inc
@@ -1219,8 +1219,18 @@ integer function expression_value_kind(arena, node_index, context, &
         arg_count = size(node%arg_indices)
         if (arg_count > MAX_PROC_ARGS) arg_count = MAX_PROC_ARGS
         do i = 1, arg_count
-            arg_kinds(i) = expression_value_kind(arena, node%arg_indices(i), &
-                                                 context, default_kind)
+            ! Generic matching uses a real literal's source kind before the
+            ! selected procedure applies any contextual conversion.
+            if (is_real_literal(arena, node%arg_indices(i))) then
+                if (is_f32_expression(arena, node%arg_indices(i), context)) then
+                    arg_kinds(i) = VALUE_F32
+                else
+                    arg_kinds(i) = VALUE_F64
+                end if
+            else
+                arg_kinds(i) = expression_value_kind(arena, &
+                    node%arg_indices(i), context, default_kind)
+            end if
         end do
     end subroutine call_argument_kinds
 

--- a/src/session_program_lowering_interface.inc
+++ b/src/session_program_lowering_interface.inc
@@ -329,8 +329,7 @@
             select type (decl => context%arena%entries(body_indices(i))%node)
             type is (declaration_node)
                 if (.not. allocated(decl%type_name)) cycle
-                if (.not. allocated(decl%var_name)) cycle
-                if (.not. same_name(decl%var_name, param_name)) cycle
+                if (.not. declaration_names_var(decl, param_name)) cycle
                 if (declaration_derived_type_index(context, decl) > 0) then
                     kind = VALUE_DERIVED
                     return
@@ -385,8 +384,7 @@
             if (.not. node_exists(context%arena, body_indices(i))) cycle
             select type (decl => context%arena%entries(body_indices(i))%node)
             type is (declaration_node)
-                if (.not. allocated(decl%var_name)) cycle
-                if (.not. same_name(decl%var_name, param_name)) cycle
+                if (.not. declaration_names_var(decl, param_name)) cycle
                 if (decl%is_array .and. allocated(decl%dimension_indices)) then
                     rank = size(decl%dimension_indices)
                 end if

--- a/test/conformance/xfail_fortfront_f90.txt
+++ b/test/conformance/xfail_fortfront_f90.txt
@@ -31,7 +31,6 @@ issue_1614_character_module_variable.f90
 issue_1615_target_attribute.f90
 issue_1619_nested_types_complex.f90
 issue_1621_intent_out_array_shape.f90
-issue_1705_real_literal_generic.f90
 issue_1738_derived_type_allocatable.f90
 issue_1740_optional_keyword_arguments.f90
 issue_1744_operator_interface.f90

--- a/test/test_session_generic_interface_compiler.f90
+++ b/test/test_session_generic_interface_compiler.f90
@@ -9,6 +9,7 @@ program test_session_generic_interface_compiler
     all_passed = .true.
     if (.not. test_generic_integer_specific()) all_passed = .false.
     if (.not. test_generic_real_specific()) all_passed = .false.
+    if (.not. test_generic_real_result()) all_passed = .false.
     if (.not. test_generic_subroutine()) all_passed = .false.
     if (.not. test_generic_full_signature_dispatch()) all_passed = .false.
     if (.not. test_generic_rank_dispatch()) all_passed = .false.
@@ -77,6 +78,32 @@ contains
         test_generic_real_specific = expect_exit_status( &
             source, 23, '/tmp/ffc_session_generic_real')
     end function test_generic_real_specific
+
+    logical function test_generic_real_result()
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  interface add_values'//new_line('a')// &
+            '    module procedure add_integers, add_reals'//new_line('a')// &
+            '  end interface'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  integer function add_integers(a, b)'//new_line('a')// &
+            '    integer, intent(in) :: a, b'//new_line('a')// &
+            '    add_integers = a + b'//new_line('a')// &
+            '  end function add_integers'//new_line('a')// &
+            '  real function add_reals(a, b)'//new_line('a')// &
+            '    real, intent(in) :: a, b'//new_line('a')// &
+            '    add_reals = a + b'//new_line('a')// &
+            '  end function add_reals'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  stop int(add_values(5.0, 3.0))'//new_line('a')// &
+            'end program main'
+
+        test_generic_real_result = expect_exit_status( &
+            source, 8, '/tmp/ffc_session_generic_real_result')
+    end function test_generic_real_result
 
     logical function test_generic_subroutine()
         ! B7c: generic subroutine interface dispatches by first arg type.


### PR DESCRIPTION
## Summary

- derive real literal kinds from source syntax during generic matching
- include every name in multi-variable dummy declarations in generic signatures
- promote `issue_1705_real_literal_generic.f90` from the expected-failure list

Refs #280.

## Verification

Failing before:

```text
$ LIBRARY_PATH=/home/ert/code/liric/build fo test test_session_generic_interface_compiler
test_session_generic_interface_compiler    FAIL       0.05s
STOP 0
FAIL: exit status 0 expected 8
Summary: 0 passed, 1 failed, 0 skipped
```

Passing after:

```text
$ LIBRARY_PATH=/home/ert/code/liric/build fo test test_session_generic_interface_compiler
test_session_generic_interface_compiler    PASS       0.05s
Summary: 1 passed, 0 failed, 0 skipped

$ LIBRARY_PATH=/home/ert/code/liric/build fo test test_fortfront_corpus_conformance
test_fortfront_corpus_conformance          PASS      34.65s
Summary: 1 passed, 0 failed, 0 skipped

$ LIBRARY_PATH=/home/ert/code/liric/build fo
Static: OK (308 modules, 288 changed, 288 affected)
Build: OK
Tests: OK
Lint: OK
All stages passed
```
