### PR TITLE
Normalize undefined FortFront output

### DIFF
--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -8,7 +8,7 @@ source, and writes an xfail-style report.
 ## No-vendoring rule
 
 The runner never copies source files from external suites into this
-repository. Only xfail manifests live here. External checkouts are
+repository. Only conformance manifests live here. External checkouts are
 referenced by path.
 
 ## Suites
@@ -166,8 +166,9 @@ they contain these normalized entry counts, ignoring comments and blank lines:
 
 | Manifest | Entries |
 |---|---:|
-| `test/conformance/xfail_fortfront_f90.txt` | 103 |
+| `test/conformance/xfail_fortfront_f90.txt` | 100 |
 | `test/conformance/xfail_fortfront_lf.txt` | 60 |
+| `test/conformance/undefined_output_fortfront_f90.txt` | 3 |
 | `test/conformance/xfail_lfortran.txt` | 3425 |
 | `test/conformance/xfail_gfortran_dg.txt` | 2121 |
 | `test/conformance/skip_lfortran.txt` | 0 |
@@ -240,6 +241,12 @@ Current xfail manifests:
 
 - `test/conformance/xfail_fortfront_f90.txt`
 - `test/conformance/xfail_fortfront_lf.txt`
+
+`test/conformance/undefined_output_fortfront_f90.txt` lists programs whose
+printed values depend on uninitialized data. Both ffc and gfortran must build
+and terminate with exit zero. The runner ignores stdout only for those named
+files; compilation, control flow, and termination remain enforced.
+Undefined-output entries must not also appear in an xfail or skip manifest.
 
 ## gfortran.dg testsuite
 

--- a/docs/PARITY_PLAN.md
+++ b/docs/PARITY_PLAN.md
@@ -21,7 +21,7 @@ Current checked-in manifest counts in this checkout:
 
 | Suite | XFAIL entries | SKIP entries |
 |-------|--------------:|-------------:|
-| fortfront-f90 | 103 | 0 |
+| fortfront-f90 | 100 | 0 |
 | fortfront-lf  | 60  | 0 |
 | lfortran      | 3425 | 0 |
 | gfortran-dg   | 2121 | 2371 |
@@ -30,7 +30,7 @@ Latest recorded full-dashboard state in #299 after wave 14:
 
 | Suite | PASS | Notes |
 |-------|-----:|-------|
-| fortfront-f90 | 336 | Near complete; one local/CI gfortran-version XPASS can appear. |
+| fortfront-f90 | 339 | Three undefined-output cases use a version-independent completion oracle. |
 | fortfront-lf  | 204 | No gfortran oracle for lazy syntax. |
 | lfortran      | 837 | Remaining backlog is mostly feature stacking and architecture. |
 | gfortran-dg   | 1176 | Positive gains are offset by invalid-program acceptance debt. |

--- a/scripts/conformance_gauntlet.sh
+++ b/scripts/conformance_gauntlet.sh
@@ -124,6 +124,12 @@ resolve_skip_manifest() {
     echo "$PROJECT_DIR/test/conformance/skip_${safe_suite}.txt"
 }
 
