### PR TITLE
Separate dg warning expectations

### DIFF
--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -195,11 +195,12 @@ Fields:
 | `ffc_exit` | int | ffc exit code (0 = built and ran) |
 | `ref_exit` | int | gfortran exit code (0 = built and ran) |
 | `note` | string | Human-readable explanation |
+| `warning_expectation` | string | `unchecked` for warning-only gfortran.dg files; omitted otherwise |
 
 A final SUMMARY record closes the file:
 
 ```json
-{"suite":"fortfront-f90","status":"SUMMARY","pass":15,"xfail":3,"xpass":1,"fail":2,"noref":1,"skip":0,"total":21}
+{"suite":"fortfront-f90","status":"SUMMARY","pass":15,"xfail":3,"xpass":1,"fail":2,"noref":1,"skip":0,"warning_unchecked":0,"total":21}
 ```
 
 ## Disposition states
@@ -224,6 +225,9 @@ The `skip` summary count is the number of files listed in
 `test/conformance/skip_<suite>.txt`. Skip lines use the format
 `basename.f90 # reason`. They are explicit entries, not silent drops.
 
+The `warning_unchecked` count is the number of warning-only gfortran.dg files
+whose compile or run disposition was checked without matching warning text.
+
 ## FortFront corpus gate
 
 The fpm test `test_fortfront_corpus_conformance` runs the full
@@ -240,9 +244,9 @@ Current xfail manifests:
 ## gfortran.dg testsuite
 
 The `gfortran-dg` suite reads `$FFC_GFORTRAN_DG_DIR/*.f90` from a local
-GCC checkout. The runner evaluates each file with `ffc -c` (compile) or
-checks rejection of negative tests (`dg-error`/`dg-warning`). Files that
-use `dg-do run` build, execute, and compare output against `gfortran -w`.
+GCC checkout. The runner evaluates each file with `ffc -c` (compile), checks
+rejection of `dg-error` tests, or executes `dg-do run` files and compares their
+output against `gfortran -w`.
 
 ### Local checkout
 
@@ -257,7 +261,8 @@ The runner models these gfortran.dg directives:
 
 - `dg-do compile` (default): compile with `ffc -c`
 - `dg-do run`: build, execute, and compare stdout and exit status against `gfortran -w`
-- `dg-error` / `dg-warning`: negative tests; ffc must reject compilation
+- `dg-error`: negative test; `ffc -c` must reject compilation
+- `dg-warning` without `dg-error`: follow `dg-do`; warning text remains unchecked
 - `dg-additional-sources`: multifile tests (skipped)
 - `dg-options` / `dg-add-options`: compiler flag tests (skipped)
 - `dg-require`, `dg-skip-if`, `dg-final`, `dg-prune-output`,
@@ -265,6 +270,12 @@ The runner models these gfortran.dg directives:
 
 Files with unlisted skip reasons are marked FAIL until added to the skip
 manifest.
+
+`dg-error` takes precedence when a file also contains `dg-warning`. A
+warning-only file records `"warning_expectation":"unchecked"`, increments
+`warning_unchecked`, and otherwise uses the normal compile or run disposition.
+Successful compilation is not accepted-invalid behavior. This accounting does
+not claim warning-text parity.
 
 ### Skip manifest
 

--- a/scripts/conformance_gauntlet.sh
+++ b/scripts/conformance_gauntlet.sh
@@ -163,7 +163,7 @@ dg_skip_reason() {
 
 dg_test_kind() {
     local source="$1"
-    if grep -Eq 'dg-(error|warning)' "$source"; then
+    if grep -Eq 'dg-error' "$source"; then
         echo "negative"
         return
     fi
@@ -173,6 +173,11 @@ dg_test_kind() {
         *"dg-do run"*) echo "run" ;;
         *) echo "compile" ;;
     esac
+}
+
+dg_warning_only() {
+    local source="$1"
+    grep -Eq 'dg-warning' "$source" && ! grep -Eq 'dg-error' "$source"
 }
 
 # Resolve ffc
