### PR TITLE
Pin external corpus CI buckets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,52 @@ jobs:
         with:
           path: ffc
 
+      - name: Read corpus pins
+        id: corpus_pins
+        working-directory: ffc
+        run: scripts/fetch_corpora.sh --print-pins >> "$GITHUB_OUTPUT"
+
+      - name: Restore LFortran corpus
+        id: lfortran_cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/lfortran
+          key: corpus-v1-${{ runner.os }}-lfortran-${{ steps.corpus_pins.outputs.lfortran_sha }}
+
+      - name: Restore gfortran.dg corpus
+        id: gcc_cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/gcc
+          key: corpus-v1-${{ runner.os }}-gcc-gfortran-dg-${{ steps.corpus_pins.outputs.gcc_sha }}
+
+      - name: Fetch and verify pinned corpora
+        working-directory: ffc
+        env:
+          FFC_LFORTRAN_DIR: ${{ github.workspace }}/lfortran
+          FFC_GFORTRAN_DG_DIR: ${{ github.workspace }}/gcc/gcc/testsuite/gfortran.dg
+        run: scripts/fetch_corpora.sh
+
+      - name: Test corpus verifier
+        working-directory: ffc
+        env:
+          FFC_LFORTRAN_DIR: ${{ github.workspace }}/lfortran
+        run: test/test_fetch_corpora.sh
+
+      - name: Save LFortran corpus
+        if: steps.lfortran_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/lfortran
+          key: corpus-v1-${{ runner.os }}-lfortran-${{ steps.corpus_pins.outputs.lfortran_sha }}
+
+      - name: Save gfortran.dg corpus
+        if: steps.gcc_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/gcc
+          key: corpus-v1-${{ runner.os }}-gcc-gfortran-dg-${{ steps.corpus_pins.outputs.gcc_sha }}
+
       - name: Checkout fortfront (sibling path)
         uses: actions/checkout@v4
         with:
@@ -70,3 +116,15 @@ jobs:
         env:
           LIBRARY_PATH: ${{ github.workspace }}/liric/build
         run: fpm test
+
+      - name: Run pinned corpus buckets
+        working-directory: ffc
+        env:
+          LIBRARY_PATH: ${{ github.workspace }}/liric/build
+          FFC_LFORTRAN_DIR: ${{ github.workspace }}/lfortran
+          FFC_GFORTRAN_DG_DIR: ${{ github.workspace }}/gcc/gcc/testsuite/gfortran.dg
+        run: |
+          scripts/conformance_check.sh --no-build --suite lfortran \
+            --files-from test/conformance/ci_lfortran.txt
+          scripts/conformance_check.sh --no-build --suite gfortran-dg \
+            --files-from test/conformance/ci_gfortran_dg.txt

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -22,16 +22,25 @@ referenced by path.
 
 ## Fetching corpora
 
-`scripts/fetch_corpora.sh` clones the external corpora to the default
-sibling paths: a shallow lfortran clone and a blobless sparse checkout
-of `gcc/testsuite/gfortran.dg` from the GCC mirror. Existing checkouts
-are left untouched; `--update` pulls the latest upstream. A corpus
-argument (`lfortran`, `gfortran-dg`) restricts the fetch.
+`scripts/fetch_corpora.sh` checks out reviewed external corpus revisions at
+the default sibling paths: a shallow LFortran clone and a blobless sparse GCC
+checkout containing `gcc/testsuite/gfortran.dg`. Existing checkouts must
+already match the detached pins; the script never repairs a stale or corrupt
+cache. A corpus argument (`lfortran`, `gfortran-dg`) restricts the operation.
 
 ```bash
-scripts/fetch_corpora.sh              # fetch anything missing
-scripts/fetch_corpora.sh --update     # pull latest upstream
+scripts/fetch_corpora.sh               # fetch or verify both pins
+scripts/fetch_corpora.sh --verify-only # verify without fetching
 ```