+resolve_undefined_output_manifest() {
+    local safe_suite
+    safe_suite=${SUITE//-/_}
+    echo "${FFC_UNDEFINED_OUTPUT_MANIFEST:-$PROJECT_DIR/test/conformance/undefined_output_${safe_suite}.txt}"
+}
+
 # File extension for single-extension suites.
 file_extension() {
     case "$SUITE" in
@@ -212,13 +218,24 @@ export FFC_COMPILE_TIMEOUT="$TIMEOUT"
 SUITE_ROOT=$(resolve_suite_root)
 XFAIL_MANIFEST=$(resolve_xfail_manifest)
 SKIP_MANIFEST=$(resolve_skip_manifest)
+UNDEFINED_OUTPUT_MANIFEST=$(resolve_undefined_output_manifest)
 EXT=$(file_extension)
 TMPDIR_WORK=$(mktemp -d /tmp/ffc_gauntlet_XXXXXX)
 trap 'rm -rf "$TMPDIR_WORK"' EXIT
 XFAIL_LOOKUP="$TMPDIR_WORK/xfail_lookup.txt"
 SKIP_LOOKUP="$TMPDIR_WORK/skip_lookup.txt"
+UNDEFINED_OUTPUT_LOOKUP="$TMPDIR_WORK/undefined_output_lookup.txt"
 normalize_manifest "$XFAIL_MANIFEST" "$XFAIL_LOOKUP"
 normalize_manifest "$SKIP_MANIFEST" "$SKIP_LOOKUP"
+normalize_manifest "$UNDEFINED_OUTPUT_MANIFEST" "$UNDEFINED_OUTPUT_LOOKUP"
+manifest_overlap=$(grep -Fxf "$XFAIL_LOOKUP" "$UNDEFINED_OUTPUT_LOOKUP" || true)
+if [ -n "$manifest_overlap" ]; then
+    fail "files cannot be both xfail and undefined-output: $manifest_overlap"
+fi
+manifest_overlap=$(grep -Fxf "$SKIP_LOOKUP" "$UNDEFINED_OUTPUT_LOOKUP" || true)
+if [ -n "$manifest_overlap" ]; then
+    fail "files cannot be both skip and undefined-output: $manifest_overlap"
+fi
 
 # Counters
 PASS_COUNT=0
@@ -564,6 +581,16 @@ while IFS= read -r full_path <&3; do
 
     # Step 6: gfortran failed, but ffc already compiled and ran the file.
     if [ "$ref_exit" -ne 0 ]; then
+        if check_xfail "$UNDEFINED_OUTPUT_LOOKUP" "$rel_path"; then
+            status="FAIL"
+            note="undefined-output reference failed to compile"
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+            HAS_FAIL=1
+            write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+                "$note" "$warning_expectation"
+            echo "  FAIL: $rel_path (undefined-output reference failed)"
+            continue
+        fi
         NOREF_COUNT=$((NOREF_COUNT + 1))
         if check_xfail "$XFAIL_LOOKUP" "$rel_path"; then
             status="XPASS"
@@ -583,6 +610,25 @@ while IFS= read -r full_path <&3; do
     # Step 7: run gfortran reference
     run_capture "$ref_exe" "$ref_out" "$TIMEOUT"
     ref_exit=$?
+
+    if check_xfail "$UNDEFINED_OUTPUT_LOOKUP" "$rel_path"; then
+        if [ "$ffc_exit" -eq 0 ] && [ "$ref_exit" -eq 0 ]; then
+            status="PASS"
+            note="undefined reference output; both executions completed"
+            PASS_COUNT=$((PASS_COUNT + 1))
+            write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+                "$note" "$warning_expectation"
+            continue
+        fi
+        status="FAIL"
+        note="undefined-output execution did not terminate normally"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        HAS_FAIL=1
+        write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+            "$note" "$warning_expectation"
+        echo "  FAIL: $rel_path (undefined-output execution failed)"
+        continue
+    fi
 
     # Step 8: compare outputs.
     if compare_outputs "$ffc_out" "$ref_out" "$ffc_exit" "$ref_exit"; then

--- a/test/conformance/undefined_output_fortfront_f90.txt
+++ b/test/conformance/undefined_output_fortfront_f90.txt
@@ -1,0 +1,4 @@
+# Runtime values are undefined; both compilers must build and terminate normally.
+issue_104_if_condition_identifiers.f90
+issue_2349_data_implied_do.f90
+undefined_var_segfault.f90

--- a/test/conformance/xfail_fortfront_f90.txt
+++ b/test/conformance/xfail_fortfront_f90.txt
@@ -18,9 +18,6 @@ external_tool_example.f90
 f2003_abstract_interface.f90
 f2003_block_construct.f90
 f2003_type_bound_array_call.f90
-# Uninitialized vars: output matches gfortran-14 but mismatches gfortran-16 (local).
-# Kept in xfail so local dev does not FAIL; produces XPASS on CI gfortran-14.
-issue_104_if_condition_identifiers.f90
 issue_1324_if_inside_do_loop.f90
 issue_1353_class_pointer_declaration.f90
 issue_1570_pure_elemental_preservation.f90
@@ -93,9 +90,6 @@ library_usage_ast_node_position.f90
 tmp_goto_ast.f90
 tooling_lightweight_ast.f90
 undefined_var_recursive_type.f90
-# Output matches gfortran-14 (structural) but mismatches gfortran-16 (local).
-# Kept in xfail so local dev does not FAIL; produces XPASS on CI gfortran-14.
-undefined_var_segfault.f90
 # C interoperability: c_funloc/c_funptr/c_f_procpointer and bind(c) procedure
 # pointers are not yet lowered by the direct LIRIC session.
 issue_2814_c_funloc.f90
@@ -123,6 +117,3 @@ issue_2848_dimension_statement.f90  # ff#2848 DIMENSION statement -> unsupported
 issue_2850_bare_function_interface.f90  # ff#2850 bare interface: duplicate decl
 issue_2850_bare_subroutine_interface.f90  # ff#2850 bare interface
 issue_2855_external_intrinsic_conflict.f90  # ff#2855 external/intrinsic conflict
-# DATA with implied-DO: ffc output matches gfortran-16 but mismatches gfortran-14
-# (CI runner). Kept in xfail so CI does not FAIL; produces XPASS locally on gfortran-16+.
-issue_2349_data_implied_do.f90

--- a/test/test_conformance_gauntlet_smoke.f90
+++ b/test/test_conformance_gauntlet_smoke.f90
@@ -28,6 +28,14 @@ program test_conformance_gauntlet_smoke
         '/tmp/ffc_gauntlet_dg_warning.jsonl'
     character(len=*), parameter :: DG_NEGATIVE_REPORT = &
         '/tmp/ffc_gauntlet_dg_negative.jsonl'
+    character(len=*), parameter :: UNDEFINED_REPORT = &
+        '/tmp/ffc_gauntlet_undefined_output.jsonl'
+    character(len=*), parameter :: UNDEFINED_NEGATIVE_REPORT = &
+        '/tmp/ffc_gauntlet_undefined_negative.jsonl'
+    character(len=*), parameter :: UNDEFINED_FIXTURE_ROOT = &
+        '/tmp/ffc_gauntlet_undefined_fortfront'
+    character(len=*), parameter :: UNDEFINED_MANIFEST = &
+        '/tmp/ffc_gauntlet_undefined_manifest.txt'
 
     logical :: all_passed
 
@@ -95,6 +103,7 @@ program test_conformance_gauntlet_smoke
         'unknown selected file')) all_passed = .false.
 
     call run_dg_directive_smoke(all_passed)