@@ -189,6 +194,17 @@ normalize_manifest() {
     sed 's/#.*$//' "$src" | \
         sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | \
         awk 'NF' > "$dst"
+}
+
+write_result_record() {
+    local file="$1" result_status="$2" compiler_exit="$3" reference_exit="$4"
+    local result_note="$5" warning_expectation="$6" warning_json=""
+    if [ -n "$warning_expectation" ]; then
+        warning_json=',"warning_expectation":"unchecked"'
+    fi
+    printf '{"suite":"%s","file":"%s","status":"%s","ffc_exit":%d,"ref_exit":%d,"note":"%s"%s}\n' \
+        "$SUITE" "$(json_escape "$file")" "$result_status" "$compiler_exit" \
+        "$reference_exit" "$(json_escape "$result_note")" "$warning_json" >> "$REPORT"
 }
 
 # Setup
@@ -211,6 +227,7 @@ XPASS_COUNT=0
 FAIL_COUNT=0
 NOREF_COUNT=0
 SKIP_COUNT=0
+WARNING_UNCHECKED_COUNT=0
 TOTAL_COUNT=0
 
 # Clear report
@@ -219,8 +236,9 @@ TOTAL_COUNT=0
 # Check suite root exists.
 if [ ! -d "$SUITE_ROOT" ]; then
     echo "SKIP: $SUITE not found at $SUITE_ROOT"
-    printf '{"suite":"%s","status":"SUMMARY","pass":%d,"xfail":%d,"xpass":%d,"fail":%d,"noref":%d,"skip":%d,"total":%d}\n' \
-        "$SUITE" "$PASS_COUNT" "$XFAIL_COUNT" "$XPASS_COUNT" "$FAIL_COUNT" "$NOREF_COUNT" "$SKIP_COUNT" "$TOTAL_COUNT" >> "$REPORT"
+    printf '{"suite":"%s","status":"SUMMARY","pass":%d,"xfail":%d,"xpass":%d,"fail":%d,"noref":%d,"skip":%d,"warning_unchecked":%d,"total":%d}\n' \
+        "$SUITE" "$PASS_COUNT" "$XFAIL_COUNT" "$XPASS_COUNT" "$FAIL_COUNT" \
+        "$NOREF_COUNT" "$SKIP_COUNT" "$WARNING_UNCHECKED_COUNT" "$TOTAL_COUNT" >> "$REPORT"
     exit 0
 fi
 
@@ -286,8 +304,9 @@ fi
 FILE_COUNT=$(wc -l < "$FILE_LIST")
 if [ "$FILE_COUNT" -eq 0 ]; then
     echo "SKIP: no files found in $SUITE_ROOT for $SUITE"
-    printf '{"suite":"%s","status":"SUMMARY","pass":%d,"xfail":%d,"xpass":%d,"fail":%d,"noref":%d,"skip":%d,"total":%d}\n' \
-        "$SUITE" "$PASS_COUNT" "$XFAIL_COUNT" "$XPASS_COUNT" "$FAIL_COUNT" "$NOREF_COUNT" "$SKIP_COUNT" "$TOTAL_COUNT" >> "$REPORT"
+    printf '{"suite":"%s","status":"SUMMARY","pass":%d,"xfail":%d,"xpass":%d,"fail":%d,"noref":%d,"skip":%d,"warning_unchecked":%d,"total":%d}\n' \
+        "$SUITE" "$PASS_COUNT" "$XFAIL_COUNT" "$XPASS_COUNT" "$FAIL_COUNT" \
+        "$NOREF_COUNT" "$SKIP_COUNT" "$WARNING_UNCHECKED_COUNT" "$TOTAL_COUNT" >> "$REPORT"
     exit 0
 fi
 
@@ -348,9 +367,14 @@ while IFS= read -r full_path <&3; do
     ref_exit=-1
     status=""
     note=""
+    warning_expectation=""
 
     if [ "$SUITE" = "gfortran-dg" ]; then
         dg_kind=$(dg_test_kind "$full_path")
+        if dg_warning_only "$full_path"; then
+            warning_expectation="unchecked"
+            WARNING_UNCHECKED_COUNT=$((WARNING_UNCHECKED_COUNT + 1))
+        fi
         if [ "$dg_kind" = "compile" ]; then
             if compile_object_with_ffc "$full_path" "$ffc_obj" "$FFC_BIN"; then
                 ffc_exit=0
@@ -378,13 +402,13 @@ while IFS= read -r full_path <&3; do
                     echo "  FAIL: $rel_path (ffc -c failed)"
                 fi
             fi