+
+| Corpus | Pinned revision |
+|---|---|
+| LFortran | `caf87b660f803148f000046392a5da803f9fc630` |
+| GCC gfortran.dg | `395e3d8131c189cd58e8c8061cdc77d1c44e3822` |
+
+Update a pin by changing its full SHA in `scripts/fetch_corpora.sh` and
+reviewing the resulting corpus reports. CI cache keys include that SHA and do
+not use prefix restore keys, so another revision cannot satisfy the cache.
 
 ## Environment variables
 
@@ -145,8 +154,8 @@ manifest. Promote by removing the entry from the manifest.
 repositories. `scripts/fetch_corpora.sh` handles this:
 
 ```bash
-scripts/fetch_corpora.sh              # clone missing corpora to sibling dirs
-scripts/fetch_corpora.sh --update     # pull latest upstream
+scripts/fetch_corpora.sh               # fetch or verify pinned revisions
+scripts/fetch_corpora.sh --verify-only # verify exact revisions only
 ```
 
 Alternatively, set the environment variables to point at existing checkouts:
@@ -158,6 +167,15 @@ Alternatively, set the environment variables to point at existing checkouts:
 
 When the conformance check script finds the directory, it includes the suite
 automatically. When absent, it prints a SKIP message.
+
+CI restores and verifies separate exact-revision caches, then runs these named
+buckets through `conformance_check.sh`:
+
+- `test/conformance/ci_lfortran.txt`: `common_39.f90`
+- `test/conformance/ci_gfortran_dg.txt`: `host_assoc_function_3.f90`
+
+The expected selected total is one for each suite. Cache misses fetch and verify the
+same detached revisions before saving; cache hits run the identical verifier.
 
 ## Current checked-in manifests
 

--- a/scripts/fetch_corpora.sh
+++ b/scripts/fetch_corpora.sh
@@ -2,10 +2,10 @@
 # fetch_corpora.sh: fetch external conformance corpora next to this checkout.
 #
 # Usage:
-#   scripts/fetch_corpora.sh [--update] [lfortran|gfortran-dg ...]
+#   scripts/fetch_corpora.sh [--verify-only] [lfortran|gfortran-dg ...]
+#   scripts/fetch_corpora.sh --print-pins
 #
-# With no corpus arguments, fetches all corpora. Existing checkouts are
-# left untouched unless --update is given, which pulls the latest upstream.
+# With no corpus arguments, fetches or verifies both pinned corpora.
 #
 # Destinations match the conformance gauntlet defaults (sibling directories
 # under the parent of this repository) and honor the same overrides:
@@ -24,53 +24,129 @@ PARENT="$(dirname "$REPO_ROOT")"
 
 LFORTRAN_URL="https://github.com/lfortran/lfortran"
 GCC_URL="https://github.com/gcc-mirror/gcc"
+LFORTRAN_SHA="caf87b660f803148f000046392a5da803f9fc630"
+GCC_SHA="395e3d8131c189cd58e8c8061cdc77d1c44e3822"
 
-UPDATE=0
+if [ "${FFC_CORPUS_TEST_MODE:-0}" = "1" ]; then
+    LFORTRAN_URL="${FFC_LFORTRAN_URL:?}"
+    GCC_URL="${FFC_GCC_URL:?}"
+    LFORTRAN_SHA="${FFC_LFORTRAN_SHA:?}"
+    GCC_SHA="${FFC_GCC_SHA:?}"
+fi
+
+VERIFY_ONLY=0
 CORPORA=()
+
+for pin in "$LFORTRAN_SHA" "$GCC_SHA"; do
+    if [[ ! "$pin" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "ERROR: corpus pin must be a lowercase 40-hex SHA: $pin" >&2
+        exit 2
+    fi
+done
 
 for arg in "$@"; do
     case "$arg" in
-        --update) UPDATE=1 ;;
+        --verify-only) VERIFY_ONLY=1 ;;
+        --print-pins)
+            printf 'lfortran_sha=%s\ngcc_sha=%s\n' "$LFORTRAN_SHA" "$GCC_SHA"
+            exit 0 ;;
         lfortran|gfortran-dg) CORPORA+=("$arg") ;;
