### PR TITLE
Add named conformance selection

### DIFF
--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -62,6 +62,8 @@ Options:
 | `--suite SUITE` | Required. One of `fortfront-f90`, `fortfront-lf`, `lfortran`, `gfortran-dg` |
 | `--ffc PATH` | Path to the `ffc` binary. Auto-discovered from `build/` or `PATH` if omitted. |
 | `--report PATH` | JSONL report path. Defaults to `/tmp/ffc_gauntlet_<suite>.jsonl`. |
+| `--file PATH` | Select one suite-relative file. Repeat to select more files. |
+| `--files-from PATH` | Read suite-relative files from a list. Repeat to read more lists. |
 | `--max-files N` | Only test the first N files. Use for smoke runs. |
 | `--timeout N` | Per-file timeout in seconds. Default: 5. |
 
@@ -78,6 +80,37 @@ scripts/conformance_gauntlet.sh --suite fortfront-f90 \
     --ffc "$(find build -name ffc -type f -executable | head -1)"
 ```
 
+### Named files
+
+Run one external regression without scanning the full corpus:
+
+```bash
+scripts/conformance_gauntlet.sh --suite fortfront-f90 \
+    --file ast_coverage_control_flow.f90 \
+    --report /tmp/ffc-one.jsonl
+```
+
+A list contains one suite-relative path per line. Leading and trailing
+whitespace is ignored. Blank lines and lines whose first nonblank character is
+`#` are ignored.
+
+```text
+# scope regressions
+ast_coverage_control_flow.f90
+ast_coverage_io_statements.f90
+```
+
+```bash
+scripts/conformance_gauntlet.sh --suite fortfront-f90 \
+    --files-from /tmp/ffc-scope-files.txt
+```
+
+`--file` and `--files-from` entries accumulate in command order. Duplicate,
+unknown, absolute, and parent-traversal paths are errors. Named selection is
+applied before `--max-files`, so `--max-files 1` runs the first named entry.
+The report contains one file record per selected entry followed by a SUMMARY
+whose `total` is the number of entries run.
+
 ## Single-command conformance gate
 
 `scripts/conformance_check.sh` is the documented routine contributors run
@@ -89,7 +122,12 @@ the promotable XPASS list.
 scripts/conformance_check.sh                    # build + all available suites
 scripts/conformance_check.sh --no-build          # skip build, run suites
 scripts/conformance_check.sh --suite fortfront-f90  # single suite