-            printf '{"suite":"%s","file":"%s","status":"%s","ffc_exit":%d,"ref_exit":%d,"note":"%s"}\n' \
-                "$SUITE" "$(json_escape "$rel_path")" "$status" "$ffc_exit" "$ref_exit" "$(json_escape "$note")" >> "$REPORT"
+            write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+                "$note" "$warning_expectation"
             continue
         fi
 
         if [ "$dg_kind" = "negative" ]; then
-            if compile_with_ffc "$full_path" "$ffc_exe" "$FFC_BIN"; then
+            if compile_object_with_ffc "$full_path" "$ffc_obj" "$FFC_BIN"; then
                 ffc_exit=0
             else
                 ffc_exit=1
@@ -413,8 +437,8 @@ while IFS= read -r full_path <&3; do
                     echo "  FAIL: $rel_path (negative test accepted)"
                 fi
             fi
-            printf '{"suite":"%s","file":"%s","status":"%s","ffc_exit":%d,"ref_exit":%d,"note":"%s"}\n' \
-                "$SUITE" "$(json_escape "$rel_path")" "$status" "$ffc_exit" "$ref_exit" "$(json_escape "$note")" >> "$REPORT"
+            write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+                "$note" "$warning_expectation"
             continue
         fi
     fi
@@ -468,16 +492,16 @@ while IFS= read -r full_path <&3; do
             status="XFAIL"
             note="listed in xfail manifest"
             XFAIL_COUNT=$((XFAIL_COUNT + 1))
-            printf '{"suite":"%s","file":"%s","status":"%s","ffc_exit":%d,"ref_exit":%d,"note":"%s"}\n' \
-                "$SUITE" "$(json_escape "$rel_path")" "$status" "$ffc_exit" "$ref_exit" "$(json_escape "$note")" >> "$REPORT"
+            write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+                "$note" "$warning_expectation"
             continue
         else
             status="FAIL"
             note="ffc compilation failed"
             FAIL_COUNT=$((FAIL_COUNT + 1))
             HAS_FAIL=1
-            printf '{"suite":"%s","file":"%s","status":"%s","ffc_exit":%d,"ref_exit":%d,"note":"%s"}\n' \
-                "$SUITE" "$(json_escape "$rel_path")" "$status" "$ffc_exit" "$ref_exit" "$(json_escape "$note")" >> "$REPORT"
+            write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+                "$note" "$warning_expectation"
             echo "  FAIL: $rel_path (ffc failed)"
             continue
         fi
@@ -498,16 +522,16 @@ while IFS= read -r full_path <&3; do
             status="XFAIL"
             note="listed in xfail manifest (runtime failure)"
             XFAIL_COUNT=$((XFAIL_COUNT + 1))
-            printf '{"suite":"%s","file":"%s","status":"%s","ffc_exit":%d,"ref_exit":%d,"note":"%s"}\n' \
-                "$SUITE" "$(json_escape "$rel_path")" "$status" "$ffc_exit" "$ref_exit" "$(json_escape "$note")" >> "$REPORT"
+            write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+                "$note" "$warning_expectation"
             continue
         else
             status="FAIL"
             note="ffc runtime failed (exit $ffc_exit)"
             FAIL_COUNT=$((FAIL_COUNT + 1))
             HAS_FAIL=1
-            printf '{"suite":"%s","file":"%s","status":"%s","ffc_exit":%d,"ref_exit":%d,"note":"%s"}\n' \
-                "$SUITE" "$(json_escape "$rel_path")" "$status" "$ffc_exit" "$ref_exit" "$(json_escape "$note")" >> "$REPORT"
+            write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+                "$note" "$warning_expectation"
             echo "  FAIL: $rel_path (runtime exit $ffc_exit)"
             continue
         fi
@@ -525,8 +549,8 @@ while IFS= read -r full_path <&3; do
             note="lazy suite, ffc ran successfully"
             PASS_COUNT=$((PASS_COUNT + 1))
         fi
-        printf '{"suite":"%s","file":"%s","status":"%s","ffc_exit":%d,"ref_exit":%d,"note":"%s"}\n' \
-            "$SUITE" "$(json_escape "$rel_path")" "$status" "$ffc_exit" "$ref_exit" "$(json_escape "$note")" >> "$REPORT"
+        write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+            "$note" "$warning_expectation"
         continue
     fi
 