+    call run_undefined_output_smoke(all_passed)
 
     if (.not. all_passed) stop 1
     print *, 'PASS: gauntlet smoke test completed with zero FAIL records'
@@ -326,6 +335,88 @@ contains
         write(unit, '(A)') 'end subroutine no_main_accepted'
         close(unit)
     end subroutine write_dg_fixtures
+
+    subroutine run_undefined_output_smoke(passed)
+        logical, intent(inout) :: passed
+
+        if (.not. run_smoke('timeout 120 bash '//SCRIPT// &
+            ' --suite fortfront-f90'// &
+            ' --file issue_104_if_condition_identifiers.f90'// &
+            ' --file undefined_var_segfault.f90'// &
+            ' --file issue_2349_data_implied_do.f90'// &
+            ' --report '//UNDEFINED_REPORT, UNDEFINED_REPORT, 3)) &
+            passed = .false.
+        if (count_lines_with(UNDEFINED_REPORT, &
+            '"status":"PASS"', 'undefined reference output') /= 3) &
+            passed = .false.
+
+        call write_undefined_output_fixture()
+        if (.not. run_failure('FFC_FORTFRONT_DIR='//UNDEFINED_FIXTURE_ROOT// &
+            ' FFC_UNDEFINED_OUTPUT_MANIFEST='//UNDEFINED_MANIFEST// &
+            ' bash '//SCRIPT//' --suite fortfront-f90'// &
+            ' --file undefined_nonzero.f90 --report '// &
+            UNDEFINED_NEGATIVE_REPORT, &
+            'undefined-output execution failed')) passed = .false.
+        if (.not. file_contains(UNDEFINED_NEGATIVE_REPORT, &
+            '"file":"undefined_nonzero.f90","status":"FAIL",'// &
+            '"ffc_exit":1,"ref_exit":1')) &
+            passed = .false.
+
+        call write_undefined_manifest('ast_coverage_control_flow.f90')
+        if (.not. run_failure('FFC_UNDEFINED_OUTPUT_MANIFEST='// &
+            UNDEFINED_MANIFEST//' bash '//SCRIPT//' --suite fortfront-f90', &
+            'both xfail and undefined-output')) passed = .false.
+        call write_undefined_manifest('20231103-1.f90')
+        if (.not. run_failure('FFC_UNDEFINED_OUTPUT_MANIFEST='// &
+            UNDEFINED_MANIFEST//' bash '//SCRIPT//' --suite gfortran-dg', &
+            'both skip and undefined-output')) passed = .false.
+    end subroutine run_undefined_output_smoke
+
+    subroutine write_undefined_output_fixture()
+        integer :: unit
+
+        call execute_command_line('rm -rf '//UNDEFINED_FIXTURE_ROOT)
+        call execute_command_line('mkdir -p '//UNDEFINED_FIXTURE_ROOT// &
+            '/examples/f90')
+        open(newunit=unit, file=UNDEFINED_FIXTURE_ROOT// &
+            '/examples/f90/undefined_nonzero.f90', &
+            status='replace', action='write')
+        write(unit, '(A)') 'program undefined_nonzero'
+        write(unit, '(A)') 'stop 1'
+        write(unit, '(A)') 'end program undefined_nonzero'
+        close(unit)
+        call write_undefined_manifest('undefined_nonzero.f90')
+    end subroutine write_undefined_output_fixture
+
+    subroutine write_undefined_manifest(entry)
+        character(len=*), intent(in) :: entry
+        integer :: unit
+
+        open(newunit=unit, file=UNDEFINED_MANIFEST, status='replace', &
+            action='write')
+        write(unit, '(A)') entry
+        close(unit)
+    end subroutine write_undefined_manifest
+
+    integer function count_lines_with(path, first, second) result(count)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: first
+        character(len=*), intent(in) :: second
+        integer :: unit
+        integer :: io_stat
+        character(len=4096) :: line
+
+        count = 0
+        open(newunit=unit, file=path, status='old', action='read', iostat=io_stat)
+        if (io_stat /= 0) return
+        do
+            read(unit, '(A)', iostat=io_stat) line
+            if (io_stat /= 0) exit
+            if (index(line, first) > 0 .and. index(line, second) > 0) &
+                count = count + 1
+        end do
+        close(unit)
+    end function count_lines_with
 
     logical function is_blank_or_comment(line)
         character(len=*), intent(in) :: line


### PR DESCRIPTION
## Summary

- add an exact manifest for three FortFront programs with undefined printed values
- require both ffc and gfortran builds and zero runtime exits for those files
- ignore stdout only for the named cases and reject manifest overlap
- replace platform-dependent XFAIL/XPASS results with portable PASS records

Closes #441

Invariant: program text, successful compilation, control flow, and normal
termination remain enforced. Only stdout values left undefined by the source
are excluded from comparison.

## Verification

Failing before:

```text
$ scripts/conformance_gauntlet.sh --suite fortfront-f90 --file issue_104_if_condition_identifiers.f90 --file undefined_var_segfault.f90 --file issue_2349_data_implied_do.f90 --report /tmp/ffc-fortfront-variants.jsonl
PASS=0 XFAIL=2 XPASS=1 FAIL=0 TOTAL=3
```

Passing after:

```text
$ scripts/conformance_gauntlet.sh --suite fortfront-f90 --file issue_104_if_condition_identifiers.f90 --file undefined_var_segfault.f90 --file issue_2349_data_implied_do.f90 --report /tmp/ffc-fortfront-undefined.jsonl
PASS=3 XFAIL=0 XPASS=0 FAIL=0 TOTAL=3

$ fo test test_conformance_gauntlet_smoke
1 passed, 0 failed, 0 skipped

$ fo test test_fortfront_corpus_conformance
fortfront-f90: PASS=339 XFAIL=100 XPASS=0 FAIL=0 TOTAL=439
fortfront-lf: PASS=204 XFAIL=59 XPASS=1 FAIL=0 TOTAL=264
1 passed, 0 failed, 0 skipped

$ fo
Static analysis: OK
Build: 377/377
Tests: 246/246
Lint: OK
```

The smoke test also proves nonzero exits remain FAIL and rejects overlap with
xfail or skip manifests.
