### PR TITLE
Fail FortFront gate on XPASS

### DIFF
--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -167,7 +167,7 @@ they contain these normalized entry counts, ignoring comments and blank lines:
 | Manifest | Entries |
 |---|---:|
 | `test/conformance/xfail_fortfront_f90.txt` | 100 |
-| `test/conformance/xfail_fortfront_lf.txt` | 60 |
+| `test/conformance/xfail_fortfront_lf.txt` | 59 |
 | `test/conformance/undefined_output_fortfront_f90.txt` | 3 |
 | `test/conformance/xfail_lfortran.txt` | 3425 |
 | `test/conformance/xfail_gfortran_dg.txt` | 2121 |
@@ -236,6 +236,9 @@ The fpm test `test_fortfront_corpus_conformance` runs the full
 reports under `/tmp`. Passing files need no manifest entry. A new
 FortFront example fails the ffc test until ffc supports it or its
 basename is added to the matching xfail manifest.
+
+The maintained fpm test rejects both FAIL and XPASS records. An XPASS is a
+stale manifest entry and must be promoted before merging.
 
 Current xfail manifests:
 

--- a/docs/PARITY_PLAN.md
+++ b/docs/PARITY_PLAN.md
@@ -22,7 +22,7 @@ Current checked-in manifest counts in this checkout:
 | Suite | XFAIL entries | SKIP entries |
 |-------|--------------:|-------------:|
 | fortfront-f90 | 100 | 0 |
-| fortfront-lf  | 60  | 0 |
+| fortfront-lf  | 59  | 0 |
 | lfortran      | 3425 | 0 |
 | gfortran-dg   | 2121 | 2371 |
 
@@ -31,7 +31,7 @@ Latest recorded full-dashboard state in #299 after wave 14:
 | Suite | PASS | Notes |
 |-------|-----:|-------|
 | fortfront-f90 | 339 | Three undefined-output cases use a version-independent completion oracle. |
-| fortfront-lf  | 204 | No gfortran oracle for lazy syntax. |
+| fortfront-lf  | 205 | No gfortran oracle for lazy syntax. |
 | lfortran      | 837 | Remaining backlog is mostly feature stacking and architecture. |
 | gfortran-dg   | 1176 | Positive gains are offset by invalid-program acceptance debt. |
 

--- a/test/conformance/xfail_fortfront_lf.txt
+++ b/test/conformance/xfail_fortfront_lf.txt
@@ -26,7 +26,6 @@ issue_1814_nested_lazy_function.lf
 issue_1816_multiple_return_values.lf
 issue_1816_multiple_returns.lf
 issue_1968_lazy_function_result.lf
-issue_1973_empty_typed_array_constructor.lf
 issue_2012_subroutine_local_not_inferred.lf
 issue_2062_nested_do_missing_var_type_mismatch.lf
 issue_2063_deferred_char_function_syntax.lf

--- a/test/test_fortfront_corpus_conformance.f90
+++ b/test/test_fortfront_corpus_conformance.f90
@@ -12,12 +12,15 @@ program test_fortfront_corpus_conformance
         '/tmp/ffc_fortfront_f90_corpus.out'
     character(len=*), parameter :: LF_LOG = &
         '/tmp/ffc_fortfront_lf_corpus.out'
+    character(len=*), parameter :: SYNTHETIC_XPASS_REPORT = &
+        '/tmp/ffc_fortfront_synthetic_xpass.jsonl'
 
     integer :: failed
 
     print *, '=== fortfront corpus conformance test ==='
 
     failed = 0
+    call verify_xpass_rejection(failed)
     call run_suite('fortfront-f90', F90_REPORT, F90_LOG, 439, failed)
     call run_suite('fortfront-lf', LF_REPORT, LF_LOG, 264, failed)
 
@@ -34,10 +37,7 @@ contains
         integer, intent(inout) :: failed
         character(len=:), allocatable :: cmd
         character(len=32) :: timeout_text
-        character(len=32) :: expected_text
-        character(len=4096) :: summary
         integer :: exit_stat