@@ -551,8 +575,8 @@ while IFS= read -r full_path <&3; do
             note="gfortran rejects; ffc runs (NO-REF)"
             PASS_COUNT=$((PASS_COUNT + 1))
         fi
-        printf '{"suite":"%s","file":"%s","status":"%s","ffc_exit":%d,"ref_exit":%d,"note":"%s"}\n' \
-            "$SUITE" "$(json_escape "$rel_path")" "$status" "$ffc_exit" "$ref_exit" "$(json_escape "$note")" >> "$REPORT"
+        write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+            "$note" "$warning_expectation"
         continue
     fi
 
@@ -572,8 +596,8 @@ while IFS= read -r full_path <&3; do
             note="output matches gfortran"
             PASS_COUNT=$((PASS_COUNT + 1))
         fi
-        printf '{"suite":"%s","file":"%s","status":"%s","ffc_exit":%d,"ref_exit":%d,"note":"%s"}\n' \
-            "$SUITE" "$(json_escape "$rel_path")" "$status" "$ffc_exit" "$ref_exit" "$(json_escape "$note")" >> "$REPORT"
+        write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+            "$note" "$warning_expectation"
         continue
     fi
 
@@ -594,8 +618,8 @@ while IFS= read -r full_path <&3; do
             note="numeric structure matches nondeterministic gfortran"
             PASS_COUNT=$((PASS_COUNT + 1))
         fi
-        printf '{"suite":"%s","file":"%s","status":"%s","ffc_exit":%d,"ref_exit":%d,"note":"%s"}\n' \
-            "$SUITE" "$(json_escape "$rel_path")" "$status" "$ffc_exit" "$ref_exit" "$(json_escape "$note")" >> "$REPORT"
+        write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+            "$note" "$warning_expectation"
         continue
     fi
 
@@ -604,8 +628,8 @@ while IFS= read -r full_path <&3; do
         status="XFAIL"
         note="output mismatch listed in xfail manifest"
         XFAIL_COUNT=$((XFAIL_COUNT + 1))
-        printf '{"suite":"%s","file":"%s","status":"%s","ffc_exit":%d,"ref_exit":%d,"note":"%s"}\n' \
-            "$SUITE" "$(json_escape "$rel_path")" "$status" "$ffc_exit" "$ref_exit" "$(json_escape "$note")" >> "$REPORT"
+        write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+            "$note" "$warning_expectation"
         continue
     fi
 
@@ -613,19 +637,20 @@ while IFS= read -r full_path <&3; do
     note="stdout or exit mismatch with gfortran"
     FAIL_COUNT=$((FAIL_COUNT + 1))
     HAS_FAIL=1
-    printf '{"suite":"%s","file":"%s","status":"%s","ffc_exit":%d,"ref_exit":%d,"note":"%s"}\n' \
-        "$SUITE" "$(json_escape "$rel_path")" "$status" "$ffc_exit" "$ref_exit" "$(json_escape "$note")" >> "$REPORT"
+    write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+        "$note" "$warning_expectation"
     echo "  FAIL: $rel_path (output mismatch)"
 
 done 3< "$FILE_LIST"
 
 # Summary
-printf '{"suite":"%s","status":"SUMMARY","pass":%d,"xfail":%d,"xpass":%d,"fail":%d,"noref":%d,"skip":%d,"total":%d}\n' \
-    "$SUITE" "$PASS_COUNT" "$XFAIL_COUNT" "$XPASS_COUNT" "$FAIL_COUNT" "$NOREF_COUNT" "$SKIP_COUNT" "$TOTAL_COUNT" >> "$REPORT"
+printf '{"suite":"%s","status":"SUMMARY","pass":%d,"xfail":%d,"xpass":%d,"fail":%d,"noref":%d,"skip":%d,"warning_unchecked":%d,"total":%d}\n' \
+    "$SUITE" "$PASS_COUNT" "$XFAIL_COUNT" "$XPASS_COUNT" "$FAIL_COUNT" \
+    "$NOREF_COUNT" "$SKIP_COUNT" "$WARNING_UNCHECKED_COUNT" "$TOTAL_COUNT" >> "$REPORT"
 
 echo ""
 echo "=== $SUITE summary ==="