-        *) echo "usage: $0 [--update] [lfortran|gfortran-dg ...]" >&2; exit 2 ;;
+        *) echo "usage: $0 [--verify-only] [lfortran|gfortran-dg ...]" >&2; exit 2 ;;
     esac
 done
 [ ${#CORPORA[@]} -eq 0 ] && CORPORA=(lfortran gfortran-dg)
 
+normalized_url() {
+    local url="$1"
+    url=${url%/}
+    printf '%s\n' "${url%.git}"
+}
+
+verify_checkout() {
+    local name="$1" dir="$2" url="$3" sha="$4" required_dir="$5"
+    local actual_url actual_sha
+    if [ ! -d "$dir/.git" ]; then
+        echo "ERROR: $name checkout missing at $dir" >&2
+        return 1
+    fi
+    actual_url=$(git -C "$dir" config --get remote.origin.url)
+    if [ "$(normalized_url "$actual_url")" != "$(normalized_url "$url")" ]; then
+        echo "ERROR: $name origin is $actual_url, expected $url" >&2
+        return 1
+    fi
+    if [ -n "$(git -C "$dir" status --porcelain)" ]; then
+        echo "ERROR: $name checkout is dirty at $dir" >&2
+        return 1
+    fi
+    actual_sha=$(git -C "$dir" rev-parse HEAD)
+    if [ "$actual_sha" != "$sha" ]; then
+        echo "ERROR: $name HEAD is $actual_sha, expected $sha" >&2
+        return 1
+    fi
+    if git -C "$dir" symbolic-ref -q HEAD >/dev/null; then
+        echo "ERROR: $name checkout must be detached at $sha" >&2
+        return 1
+    fi
+    if [ ! -d "$required_dir" ] || \
+        ! find "$required_dir" -maxdepth 1 -name '*.f90' -type f -print -quit | grep -q .; then
+        echo "ERROR: $name corpus is incomplete at $required_dir" >&2
+        return 1
+    fi
+    echo "$name pinned at $actual_sha"
+}
+
+fetch_exact() {
+    local name="$1" dir="$2" url="$3" sha="$4" required_dir="$5"
+    local sparse_path="${6:-}"
+    local object_filter="${7:-}"
+    local fetch_args=(--depth 1)
+    if [ -d "$dir/.git" ]; then
+        verify_checkout "$name" "$dir" "$url" "$sha" "$required_dir"
+        return
+    fi
+    if [ "$VERIFY_ONLY" -eq 1 ]; then
+        echo "ERROR: $name checkout missing at $dir" >&2
+        return 1
+    fi
+    if [ -e "$dir" ] && \
+        find "$dir" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+        echo "ERROR: $name path exists but is not a git checkout: $dir" >&2
+        return 1
+    fi
+    mkdir -p "$dir"
+    git -C "$dir" init
+    git -C "$dir" remote add origin "$url"
+    if [ -n "$sparse_path" ]; then
+        git -C "$dir" sparse-checkout init --cone
+        git -C "$dir" sparse-checkout set "$sparse_path"
+    fi
+    if [ -n "$object_filter" ]; then
+        fetch_args+=("--filter=$object_filter")
+    fi
+    git -C "$dir" fetch "${fetch_args[@]}" origin "$sha"
+    git -C "$dir" checkout --detach "$sha"
+    verify_checkout "$name" "$dir" "$url" "$sha" "$required_dir"
+}
+
 fetch_lfortran() {
     local dir="${FFC_LFORTRAN_DIR:-$PARENT/lfortran}"
-    if [ -d "$dir/.git" ]; then
-        if [ "$UPDATE" -eq 1 ]; then
-            echo "updating lfortran at $dir"
-            git -C "$dir" pull --ff-only
-        else
-            echo "lfortran present at $dir ($(git -C "$dir" rev-parse --short HEAD))"
-        fi
-    else
-        echo "cloning lfortran to $dir"
-        git clone --depth 1 "$LFORTRAN_URL" "$dir"
-    fi
+    fetch_exact "lfortran" "$dir" "$LFORTRAN_URL" "$LFORTRAN_SHA" \
+        "$dir/integration_tests"
 }
 
 fetch_gfortran_dg() {
     local dg_dir="${FFC_GFORTRAN_DG_DIR:-$PARENT/gcc/gcc/testsuite/gfortran.dg}"
     local gcc_root="${dg_dir%/gcc/testsuite/gfortran.dg}"
     if [ "$gcc_root" = "$dg_dir" ]; then
-        echo "FFC_GFORTRAN_DG_DIR must end in gcc/testsuite/gfortran.dg" >&2
-        exit 2
+        echo "ERROR: FFC_GFORTRAN_DG_DIR must end in gcc/testsuite/gfortran.dg" >&2
+        return 2
     fi
-    if [ -d "$gcc_root/.git" ]; then
-        if [ "$UPDATE" -eq 1 ]; then
-            echo "updating gcc sparse checkout at $gcc_root"
-            git -C "$gcc_root" pull --ff-only
-        else
-            echo "gcc present at $gcc_root ($(git -C "$gcc_root" rev-parse --short HEAD))"
-        fi
-    else
-        echo "sparse-cloning gcc gfortran.dg to $gcc_root"
-        git clone --filter=blob:none --no-checkout --depth 1 "$GCC_URL" "$gcc_root"
-        git -C "$gcc_root" sparse-checkout set gcc/testsuite/gfortran.dg
-        git -C "$gcc_root" checkout
+    fetch_exact "gcc" "$gcc_root" "$GCC_URL" "$GCC_SHA" "$dg_dir" \
+        "gcc/testsuite/gfortran.dg" "blob:none"
+    if [ "$(git -C "$gcc_root" sparse-checkout list)" != \
+        "gcc/testsuite/gfortran.dg" ]; then
+        echo "ERROR: gcc sparse checkout does not select gfortran.dg" >&2
+        return 1
     fi
     echo "gfortran.dg files: $(find "$dg_dir" -maxdepth 1 -name '*.f90' | wc -l)"
 }

--- a/test/conformance/ci_gfortran_dg.txt
+++ b/test/conformance/ci_gfortran_dg.txt
@@ -1,0 +1,2 @@
+# Host-association regression from issue #304
+host_assoc_function_3.f90

--- a/test/conformance/ci_lfortran.txt
+++ b/test/conformance/ci_lfortran.txt
@@ -1,0 +1,2 @@
+# COMMON regression from issue #305
+common_39.f90

--- a/test/test_fetch_corpora.sh
+++ b/test/test_fetch_corpora.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROJECT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+FETCH="$PROJECT_DIR/scripts/fetch_corpora.sh"
+SOURCE="${FFC_LFORTRAN_DIR:-$(dirname "$PROJECT_DIR")/lfortran}"
+PIN=$("$FETCH" --print-pins | sed -n 's/^lfortran_sha=//p')
+EXPECTED_URL="https://github.com/lfortran/lfortran"
+WORK=$(mktemp -d /tmp/ffc_fetch_test_XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+
+make_checkout() {
+    local dir="$1"
+    git clone --shared "$SOURCE" "$dir" >/dev/null 2>&1
+    git -C "$dir" remote set-url origin "$EXPECTED_URL"
+    git -C "$dir" checkout --detach "$PIN" >/dev/null 2>&1
+}
+
+create_origin() {
+    local repo="$1" bare="$2" source_path="$3"
+    git init "$repo" >/dev/null
+    git -C "$repo" config user.name test
+    git -C "$repo" config user.email test@example.invalid
+    mkdir -p "$repo/$(dirname "$source_path")"
+    printf 'program smoke\nend program smoke\n' > "$repo/$source_path"
+    git -C "$repo" add "$source_path"
+    git -C "$repo" commit -m initial >/dev/null
+    git clone --bare "$repo" "$bare" >/dev/null 2>&1
+    git -C "$bare" config uploadpack.allowFilter true
+}
+
+run_test_fetch() {
+    FFC_CORPUS_TEST_MODE=1 \
+        FFC_LFORTRAN_URL="file://$LF_ORIGIN" \
+        FFC_GCC_URL="file://$GCC_ORIGIN" \
+        FFC_LFORTRAN_SHA="$LF_TEST_SHA" \
+        FFC_GCC_SHA="$GCC_TEST_SHA" \
+        FFC_LFORTRAN_DIR="$LF_TARGET" \
+        FFC_GFORTRAN_DG_DIR="$GCC_TARGET/gcc/testsuite/gfortran.dg" \
+        "$FETCH" "$@"
+}
+
+expect_failure() {
+    local name="$1" expected="$2" dir="$3" mode="${4:-verify}"
+    local output
+    if [ "$mode" = "normal" ]; then
+        if output=$(FFC_LFORTRAN_DIR="$dir" "$FETCH" lfortran 2>&1); then
+            echo "FAIL: $name unexpectedly passed" >&2
+            return 1
+        fi
+    else
+        if output=$(FFC_LFORTRAN_DIR="$dir" "$FETCH" --verify-only lfortran 2>&1); then
+            echo "FAIL: $name unexpectedly passed" >&2
+            return 1
+        fi
+    fi
+    if ! grep -Fq "$expected" <<< "$output"; then
+        echo "FAIL: $name missing diagnostic: $expected" >&2
+        echo "$output" >&2
+        return 1
+    fi
+}
+
+expect_failure "missing" "checkout missing" "$WORK/missing"
+
+make_checkout "$WORK/wrong-origin"
+git -C "$WORK/wrong-origin" remote set-url origin https://example.invalid/lfortran
+expect_failure "wrong origin" "origin is" "$WORK/wrong-origin"
+
+make_checkout "$WORK/attached"
+git -C "$WORK/attached" switch -c test-attached >/dev/null 2>&1
+expect_failure "attached" "must be detached" "$WORK/attached" "normal"
+
+make_checkout "$WORK/dirty"
+touch "$WORK/dirty/untracked.marker"
+expect_failure "dirty" "checkout is dirty" "$WORK/dirty"
+
+make_checkout "$WORK/wrong-sha"
+git -C "$WORK/wrong-sha" -c user.name=test -c user.email=test@example.invalid \
+    commit --allow-empty -m drift >/dev/null 2>&1
+expect_failure "wrong SHA" "HEAD is" "$WORK/wrong-sha"
+
+make_checkout "$WORK/incomplete"
+git -C "$WORK/incomplete" sparse-checkout init --cone
+git -C "$WORK/incomplete" sparse-checkout set src
+expect_failure "incomplete" "corpus is incomplete" "$WORK/incomplete"
+
+mkdir -p "$WORK/non-git"
+touch "$WORK/non-git/marker"
+expect_failure "non-git" "not a git checkout" "$WORK/non-git" "normal"
+
+LF_REPO="$WORK/lfortran-repo"
+LF_ORIGIN="$WORK/lfortran-origin.git"
+GCC_REPO="$WORK/gcc-repo"
+GCC_ORIGIN="$WORK/gcc-origin.git"
+LF_TARGET="$WORK/lfortran-fresh"
+GCC_TARGET="$WORK/gcc-fresh"
+create_origin "$LF_REPO" "$LF_ORIGIN" "integration_tests/smoke.f90"
+create_origin "$GCC_REPO" "$GCC_ORIGIN" \
+    "gcc/testsuite/gfortran.dg/smoke.f90"
+LF_TEST_SHA=$(git -C "$LF_REPO" rev-parse HEAD)
+GCC_TEST_SHA=$(git -C "$GCC_REPO" rev-parse HEAD)
+
+run_test_fetch >/dev/null
+test "$(git -C "$LF_TARGET" rev-parse HEAD)" = "$LF_TEST_SHA"
+test "$(git -C "$GCC_TARGET" rev-parse HEAD)" = "$GCC_TEST_SHA"
+! git -C "$LF_TARGET" symbolic-ref -q HEAD >/dev/null
+! git -C "$GCC_TARGET" symbolic-ref -q HEAD >/dev/null
+test "$(git -C "$GCC_TARGET" sparse-checkout list)" = \
+    "gcc/testsuite/gfortran.dg"
+test "$(git -C "$GCC_TARGET" config --get remote.origin.promisor)" = "true"
+test "$(git -C "$GCC_TARGET" config --get remote.origin.partialclonefilter)" = \
+    "blob:none"
+
+mv "$LF_ORIGIN" "$LF_ORIGIN.offline"
+mv "$GCC_ORIGIN" "$GCC_ORIGIN.offline"
+run_test_fetch --verify-only >/dev/null
+mv "$LF_ORIGIN.offline" "$LF_ORIGIN"
+mv "$GCC_ORIGIN.offline" "$GCC_ORIGIN"
+
+UNREACHABLE_SENTINEL="$WORK/suite-ran"
+if FFC_CORPUS_TEST_MODE=1 \
+    FFC_LFORTRAN_URL="file://$LF_ORIGIN" \
+    FFC_GCC_URL="file://$GCC_ORIGIN" \
+    FFC_LFORTRAN_SHA="0000000000000000000000000000000000000000" \
+    FFC_GCC_SHA="$GCC_TEST_SHA" \
+    FFC_LFORTRAN_DIR="$WORK/unreachable" \
+    "$FETCH" lfortran >/dev/null 2>&1 && touch "$UNREACHABLE_SENTINEL"; then
+    echo "FAIL: unreachable pin unexpectedly fetched" >&2
+    exit 1
+fi
+test ! -e "$UNREACHABLE_SENTINEL"
+
+FFC_LFORTRAN_DIR="$SOURCE" "$FETCH" --verify-only lfortran >/dev/null
+echo "PASS: pinned corpus verifier rejects invalid checkouts"


### PR DESCRIPTION
## Summary

- pin exact LFortran and GCC corpus revisions in the fetcher
- reject stale, dirty, attached, wrong-origin, and incomplete cached checkouts
- restore, verify, test, and save separate SHA-keyed CI caches without fallback keys
- run one reviewed regression from each external corpus on every CI job

Closes #398

## Verification

Failing before:

```text
$ scripts/fetch_corpora.sh --print-pins
usage: scripts/fetch_corpora.sh [--update] [lfortran|gfortran-dg ...]
```

Passing after:

```text
$ scripts/fetch_corpora.sh --print-pins
lfortran_sha=caf87b660f803148f000046392a5da803f9fc630
gcc_sha=395e3d8131c189cd58e8c8061cdc77d1c44e3822

$ scripts/fetch_corpora.sh --verify-only
lfortran pinned at caf87b660f803148f000046392a5da803f9fc630
gcc pinned at 395e3d8131c189cd58e8c8061cdc77d1c44e3822
gfortran.dg files: 5938

$ test/test_fetch_corpora.sh
PASS: pinned corpus verifier rejects invalid checkouts

$ scripts/conformance_check.sh --no-build --suite lfortran --files-from test/conformance/ci_lfortran.txt
PASS=1 XFAIL=0 XPASS=0 FAIL=0 TOTAL=1

$ scripts/conformance_check.sh --no-build --suite gfortran-dg --files-from test/conformance/ci_gfortran_dg.txt
PASS=1 XFAIL=0 XPASS=0 FAIL=0 TOTAL=1

$ fo
Static analysis: OK
Build: 377/377
Tests: 246/246
Lint: OK
```

The verifier test covers fresh LFortran and sparse/blobless GCC fetches,
detached exact SHAs, offline cache hits, invalid cache states, and an
unreachable pin that cannot reach a downstream suite sentinel.

CI cache acceptance:

```text
Attempt 1: LFortran MISS, GCC MISS; both exact keys saved; job passed
Attempt 2: LFortran HIT, GCC HIT; both save steps skipped; job passed
```