+scripts/conformance_check.sh --no-build --suite fortfront-f90 \
+    --file ast_coverage_control_flow.f90
 ```
+
+Named selection requires `--suite`; the check forwards all `--file` and
+`--files-from` options to that suite.
 
 The script auto-detects available suites by checking the suite root
 directories. If a suite root does not exist, it prints a SKIP message and

--- a/scripts/conformance_check.sh
+++ b/scripts/conformance_check.sh
@@ -5,11 +5,13 @@
 # and prints the promotable XPASS list.
 #
 # Usage:
-#   scripts/conformance_check.sh [--no-build] [--suite SUITE]
+#   scripts/conformance_check.sh [--no-build] [--suite SUITE] [SELECTION]
 #
 # Options:
 #   --no-build   skip build step (use existing ffc binary)
 #   --suite S    run only one suite instead of all available suites
+#   --file PATH  forward one suite-relative file (repeatable)
+#   --files-from PATH  forward a named-file list (repeatable)
 #
 # This script is the documented routine contributors run before pushing
 # and after dependency (fortfront, liric) updates.
@@ -28,6 +30,7 @@ GAUNTLET="$SCRIPT_DIR/conformance_gauntlet.sh"
 NO_BUILD=0
 SINGLE_SUITE=""
 TIMEOUT=5
+NAMED_ARGS=()
 
 # Argument parsing
 while [ $# -gt 0 ]; do
@@ -36,12 +39,29 @@ while [ $# -gt 0 ]; do
             NO_BUILD=1; shift ;;
         --suite)
             SINGLE_SUITE="$2"; shift 2 ;;
+        --file)
+            if [ $# -lt 2 ]; then
+                echo "ERROR: --file requires a path" >&2; exit 1
+            fi
+            NAMED_ARGS+=("--file" "$2"); shift 2 ;;
+        --files-from)
+            if [ $# -lt 2 ]; then
+                echo "ERROR: --files-from requires a path" >&2; exit 1
+            fi
+            list_path="$2"
+            case "$list_path" in /*) ;; *) list_path="$PWD/$list_path" ;; esac
+            NAMED_ARGS+=("--files-from" "$list_path"); shift 2 ;;
         --timeout)
             TIMEOUT="$2"; shift 2 ;;
         *)
             echo "ERROR: unknown option $1" >&2; exit 1 ;;
     esac
 done
+
+if [ "${#NAMED_ARGS[@]}" -gt 0 ] && [ -z "$SINGLE_SUITE" ]; then
+    echo "ERROR: --file and --files-from require --suite" >&2
+    exit 1
+fi
 
 # Determine suites to run
 ALL_SUITES="fortfront-f90 fortfront-lf lfortran gfortran-dg"
@@ -106,12 +126,17 @@ for SUITE in $SUITES; do
 
     rm -f "$REPORT" "$LOG"
 
-    bash "$GAUNTLET" --suite "$SUITE" --ffc "$FFC_BIN" \
-        --report "$REPORT" --timeout "$TIMEOUT" > "$LOG" 2>&1
-    suite_exit=$?
+    gauntlet_args=(--suite "$SUITE" --ffc "$FFC_BIN" \
+        --report "$REPORT" --timeout "$TIMEOUT")
+    gauntlet_args+=("${NAMED_ARGS[@]}")
+    if bash "$GAUNTLET" "${gauntlet_args[@]}" > "$LOG" 2>&1; then
+        suite_exit=0
+    else
+        suite_exit=$?
+    fi
 
     # Print the log (summary line and any FAIL/XPASS)
-    grep -E '(===|PASS=|FAIL:|XPASS:)' "$LOG" || true
+    grep -E '(===|PASS=|FAIL:|XPASS:|ERROR:)' "$LOG" || true
     echo ""
 
     # Parse summary

--- a/scripts/conformance_gauntlet.sh
+++ b/scripts/conformance_gauntlet.sh
@@ -14,6 +14,8 @@
 #   --suite SUITE       required
 #   --ffc PATH          path to ffc binary (auto-discovered if omitted)
 #   --report PATH       JSONL report path (default: /tmp/ffc_gauntlet_<suite>.jsonl)
+#   --file PATH         select one suite-relative file (repeatable)
+#   --files-from PATH   read suite-relative files from PATH (repeatable)
 #   --max-files N       only test the first N files (for smoke runs)
 #   --timeout N         per-file timeout in seconds (default: 5)
 #
@@ -39,6 +41,13 @@ REPORT=""
 MAX_FILES=""
 TIMEOUT=5
 HAS_FAIL=0
+SELECTOR_KINDS=()
+SELECTOR_VALUES=()
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
 
 # Argument parsing
 SUITE=""
@@ -50,12 +59,22 @@ while [ $# -gt 0 ]; do
             FFC_BIN="$2"; shift 2 ;;
         --report)
             REPORT="$2"; shift 2 ;;
+        --file)
+            if [ $# -lt 2 ]; then fail "--file requires a path"; fi
+            SELECTOR_KINDS+=("file")
+            SELECTOR_VALUES+=("$2")
+            shift 2 ;;
+        --files-from)
+            if [ $# -lt 2 ]; then fail "--files-from requires a path"; fi
+            SELECTOR_KINDS+=("list")
+            SELECTOR_VALUES+=("$2")
+            shift 2 ;;
         --max-files)
             MAX_FILES="$2"; shift 2 ;;
         --timeout)
             TIMEOUT="$2"; shift 2 ;;
         *)
-            echo "ERROR: unknown option $1" >&2; exit 1 ;;
+            fail "unknown option $1" ;;
     esac
 done
 
@@ -206,13 +225,58 @@ if [ ! -d "$SUITE_ROOT" ]; then
 fi
 
 # Collect files.
+ALL_FILE_LIST="$TMPDIR_WORK/all_files.txt"
 FILE_LIST="$TMPDIR_WORK/files.txt"
 case "$SUITE" in
     fortfront-lf)
-        find "$SUITE_ROOT" -maxdepth 1 \( -name "*.lf" -o -name "*.f90" \) -type f | sort > "$FILE_LIST" ;;
+        find "$SUITE_ROOT" -maxdepth 1 \( -name "*.lf" -o -name "*.f90" \) -type f | sort > "$ALL_FILE_LIST" ;;
     *)
-        find "$SUITE_ROOT" -maxdepth 1 -name "*.$EXT" -type f | sort > "$FILE_LIST" ;;
+        find "$SUITE_ROOT" -maxdepth 1 -name "*.$EXT" -type f | sort > "$ALL_FILE_LIST" ;;
 esac
+
+SELECTED_LOOKUP="$TMPDIR_WORK/selected_files.txt"
+: > "$SELECTED_LOOKUP"
+
+add_selected_file() {
+    local rel_path="$1"
+    case "$rel_path" in
+        "") fail "selected file path must not be empty" ;;
+        /*) fail "selected file must be suite-relative: $rel_path" ;;
+        ..|../*|*/../*|*/..) fail "selected file contains parent traversal: $rel_path" ;;
+    esac
+    if grep -Fqx -- "$rel_path" "$SELECTED_LOOKUP"; then
+        fail "duplicate selected file: $rel_path"
+    fi
+    if ! grep -Fqx -- "$SUITE_ROOT/$rel_path" "$ALL_FILE_LIST"; then
+        fail "unknown selected file: $rel_path"
+    fi
+    printf '%s\n' "$rel_path" >> "$SELECTED_LOOKUP"
+    printf '%s\n' "$SUITE_ROOT/$rel_path" >> "$FILE_LIST"
+}
+
+if [ "${#SELECTOR_KINDS[@]}" -gt 0 ]; then
+    : > "$FILE_LIST"
+    for selector_index in "${!SELECTOR_KINDS[@]}"; do
+        selector_kind=${SELECTOR_KINDS[$selector_index]}
+        selector_value=${SELECTOR_VALUES[$selector_index]}
+        if [ "$selector_kind" = "file" ]; then
+            add_selected_file "$selector_value"
+            continue
+        fi
+        if [ ! -f "$selector_value" ]; then
+            fail "files-from path does not exist: $selector_value"
+        fi
+        while IFS= read -r selected_line || [ -n "$selected_line" ]; do
+            selected_line=$(printf '%s\n' "$selected_line" | \
+                sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            [ -z "$selected_line" ] && continue
+            case "$selected_line" in \#*) continue ;; esac
+            add_selected_file "$selected_line"
+        done < "$selector_value"
+    done
+else
+    cp "$ALL_FILE_LIST" "$FILE_LIST"
+fi
 
 if [ "$MAX_FILES" -gt 0 ] 2>/dev/null; then
     head -n "$MAX_FILES" "$FILE_LIST" > "$TMPDIR_WORK/files_limited.txt"

--- a/test/test_conformance_gauntlet_smoke.f90
+++ b/test/test_conformance_gauntlet_smoke.f90
@@ -8,6 +8,20 @@ program test_conformance_gauntlet_smoke
         '/tmp/ffc_gauntlet_smoke_root.jsonl'
     character(len=*), parameter :: TMP_CWD_REPORT = &
         '/tmp/ffc_gauntlet_smoke_tmpcwd.jsonl'
+    character(len=*), parameter :: NAMED_REPORT = &
+        '/tmp/ffc_gauntlet_smoke_named.jsonl'
+    character(len=*), parameter :: LIST_REPORT = &
+        '/tmp/ffc_gauntlet_smoke_list.jsonl'
+    character(len=*), parameter :: LIMITED_REPORT = &
+        '/tmp/ffc_gauntlet_smoke_limited.jsonl'
+    character(len=*), parameter :: FORWARDED_REPORT = &
+        '/tmp/ffc_conformance_fortfront-f90.jsonl'
+    character(len=*), parameter :: SELECTION_LIST = &
+        '/tmp/ffc_gauntlet_smoke_files.txt'
+    character(len=*), parameter :: FORWARD_SELECTION_LIST = &
+        '/tmp/ffc_gauntlet_smoke_forward_files.txt'
+    character(len=*), parameter :: FAILURE_LOG = &
+        '/tmp/ffc_gauntlet_smoke_failure.log'
 
     logical :: all_passed
 
@@ -16,27 +30,74 @@ program test_conformance_gauntlet_smoke
     all_passed = .true.
     if (.not. run_smoke('timeout 120 bash '//SCRIPT// &
         ' --suite fortfront-f90 --max-files 20 --report '// &
-        ROOT_REPORT, ROOT_REPORT)) all_passed = .false.
+        ROOT_REPORT, ROOT_REPORT, 20)) all_passed = .false.
     if (.not. run_smoke('repo="$PWD"; cd /tmp && timeout 120 bash '// &
         '"$repo/'//SCRIPT//'" --suite fortfront-f90 --max-files 20 '// &
         '--report '//TMP_CWD_REPORT, &
-        TMP_CWD_REPORT)) all_passed = .false.
+        TMP_CWD_REPORT, 20)) all_passed = .false.
+
+    if (.not. run_smoke('timeout 120 bash '//SCRIPT// &
+        ' --suite fortfront-f90 --file ast_coverage_control_flow.f90'// &
+        ' --report '//NAMED_REPORT, NAMED_REPORT, 1)) all_passed = .false.
+    if (.not. file_contains(NAMED_REPORT, &
+        '"file":"ast_coverage_control_flow.f90","status":"XFAIL"')) &
+        all_passed = .false.
+
+    call write_selection_list()
+    if (.not. run_smoke('timeout 120 bash '//SCRIPT// &
+        ' --suite fortfront-f90 --files-from '//SELECTION_LIST// &
+        ' --report '//LIST_REPORT, LIST_REPORT, 2)) all_passed = .false.
+    if (.not. report_has_file_order(LIST_REPORT, &
+        'ast_coverage_control_flow.f90', &
+        'ast_coverage_io_statements.f90')) all_passed = .false.
+    if (.not. run_smoke('timeout 120 bash '//SCRIPT// &
+        ' --suite fortfront-f90 --files-from '//SELECTION_LIST// &
+        ' --max-files 1 --report '//LIMITED_REPORT, LIMITED_REPORT, 1)) &
+        all_passed = .false.
+    if (.not. file_contains(LIMITED_REPORT, &
+        '"file":"ast_coverage_control_flow.f90"')) all_passed = .false.
+
+    if (.not. run_smoke('repo="$PWD"; cd /tmp && timeout 120 bash'// &
+        ' "$repo/scripts/conformance_check.sh"'// &
+        ' --no-build --suite fortfront-f90'// &
+        ' --file ast_coverage_control_flow.f90'// &
+        ' --files-from ffc_gauntlet_smoke_forward_files.txt', &
+        FORWARDED_REPORT, 2)) &
+        all_passed = .false.
+    if (.not. report_has_file_order(FORWARDED_REPORT, &
+        'ast_coverage_control_flow.f90', &
+        'ast_coverage_io_statements.f90')) all_passed = .false.
+
+    if (.not. run_failure('bash '//SCRIPT// &
+        ' --suite fortfront-f90 --file missing_named_file.f90', &
+        'unknown selected file')) all_passed = .false.
+    if (.not. run_failure('bash '//SCRIPT// &
+        ' --suite fortfront-f90 --file ast_coverage_control_flow.f90'// &
+        ' --file ast_coverage_control_flow.f90', &
+        'duplicate selected file')) all_passed = .false.
+    if (.not. run_failure('bash '//SCRIPT// &
+        ' --suite fortfront-f90 --file /tmp/absolute.f90', &
+        'suite-relative')) all_passed = .false.
+    if (.not. run_failure('bash '//SCRIPT// &
+        ' --suite fortfront-f90 --file ../ast_coverage_control_flow.f90', &
+        'parent traversal')) all_passed = .false.
+    if (.not. run_failure('bash scripts/conformance_check.sh --no-build'// &
+        ' --file ast_coverage_control_flow.f90', &
+        'require --suite')) all_passed = .false.
+    if (.not. run_failure('bash scripts/conformance_check.sh --no-build'// &
+        ' --suite fortfront-f90 --file missing_named_file.f90', &
+        'unknown selected file')) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: gauntlet smoke test completed with zero FAIL records'
 
 contains
 
-    logical function run_smoke(cmd, report) result(ok)
+    logical function run_smoke(cmd, report, expected_total) result(ok)
         character(len=*), intent(in) :: cmd
         character(len=*), intent(in) :: report
+        integer, intent(in) :: expected_total
         integer :: exit_stat
-        integer :: unit
-        integer :: io_stat
-        character(len=4096) :: line
-        logical :: has_summary
-        logical :: has_zero_fail_summary
-        logical :: has_expected_total
         logical :: report_exists
 
         ok = .false.
@@ -59,9 +120,23 @@ contains
             return
         end if
 
+        ok = report_matches(report, expected_total)
+    end function run_smoke
+
+    logical function report_matches(report, expected_total) result(ok)
+        character(len=*), intent(in) :: report
+        integer, intent(in) :: expected_total
+        integer :: unit
+        integer :: io_stat
+        integer :: record_count
+        character(len=4096) :: line
+        character(len=32) :: total_text
+        logical :: has_summary
+
+        ok = .false.
         has_summary = .false.
-        has_zero_fail_summary = .false.
-        has_expected_total = .false.
+        record_count = 0
+        write(total_text, '(I0)') expected_total
         open(newunit=unit, file=report, status='old', action='read', &
             iostat=io_stat)
         if (io_stat /= 0) then
@@ -74,35 +149,100 @@ contains
             if (io_stat /= 0) exit
             if (is_blank_or_comment(line)) cycle
             if (index(line, '"status":"SUMMARY"') > 0) then
-                has_summary = .true.
-                if (index(line, '"fail":0') > 0) then
-                    has_zero_fail_summary = .true.
-                end if
-                if (index(line, '"total":20') > 0) then
-                    has_expected_total = .true.
-                end if
-                exit
+                has_summary = index(line, '"fail":0') > 0 .and. &
+                    index(line, '"total":'//trim(total_text)//'}') > 0
+            else
+                record_count = record_count + 1
             end if
         end do
         close(unit)
 
         if (.not. has_summary) then
-            print *, 'FAIL: no SUMMARY record in report'
+            print *, 'FAIL: invalid SUMMARY record in ', trim(adjustl(report))
             return
         end if
 
-        if (.not. has_zero_fail_summary) then
-            print *, 'FAIL: SUMMARY record has nonzero fail count'
-            return
-        end if
-
-        if (.not. has_expected_total) then
-            print *, 'FAIL: SUMMARY record does not include total 20'
+        if (record_count /= expected_total) then
+            print *, 'FAIL: wrong file-record count in ', trim(adjustl(report))
             return
         end if
 
         ok = .true.
-    end function run_smoke
+    end function report_matches
+
+    logical function run_failure(cmd, expected_diagnostic) result(ok)
+        character(len=*), intent(in) :: cmd
+        character(len=*), intent(in) :: expected_diagnostic
+        integer :: exit_stat
+
+        call execute_command_line(cmd//' > '//FAILURE_LOG//' 2>&1', &
+            exitstat=exit_stat)
+        ok = exit_stat /= 0 .and. file_contains(FAILURE_LOG, expected_diagnostic)
+        if (.not. ok) print *, 'FAIL: missing rejection: ', trim(expected_diagnostic)
+    end function run_failure
+
+    logical function file_contains(path, needle) result(found)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: needle
+        integer :: unit
+        integer :: io_stat
+        character(len=4096) :: line
+
+        found = .false.
+        open(newunit=unit, file=path, status='old', action='read', iostat=io_stat)
+        if (io_stat /= 0) return
+        do
+            read(unit, '(A)', iostat=io_stat) line
+            if (io_stat /= 0) exit
+            if (index(line, needle) > 0) found = .true.
+        end do
+        close(unit)
+    end function file_contains
+
+    logical function report_has_file_order(report, first_file, second_file) &
+            result(ok)
+        character(len=*), intent(in) :: report
+        character(len=*), intent(in) :: first_file
+        character(len=*), intent(in) :: second_file
+        integer :: unit
+        integer :: io_stat
+        integer :: record_count
+        character(len=4096) :: line
+
+        ok = .false.
+        record_count = 0
+        open(newunit=unit, file=report, status='old', action='read', &
+            iostat=io_stat)
+        if (io_stat /= 0) return
+        do
+            read(unit, '(A)', iostat=io_stat) line
+            if (io_stat /= 0) exit
+            if (index(line, '"file":') == 0) cycle
+            record_count = record_count + 1
+            if (record_count == 1 .and. index(line, first_file) == 0) exit
+            if (record_count == 2 .and. index(line, second_file) == 0) exit
+            if (record_count == 2) ok = .true.
+        end do
+        close(unit)
+        if (.not. ok) print *, 'FAIL: wrong selected-file order'
+    end function report_has_file_order
+
+    subroutine write_selection_list()
+        integer :: unit
+
+        open(newunit=unit, file=SELECTION_LIST, status='replace', &
+            action='write')
+        write(unit, '(A)') '# exact named cases'
+        write(unit, '(A)') ''
+        write(unit, '(A)') 'ast_coverage_control_flow.f90'
+        write(unit, '(A)') 'ast_coverage_io_statements.f90'
+        close(unit)
+
+        open(newunit=unit, file=FORWARD_SELECTION_LIST, status='replace', &
+            action='write')
+        write(unit, '(A)') 'ast_coverage_io_statements.f90'
+        close(unit)
+    end subroutine write_selection_list
 
     logical function is_blank_or_comment(line)
         character(len=*), intent(in) :: line


### PR DESCRIPTION
## Summary

- add repeatable `--file` and `--files-from` corpus selection
- validate named paths and preserve declared order before `--max-files`
- forward named selection through the single-suite conformance check
- cover positive, ordering, forwarding, and rejection behavior

Closes #340

The report keeps the documented final SUMMARY record. A one-file selection
therefore has one file record plus the SUMMARY; verification counts the file
record and checks `total:1` exactly.

## Verification

Failing before:

```text
$ scripts/conformance_gauntlet.sh --suite fortfront-f90 --file ast_coverage_control_flow.f90 --report /tmp/ffc340-before.jsonl
ERROR: unknown option --file
```

Passing after:

```text
$ fo test test_conformance_gauntlet_smoke
PASS 12.57s test_conformance_gauntlet_smoke
1 passed, 0 failed, 0 skipped

$ scripts/conformance_gauntlet.sh --suite fortfront-f90 --file ast_coverage_control_flow.f90 --report /tmp/ffc-one.jsonl
PASS=0  XFAIL=1  XPASS=0  FAIL=0  NOREF=0  SKIP=0  TOTAL=1

$ grep -c '"file":' /tmp/ffc-one.jsonl
1

$ fo
Static analysis: OK
Build: 377/377
Tests: 246/246
Lint: OK
```