-echo "  PASS=$PASS_COUNT  XFAIL=$XFAIL_COUNT  XPASS=$XPASS_COUNT  FAIL=$FAIL_COUNT  NOREF=$NOREF_COUNT  SKIP=$SKIP_COUNT  TOTAL=$TOTAL_COUNT"
+echo "  PASS=$PASS_COUNT  XFAIL=$XFAIL_COUNT  XPASS=$XPASS_COUNT  FAIL=$FAIL_COUNT  NOREF=$NOREF_COUNT  SKIP=$SKIP_COUNT  WARNING_UNCHECKED=$WARNING_UNCHECKED_COUNT  TOTAL=$TOTAL_COUNT"
 echo "  Report: $REPORT"
 
 # Exit nonzero only if non-xfail FAILs occurred

--- a/test/test_conformance_gauntlet_smoke.f90
+++ b/test/test_conformance_gauntlet_smoke.f90
@@ -22,6 +22,12 @@ program test_conformance_gauntlet_smoke
         '/tmp/ffc_gauntlet_smoke_forward_files.txt'
     character(len=*), parameter :: FAILURE_LOG = &
         '/tmp/ffc_gauntlet_smoke_failure.log'
+    character(len=*), parameter :: DG_FIXTURE_DIR = &
+        '/tmp/ffc_gauntlet_dg_fixtures'
+    character(len=*), parameter :: DG_REPORT = &
+        '/tmp/ffc_gauntlet_dg_warning.jsonl'
+    character(len=*), parameter :: DG_NEGATIVE_REPORT = &
+        '/tmp/ffc_gauntlet_dg_negative.jsonl'
 
     logical :: all_passed
 
@@ -87,6 +93,8 @@ program test_conformance_gauntlet_smoke
     if (.not. run_failure('bash scripts/conformance_check.sh --no-build'// &
         ' --suite fortfront-f90 --file missing_named_file.f90', &
         'unknown selected file')) all_passed = .false.
+
+    call run_dg_directive_smoke(all_passed)
 
     if (.not. all_passed) stop 1
     print *, 'PASS: gauntlet smoke test completed with zero FAIL records'
@@ -243,6 +251,81 @@ contains
         write(unit, '(A)') 'ast_coverage_io_statements.f90'
         close(unit)
     end subroutine write_selection_list