-        logical :: has_summary
 
         write (timeout_text, '(I0)') RUN_TIMEOUT_SECONDS
         call execute_command_line('rm -f '//report//' '//log_path)
@@ -56,6 +56,19 @@ contains
             return
         end if
 
+        call validate_report(suite, report, expected_total, failed)
+    end subroutine run_suite
+
+    subroutine validate_report(suite, report, expected_total, failed)
+        character(len=*), intent(in) :: suite
+        character(len=*), intent(in) :: report
+        integer, intent(in) :: expected_total
+        integer, intent(inout) :: failed
+        character(len=32) :: expected_text
+        character(len=4096) :: summary
+        logical :: has_summary
+        logical :: rejects_report
+
         call read_summary(report, summary, has_summary)
         if (.not. has_summary) then
             failed = failed + 1
@@ -65,22 +78,59 @@ contains
 
         print *, trim(suite)//' summary: '//trim(summary)
 
+        rejects_report = .false.
         if (index(summary, '"fail":0') == 0) then
-            failed = failed + 1
+            rejects_report = .true.
             print *, 'FAIL[', suite, ']: SUMMARY has nonzero FAIL count'
         end if
 
         if (index(summary, '"xpass":0') == 0) then
+            rejects_report = .true.
+            print *, 'FAIL[', suite, ']: SUMMARY has nonzero XPASS count'
+        end if
+
+        if (rejects_report) then
+            failed = failed + 1
             call print_failures(report)
         end if
 
-        write (expected_text, '(A,I0)') '"total":', expected_total
+        write (expected_text, '(A,I0,A)') '"total":', expected_total, '}'
         if (index(summary, trim(expected_text)) == 0) then
             failed = failed + 1
             print *, 'FAIL[', suite, ']: SUMMARY total differs from ', &
                 expected_total
         end if
-    end subroutine run_suite
+    end subroutine validate_report
+
+    subroutine verify_xpass_rejection(failed)
+        integer, intent(inout) :: failed
+        integer :: synthetic_failures
+
+        call write_synthetic_xpass_report()
+        synthetic_failures = 0
+        call validate_report('synthetic-xpass', SYNTHETIC_XPASS_REPORT, 1, &
+            synthetic_failures)
+        if (synthetic_failures /= 1) then
+            failed = failed + 1
+            print *, 'FAIL: synthetic XPASS did not fail report validation'
+        end if
+    end subroutine verify_xpass_rejection
+
+    subroutine write_synthetic_xpass_report()
+        integer :: unit
+
+        open(newunit=unit, file=SYNTHETIC_XPASS_REPORT, status='replace', &
+            action='write')
+        write(unit, '(A)') &
+            '{"suite":"synthetic-xpass","file":"stale.f90",'// &
+            '"status":"XPASS","ffc_exit":0,"ref_exit":0,'// &
+            '"note":"synthetic stale manifest entry"}'
+        write(unit, '(A)') &
+            '{"suite":"synthetic-xpass","status":"SUMMARY",'// &
+            '"pass":0,"xfail":0,"xpass":1,"fail":0,'// &
+            '"noref":0,"skip":0,"warning_unchecked":0,"total":1}'
+        close(unit)
+    end subroutine write_synthetic_xpass_report
 
     subroutine print_failures(report)
         character(len=*), intent(in) :: report


### PR DESCRIPTION
## Summary

- reject nonzero XPASS counts in the maintained FortFront report validator
- exercise the live validation path with a synthetic stale manifest entry
- promote the remaining deterministic LF XPASS
- synchronize maintained corpus counts and gate documentation

Closes #341

## Verification

Failing before:

```text
$ scripts/conformance_gauntlet.sh --suite fortfront-lf --file issue_1973_empty_typed_array_constructor.lf --report /tmp/ffc-341-before.jsonl
{"suite":"fortfront-lf","file":"issue_1973_empty_typed_array_constructor.lf","status":"XPASS","ffc_exit":0,"ref_exit":-1,"note":"listed in xfail manifest but ffc ran successfully"}
{"suite":"fortfront-lf","status":"SUMMARY","pass":0,"xfail":0,"xpass":1,"fail":0,"noref":0,"skip":0,"warning_unchecked":0,"total":1}
```

Passing after:

```text
$ fo test test_fortfront_corpus_conformance
1 passed, 0 failed, 0 skipped

$ tail -1 /tmp/ffc_fortfront_f90_corpus.jsonl
{"suite":"fortfront-f90","status":"SUMMARY","pass":339,"xfail":100,"xpass":0,"fail":0,"noref":94,"skip":0,"warning_unchecked":0,"total":439}

$ tail -1 /tmp/ffc_fortfront_lf_corpus.jsonl
{"suite":"fortfront-lf","status":"SUMMARY","pass":205,"xfail":59,"xpass":0,"fail":0,"noref":0,"skip":0,"warning_unchecked":0,"total":264}

$ fo
Static analysis: OK
Build: 377/377
Tests: 246/246
Lint: OK
```

The synthetic report is expected to fail its local validation count; the outer
test passes only when that rejection occurs exactly once. Live reports contain
no XPASS records.