+
+    subroutine run_dg_directive_smoke(passed)
+        logical, intent(inout) :: passed
+
+        call write_dg_fixtures()
+        if (.not. run_smoke('FFC_GFORTRAN_DG_DIR='//DG_FIXTURE_DIR// &
+            ' timeout 120 bash '//SCRIPT//' --suite gfortran-dg'// &
+            ' --file warning_compile.f90 --file warning_run.f90'// &
+            ' --file true_error.f90 --report '//DG_REPORT, DG_REPORT, 3)) &
+            passed = .false.
+        if (.not. file_contains(DG_REPORT, &
+            '"file":"warning_compile.f90","status":"PASS","ffc_exit":0,'// &
+            '"ref_exit":-1,"note":"ffc -c succeeded",'// &
+            '"warning_expectation":"unchecked"')) passed = .false.
+        if (.not. file_contains(DG_REPORT, &
+            '"file":"warning_run.f90","status":"PASS","ffc_exit":0,'// &
+            '"ref_exit":0,"note":"output matches gfortran",'// &
+            '"warning_expectation":"unchecked"')) passed = .false.
+        if (.not. file_contains(DG_REPORT, &
+            '"file":"true_error.f90","status":"PASS"')) passed = .false.
+        if (.not. file_contains(DG_REPORT, &
+            '"warning_unchecked":2,"total":3}')) &
+            passed = .false.
+        if (.not. run_failure('FFC_GFORTRAN_DG_DIR='//DG_FIXTURE_DIR// &
+            ' bash '//SCRIPT//' --suite gfortran-dg'// &
+            ' --file no_main_accepted.f90 --report '//DG_NEGATIVE_REPORT, &
+            'negative test accepted')) passed = .false.
+        if (.not. file_contains(DG_NEGATIVE_REPORT, &
+            '"file":"no_main_accepted.f90","status":"FAIL",'// &
+            '"ffc_exit":0')) &
+            passed = .false.
+    end subroutine run_dg_directive_smoke
+
+    subroutine write_dg_fixtures()
+        integer :: unit
+
+        call execute_command_line('rm -rf '//DG_FIXTURE_DIR)
+        call execute_command_line('mkdir -p '//DG_FIXTURE_DIR)
+        open(newunit=unit, file=DG_FIXTURE_DIR//'/warning_compile.f90', &
+            status='replace', action='write')
+        write(unit, '(A)') '! { dg-do compile }'
+        write(unit, '(A)') 'program warning_compile'
+        write(unit, '(A)') 'integer :: value ! { dg-warning "unchecked" }'
+        write(unit, '(A)') 'value = 1'
+        write(unit, '(A)') 'end program warning_compile'
+        close(unit)
+
+        open(newunit=unit, file=DG_FIXTURE_DIR//'/warning_run.f90', &
+            status='replace', action='write')
+        write(unit, '(A)') '! { dg-do run }'
+        write(unit, '(A)') 'program warning_run'
+        write(unit, '(A)') 'integer :: value ! { dg-warning "unchecked" }'
+        write(unit, '(A)') 'value = 1'
+        write(unit, '(A)') 'if (value /= 1) stop 1'
+        write(unit, '(A)') 'end program warning_run'
+        close(unit)
+
+        open(newunit=unit, file=DG_FIXTURE_DIR//'/true_error.f90', &
+            status='replace', action='write')
+        write(unit, '(A)') '! { dg-do compile }'
+        write(unit, '(A)') 'program true_error'
+        write(unit, '(A)') 'integer :: value'
+        write(unit, '(A)') 'value = @'
+        write(unit, '(A)') '! { dg-error "invalid expression" }'
+        write(unit, '(A)') '! { dg-warning "secondary expectation" }'
+        write(unit, '(A)') 'end program true_error'
+        close(unit)
+
+        open(newunit=unit, file=DG_FIXTURE_DIR//'/no_main_accepted.f90', &
+            status='replace', action='write')
+        write(unit, '(A)') 'subroutine no_main_accepted'
+        write(unit, '(A)') '! { dg-error "synthetic accepted case" }'
+        write(unit, '(A)') 'end subroutine no_main_accepted'
+        close(unit)
+    end subroutine write_dg_fixtures
 
     logical function is_blank_or_comment(line)
         character(len=*), intent(in) :: line


### PR DESCRIPTION
## Summary

- route warning-only gfortran.dg files through their `dg-do` compile or run path
- keep `dg-error` authoritative and require rejection during object compilation
- record unchecked warning expectations per file and in the SUMMARY
- add checkout-independent behavioral coverage for compile, run, precedence, and link-failure hazards

Closes #377

The issue fixture inventory was corrected to 25 warning-only files plus
`bom_error.f90` as a true `dg-error` case. No xfails were added.

## Verification

Failing before:

```text
$ fo test test_conformance_gauntlet_smoke
warning_compile.f90: FAIL (negative test accepted by ffc)
warning_run.f90: FAIL (negative test accepted by ffc)
0 passed, 1 failed, 0 skipped
```

Passing after:

```text
$ fo test test_conformance_gauntlet_smoke
warning_compile.f90: PASS, warning_expectation=unchecked
warning_run.f90: PASS, warning_expectation=unchecked
true_error.f90: PASS, negative test rejected
PASS=3 FAIL=0 WARNING_UNCHECKED=2 TOTAL=3
1 passed, 0 failed, 0 skipped

$ fo
Static analysis: OK
Build: 377/377
Tests: 246/246
Lint: OK
```

Full corpus audit:

```text
$ scripts/conformance_gauntlet.sh --suite gfortran-dg --report /tmp/ffc-377-gfortran.jsonl
PASS=1157 XFAIL=2072 XPASS=5 FAIL=333 NOREF=1 SKIP=2371 WARNING_UNCHECKED=73 TOTAL=5938
```

The audit exits 1 because later owned corpus failures remain open. All 25
issue-listed warning-only files carry `warning_expectation:unchecked`; none is
classified as accepted invalid. `bom_error.f90` remains negative and exposes
ffc's current acceptance as FAIL.
