### PR TITLE
Require ownership metadata for conformance manifests

### DIFF
--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -187,8 +187,8 @@ they contain these normalized entry counts, ignoring comments and blank lines:
 | `test/conformance/xfail_fortfront_f90.txt` | 100 |
 | `test/conformance/xfail_fortfront_lf.txt` | 59 |
 | `test/conformance/undefined_output_fortfront_f90.txt` | 3 |
-| `test/conformance/xfail_lfortran.txt` | 3425 |
-| `test/conformance/xfail_gfortran_dg.txt` | 2141 |
+| `test/conformance/xfail_lfortran.txt` | 3421 |
+| `test/conformance/xfail_gfortran_dg.txt` | 2136 |
 | `test/conformance/skip_lfortran.txt` | 0 |
 | `test/conformance/skip_gfortran_dg.txt` | 2298 |
 
@@ -241,8 +241,8 @@ records are `PASS` unless the file is still listed in the xfail manifest,
 in which case they are `XPASS`.
 
 The `skip` summary count is the number of files listed in
-`test/conformance/skip_<suite>.txt`. Skip lines use the format
-`basename.f90 # reason`. They are explicit entries, not silent drops.
+`test/conformance/skip_<suite>.txt`. They are explicit entries, not silent
+drops.
 
 The `warning_unchecked` count is the number of warning-only gfortran.dg files
 whose compile or run disposition was checked without matching warning text.
@@ -309,9 +309,33 @@ not claim warning-text parity.
 ### Skip manifest
 
 `test/conformance/skip_gfortran_dg.txt` lists files the runner skips.
-Lines use the format `basename.f90 # reason`. Reasons are `multifile`,
-`flags`, or `directive`. The runner exits nonzero for files that trigger
-a skip reason but are not listed in the manifest.
+The runner exits nonzero for files that trigger a skip reason but are not
+listed in the manifest.
+
+### Expected-disposition metadata
+
+Every xfail and skip entry names either one implementation issue or one
+excluded scope and gives a reason:
+
+```text
+basename.f90 # owner=ORG/REPO#123; reason=nonempty text
+basename.f90 # scope=OpenMP; reason=nonempty text
+```
+
+Allowed scope values are `coarray`, `OpenMP`, `OpenACC`, `GPU`, `vendor`,
+`legacy`, `compiler-flags`, and `harness`. The last two cover tests whose result
+depends on unmodeled compiler options or DejaGNU behavior rather than the source alone.
+Owner syntax and metadata are validated offline during every gauntlet run. The
+ordinary runner does not contact GitHub. Use the explicit liveness audit to
+require every referenced issue to be open:
+
+```bash
+scripts/audit_manifest_owners.sh
+```
+
+Duplicate paths and malformed entries fail with the manifest path and line
+number. Undefined-output manifests remain plain filename lists because they
+describe the comparison oracle, not an expected failure or skip.
 
 ### Seed baseline
 
@@ -323,7 +347,7 @@ from the FAIL records of this run.
 ### Current pinned measurement
 
 At GCC revision `395e3d8131c189cd58e8c8061cdc77d1c44e3822`, the post-cleanup
-summary is `PASS=1170`, `XFAIL=2132`, `XPASS=5`, `FAIL=333`, `NOREF=4`,
+summary is `PASS=1175`, `XFAIL=2132`, `XPASS=0`, `FAIL=333`, `NOREF=1`,
 `SKIP=2298`, `WARNING_UNCHECKED=75`, `TOTAL=5938`.
 
 ## LFortran integration tests
@@ -346,6 +370,10 @@ are:
 Seed baseline from lfortran commit `5e3229bd6`: `PASS=123`,
 `XFAIL=4134`, `XPASS=0`, `FAIL=0`, `NOREF=72`, `SKIP=0`,
 `TOTAL=4257`.
+
+At LFortran revision `caf87b660f803148f000046392a5da803f9fc630`, the current
+summary is `PASS=848`, `XFAIL=3421`, `XPASS=0`, `FAIL=11`, `NOREF=145`,
+`SKIP=0`, `TOTAL=4280`.
 
 ## Separate compilation
 

--- a/docs/PARITY_PLAN.md
+++ b/docs/PARITY_PLAN.md
@@ -23,8 +23,8 @@ Current checked-in manifest counts in this checkout:
 |-------|--------------:|-------------:|
 | fortfront-f90 | 100 | 0 |
 | fortfront-lf  | 59  | 0 |
-| lfortran      | 3425 | 0 |
-| gfortran-dg   | 2141 | 2298 |
+| lfortran      | 3421 | 0 |
+| gfortran-dg   | 2136 | 2298 |
 
 Latest recorded full-dashboard state in #299 after wave 14:
 

--- a/scripts/audit_manifest_owners.sh
+++ b/scripts/audit_manifest_owners.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib_expected_manifest.sh"
+
+if [ "$#" -gt 0 ]; then
+    MANIFESTS=("$@")
+else
+    MANIFESTS=("$PROJECT_DIR"/test/conformance/xfail_*.txt)
+    MANIFESTS+=("$PROJECT_DIR"/test/conformance/skip_*.txt)
+fi
+
+TMPDIR_WORK=$(mktemp -d /tmp/ffc_manifest_audit_XXXXXX)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+OWNER_LIST="$TMPDIR_WORK/owners.txt"
+: > "$OWNER_LIST"
+
+for manifest in "${MANIFESTS[@]}"; do
+    if [ ! -f "$manifest" ]; then
+        printf 'ERROR: manifest not found: %s\n' "$manifest" >&2
+        exit 1
+    fi
+    validate_expected_manifest "$manifest" "$TMPDIR_WORK/lookup.txt" || exit 1
+    manifest_owner_references "$manifest" >> "$OWNER_LIST"
+done
+
+sort -u "$OWNER_LIST" -o "$OWNER_LIST"
+failed=0
+while IFS= read -r owner; do
+    [ -z "$owner" ] && continue
+    repository=${owner%#*}
+    issue_number=${owner##*#}
+    state=$(gh issue view "$issue_number" --repo "$repository" \
+        --json state --jq .state 2>/dev/null) || state="MISSING"
+    if [ "$state" != "OPEN" ]; then
+        printf 'ERROR: owner %s is %s\n' "$owner" "$state" >&2
+        failed=1
+    fi
+done < "$OWNER_LIST"
+
+if [ "$failed" -ne 0 ]; then
+    exit 1
+fi
+printf 'PASS: %s open manifest owners\n' "$(wc -l < "$OWNER_LIST")"

--- a/scripts/conformance_gauntlet.sh
+++ b/scripts/conformance_gauntlet.sh
@@ -30,6 +30,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib_conformance.sh"
+source "$SCRIPT_DIR/lib_expected_manifest.sh"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PRIMARY_REPO_ROOT="$(resolve_primary_checkout_root "$PROJECT_DIR")"
 CORPUS_PARENT="$(dirname "$PRIMARY_REPO_ROOT")"
@@ -115,13 +116,13 @@ resolve_suite_root() {
 resolve_xfail_manifest() {
     local safe_suite
     safe_suite=${SUITE//-/_}
-    echo "$PROJECT_DIR/test/conformance/xfail_${safe_suite}.txt"
+    echo "${FFC_XFAIL_MANIFEST:-$PROJECT_DIR/test/conformance/xfail_${safe_suite}.txt}"
 }
 
 resolve_skip_manifest() {
     local safe_suite
     safe_suite=${SUITE//-/_}
-    echo "$PROJECT_DIR/test/conformance/skip_${safe_suite}.txt"
+    echo "${FFC_SKIP_MANIFEST:-$PROJECT_DIR/test/conformance/skip_${safe_suite}.txt}"
 }
 
 resolve_undefined_output_manifest() {
@@ -240,8 +241,8 @@ trap 'rm -rf "$TMPDIR_WORK"' EXIT
 XFAIL_LOOKUP="$TMPDIR_WORK/xfail_lookup.txt"
 SKIP_LOOKUP="$TMPDIR_WORK/skip_lookup.txt"
 UNDEFINED_OUTPUT_LOOKUP="$TMPDIR_WORK/undefined_output_lookup.txt"
-normalize_manifest "$XFAIL_MANIFEST" "$XFAIL_LOOKUP"
-normalize_manifest "$SKIP_MANIFEST" "$SKIP_LOOKUP"
+validate_expected_manifest "$XFAIL_MANIFEST" "$XFAIL_LOOKUP" || exit 1
+validate_expected_manifest "$SKIP_MANIFEST" "$SKIP_LOOKUP" || exit 1
 normalize_manifest "$UNDEFINED_OUTPUT_MANIFEST" "$UNDEFINED_OUTPUT_LOOKUP"
 manifest_overlap=$(grep -Fxf "$XFAIL_LOOKUP" "$UNDEFINED_OUTPUT_LOOKUP" || true)
 if [ -n "$manifest_overlap" ]; then

--- a/scripts/lib_expected_manifest.sh
+++ b/scripts/lib_expected_manifest.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+trim_manifest_field() {
+    local value="$1"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    printf '%s\n' "$value"
+}
+
+manifest_error() {
+    local source="$1" line_number="$2" message="$3"
+    printf 'ERROR: %s:%s: %s\n' "$source" "$line_number" "$message" >&2
+    return 1
+}
+
+validate_manifest_owner() {
+    local source="$1" line_number="$2" owner="$3"
+    if [[ ! "$owner" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[1-9][0-9]*$ ]]; then
+        manifest_error "$source" "$line_number" "malformed owner: $owner"
+    fi
+}
+
+validate_manifest_scope() {
+    local source="$1" line_number="$2" scope="$3"
+    case "$scope" in
+        coarray|OpenMP|OpenACC|GPU|vendor|legacy|compiler-flags|harness) ;;
+        *) manifest_error "$source" "$line_number" "unknown scope: $scope" ;;
+    esac
+}
+
+validate_manifest_metadata() {
+    local source="$1" line_number="$2" metadata="$3"
+    local identity reason
+    if [[ "$metadata" != *'; reason='* ]]; then
+        if [[ "$metadata" == owner=* || "$metadata" == scope=* ]]; then
+            manifest_error "$source" "$line_number" "reason is required"
+        else
+            manifest_error "$source" "$line_number" \
+                "owner or scope is required"
+        fi
+        return
+    fi
+    identity=${metadata%%; reason=*}
+    reason=${metadata#*; reason=}
+    if [[ "$identity" == owner=*scope=* || "$identity" == scope=*owner=* ]]; then
+        manifest_error "$source" "$line_number" \
+            "owner and scope cannot both appear"
+        return
+    fi
+    reason=$(trim_manifest_field "$reason")
+    if [ -z "$reason" ]; then
+        manifest_error "$source" "$line_number" "reason is required"
+        return
+    fi
+    case "$identity" in
+        owner=*) validate_manifest_owner "$source" "$line_number" \
+            "${identity#owner=}" ;;
+        scope=*) validate_manifest_scope "$source" "$line_number" \
+            "${identity#scope=}" ;;
+        *) manifest_error "$source" "$line_number" \
+            "owner or scope is required" ;;
+    esac
+}
+
+validate_manifest_path() {
+    local source="$1" line_number="$2" path="$3"
+    case "$path" in
+        "") manifest_error "$source" "$line_number" "path is required" ;;
+        /*) manifest_error "$source" "$line_number" \
+            "path must be suite-relative: $path" ;;
+        ..|../*|*/../*|*/..) manifest_error "$source" "$line_number" \
+            "path contains parent traversal: $path" ;;
+    esac
+}
+
+validate_expected_manifest() {
+    local source="$1" lookup="$2" line line_number=0 path metadata
+    declare -A seen_paths=()
+    : > "$lookup"
+    [ -f "$source" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        line_number=$((line_number + 1))
+        line=$(trim_manifest_field "$line")
+        [ -z "$line" ] && continue
+        [[ "$line" == \#* ]] && continue
+        if [[ "$line" != *' # '* ]]; then
+            manifest_error "$source" "$line_number" "malformed delimiter"
+            return 1
+        fi
+        path=$(trim_manifest_field "${line%% # *}")
+        metadata=${line#* # }
+        validate_manifest_path "$source" "$line_number" "$path" || return 1
+        validate_manifest_metadata "$source" "$line_number" "$metadata" || \
+            return 1
+        if [[ -v "seen_paths[$path]" ]]; then
+            manifest_error "$source" "$line_number" "duplicate path: $path"
+            return 1
+        fi
+        seen_paths["$path"]=1
+        printf '%s\n' "$path" >> "$lookup"
+    done < "$source"
+}
+
+manifest_owner_references() {
+    sed -n 's/^[^#]* # owner=\([^;]*\); reason=.*/\1/p' "$1"
+}

--- a/test/conformance/skip_gfortran_dg.txt
+++ b/test/conformance/skip_gfortran_dg.txt
@@ -1,2300 +1,2300 @@
 # gfortran.dg entries skipped by the gauntlet.
-# Format: basename.f90 # reason
-20231103-1.f90 # flags
-20231103-2.f90 # flags
-ISO_Fortran_binding_1.f90 # multifile
-ISO_Fortran_binding_10.f90 # multifile
-ISO_Fortran_binding_11.f90 # multifile
-ISO_Fortran_binding_12.f90 # multifile
-ISO_Fortran_binding_13.f90 # multifile
-ISO_Fortran_binding_15.f90 # multifile
-ISO_Fortran_binding_16.f90 # multifile
-ISO_Fortran_binding_17.f90 # multifile
-ISO_Fortran_binding_18.f90 # multifile
-ISO_Fortran_binding_3.f90 # multifile
-ISO_Fortran_binding_5.f90 # multifile
-ISO_Fortran_binding_6.f90 # multifile
-ISO_Fortran_binding_7.f90 # multifile
-ISO_Fortran_binding_8.f90 # multifile
-ISO_Fortran_binding_9.f90 # multifile
-PR100097.f90 # flags
-PR100098.f90 # flags
-PR100136.f90 # flags
-PR100906.f90 # multifile
-PR100911.f90 # multifile
-PR100914.f90 # multifile
-PR100915.f90 # multifile
-PR105658.f90 # flags
-PR113061.f90 # flags
-PR37039.f90 # flags
-PR40660.f90 # flags
-PR49268.f90 # flags
-PR82376.f90 # flags
-PR93963.f90 # directive
-PR94104a.f90 # flags
-PR94104b.f90 # flags
-PR94327.f90 # multifile
-PR94331.f90 # multifile
-Wall.f90 # flags
-Wno-all.f90 # flags
-abort_shouldfail.f90 # directive
-abstract_type_1.f90 # flags
-access_spec_1.f90 # directive
-access_spec_2.f90 # flags
-achar_3.f90 # flags
-achar_4.f90 # flags
-actual_array_substr_3.f90 # directive
-addressing-modes_1.f90 # directive
-addressing-modes_2.f90 # directive
-aliasing_dummy_1.f90 # flags
-all_bounds_1.f90 # flags
-alloc_comp_assign_5.f90 # flags
-alloc_comp_auto_array_3.f90 # flags
-alloc_comp_basics_1.f90 # flags
-alloc_comp_constraint_1.f90 # flags
-alloc_comp_constraint_7.f90 # flags
-alloc_comp_constructor_1.f90 # flags
-alloc_comp_constructor_5.f90 # flags
-alloc_comp_constructor_6.f90 # flags
-alloc_comp_misc_1.f90 # flags
-alloc_comp_std.f90 # flags
-allocatable_char_1.f90 # directive
-allocatable_function_1.f90 # flags
-allocatable_function_4.f90 # flags
-allocatable_function_8.f90 # directive
-allocatable_length.f90 # flags
-allocatable_scalar_13.f90 # flags
-allocatable_scalar_2.f90 # flags
-allocatable_scalar_5.f90 # flags
-allocatable_scalar_6.f90 # flags
-allocatable_scalar_9.f90 # flags
-allocatable_uninitialized_1.f90 # flags
-allocate_alloc_opt_15.f90 # directive
-allocate_alloc_opt_4.f90 # flags
-allocate_alloc_opt_5.f90 # flags
-allocate_alloc_opt_8.f90 # flags
-allocate_error_1.f90 # directive
-allocate_error_5.f90 # directive
-allocate_error_6.f90 # directive
-allocate_with_arrayspec_1.f90 # flags
-allocate_with_mold_2.f90 # flags
-allocate_with_source_25.f90 # flags
-allocate_with_source_29.f90 # flags
-allocate_with_source_30.f90 # directive
-allocate_with_source_33.f90 # flags
-allocate_with_source_6.f90 # flags
-allocate_with_typespec_4.f90 # flags
-altreturn_1.f90 # flags
-altreturn_10.f90 # flags
-altreturn_11.f90 # directive
-altreturn_2.f90 # flags
-altreturn_3.f90 # flags
-altreturn_4.f90 # flags
-altreturn_5.f90 # flags
-altreturn_6.f90 # flags
-altreturn_7.f90 # flags
-altreturn_8.f90 # flags
-altreturn_9_0.f90 # multifile
-altreturn_9_1.f90 # flags
-any_loc.f90 # flags
-argument_checking_11.f90 # flags
-argument_checking_12.f90 # flags
-argument_checking_14.f90 # flags
-argument_checking_2.f90 # flags
-argument_checking_21.f90 # flags
-argument_checking_23.f90 # flags
-argument_checking_9.f90 # flags
-arith_divide_3.f90 # flags
-arithmetic_if.f90 # flags
-arithmetic_overflow_3.f90 # directive
-array_assignment_5.f90 # flags
-array_constructor_11.f90 # flags
-array_constructor_13.f90 # flags
-array_constructor_14.f90 # flags
-array_constructor_15.f90 # flags
-array_constructor_18.f90 # flags
-array_constructor_22.f90 # flags
-array_constructor_38.f90 # flags
-array_constructor_40.f90 # flags
-array_constructor_41.f90 # flags
-array_constructor_43.f90 # flags
-array_constructor_44.f90 # flags
-array_constructor_46.f90 # flags
-array_constructor_47.f90 # flags
-array_constructor_49.f90 # flags
-array_constructor_51.f90 # directive
-array_constructor_54.f90 # flags
-array_constructor_type_13.f90 # flags
-array_function_2.f90 # flags
-array_memcpy_1.f90 # flags
-array_memcpy_2.f90 # flags
-array_memcpy_3.f90 # flags
-array_memcpy_4.f90 # flags
-array_memset_1.f90 # flags
-array_memset_2.f90 # flags
-array_memset_3.f90 # flags
-array_reference_3.f90 # directive
-array_section_1.f90 # flags
-array_section_2.f90 # flags
-array_temporaries_1.f90 # flags
-array_temporaries_2.f90 # flags
-array_temporaries_4.f90 # flags
-array_temporaries_5.f90 # flags
-arrayio_7.f90 # flags
-arrayio_8.f90 # flags
-assign-debug.f90 # flags
-assign_1.f90 # flags
-assign_10.f90 # flags
-assign_14.f90 # directive
-assign_2.f90 # flags
-assign_3.f90 # flags
-assign_5.f90 # flags
-assign_func_dtcomp_1.f90 # flags
-assignment_1.f90 # flags
-assignment_4.f90 # flags
-associate_11.f90 # flags
-associate_21.f90 # flags
-associate_26.f90 # flags
-associate_26a.f90 # flags
-associate_37.f90 # flags
-associate_40.f90 # flags
-associate_64.f90 # flags
-associate_66.f90 # flags
-associate_69.f90 # flags
-associate_70.f90 # flags
-associate_72.f90 # flags
-associate_78.f90 # flags
-associative_1.f90 # flags
-assumed_charlen_function_1.f90 # flags
-assumed_charlen_function_4.f90 # flags
-assumed_charlen_function_7.f90 # flags
-assumed_charlen_substring_1.f90 # flags
-assumed_rank_1.f90 # multifile
-assumed_rank_10.f90 # flags
-assumed_rank_11.f90 # flags
-assumed_rank_12.f90 # flags
-assumed_rank_14.f90 # flags
-assumed_rank_15.f90 # flags
-assumed_rank_2.f90 # flags
-assumed_rank_22.f90 # multifile
-assumed_rank_3.f90 # flags
-assumed_rank_4.f90 # flags
-assumed_rank_5.f90 # flags
-assumed_rank_6.f90 # flags
-assumed_rank_8.f90 # multifile
-assumed_rank_9.f90 # multifile
-assumed_type_10.f90 # flags
-assumed_type_11.f90 # flags
-assumed_type_13.f90 # multifile
-assumed_type_14.f90 # directive
-assumed_type_17.f90 # directive
-assumed_type_2.f90 # flags
-assumed_type_3.f90 # flags
-assumed_type_4.f90 # flags
-asynchronous_2.f90 # flags
-atan2_1.f90 # flags
-atan2_2.f90 # flags
-auto_dealloc_1.f90 # flags
-auto_dealloc_2.f90 # flags
-auto_in_equiv_1.f90 # flags
-auto_in_equiv_2.f90 # flags
-auto_in_equiv_3.f90 # flags
-auto_in_equiv_4.f90 # flags
-auto_in_equiv_5.f90 # flags
-auto_in_equiv_6.f90 # flags
-auto_in_equiv_7.f90 # flags
-auto_save_2.f90 # flags
-automatic_1.f90 # flags
-automatic_char_len_2.f90 # flags
-automatic_default_init_1.f90 # flags
-automatic_repeat.f90 # flags
-automatic_save.f90 # flags
-backslash_2.f90 # flags
-bessel_3.f90 # flags
-bessel_4.f90 # flags
-bessel_5.f90 # flags
-bessel_5_redux.f90 # flags
-bessel_6.f90 # flags
-bessel_7.f90 # flags
-bind-c-contiguous-1.f90 # multifile
-bind-c-contiguous-2.f90 # directive
-bind-c-contiguous-3.f90 # multifile
-bind-c-contiguous-4.f90 # multifile
-bind-c-contiguous-5.f90 # multifile
-bind-c-intent-out.f90 # flags
-bind_c_array_params_2.f90 # flags
-bind_c_array_params_3.f90 # multifile
-bind_c_bool_1.f90 # flags
-bind_c_char_10.f90 # directive
-bind_c_char_4.f90 # directive
-bind_c_char_5.f90 # directive
-bind_c_char_9.f90 # directive
-bind_c_coms.f90 # multifile
-bind_c_dts.f90 # multifile
-bind_c_usage_17.f90 # multifile
-bind_c_usage_18.f90 # flags
-bind_c_usage_20.f90 # flags
-bind_c_usage_22.f90 # flags
-bind_c_usage_23.f90 # flags
-bind_c_usage_24.f90 # multifile
-bind_c_usage_25.f90 # flags
-bind_c_usage_27.f90 # flags
-bind_c_usage_28.f90 # flags
-bind_c_usage_33.f90 # multifile
-bind_c_vars.f90 # multifile
-binding_label_tests_20.f90 # flags
-binding_label_tests_26b.f90 # directive
-binding_label_tests_35.f90 # flags
-block_11.f90 # directive
-block_12.f90 # directive
-block_3.f90 # flags
-block_end_error_1.f90 # directive
-blockdata_3.f90 # flags
-blockdata_4.f90 # flags
-blockdata_5.f90 # flags
-blockdata_6.f90 # flags
-blocks_nested_incomplete_1.f90 # directive
-bound_2.f90 # flags
-bound_7.f90 # flags
-bound_8.f90 # flags
-bound_9.f90 # flags
-bound_simplification_3.f90 # flags
-bound_simplification_4.f90 # directive
-bound_simplification_5.f90 # directive
-bound_simplification_6.f90 # directive
-bounds_check_1.f90 # flags
-bounds_check_10.f90 # flags
-bounds_check_11.f90 # flags
-bounds_check_12.f90 # flags
-bounds_check_14.f90 # flags
-bounds_check_15.f90 # flags
-bounds_check_16.f90 # flags
-bounds_check_17.f90 # flags
-bounds_check_19.f90 # flags
-bounds_check_21.f90 # flags
-bounds_check_22.f90 # flags
-bounds_check_23.f90 # flags
-bounds_check_24.f90 # directive
-bounds_check_25.f90 # directive
-bounds_check_26.f90 # flags
-bounds_check_28.f90 # flags
-bounds_check_4.f90 # flags
-bounds_check_5.f90 # flags
-bounds_check_6.f90 # flags
-bounds_check_7.f90 # flags
-bounds_check_8.f90 # flags
-bounds_check_9.f90 # flags
-bounds_check_array_ctor_1.f90 # flags
-bounds_check_array_ctor_2.f90 # flags
-bounds_check_array_ctor_4.f90 # flags
-bounds_check_array_ctor_6.f90 # flags
-bounds_check_array_ctor_7.f90 # flags
-bounds_check_array_ctor_8.f90 # flags
-bounds_check_array_io.f90 # directive
-bounds_check_fail_1.f90 # flags
-bounds_check_fail_2.f90 # flags
-bounds_check_fail_3.f90 # flags
-bounds_check_fail_4.f90 # flags
-bounds_check_fail_5.f90 # directive
-bounds_check_fail_6.f90 # directive
-bounds_check_fail_7.f90 # directive
-bounds_check_fail_8.f90 # directive
-bounds_check_strlen_1.f90 # flags
-bounds_check_strlen_10.f90 # directive
-bounds_check_strlen_2.f90 # flags
-bounds_check_strlen_3.f90 # flags
-bounds_check_strlen_4.f90 # flags
-bounds_check_strlen_5.f90 # flags
-bounds_check_strlen_6.f90 # flags
-bounds_check_strlen_7.f90 # flags
-bounds_check_strlen_8.f90 # flags
-bounds_check_strlen_9.f90 # flags
-boz_1.f90 # flags
-boz_10.f90 # flags
-boz_14.f90 # flags
-boz_15.f90 # directive
-boz_3.f90 # flags
-boz_4.f90 # flags
-boz_6.f90 # flags
-boz_7.f90 # flags
-boz_8.f90 # flags
-boz_9.f90 # flags
-boz_complex_2.f90 # flags
-boz_complex_3.f90 # flags
-boz_float_2.f90 # flags
-boz_float_3.f90 # flags
-byte_1.f90 # flags
-byte_2.f90 # flags
-byte_4.f90 # flags
-c_assoc.f90 # multifile
-c_by_val_2.f90 # flags
-c_by_val_3.f90 # flags
-c_by_val_5.f90 # flags
-c_char_tests_3.f90 # multifile
-c_char_tests_5.f90 # flags
-c_f_pointer_shape_tests_7.f90 # flags
-c_f_pointer_shape_tests_8.f90 # flags
-c_f_pointer_shape_tests_9.f90 # flags
-c_f_pointer_tests.f90 # multifile
-c_f_pointer_tests_3.f90 # flags
-c_f_pointer_tests_8.f90 # flags
-c_funloc_tests_6.f90 # flags
-c_funloc_tests_7.f90 # flags
-c_funloc_tests_9.f90 # flags
-c_funptr_1.f90 # directive
-c_funptr_1_mod.f90 # multifile
-c_kind_params.f90 # multifile
-c_loc_pure_1.f90 # flags
-c_loc_test.f90 # multifile
-c_loc_test_19.f90 # flags
-c_loc_test_21.f90 # flags
-c_loc_test_22.f90 # flags
-c_loc_tests_16.f90 # flags
-c_ptr_tests_14.f90 # flags
-c_ptr_tests_15.f90 # flags
-c_ptr_tests_16.f90 # flags
-c_sizeof_2.f90 # flags
-c_sizeof_3.f90 # directive
-c_sizeof_4.f90 # directive
-c_sizeof_5.f90 # flags
-char4-subscript.f90 # directive
-char4_decl-2.f90 # directive
-char4_decl.f90 # directive
-char_array_constructor_4.f90 # flags
-char_assign_1.f90 # flags
-char_bounds_check_fail_1.f90 # flags
-char_cast_1.f90 # flags
-char_cast_2.f90 # flags
-char_component_initializer_2.f90 # flags
-char_decl_1.f90 # flags
-char_eoshift_5.f90 # flags
-char_initialiser_actual.f90 # flags
-char_length_1.f90 # flags
-char_length_17.f90 # flags
-char_length_20.f90 # flags
-char_length_22.f90 # flags
-char_length_3.f90 # flags
-char_pointer_assign.f90 # flags
-char_pointer_assign_4.f90 # flags
-char_pointer_assign_5.f90 # flags
-char_pointer_dependency.f90 # flags
-char_pointer_dummy.f90 # flags
-char_pointer_func.f90 # flags
-char_result_11.f90 # directive
-char_result_16.f90 # flags
-char_result_19.f90 # directive
-char_result_mod_19.f90 # multifile
-character_comparison_1.f90 # flags
-character_comparison_2.f90 # flags
-character_comparison_3.f90 # flags
-character_comparison_4.f90 # flags
-character_comparison_5.f90 # flags
-character_comparison_6.f90 # flags
-character_comparison_7.f90 # flags
-character_comparison_8.f90 # flags
-character_comparison_9.f90 # flags
-charlen_18.f90 # flags
-check_bits_1.f90 # flags
-check_bits_2.f90 # flags
-chmod_1.f90 # flags
-chmod_2.f90 # flags
-chmod_3.f90 # flags
-class_51.f90 # flags
-class_52.f90 # flags
-class_62.f90 # flags
-class_64.f90 # flags
-class_76.f90 # directive
-class_77.f90 # directive
-class_alias.f90 # flags
-class_allocate_14.f90 # flags
-class_allocate_15.f90 # flags
-class_allocate_16.f90 # flags
-class_allocate_17.f90 # flags
-class_allocate_24.f90 # flags
-class_allocate_25.f90 # flags
-class_array_13.f90 # flags
-class_array_16.f90 # flags
-class_array_17.f90 # flags
-class_array_24.f90 # directive
-class_assign_2.f90 # directive
-class_assign_3.f90 # directive
-class_optional_1.f90 # flags
-class_optional_2.f90 # flags
-class_result_7.f90 # flags
-class_result_8.f90 # flags
-co_reduce_1.f90 # directive
-co_reduce_2.f90 # flags
-coarray_1.f90 # flags
-coarray_10.f90 # flags
-coarray_11.f90 # flags
-coarray_12.f90 # flags
-coarray_13.f90 # flags
-coarray_14.f90 # flags
-coarray_15.f90 # flags
-coarray_16.f90 # flags
-coarray_17.f90 # flags
-coarray_18.f90 # flags
-coarray_19.f90 # flags
-coarray_2.f90 # flags
-coarray_20.f90 # flags
-coarray_21.f90 # flags
-coarray_22.f90 # flags
-coarray_23.f90 # flags
-coarray_24.f90 # flags
-coarray_25.f90 # flags
-coarray_26.f90 # flags
-coarray_27.f90 # flags
-coarray_28.f90 # flags
-coarray_29_1.f90 # flags
-coarray_29_2.f90 # flags
-coarray_3.f90 # flags
-coarray_30.f90 # flags
-coarray_31.f90 # flags
-coarray_32.f90 # flags
-coarray_33.f90 # flags
-coarray_34.f90 # flags
-coarray_35.f90 # flags
-coarray_35a.f90 # flags
-coarray_37.f90 # flags
-coarray_38.f90 # flags
-coarray_39.f90 # flags
-coarray_4.f90 # flags
-coarray_40.f90 # flags
-coarray_41.f90 # flags
-coarray_42.f90 # flags
-coarray_43.f90 # flags
-coarray_44.f90 # flags
-coarray_45.f90 # flags
-coarray_46.f90 # flags
-coarray_47.f90 # flags
-coarray_48.f90 # flags
-coarray_49.f90 # flags
-coarray_5.f90 # flags
-coarray_50.f90 # flags
-coarray_6.f90 # flags
-coarray_7.f90 # flags
-coarray_8.f90 # flags
-coarray_9.f90 # directive
-coarray_alloc_with_implicit_sync_1.f90 # flags
-coarray_alloc_with_implicit_sync_2.f90 # flags
-coarray_allocate_1.f90 # flags
-coarray_allocate_12.f90 # flags
-coarray_args_1.f90 # flags
-coarray_args_2.f90 # flags
-coarray_atomic_1.f90 # flags
-coarray_atomic_2.f90 # flags
-coarray_atomic_3.f90 # flags
-coarray_atomic_4.f90 # flags
-coarray_atomic_5.f90 # flags
-coarray_atomic_6.f90 # flags
-coarray_class_1.f90 # flags
-coarray_class_2.f90 # flags
-coarray_collectives_1.f90 # flags
-coarray_collectives_10.f90 # flags
-coarray_collectives_11.f90 # flags
-coarray_collectives_12.f90 # flags
-coarray_collectives_13.f90 # flags
-coarray_collectives_14.f90 # flags
-coarray_collectives_15.f90 # flags
-coarray_collectives_16.f90 # flags
-coarray_collectives_17.f90 # flags
-coarray_collectives_18.f90 # directive
-coarray_collectives_2.f90 # flags
-coarray_collectives_3.f90 # directive
-coarray_collectives_4.f90 # flags
-coarray_collectives_5.f90 # flags
-coarray_collectives_6.f90 # flags
-coarray_collectives_8.f90 # flags
-coarray_collectives_9.f90 # flags
-coarray_critical_1.f90 # flags
-coarray_critical_3.f90 # flags
-coarray_data_1.f90 # flags
-coarray_dependency_1.f90 # flags
-coarray_fail_st.f90 # flags
-coarray_lib_alloc_1.f90 # flags
-coarray_lib_alloc_2.f90 # flags
-coarray_lib_alloc_3.f90 # flags
-coarray_lib_alloc_4.f90 # flags
-coarray_lib_comm_1.f90 # flags
-coarray_lib_move_alloc_1.f90 # flags
-coarray_lib_realloc_1.f90 # flags
-coarray_lib_this_image_1.f90 # flags
-coarray_lib_this_image_2.f90 # flags
-coarray_lib_token_1.f90 # flags
-coarray_lib_token_2.f90 # flags
-coarray_lib_token_3.f90 # flags
-coarray_lib_token_4.f90 # flags
-coarray_lock_1.f90 # flags
-coarray_lock_2.f90 # flags
-coarray_lock_3.f90 # flags
-coarray_lock_4.f90 # flags
-coarray_lock_5.f90 # flags
-coarray_lock_6.f90 # flags
-coarray_lock_7.f90 # flags
-coarray_poly_1.f90 # flags
-coarray_poly_2.f90 # flags
-coarray_poly_3.f90 # flags
-coarray_poly_4.f90 # flags
-coarray_poly_5.f90 # flags
-coarray_poly_6.f90 # flags
-coarray_poly_7.f90 # flags
-coarray_poly_8.f90 # flags
-coarray_poly_9.f90 # flags
-coarray_stat_2.f90 # flags
-coarray_stat_function.f90 # flags
-coarray_stat_whitespace.f90 # flags
-coarray_subobject_1.f90 # flags
-coarray_sync.f90 # flags
-coarray_sync_memory.f90 # flags
-coarray_this_image_1.f90 # flags
-coarray_this_image_2.f90 # directive
-coarray_this_image_3.f90 # flags
-coindexed_1.f90 # flags
-comma_IO_extension_2.f90 # flags
-common_14.f90 # flags
-common_16.f90 # flags
-common_17.f90 # flags
-common_18.f90 # directive
-common_19.f90 # flags
-common_20.f90 # flags
-common_21.f90 # flags
-common_4.f90 # flags
-common_8.f90 # flags
-common_9.f90 # flags
-common_align_1.f90 # flags
-common_align_2.f90 # flags
-complex_intrinsic_4.f90 # flags
-complex_intrinsic_6.f90 # flags
-complex_intrinsic_7.f90 # flags
-complex_intrinsic_8.f90 # directive
-complex_parameter_1.f90 # flags
-conditional_1.f90 # flags
-conditional_2.f90 # flags
-conditional_3.f90 # flags
-conditional_4.f90 # flags
-conditional_5.f90 # flags
-conditional_6.f90 # flags
-conditional_7.f90 # flags
-conditional_8.f90 # flags
-conditional_9.f90 # flags
-constructor_4.f90 # flags
-constructor_7.f90 # flags
-constructor_8.f90 # flags
-constructor_9.f90 # flags
-contains.f90 # flags
-contiguous_1.f90 # flags
-contiguous_10.f90 # directive
-contiguous_15.f90 # directive
-contiguous_16.f90 # flags
-contiguous_2.f90 # flags
-contiguous_3.f90 # flags
-continuation_1.f90 # flags
-continuation_10.f90 # flags
-continuation_11.f90 # flags
-continuation_13.f90 # flags
-continuation_15.f90 # flags
-continuation_16.f90 # flags
-continuation_17.f90 # flags
-continuation_18.f90 # flags
-continuation_3.f90 # flags
-continuation_4.f90 # flags
-continuation_7.f90 # flags
-continuation_9.f90 # flags
-convert_implied_open.f90 # flags
-coshape_1.f90 # flags
-cr_lf.f90 # flags
-cray_pointers_1.f90 # flags
-cray_pointers_10.f90 # flags
-cray_pointers_11.f90 # flags
-cray_pointers_12.f90 # flags
-cray_pointers_2.f90 # flags
-cray_pointers_4.f90 # flags
-cray_pointers_5.f90 # flags
-cray_pointers_6.f90 # flags
-cray_pointers_7.f90 # flags
-cray_pointers_8.f90 # flags
-cray_pointers_9.f90 # flags
-cshift_bounds_1.f90 # flags
-cshift_bounds_2.f90 # flags
-cshift_bounds_3.f90 # flags
-cshift_bounds_4.f90 # flags
-cshift_large_1.f90 # directive
-data_bounds_1.f90 # flags
-data_bounds_2.f90 # flags
-data_char_1.f90 # flags
-data_char_2.f90 # flags
-data_char_3.f90 # flags
-data_char_4.f90 # flags
-data_constraints_2.f90 # flags
-data_initialized.f90 # flags
-data_invalid.f90 # flags
-data_pointer_2.f90 # flags
-date_and_time_4.f90 # directive
-deallocate_error_1.f90 # directive
-deallocate_error_2.f90 # directive
-debug_1.f90 # flags
-dec-comparison-character_1.f90 # flags
-dec-comparison-character_2.f90 # flags
-dec-comparison-complex_1.f90 # flags
-dec-comparison-complex_2.f90 # flags
-dec-comparison-int_1.f90 # flags
-dec-comparison-int_2.f90 # flags
-dec-comparison-real_1.f90 # flags
-dec-comparison-real_2.f90 # flags
-dec-comparison.f90 # flags
-dec_bitwise_ops_1.f90 # flags
-dec_bitwise_ops_2.f90 # flags
-dec_bitwise_ops_3.f90 # flags
-dec_char_conversion_in_assignment_1.f90 # flags
-dec_char_conversion_in_assignment_2.f90 # flags
-dec_char_conversion_in_assignment_3.f90 # flags
-dec_char_conversion_in_assignment_4.f90 # flags
-dec_char_conversion_in_assignment_5.f90 # flags
-dec_char_conversion_in_assignment_6.f90 # flags
-dec_char_conversion_in_assignment_7.f90 # flags
-dec_char_conversion_in_assignment_8.f90 # flags
-dec_char_conversion_in_data_1.f90 # flags
-dec_char_conversion_in_data_2.f90 # flags
-dec_char_conversion_in_data_3.f90 # flags
-dec_char_conversion_in_data_4.f90 # flags
-dec_char_conversion_in_data_5.f90 # flags
-dec_char_conversion_in_data_6.f90 # flags
-dec_char_conversion_in_data_7.f90 # flags
-dec_exp_1.f90 # flags
-dec_exp_4.f90 # flags
-dec_exp_5.f90 # flags
-dec_init_1.f90 # flags
-dec_init_2.f90 # flags
-dec_init_3.f90 # flags
-dec_init_4.f90 # flags
-dec_intrinsic_ints.f90 # flags
-dec_io_1.f90 # flags
-dec_io_2.f90 # flags
-dec_io_2a.f90 # flags
-dec_io_4.f90 # flags
-dec_io_5.f90 # flags
-dec_io_6.f90 # flags
-dec_io_7.f90 # flags
-dec_loc_rval_1.f90 # flags
-dec_loc_rval_2.f90 # flags
-dec_logical_xor_1.f90 # flags
-dec_logical_xor_2.f90 # flags
-dec_math.f90 # flags
-dec_math_2.f90 # flags
-dec_math_3.f90 # flags
-dec_math_4.f90 # flags
-dec_math_5.f90 # directive
-dec_math_6.f90 # flags
-dec_parameter_2.f90 # flags
-dec_parameter_3.f90 # flags
-dec_parameter_4.f90 # flags
-dec_static_1.f90 # flags
-dec_static_2.f90 # flags
-dec_static_4.f90 # flags
-dec_structure_1.f90 # flags
-dec_structure_10.f90 # flags
-dec_structure_11.f90 # flags
-dec_structure_12.f90 # flags
-dec_structure_13.f90 # flags
-dec_structure_14.f90 # flags
-dec_structure_16.f90 # flags
-dec_structure_17.f90 # flags
-dec_structure_18.f90 # flags
-dec_structure_19.f90 # flags
-dec_structure_2.f90 # flags
-dec_structure_20.f90 # flags
-dec_structure_21.f90 # flags
-dec_structure_22.f90 # flags
-dec_structure_23.f90 # flags
-dec_structure_25.f90 # flags
-dec_structure_26.f90 # flags
-dec_structure_27.f90 # flags
-dec_structure_28.f90 # flags
-dec_structure_3.f90 # flags
-dec_structure_4.f90 # flags
-dec_structure_5.f90 # flags
-dec_structure_6.f90 # flags
-dec_structure_7.f90 # flags
-dec_structure_8.f90 # flags
-dec_structure_9.f90 # flags
-dec_type_print.f90 # flags
-dec_type_print_3.f90 # flags
-dec_union_1.f90 # flags
-dec_union_10.f90 # flags
-dec_union_11.f90 # flags
-dec_union_12.f90 # flags
-dec_union_2.f90 # flags
-dec_union_3.f90 # flags
-dec_union_4.f90 # flags
-dec_union_5.f90 # flags
-dec_union_6.f90 # flags
-dec_union_7.f90 # flags
-dec_union_8.f90 # flags
-dec_union_9.f90 # flags
-default_format_2.f90 # directive
-default_format_denormal_1.f90 # flags
-default_format_denormal_2.f90 # flags
-default_initialization_1.f90 # flags
-default_initialization_5.f90 # flags
-default_numeric_type_1.f90 # flags
-deferred_character_21.f90 # flags
-deferred_character_33.f90 # multifile
-deferred_character_40.f90 # flags
-deferred_type_param_1.f90 # flags
-deferred_type_param_2.f90 # flags
-defined_operators_1.f90 # flags
-dependency_10.f90 # flags
-dependency_11.f90 # flags
-dependency_12.f90 # flags
-dependency_13.f90 # flags
-dependency_14.f90 # flags
-dependency_15.f90 # flags
-dependency_16.f90 # flags
-dependency_17.f90 # flags
-dependency_18.f90 # flags
-dependency_20.f90 # flags
-dependency_26.f90 # flags
-dependency_27.f90 # flags
-dependency_28.f90 # flags
-dependency_29.f90 # flags
-dependency_30.f90 # flags
-dependency_31.f90 # flags
-dependency_32.f90 # flags
-dependency_33.f90 # flags
-dependency_34.f90 # flags
-dependency_35.f90 # flags
-dependency_36.f90 # flags
-dependency_37.f90 # flags
-dependency_38.f90 # flags
-dependency_4.f90 # flags
-dependency_41.f90 # flags
-dependency_42.f90 # flags
-dependency_43.f90 # flags
-dependency_45.f90 # flags
-dependency_47.f90 # flags
-dependency_48.f90 # flags
-dependency_49.f90 # flags
-dependency_5.f90 # flags
-dependency_54.f90 # directive
-dependency_6.f90 # flags
-dependency_7.f90 # flags
-dependency_8.f90 # flags
-dependency_9.f90 # flags
-dependency_generation_1.f90 # directive
-der_array_io_1.f90 # flags
-der_array_io_2.f90 # flags
-der_array_io_3.f90 # flags
-der_charlen_1.f90 # directive
-der_io_3.f90 # flags
-derived_array_intrinisics_1.f90 # flags
-derived_constructor_char_1.f90 # flags
-derived_constructor_char_2.f90 # flags
-derived_constructor_comps_6.f90 # directive
-derived_pointer_null_1.f90 # flags
-derived_pointer_recursion.f90 # flags
-derived_recursion.f90 # flags
-diagnostic-format-sarif-pr105916.f90 # flags
-dim_sum_1.f90 # directive
-dim_sum_2.f90 # directive
-dim_sum_3.f90 # directive
-direct_io_2.f90 # flags
-directive_unroll_1.f90 # flags
-directive_unroll_2.f90 # flags
-directive_unroll_3.f90 # flags
-directive_unroll_4.f90 # flags
-do_1.f90 # flags
-do_check_1.f90 # flags
-do_check_10.f90 # flags
-do_check_11.f90 # flags
-do_check_12.f90 # flags
-do_check_19.f90 # directive
-do_check_2.f90 # flags
-do_check_3.f90 # flags
-do_check_4.f90 # flags
-do_check_5.f90 # flags
-do_concurrent_1.f90 # flags
-do_concurrent_10.f90 # flags
-do_concurrent_11.f90 # directive
-do_concurrent_4.f90 # flags
-do_concurrent_6.f90 # directive
-do_concurrent_7.f90 # directive
-do_concurrent_8_f2018.f90 # flags
-do_concurrent_8_f2023.f90 # flags
-do_concurrent_9.f90 # flags
-do_concurrent_constraints.f90 # flags
-do_concurrent_local_init.f90 # flags
-do_concurrent_typespec_1.f90 # flags
-do_corner_warn.f90 # flags
-do_iterator_2.f90 # flags
-do_subscript_3.f90 # flags
-do_subscript_6.f90 # flags
-dollar_sym_1.f90 # directive
-dollar_sym_2.f90 # flags
-dot_product_2.f90 # flags
-dot_product_3.f90 # flags
-double_complex_1.f90 # flags
-dtio_13.f90 # flags
-dummy_procedure_1.f90 # flags
-dup_save_2.f90 # flags
-duplicate_type_1.f90 # flags
-duplicate_type_2.f90 # flags
-e_d_fmt.f90 # flags
-elemental_args_check_5.f90 # flags
-elemental_args_check_6.f90 # flags
-elemental_dependency_1.f90 # flags
-elemental_dependency_3.f90 # flags
-elemental_dependency_4.f90 # directive
-elemental_dependency_5.f90 # directive
-elemental_optional_args_1.f90 # flags
-elemental_optional_args_6.f90 # flags
-empty_format_1.f90 # flags
-end_subroutine_1.f90 # flags
-end_subroutine_2.f90 # flags
-endfile_3.f90 # directive
-endfile_4.f90 # directive
-entry_19.f90 # flags
-entry_7.f90 # flags
-enum_10.f90 # multifile
-enum_9.f90 # flags
-eof_6.f90 # flags
-eor_1.f90 # flags
-eoshift_bounds_1.f90 # flags
-eoshift_large_1.f90 # directive
-equiv_11.f90 # flags
-equiv_2.f90 # flags
-equiv_7.f90 # flags
-equiv_constraint_1.f90 # flags
-equiv_constraint_2.f90 # flags
-equiv_constraint_4.f90 # flags
-equiv_constraint_5.f90 # flags
-equiv_constraint_7.f90 # flags
-equiv_constraint_8.f90 # flags
-equiv_substr.f90 # flags
-errnocheck_1.f90 # directive
-error_format.f90 # directive
-error_stop_3.f90 # flags
-error_stop_4.f90 # flags
-exponent_2.f90 # flags
-extends_type_of_3.f90 # flags
-external_procedures_1.f90 # flags
-f2018_obs.f90 # flags
-f2c_1.f90 # flags
-f2c_2.f90 # flags
-f2c_3.f90 # flags
-f2c_4.f90 # multifile
-f2c_5.f90 # multifile
-f2c_6.f90 # flags
-f2c_7.f90 # flags
-f2c_8.f90 # flags
-f2c_9.f90 # flags
-feed_1.f90 # flags
-feed_2.f90 # flags
-fimplicit_none_1.f90 # flags
-fimplicit_none_2.f90 # flags
-finalize_10.f90 # flags
-finalize_11.f90 # flags
-finalize_12.f90 # flags
-finalize_16.f90 # flags
-finalize_18.f90 # flags
-finalize_21.f90 # flags
-finalize_28.f90 # flags
-finalize_30.f90 # flags
-finalize_33.f90 # flags
-finalize_34.f90 # directive
-finalize_35.f90 # directive
-finalize_36.f90 # directive
-finalize_37.f90 # directive
-finalize_38a.f90 # flags
-finalize_49.f90 # flags
-finalize_57.f90 # directive
-finalize_6.f90 # flags
-findloc_10.f90 # flags
-findloc_9.f90 # flags
-fmt_en_rd.f90 # directive
-fmt_en_rn.f90 # directive
-fmt_en_ru.f90 # directive
-fmt_en_rz.f90 # directive
-fmt_error_2.f90 # flags
-fmt_error_4.f90 # directive
-fmt_error_5.f90 # directive
-fmt_f_default_field_width_1.f90 # flags
-fmt_f_default_field_width_2.f90 # flags
-fmt_f_default_field_width_3.f90 # flags
-fmt_fw_d.f90 # flags
-fmt_g_default_field_width_1.f90 # flags
-fmt_g_default_field_width_2.f90 # flags
-fmt_g_default_field_width_3.f90 # flags
-fmt_i_default_field_width_1.f90 # flags
-fmt_i_default_field_width_2.f90 # flags
-fmt_i_default_field_width_3.f90 # flags
-fmt_int_sign.f90 # flags
-fmt_l.f90 # flags
-fmt_l0.f90 # flags
-fmt_read_bz_bn.f90 # flags
-fmt_tab_1.f90 # flags
-fmt_tab_2.f90 # flags
-forall_10.f90 # flags
-forall_13.f90 # flags
-forall_15.f90 # flags
-forall_17.f90 # flags
-forall_8.f90 # flags
-forall_9.f90 # flags
-func_decl_4.f90 # flags
-func_decl_5.f90 # flags
-func_derived_1.f90 # flags
-func_result_4.f90 # flags
-function_charlen_4.f90 # flags
-function_kinds_4.f90 # flags
-function_kinds_5.f90 # directive
-function_optimize_1.f90 # flags
-function_optimize_11.f90 # flags
-function_optimize_12.f90 # flags
-function_optimize_2.f90 # flags
-function_optimize_3.f90 # flags
-function_optimize_4.f90 # flags
-function_optimize_5.f90 # flags
-function_optimize_6.f90 # flags
-function_optimize_7.f90 # flags
-function_optimize_8.f90 # flags
-function_optimize_9.f90 # flags
-gamma_2.f90 # flags
-gamma_4.f90 # directive
-generic_18.f90 # flags
-generic_26.f90 # flags
-generic_36-2.f90 # multifile
-global_references_2.f90 # flags
-global_vars_c_init.f90 # multifile
-global_vars_f90_init.f90 # multifile
-goto_9.f90 # flags
-hollerith3.f90 # flags
-hollerith5.f90 # flags
-hollerith8.f90 # flags
-hollerith_1.f90 # flags
-hollerith_character_array_constructor.f90 # flags
-hollerith_f95.f90 # flags
-hollerith_legacy.f90 # flags
-hollerith_to_char_parameter_1.f90 # flags
-host_assoc_variable_1.f90 # directive
-iall_iany_iparity_2.f90 # flags
-iargc.f90 # flags
-ibits.f90 # flags
-ichar_1.f90 # flags
-illegal_boz_arg_4.f90 # flags
-implicit_14.f90 # flags
-implicit_6.f90 # flags
-implicit_9.f90 # flags
-implicit_class_1.f90 # flags
-implicit_pure_1.f90 # directive
-implicit_pure_2.f90 # directive
-implicit_pure_3.f90 # flags
-implicit_pure_4.f90 # directive
-implicit_pure_5.f90 # multifile
-implied_do_io_1.f90 # flags
-implied_do_io_3.f90 # flags
-implied_do_io_4.f90 # directive
-implied_do_io_6.f90 # flags
-implied_shape_2.f90 # flags
-import2.f90 # flags
-import3.f90 # flags
-impure_3.f90 # flags
-include_1.f90 # flags
-include_13.f90 # flags
-include_15.f90 # directive
-include_17.f90 # flags
-include_18.f90 # flags
-include_19.f90 # flags
-include_2.f90 # flags
-include_20.f90 # flags
-include_21.f90 # flags
-include_23.f90 # directive
-include_24.f90 # directive
-include_5.f90 # flags
-include_6.f90 # flags
-include_7.f90 # flags
-include_8.f90 # flags
-include_9.f90 # directive
-index_2.f90 # flags
-index_4.f90 # flags
-index_6.f90 # flags
-init_flag_1.f90 # flags
-init_flag_10.f90 # flags
-init_flag_11.f90 # flags
-init_flag_12.f90 # flags
-init_flag_13.f90 # flags
-init_flag_14.f90 # flags
-init_flag_17.f90 # flags
-init_flag_18.f90 # flags
-init_flag_2.f90 # flags
-init_flag_20.f90 # flags
-init_flag_3.f90 # flags
-init_flag_4.f90 # flags
-init_flag_5.f90 # flags
-init_flag_6.f90 # flags
-init_flag_7.f90 # flags
-init_flag_8.f90 # flags
-init_flag_9.f90 # flags
-initialization_10.f90 # directive
-initialization_13.f90 # flags
-initialization_16.f90 # flags
-initialization_18.f90 # flags
-initialization_21.f90 # flags
-initialization_30.f90 # flags
-initialization_4.f90 # flags
-initialization_5.f90 # flags
-initialization_6.f90 # flags
-inline_matmul_1.f90 # flags
-inline_matmul_10.f90 # flags
-inline_matmul_11.f90 # directive
-inline_matmul_12.f90 # flags
-inline_matmul_13.f90 # flags
-inline_matmul_14.f90 # flags
-inline_matmul_15.f90 # flags
-inline_matmul_16.f90 # flags
-inline_matmul_17.f90 # flags
-inline_matmul_18.f90 # flags
-inline_matmul_19.f90 # flags
-inline_matmul_2.f90 # flags
-inline_matmul_23.f90 # flags
-inline_matmul_24.f90 # flags
-inline_matmul_25.f90 # flags
-inline_matmul_26.f90 # flags
-inline_matmul_3.f90 # flags
-inline_matmul_4.f90 # flags
-inline_matmul_5.f90 # flags
-inline_matmul_6.f90 # flags
-inline_matmul_7.f90 # flags
-inline_matmul_8.f90 # flags
-inline_matmul_9.f90 # flags
-inline_product_1.f90 # flags
-inline_sum_1.f90 # flags
-inline_sum_bounds_check_1.f90 # flags
-inline_sum_bounds_check_2.f90 # flags
-inline_transpose_1.f90 # flags
-inquire.f90 # flags
-inquire_13.f90 # flags
-inquire_6.f90 # flags
-inquire_iolength.f90 # flags
-inquiry_type_ref_2.f90 # flags
-inquiry_type_ref_4.f90 # flags
-inquiry_type_ref_6.f90 # flags
-inquiry_type_ref_7.f90 # directive
-inquiry_type_ref_8.f90 # directive
-int_1.f90 # flags
-int_conv_1.f90 # flags
-int_range_io_1.f90 # flags
-integer_exponentiation_1.f90 # flags
-integer_exponentiation_7.f90 # flags
-intent_optimize_1.f90 # flags
-intent_optimize_10.f90 # directive
-intent_optimize_2.f90 # flags
-intent_optimize_3.f90 # flags
-intent_optimize_4.f90 # directive
-intent_optimize_5.f90 # directive
-intent_optimize_6.f90 # directive
-intent_optimize_7.f90 # directive
-intent_optimize_8.f90 # directive
-intent_optimize_9.f90 # directive
-intent_out_11.f90 # flags
-intent_out_15.f90 # directive
-intent_out_7.f90 # flags
-intent_out_8.f90 # flags
-intent_out_9.f90 # flags
-interface_15.f90 # flags
-interface_18.f90 # flags
-interface_35.f90 # flags
-interface_42.f90 # flags
-interface_50.f90 # flags
-interface_57.f90 # flags
-interface_60.f90 # flags
-interface_61.f90 # flags
-interface_abstract_2.f90 # flags
-interface_abstract_6.f90 # flags
-internal_dummy_1.f90 # flags
-internal_pack_11.f90 # flags
-internal_pack_12.f90 # flags
-internal_pack_15.f90 # flags
-internal_pack_16.f90 # directive
-internal_pack_17.f90 # directive
-internal_pack_18.f90 # directive
-internal_pack_19.f90 # flags
-internal_pack_2.f90 # directive
-internal_pack_20.f90 # flags
-internal_pack_21.f90 # flags
-internal_pack_22.f90 # directive
-internal_pack_24.f90 # directive
-internal_pack_25.f90 # flags
-internal_pack_3.f90 # directive
-internal_pack_5.f90 # flags
-internal_pack_6.f90 # flags
-internal_pack_7.f90 # flags
-internal_pack_9.f90 # flags
-internal_write_1.f90 # directive
-intrinsic.f90 # flags
-intrinsic_2.f90 # flags
-intrinsic_3.f90 # flags
-intrinsic_4.f90 # flags
-intrinsic_5.f90 # flags
-intrinsic_6.f90 # flags
-intrinsic_actual_3.f90 # flags
-intrinsic_optional_char_arg_1.f90 # flags
-intrinsic_pack_2.f90 # directive
-intrinsic_pack_3.f90 # directive
-intrinsic_shadow_4.f90 # flags
-intrinsic_size_3.f90 # flags
-intrinsic_spread_2.f90 # directive
-intrinsic_spread_3.f90 # directive
-intrinsic_std_1.f90 # flags
-intrinsic_std_2.f90 # flags
-intrinsic_std_3.f90 # flags
-intrinsic_std_4.f90 # flags
-intrinsic_std_6.f90 # flags
-intrinsic_unpack_2.f90 # directive
-intrinsic_unpack_3.f90 # directive
-invalid_interface_assignment.f90 # flags
-io_constraints_1.f90 # flags
-io_constraints_10.f90 # flags
-io_constraints_11.f90 # flags
-io_constraints_12.f90 # flags
-io_constraints_18.f90 # flags
-io_constraints_2.f90 # flags
-io_constraints_3.f90 # flags
-io_constraints_8.f90 # flags
-io_err_1.f90 # directive
-io_real_boz2.f90 # flags
-io_real_boz_3.f90 # flags
-io_real_boz_4.f90 # flags
-io_real_boz_5.f90 # flags
-io_tags_1.f90 # flags
-io_tags_10.f90 # flags
-io_tags_2.f90 # flags
-io_tags_3.f90 # flags
-io_tags_4.f90 # flags
-io_tags_5.f90 # flags
-io_tags_6.f90 # flags
-io_tags_7.f90 # flags
-io_tags_8.f90 # flags
-io_tags_9.f90 # flags
-iostat_3.f90 # flags
-ipa-sra-1.f90 # flags
-ipcp-array-1.f90 # flags
-ipcp-array-2.f90 # flags
-is_contiguous_3.f90 # directive
-ishft_4.f90 # flags
-isnan_1.f90 # flags
-isnan_2.f90 # flags
-iso_c_binding_compiler_1.f90 # directive
-iso_c_binding_compiler_2.f90 # flags
-iso_c_binding_compiler_3.f90 # flags
-iso_c_binding_param_1.f90 # flags
-iso_c_binding_param_2.f90 # flags
-iso_fortran_binding_uint8_array.f90 # multifile
-iso_fortran_env_5.f90 # flags
-iso_fortran_env_6.f90 # flags
-iso_fortran_env_7.f90 # directive
-iso_fortran_env_9.f90 # flags
-label_4.f90 # flags
-label_5.f90 # flags
-large_integer_kind_1.f90 # directive
-large_integer_kind_2.f90 # directive
-large_real_kind_1.f90 # directive
-large_real_kind_form_io_1.f90 # directive
-large_real_kind_form_io_2.f90 # directive
-large_unit_1.f90 # directive
-ldist-1.f90 # flags
-ldist-pr43023.f90 # flags
-leadz_trailz_2.f90 # directive
-leadz_trailz_3.f90 # flags
-len_trim.f90 # flags
-line_length_10.f90 # flags
-line_length_11.f90 # flags
-line_length_12.f90 # directive
-line_length_13.f90 # directive
-line_length_2.f90 # flags
-line_length_4.f90 # flags
-line_length_5.f90 # flags
-line_length_6.f90 # flags
-line_length_7.f90 # flags
-line_length_8.f90 # flags
-line_length_9.f90 # flags
-linefile.f90 # flags
-list_directed_large.f90 # directive
-list_read_11.f90 # flags
-list_read_2.f90 # flags
-literal_constants.f90 # flags
-loc_2.f90 # flags
-logical_1.f90 # flags
-logical_temp_io_kind8.f90 # flags
-loop_versioning_1.f90 # flags
-loop_versioning_10.f90 # flags
-loop_versioning_2.f90 # flags
-loop_versioning_3.f90 # flags
-loop_versioning_4.f90 # flags
-loop_versioning_5.f90 # flags
-loop_versioning_6.f90 # flags
-loop_versioning_7.f90 # flags
-loop_versioning_8.f90 # flags
-loop_versioning_9.f90 # flags
-lrshift_1.f90 # multifile
-ltime_gmtime_1.f90 # flags
-ltime_gmtime_2.f90 # flags
-matmul_10.f90 # flags
-matmul_11.f90 # flags
-matmul_13.f90 # flags
-matmul_14.f90 # flags
-matmul_15.f90 # flags
-matmul_16.f90 # flags
-matmul_19.f90 # flags
-matmul_5.f90 # flags
-matmul_9.f90 # flags
-matmul_blas_2.f90 # flags
-matmul_blas_3.f90 # flags
-matmul_bounds_10.f90 # flags
-matmul_bounds_11.f90 # flags
-matmul_bounds_13.f90 # flags
-matmul_bounds_2.f90 # flags
-matmul_bounds_3.f90 # flags
-matmul_bounds_4.f90 # flags
-matmul_bounds_5.f90 # flags
-matmul_bounds_7.f90 # directive
-matmul_bounds_8.f90 # flags
-matmul_bounds_9.f90 # flags
-matmul_const.f90 # directive
-max_expr.f90 # flags
-maxerrors.f90 # flags
-maxloc_2.f90 # flags
-maxloc_bounds_1.f90 # flags
-maxloc_bounds_2.f90 # flags
-maxloc_bounds_3.f90 # flags
-maxloc_bounds_4.f90 # flags
-maxloc_bounds_5.f90 # flags
-maxloc_bounds_6.f90 # flags
-maxloc_bounds_7.f90 # flags
-maxloc_bounds_8.f90 # flags
-maxlocval_2.f90 # flags
-maxlocval_4.f90 # flags
-mclock.f90 # flags
-merge_char_1.f90 # flags
-merge_char_3.f90 # flags
-merge_char_const.f90 # flags
-merge_init_expr_2.f90 # flags
-min0_max0_1.f90 # flags
-min0_max0_2.f90 # flags
-min_expr.f90 # flags
-min_max_conformance.f90 # flags
-min_max_kind.f90 # flags
-minloc_1.f90 # flags
-minlocval_1.f90 # flags
-minlocval_4.f90 # flags
-minmax_char_2.f90 # flags
-minmax_integer.f90 # flags
-minmaxloc_15.f90 # directive
-minmaxloc_16.f90 # flags
-minmaxloc_18.f90 # directive
-minmaxloc_18a.f90 # directive
-minmaxloc_18b.f90 # directive
-minmaxloc_18c.f90 # directive
-minmaxloc_18d.f90 # directive
-minmaxloc_19.f90 # directive
-minmaxloc_20.f90 # directive
-minmaxloc_21.f90 # directive
-minmaxloc_3.f90 # flags
-minmaxloc_8.f90 # flags
-minmaxloc_integer_kinds_1.f90 # directive
-minmaxloc_zerosize_1.f90 # directive
-missing_optional_dummy_4.f90 # flags
-missing_optional_dummy_5.f90 # flags
-missing_optional_dummy_6.f90 # flags
-missing_optional_dummy_6a.f90 # flags
-mixed_io_1.f90 # multifile
-module_implicit_conversion.f90 # flags
-module_naming_1.f90 # directive
-module_nan.f90 # flags
-module_parameter_array_refs_2.f90 # flags
-module_private_1.f90 # flags
-module_private_2.f90 # flags
-module_procedure_double_colon_2.f90 # flags
-module_procedure_double_colon_3.f90 # flags
-module_procedure_double_colon_4.f90 # flags
-module_read_1.f90 # flags
-module_variable_1.f90 # flags
-module_variable_2.f90 # flags
-module_variable_3.f90 # directive
-module_widestring_1.f90 # flags
-move_alloc_15.f90 # flags
-move_alloc_4.f90 # flags
-mvbits_7.f90 # directive
-namelist_100.f90 # directive
-namelist_101.f90 # directive
-namelist_14.f90 # flags
-namelist_18.f90 # flags
-namelist_19.f90 # flags
-namelist_21.f90 # flags
-namelist_22.f90 # flags
-namelist_24.f90 # flags
-namelist_3.f90 # flags
-namelist_34.f90 # flags
-namelist_35.f90 # flags
-namelist_37.f90 # flags
-namelist_42.f90 # flags
-namelist_43.f90 # flags
-namelist_48.f90 # flags
-namelist_49.f90 # flags
-namelist_5.f90 # flags
-namelist_54.f90 # flags
-namelist_55.f90 # flags
-namelist_63.f90 # flags
-namelist_65.f90 # flags
-namelist_67.f90 # flags
-namelist_83.f90 # multifile
-namelist_85.f90 # flags
-namelist_86.f90 # flags
-namelist_87.f90 # flags
-namelist_args.f90 # flags
-namelist_assumed_char.f90 # flags
-namelist_char_only.f90 # flags
-namelist_empty.f90 # flags
-namelist_internal.f90 # flags
-namelist_use_only.f90 # flags
-nan_1.f90 # flags
-nan_2.f90 # flags
-nan_3.f90 # flags
-nan_4.f90 # flags
-nan_5.f90 # flags
-nan_6.f90 # flags
-nan_7.f90 # flags
-nearest_1.f90 # flags
-nearest_2.f90 # flags
-nearest_3.f90 # flags
-negative_automatic_size.f90 # flags
-nested_array_constructor_2.f90 # flags
-nested_modules_4.f90 # flags
-nested_modules_5.f90 # flags
-newunit_2.f90 # flags
-nint_p7.f90 # flags
-no-automatic.f90 # flags
-no_arg_check_2.f90 # flags
-no_arg_check_3.f90 # flags
-no_char_conversion_in_array_constructor.f90 # flags
-no_char_to_numeric_assign.f90 # flags
-no_overwrite_recursive_1.f90 # flags
-no_overwrite_recursive_2.f90 # flags
-no_range_check_1.f90 # flags
-no_range_check_2.f90 # flags
-no_unit_error_1.f90 # directive
-noinline.f90 # flags
-non_lvalue_1.f90 # directive
-nonreturning_statements.f90 # directive
-noreturn-1.f90 # flags
-noreturn-2.f90 # flags
-noreturn-4.f90 # flags
-noreturn-5.f90 # flags
-norm2_2.f90 # flags
-norm2_3.f90 # directive
-norm2_4.f90 # flags
-nosigned_zero_2.f90 # flags
-nosigned_zero_3.f90 # flags
-null_5.f90 # flags
-null_6.f90 # flags
-null_actual.f90 # flags
-null_actual_3.f90 # flags
-nullify_3.f90 # flags
-num_images_1.f90 # flags
-o_fast_stacksize.f90 # flags
-oldstyle_4.f90 # flags
-open_errors_2.f90 # flags
-open_errors_3.f90 # directive
-open_new_segv.f90 # directive
-openacc-define-1.f90 # flags
-openacc-define-2.f90 # flags
-openacc-define-3.f90 # flags
-openmp-define-1.f90 # flags
-openmp-define-2.f90 # flags
-openmp-define-3.f90 # flags
-operator_5.f90 # flags
-optional_absent_1.f90 # flags
-optional_absent_7.f90 # directive
-out_of_range_3.f90 # directive
-output_exponents_1.f90 # flags
-overload_3.f90 # flags
-pack_bounds_1.f90 # flags
-parameter_array_element_1.f90 # flags
-parameter_array_element_3.f90 # directive
-parameter_array_init_2.f90 # flags
-parameter_array_section_2.f90 # flags
-parameter_unused.f90 # flags
-parens_5.f90 # flags
-parens_6.f90 # flags
-parity_2.f90 # flags
-parity_3.f90 # flags
-pointer_assign_6.f90 # flags
-pointer_check_1.f90 # flags
-pointer_check_10.f90 # flags
-pointer_check_11.f90 # flags
-pointer_check_12.f90 # flags
-pointer_check_13.f90 # flags
-pointer_check_14.f90 # flags
-pointer_check_15.f90 # directive
-pointer_check_2.f90 # flags
-pointer_check_3.f90 # flags
-pointer_check_4.f90 # flags
-pointer_check_5.f90 # flags
-pointer_check_6.f90 # flags
-pointer_check_7.f90 # flags
-pointer_check_8.f90 # flags
-pointer_check_9.f90 # flags
-pointer_function_actual_1.f90 # flags
-pointer_init_10.f90 # directive
-pointer_init_13.f90 # flags
-pointer_intent_1.f90 # flags
-pointer_intent_2.f90 # flags
-pointer_intent_3.f90 # flags
-pointer_intent_4.f90 # flags
-pointer_remapping_1.f90 # flags
-pointer_remapping_10.f90 # flags
-pointer_target_2.f90 # flags
-power_3.f90 # flags
-power_4.f90 # flags
-power_5.f90 # flags
-power_6.f90 # flags
-power_7.f90 # directive
-power_8.f90 # directive
-pr100154.f90 # flags
-pr100950.f90 # directive
-pr100988.f90 # flags
-pr101158.f90 # flags
-pr101264.f90 # flags
-pr101267.f90 # flags
-pr101399_1.f90 # flags
-pr101399_2.f90 # flags
-pr102180.f90 # flags
-pr102366.f90 # flags
-pr102458.f90 # flags
-pr102458b.f90 # flags
-pr102532.f90 # flags
-pr102860.f90 # flags
-pr103286.f90 # flags
-pr103367.f90 # directive
-pr103475.f90 # flags
-pr103504.f90 # directive
-pr103505.f90 # directive
-pr103607.f90 # directive
-pr103608.f90 # flags
-pr103628.f90 # flags
-pr103691.f90 # flags
-pr103692.f90 # flags
-pr103715.f90 # directive
-pr103779.f90 # directive
-pr104210.f90 # flags
-pr104330.f90 # flags
-pr104466.f90 # flags
-pr104571.f90 # flags
-pr104649.f90 # flags
-pr104908.f90 # directive
-pr105456-nmlr.f90 # directive
-pr105456-nmlw.f90 # directive
-pr105456-ruf.f90 # directive
-pr105456-wf.f90 # directive
-pr105456-wuf.f90 # directive
-pr105456.f90 # directive
-pr105954.f90 # flags
-pr106331.f90 # flags
-pr106556.f90 # flags
-pr106557.f90 # directive
-pr106934.f90 # flags
-pr106945.f90 # flags
-pr107423.f90 # flags
-pr107559.f90 # flags
-pr107680.f90 # flags
-pr107681.f90 # flags
-pr107899.f90 # flags
-pr108131.f90 # directive
-pr108193.f90 # flags
-pr108501.f90 # directive
-pr108502.f90 # flags
-pr108527.f90 # directive
-pr108592.f90 # flags
-pr108889.f90 # flags
-pr109265.f90 # flags
-pr109662-a.f90 # flags
-pr109662.f90 # flags
-pr109788.f90 # flags
-pr111880.f90 # flags
-pr111891.f90 # flags
-pr112404.f90 # flags
-pr112406.f90 # flags
-pr112407b.f90 # flags
-pr112459.f90 # flags
-pr112877-1.f90 # flags
-pr113503_1.f90 # flags
-pr114883.f90 # flags
-pr114959.f90 # flags
-pr115281.f90 # flags
-pr115348.f90 # flags
-pr117060.f90 # flags
-pr117730_b.f90 # multifile
-pr117763.f90 # flags
-pr117901.f90 # flags
-pr119136.f90 # directive
-pr119273.f90 # flags
-pr120049_2.f90 # flags
-pr120049_a.f90 # multifile
-pr121743.f90 # flags
-pr122957.f90 # flags
-pr123947_2.f90 # flags
-pr124543.f90 # flags
-pr125117.f90 # flags
-pr15129.f90 # flags
-pr15140.f90 # flags
-pr16597.f90 # flags
-pr17143.f90 # flags
-pr17164.f90 # flags
-pr17706.f90 # flags
-pr18210.f90 # flags
-pr20086.f90 # flags
-pr20124.f90 # flags
-pr20865.f90 # flags
-pr25623-2.f90 # flags
-pr25623.f90 # flags
-pr25923.f90 # flags
-pr26246_1.f90 # flags
-pr26246_2.f90 # flags
-pr28158.f90 # flags
-pr29713.f90 # flags
-pr30391-1.f90 # flags
-pr31025.f90 # flags
-pr32136.f90 # flags
-pr32242.f90 # flags
-pr32533.f90 # flags
-pr32535.f90 # directive
-pr33074.f90 # flags
-pr33449.f90 # flags
-pr33794.f90 # flags
-pr34163.f90 # flags
-pr35662.f90 # flags
-pr35944-2.f90 # directive
-pr36006-2.f90 # directive
-pr36192_1.f90 # directive
-pr36680.f90 # flags
-pr37286.f90 # directive
-pr37287-1.f90 # multifile
-pr38722.f90 # flags
-pr39666-1.f90 # flags
-pr39666-2.f90 # flags
-pr41043.f90 # flags
-pr41212.f90 # flags
-pr41225.f90 # flags
-pr41229.f90 # flags
-pr41347.f90 # flags
-pr41922.f90 # flags
-pr41928.f90 # flags
-pr42108.f90 # flags
-pr42166.f90 # flags
-pr43229.f90 # flags
-pr43475.f90 # flags
-pr43688.f90 # flags
-pr43796.f90 # flags
-pr43808.f90 # flags
-pr43866.f90 # flags
-pr43984.f90 # flags
-pr44491.f90 # flags
-pr44592.f90 # flags
-pr44882.f90 # flags
-pr45636.f90 # flags
-pr46190.f90 # flags
-pr46519-2.f90 # flags
-pr46588.f90 # flags
-pr46665.f90 # flags
-pr46804.f90 # flags
-pr46945.f90 # flags
-pr46985.f90 # flags
-pr47054_1.f90 # flags
-pr47054_2.f90 # flags
-pr48636-2.f90 # flags
-pr48636.f90 # flags
-pr48958.f90 # flags
-pr49179.f90 # flags
-pr49308.f90 # flags
-pr49472.f90 # flags
-pr49494.f90 # flags
-pr49675.f90 # flags
-pr50769.f90 # flags
-pr50875.f90 # flags
-pr52370.f90 # flags
-pr52621.f90 # flags
-pr52701.f90 # flags
-pr52835.f90 # flags
-pr53217.f90 # flags
-pr53787.f90 # flags
-pr54889.f90 # flags
-pr55086_1_tfat.f90 # flags
-pr55086_2_tfat.f90 # flags
-pr55086_aliasing_dummy_4_tfat.f90 # flags
-pr55330.f90 # flags
-pr56015.f90 # flags
-pr56049.f90 # flags
-pr57393-1.f90 # flags
-pr57393-2.f90 # flags
-pr57904.f90 # flags
-pr57987.f90 # flags
-pr58290.f90 # flags
-pr59107.f90 # flags
-pr59440-1.f90 # flags
-pr59440-2.f90 # flags
-pr59440-3.f90 # flags
-pr61209.f90 # flags
-pr61335.f90 # directive
-pr61921.f90 # flags
-pr62135.f90 # flags
-pr62695.f90 # flags
-pr63331.f90 # flags
-pr63821.f90 # flags
-pr64528.f90 # flags
-pr65903.f90 # flags
-pr66545_1.f90 # flags
-pr66545_2.f90 # flags
-pr67170.f90 # flags
-pr67460.f90 # flags
-pr67614.f90 # flags
-pr67615.f90 # flags
-pr67740.f90 # flags
-pr68078.f90 # multifile
-pr68251.f90 # flags
-pr68318_1.f90 # flags
-pr68318_2.f90 # directive
-pr68379-1.f90 # flags
-pr68817.f90 # flags
-pr69055.f90 # flags
-pr69395.f90 # flags
-pr69419.f90 # flags
-pr69603.f90 # flags
-pr69955.f90 # flags
-pr69962.f90 # directive
-pr69987.f90 # flags
-pr70754.f90 # flags
-pr70870_1.f90 # flags
-pr70931.f90 # flags
-pr70937.f90 # flags
-pr71204.f90 # flags
-pr71230-1.f90 # flags
-pr71230-2.f90 # flags
-pr71252.f90 # flags
-pr71523_1.f90 # flags
-pr71523_2.f90 # flags
-pr71526.f90 # flags
-pr71642.f90 # flags
-pr71688.f90 # flags
-pr71706.f90 # flags
-pr77260_1.f90 # flags
-pr77260_2.f90 # flags
-pr77380.f90 # flags
-pr77406.f90 # flags
-pr77420_3.f90 # multifile
-pr77694.f90 # flags
-pr77719.f90 # flags
-pr77763.f90 # flags
-pr77959.f90 # flags
-pr77978_1.f90 # flags
-pr77978_2.f90 # flags
-pr77978_3.f90 # flags
-pr78240.f90 # flags
-pr78259.f90 # flags
-pr78278.f90 # flags
-pr78279.f90 # flags
-pr78571.f90 # flags
-pr78619.f90 # flags
-pr78739.f90 # flags
-pr78758.f90 # flags
-pr79315.f90 # flags
-pr79886.f90 # flags
-pr79966.f90 # flags
-pr80012.f90 # flags
-pr80494.f90 # flags
-pr80668.f90 # flags
-pr81464.f90 # flags
-pr81529.f90 # flags
-pr81735.f90 # flags
-pr81889.f90 # flags
-pr82004.f90 # flags
-pr82253.f90 # flags
-pr82973.f90 # flags
-pr83149_1.f90 # multifile
-pr83149_b.f90 # multifile
-pr83246.f90 # directive
-pr84117.f90 # flags
-pr84245.f90 # flags
-pr84565.f90 # flags
-pr84784.f90 # flags
-pr85082.f90 # flags
-pr85357.f90 # directive
-pr85543.f90 # directive
-pr85780.f90 # flags
-pr85895.f90 # flags
-pr86551.f90 # directive
-pr87117.f90 # flags
-pr87360.f90 # flags
-pr87907.f90 # directive
-pr87991.f90 # flags
-pr88138.f90 # directive
-pr88148.f90 # flags
-pr88169_1.f90 # directive
-pr88169_3.f90 # flags
-pr88228.f90 # flags
-pr88248.f90 # flags
-pr88299.f90 # flags
-pr88357_1.f90 # flags
-pr88379.f90 # flags
-pr88611.f90 # flags
-pr88624.f90 # flags
-pr88833.f90 # flags
-pr88902.f90 # flags
-pr88932.f90 # flags
-pr88934.f90 # flags
-pr88964.f90 # flags
-pr89092.f90 # flags
-pr89451.f90 # flags
-pr89462.f90 # flags
-pr89664.f90 # flags
-pr89956.f90 # flags
-pr90002.f90 # flags
-pr90021.f90 # flags
-pr90290.f90 # flags
-pr90385.f90 # flags
-pr91003.f90 # flags
-pr91296.f90 # flags
-pr91372.f90 # directive
-pr91496.f90 # flags
-pr91497.f90 # flags
-pr91497_2.f90 # flags
-pr91650_2.f90 # flags
-pr91802.f90 # flags
-pr91913.f90 # flags
-pr91945.f90 # flags
-pr92050.f90 # flags
-pr92094.f90 # flags
-pr92537.f90 # flags
-pr92613.f90 # flags
-pr92613_2.f90 # flags
-pr92629.f90 # flags
-pr92874.f90 # flags
-pr92897.f90 # flags
-pr93263_1.f90 # flags
-pr93364.f90 # flags
-pr93473.f90 # flags
-pr93524.f90 # multifile
-pr93715.f90 # flags
-pr93792.f90 # directive
-pr94285.f90 # flags
-pr94329.f90 # flags
-pr94708.f90 # flags
-pr94978.f90 # flags
-pr95088.f90 # flags
-pr95089.f90 # flags
-pr95090.f90 # flags
-pr95091.f90 # flags
-pr95373_1.f90 # flags
-pr95373_2.f90 # flags
-pr95398.f90 # flags
-pr95446.f90 # flags
-pr95687.f90 # flags
-pr95688.f90 # flags
-pr95689.f90 # flags
-pr95707.f90 # flags
-pr95709.f90 # flags
-pr95826.f90 # flags
-pr95827.f90 # flags
-pr95828.f90 # flags
-pr95879.f90 # flags
-pr95881.f90 # flags
-pr96085.f90 # flags
-pr96102b.f90 # directive
-pr96312.f90 # flags
-pr96319.f90 # flags
-pr96436_1.f90 # flags
-pr96436_10.f90 # flags
-pr96436_2.f90 # flags
-pr96436_3.f90 # flags
-pr96436_4.f90 # flags
-pr96436_5.f90 # flags
-pr96436_6.f90 # flags
-pr96436_7.f90 # flags
-pr96436_8.f90 # flags
-pr96436_9.f90 # flags
-pr96613.f90 # flags
-pr96711.f90 # directive
-pr96737.f90 # flags
-pr96986.f90 # flags
-pr97036.f90 # flags
-pr97505.f90 # flags
-pr97673.f90 # flags
-pr98076.f90 # directive
-pr98411.f90 # flags
-pr99112.f90 # flags
-pr99139.f90 # flags
-pr99204.f90 # flags
-pr99545.f90 # flags
-pr99602.f90 # flags
-pr99602a.f90 # flags
-pr99602b.f90 # flags
-pr99602c.f90 # flags
-pr99602d.f90 # flags
-pr99853.f90 # flags
-predict-1.f90 # flags
-predict-2.f90 # flags
-predict-3.f90 # flags
-print_parentheses_2.f90 # flags
-private_type_1.f90 # flags
-private_type_10.f90 # flags
-private_type_11.f90 # flags
-private_type_12.f90 # flags
-private_type_2.f90 # flags
-private_type_3.f90 # flags
-private_type_4.f90 # flags
-private_type_9.f90 # flags
-proc_assign_1.f90 # flags
-proc_decl_1.f90 # flags
-proc_decl_4.f90 # flags
-proc_ptr_13.f90 # flags
-proc_ptr_14.f90 # flags
-proc_ptr_17.f90 # flags
-proc_ptr_24.f90 # flags
-proc_ptr_3.f90 # directive
-proc_ptr_35.f90 # directive
-proc_ptr_39.f90 # directive
-proc_ptr_56.f90 # flags
-proc_ptr_7.f90 # multifile
-proc_ptr_8.f90 # multifile
-proc_ptr_common_1.f90 # flags
-proc_ptr_comp_51.f90 # flags
-proc_ptr_comp_pass_6.f90 # flags
-proc_ptr_result_3.f90 # directive
-promotion.f90 # flags
-promotion_2.f90 # flags
-promotion_3.f90 # flags
-promotion_4.f90 # flags
-protected_1.f90 # flags
-protected_2.f90 # flags
-protected_3.f90 # flags
-protected_4.f90 # flags
-protected_5.f90 # flags
-protected_6.f90 # flags
-ptr-func-1.f90 # flags
-ptr-func-2.f90 # flags
-ptr-func-4.f90 # flags
-public_private_module_2.f90 # flags
-public_private_module_3.f90 # multifile
-public_private_module_5.f90 # flags
-public_private_module_6.f90 # flags
-public_private_module_7.f90 # flags
-public_private_module_8.f90 # flags
-pure_formal_2.f90 # flags
-quad_1.f90 # directive
-quad_2.f90 # directive
-random_3.f90 # directive
-random_5.f90 # directive
-random_7.f90 # flags
-random_init_3.f90 # flags
-random_init_4.f90 # flags
-random_init_5.f90 # flags
-random_init_6.f90 # flags
-rank_1.f90 # flags
-rank_2.f90 # flags
-rank_3.f90 # flags
-rank_4.f90 # flags
-read_dir.f90 # multifile
-read_eor.f90 # flags
-read_float_1.f90 # flags
-read_infnan_1.f90 # flags
-read_legacy_comma.f90 # flags
-read_logical.f90 # flags
-real4-10-real8-16.f90 # directive
-real4-16-real8-10.f90 # directive
-real4-16-real8-16.f90 # directive
-real4-16-real8-4.f90 # directive
-real4-16.f90 # directive
-real4-8-real8-16.f90 # directive
-real8-16.f90 # directive
-real_compare_1.f90 # flags
-real_const_3.f90 # flags
-realloc_on_assign_14.f90 # flags
-realloc_on_assign_16a.f90 # flags
-realloc_on_assign_18.f90 # flags
-realloc_on_assign_19.f90 # flags
-realloc_on_assign_20.f90 # flags
-realloc_on_assign_21.f90 # flags
-realloc_on_assign_22.f90 # flags
-reassoc_1.f90 # flags
-reassoc_12.f90 # flags
-reassoc_2.f90 # flags
-reassoc_3.f90 # flags
-reassoc_5.f90 # flags
-record_marker_1.f90 # flags
-record_marker_3.f90 # flags
-recursive_check_10.f90 # flags
-recursive_check_11.f90 # flags
-recursive_check_12.f90 # flags
-recursive_check_13.f90 # flags
-recursive_check_14.f90 # flags
-recursive_check_16.f90 # flags
-recursive_check_7.f90 # flags
-recursive_check_8.f90 # flags
-recursive_check_9.f90 # flags
-recursive_reference_3.f90 # flags
-recursive_stack.f90 # flags
-recursive_statement_functions.f90 # flags
-repack_arrays_1.f90 # flags
-repeat_1.f90 # directive
-reshape_10.f90 # flags
-reshape_11.f90 # flags
-reshape_3.f90 # flags
-reshape_4.f90 # flags
-reshape_8.f90 # flags
-reshape_order_1.f90 # flags
-reshape_order_2.f90 # flags
-reshape_order_3.f90 # flags
-reshape_order_4.f90 # flags
-restricted_expression_1.f90 # flags
-restricted_expression_2.f90 # flags
-result_default_init_1.f90 # flags
-result_in_spec_3.f90 # flags
-return_1.f90 # flags
-rewind_1.f90 # flags
-round_4.f90 # flags
-runtime_warning_1.f90 # flags
-same_name_1.f90 # directive
-save_1.f90 # flags
-save_2.f90 # flags
-save_4.f90 # flags
-save_5.f90 # flags
-save_6.f90 # flags
-save_7.f90 # flags
-scalar_pointer_1.f90 # flags
-scalar_return_1.f90 # flags
-scan_2.f90 # flags
-select_char_2.f90 # flags
-select_char_3.f90 # flags
-select_contiguous.f90 # flags
-select_type_20.f90 # directive
-select_type_25.f90 # flags
-select_type_41.f90 # flags
-select_type_49.f90 # directive
-selected_char_kind_3.f90 # flags
-selected_kind_1.f90 # flags
-selected_logical_kind_2.f90 # flags
-selected_logical_kind_3.f90 # directive
-selected_real_kind_2.f90 # flags
-selected_real_kind_3.f90 # flags
-semicolon_free.f90 # flags
-semicolon_free_2.f90 # flags
-shape_11.f90 # flags
-shape_7.f90 # flags
-shape_9.f90 # flags
-short_circuiting_2.f90 # flags
-short_circuiting_3.f90 # flags
-simd-builtins-1.f90 # directive
-simd-builtins-2.f90 # directive
-simd-builtins-6.f90 # directive
-simd-builtins-7.f90 # directive
-simd-builtins-8.f90 # directive
-simd-builtins-9.f90 # directive
-single_char_string.f90 # flags
-size_kind_2.f90 # flags
-size_optional_dim_1.f90 # directive
-size_optional_dim_2.f90 # directive
-sizeof_3.f90 # flags
-sms-1.f90 # flags
-sms-2.f90 # flags
-spec_statement_in_exec.f90 # flags
-specifics_1.f90 # flags
-split_3.f90 # directive
-split_4.f90 # directive
-spread_bounds_1.f90 # flags
-spread_init_expr_2.f90 # flags
-spread_scalar_source.f90 # flags
-spread_size_limit.f90 # flags
-spread_size_limit_2.f90 # flags
-stat_1.f90 # flags
-stat_2.f90 # flags
-stat_4.f90 # directive
-statement_function_1.f90 # directive
-statement_function_2.f90 # directive
-statement_function_5.f90 # directive
-stfunc_1.f90 # flags
-stfunc_3.f90 # flags
-stfunc_4.f90 # flags
-stfunc_6.f90 # flags
-stfunc_7.f90 # flags
-stop_1.f90 # flags
-stop_3.f90 # flags
-stop_4.f90 # directive
-stop_shouldfail.f90 # directive
-storage_size_4.f90 # flags
-storage_size_5.f90 # flags
-str_comp_optimize_1.f90 # flags
-streamio_2.f90 # flags
-streamio_9.f90 # flags
-string_1.f90 # directive
-string_1_lp64.f90 # directive
-string_3.f90 # directive
-string_3_lp64.f90 # directive
-string_assign_1.f90 # flags
-string_assign_2.f90 # flags
-string_compare_4.f90 # flags
-string_ctor_1.f90 # flags
-string_length_2.f90 # flags
-string_length_3.f90 # flags
-string_length_4.f90 # flags
-structure_constructor_11.f90 # flags
-structure_constructor_9.f90 # flags
-subnormal_1.f90 # flags
-substr_6.f90 # flags
-substr_9.f90 # flags
-system_clock_1.f90 # flags
-system_clock_2.f90 # flags
-system_clock_4.f90 # flags
-team_change_1.f90 # flags
-team_change_3.f90 # directive
-team_end_1.f90 # flags
-team_end_3.f90 # directive
-team_form_1.f90 # flags
-team_form_3.f90 # directive
-team_get_1.f90 # directive
-team_number_1.f90 # flags
-team_sync_2.f90 # directive
-temporary_3.f90 # directive
-test_only_clause.f90 # multifile
-tl_editing.f90 # flags
-trans-mem-skel.f90 # flags
-transfer_array_intrinsic_4.f90 # flags
-transfer_array_subref.f90 # directive
-transfer_array_subref_2.f90 # directive
-transfer_check_1.f90 # flags
-transfer_check_2.f90 # flags
-transfer_check_3.f90 # flags
-transfer_check_4.f90 # flags
-transfer_check_5.f90 # flags
-transfer_class_1.f90 # flags
-transfer_hollerith_1.f90 # flags
-transfer_intrinsic_1.f90 # flags
-transfer_intrinsic_6.f90 # flags
-transfer_resolve_3.f90 # flags
-transfer_simplify_1.f90 # flags
-transfer_simplify_12.f90 # flags
-transfer_simplify_13.f90 # flags
-transfer_simplify_14.f90 # flags
-transfer_simplify_2.f90 # flags
-transfer_simplify_3.f90 # flags
-transfer_simplify_8.f90 # flags
-transpose_2.f90 # flags
-transpose_5.f90 # flags
-transpose_optimization_1.f90 # flags
-transpose_optimization_2.f90 # flags
-transpose_reshape_r10.f90 # directive
-trim_optimize_1.f90 # flags
-trim_optimize_2.f90 # flags
-trim_optimize_3.f90 # flags
-trim_optimize_5.f90 # flags
-trim_optimize_7.f90 # flags
-trim_optimize_8.f90 # flags
-type_decl_1.f90 # flags
-type_decl_2.f90 # flags
-typebound_proc_19.f90 # directive
-typebound_proc_2.f90 # flags
-unexpected_eof_4.f90 # flags
-unf_io_convert_1.f90 # flags
-unf_io_convert_3.f90 # directive
-unf_io_convert_4.f90 # flags
-unformatted_subrecord_1.f90 # flags
-unlimited_polymorphic_11.f90 # flags
-unlimited_polymorphic_8.f90 # flags
-unpack_bounds_1.f90 # flags
-unpack_bounds_2.f90 # flags
-unpack_bounds_3.f90 # flags
-unsigned_1.f90 # flags
-unsigned_10.f90 # flags
-unsigned_11.f90 # flags
-unsigned_12.f90 # flags
-unsigned_13.f90 # flags
-unsigned_14.f90 # flags
-unsigned_15.f90 # flags
-unsigned_16.f90 # flags
-unsigned_17.f90 # flags
-unsigned_18.f90 # flags
-unsigned_19.f90 # flags
-unsigned_2.f90 # flags
-unsigned_20.f90 # flags
-unsigned_21.f90 # flags
-unsigned_21_be.f90 # flags
-unsigned_22.f90 # flags
-unsigned_23.f90 # flags
-unsigned_25.f90 # flags
-unsigned_26.f90 # flags
-unsigned_29.f90 # flags
-unsigned_3.f90 # flags
-unsigned_30.f90 # flags
-unsigned_31.f90 # flags
-unsigned_32.f90 # flags
-unsigned_33.f90 # flags
-unsigned_34.f90 # flags
-unsigned_35.f90 # flags
-unsigned_36.f90 # flags
-unsigned_38.f90 # flags
-unsigned_39.f90 # flags
-unsigned_4.f90 # flags
-unsigned_40.f90 # flags
-unsigned_41.f90 # flags
-unsigned_42.f90 # flags
-unsigned_43.f90 # flags
-unsigned_44.f90 # flags
-unsigned_5.f90 # flags
-unsigned_6.f90 # flags
-unsigned_7.f90 # flags
-unsigned_8.f90 # flags
-unsigned_9.f90 # flags
-unsigned_kiss.f90 # flags
-unsigned_write.f90 # directive
-unused_artificial_dummies_1.f90 # flags
-use_1.f90 # flags
-use_12.f90 # flags
-use_21.f90 # flags
-use_6.f90 # flags
-use_only_1.f90 # flags
-use_rename_2.f90 # flags
-use_rename_6.f90 # flags
-use_without_only_1.f90 # flags
-used_before_typed_1.f90 # flags
-used_before_typed_2.f90 # flags
-used_before_typed_3.f90 # flags
-used_before_typed_4.f90 # flags
-used_before_typed_5.f90 # flags
-used_before_typed_6.f90 # flags
-used_types_18.f90 # flags
-value_1.f90 # flags
-value_10.f90 # directive
-value_2.f90 # flags
-value_4.f90 # multifile
-vax_structure_1.f90 # flags
-vector_subscript_4.f90 # flags
-vector_subscript_6.f90 # flags
-volatile10.f90 # flags
-volatile11.f90 # flags
-volatile12.f90 # flags
-volatile2.f90 # flags
-volatile3.f90 # directive
-volatile4.f90 # flags
-volatile5.f90 # flags
-volatile6.f90 # flags
-volatile7.f90 # flags
-warn_alias.f90 # flags
-warn_align_commons.f90 # flags
-warn_conversion.f90 # flags
-warn_conversion_10.f90 # flags
-warn_conversion_11.f90 # flags
-warn_conversion_2.f90 # flags
-warn_conversion_3.f90 # flags
-warn_conversion_4.f90 # flags
-warn_conversion_5.f90 # flags
-warn_conversion_6.f90 # flags
-warn_conversion_7.f90 # flags
-warn_conversion_8.f90 # flags
-warn_conversion_9.f90 # flags
-warn_function_without_result.f90 # flags
-warn_function_without_result_2.f90 # flags
-warn_implicit_procedure_1.f90 # flags
-warn_intent_out_not_set.f90 # flags
-warn_std_1.f90 # flags
-warn_std_2.f90 # flags
-warn_std_3.f90 # flags
-warn_target_lifetime_1.f90 # flags
-warn_target_lifetime_2.f90 # flags
-warn_target_lifetime_3.f90 # flags
-warn_target_lifetime_4.f90 # flags
-warn_undefined_1.f90 # flags
-warn_unused_dummy_argument_1.f90 # flags
-warn_unused_dummy_argument_2.f90 # flags
-warn_unused_dummy_argument_3.f90 # flags
-warn_unused_dummy_argument_4.f90 # flags
-warn_unused_dummy_argument_6.f90 # flags
-warn_unused_function.f90 # flags
-warn_unused_function_2.f90 # flags
-warn_unused_function_3.f90 # flags
-warn_unused_var.f90 # flags
-warn_unused_var_2.f90 # flags
-warn_unused_var_3.f90 # flags
-warnings_are_errors_1.f90 # flags
-weak-1.f90 # directive
-weak-2.f90 # directive
-weak-3.f90 # directive
-where_5.f90 # flags
-where_6.f90 # flags
-where_7.f90 # flags
-whole_file_14.f90 # flags
-whole_file_17.f90 # flags
-whole_file_18.f90 # flags
-whole_file_21.f90 # directive
-whole_file_22.f90 # flags
-whole_file_25.f90 # flags
-whole_file_26.f90 # flags
-whole_file_29.f90 # directive
-whole_file_31.f90 # directive
-whole_file_32.f90 # flags
-whole_file_4.f90 # flags
-whole_file_5.f90 # flags
-whole_file_6.f90 # flags
-widechar_1.f90 # flags
-widechar_10.f90 # flags
-widechar_11.f90 # directive
-widechar_2.f90 # flags
-widechar_3.f90 # flags
-widechar_4.f90 # flags
-widechar_5.f90 # flags
-widechar_7.f90 # flags
-widechar_8.f90 # flags
-widechar_IO_4.f90 # flags
-widechar_intrinsics_1.f90 # flags
-widechar_intrinsics_10.f90 # flags
-widechar_intrinsics_2.f90 # flags
-widechar_intrinsics_3.f90 # flags
-widechar_intrinsics_4.f90 # flags
-widechar_intrinsics_5.f90 # flags
-widechar_intrinsics_6.f90 # flags
-widechar_intrinsics_7.f90 # flags
-widechar_intrinsics_8.f90 # flags
-widechar_intrinsics_9.f90 # flags
-widechar_select_1.f90 # flags
-winapi.f90 # flags
-write_check.f90 # directive
-wtruncate.f90 # flags
-wunused-parameter.f90 # flags
-wunused-parameter_2.f90 # flags
-zero_sized_13.f90 # flags
-zero_sized_8.f90 # directive
-bounds_check_20.f90 # directive
-implied_do_io_5.f90 # directive
-inline_matmul_20.f90 # directive
-unsigned_write_2.f90 # directive
-always_inline_1.f90 # flags
-binding_label_tests_34.f90 # flags
-binding_label_tests_36.f90 # flags
-coarray_51.f90 # flags
-do_concurrent_assoc_default_none.f90 # flags
-f_c_string3.f90 # directive
-f_c_string4.f90 # directive
-inline_1.f90 # flags
-inline_matmul_27.f90 # flags
-pdt_86_reduced.f90 # flags
-power_10.f90 # directive
-pr105594.f90 # flags
-pr84622.f90 # flags
-submodule_35_aux.f90 # multifile
-submodule_37.f90 # flags
-submodule_host_assoc_1.f90 # multifile
-submodule_host_assoc_1_aux.f90 # directive
-submodule_private_host.f90 # multifile
-submodule_private_host_aux.f90 # directive
-warn_undefined_vars_1.f90 # flags
-warn_undefined_vars_2.f90 # flags
-warn_undefined_vars_3.f90 # flags
-warn_undefined_vars_4.f90 # flags
-warn_unused_but_set_1.f90 # flags
-warn_unused_but_set_error_1.f90 # flags
-warn_unused_intent_out_2.f90 # flags
+# Format: path # owner=ORG/REPO#N; reason=text or path # scope=TAG; reason=text
+20231103-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+20231103-2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+ISO_Fortran_binding_1.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_10.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_11.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_12.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_13.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_15.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_16.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_17.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_18.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_3.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_5.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_6.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_7.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_8.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ISO_Fortran_binding_9.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+PR100097.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+PR100098.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+PR100136.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+PR100906.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+PR100911.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+PR100914.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+PR100915.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+PR105658.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+PR113061.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+PR37039.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+PR40660.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+PR49268.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+PR82376.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+PR93963.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+PR94104a.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+PR94104b.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+PR94327.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+PR94331.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+Wall.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+Wno-all.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+abort_shouldfail.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+abstract_type_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+access_spec_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+access_spec_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+achar_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+achar_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+actual_array_substr_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+addressing-modes_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+addressing-modes_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+aliasing_dummy_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+all_bounds_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+alloc_comp_assign_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+alloc_comp_auto_array_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+alloc_comp_basics_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+alloc_comp_constraint_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+alloc_comp_constraint_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+alloc_comp_constructor_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+alloc_comp_constructor_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+alloc_comp_constructor_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+alloc_comp_misc_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+alloc_comp_std.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocatable_char_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+allocatable_function_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocatable_function_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocatable_function_8.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+allocatable_length.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocatable_scalar_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocatable_scalar_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocatable_scalar_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocatable_scalar_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocatable_scalar_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocatable_uninitialized_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocate_alloc_opt_15.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+allocate_alloc_opt_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocate_alloc_opt_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocate_alloc_opt_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocate_error_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+allocate_error_5.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+allocate_error_6.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+allocate_with_arrayspec_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocate_with_mold_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocate_with_source_25.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocate_with_source_29.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocate_with_source_30.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+allocate_with_source_33.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocate_with_source_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+allocate_with_typespec_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+altreturn_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+altreturn_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+altreturn_11.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+altreturn_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+altreturn_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+altreturn_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+altreturn_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+altreturn_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+altreturn_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+altreturn_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+altreturn_9_0.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+altreturn_9_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+any_loc.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+argument_checking_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+argument_checking_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+argument_checking_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+argument_checking_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+argument_checking_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+argument_checking_23.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+argument_checking_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+arith_divide_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+arithmetic_if.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+arithmetic_overflow_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+array_assignment_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_22.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_38.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_40.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_41.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_43.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_44.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_46.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_47.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_49.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_51.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+array_constructor_54.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_constructor_type_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_function_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_memcpy_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_memcpy_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_memcpy_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_memcpy_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_memset_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_memset_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_memset_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_reference_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+array_section_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_section_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_temporaries_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_temporaries_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_temporaries_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+array_temporaries_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+arrayio_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+arrayio_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assign-debug.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assign_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assign_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assign_14.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+assign_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assign_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assign_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assign_func_dtcomp_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assignment_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assignment_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+associate_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+associate_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+associate_26.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+associate_26a.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+associate_37.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+associate_40.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+associate_64.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+associate_66.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+associate_69.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+associate_70.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+associate_72.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+associate_78.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+associative_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_charlen_function_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_charlen_function_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_charlen_function_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_charlen_substring_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_rank_1.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+assumed_rank_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_rank_11.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+assumed_rank_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_rank_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_rank_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_rank_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_rank_22.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+assumed_rank_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_rank_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_rank_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_rank_6.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+assumed_rank_8.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+assumed_rank_9.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+assumed_type_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_type_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_type_13.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+assumed_type_14.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+assumed_type_17.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+assumed_type_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+assumed_type_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+assumed_type_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+asynchronous_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+atan2_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+atan2_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+auto_dealloc_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+auto_dealloc_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+auto_in_equiv_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+auto_in_equiv_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+auto_in_equiv_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+auto_in_equiv_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+auto_in_equiv_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+auto_in_equiv_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+auto_in_equiv_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+auto_save_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+automatic_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+automatic_char_len_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+automatic_default_init_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+automatic_repeat.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+automatic_save.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+backslash_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bessel_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bessel_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bessel_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bessel_5_redux.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bessel_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bessel_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bind-c-contiguous-1.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+bind-c-contiguous-2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bind-c-contiguous-3.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+bind-c-contiguous-4.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+bind-c-contiguous-5.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+bind-c-intent-out.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bind_c_array_params_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bind_c_array_params_3.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+bind_c_bool_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bind_c_char_10.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bind_c_char_4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bind_c_char_5.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bind_c_char_9.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bind_c_coms.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+bind_c_dts.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+bind_c_usage_17.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+bind_c_usage_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bind_c_usage_20.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bind_c_usage_22.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bind_c_usage_23.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bind_c_usage_24.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+bind_c_usage_25.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bind_c_usage_27.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bind_c_usage_28.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bind_c_usage_33.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+bind_c_vars.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+binding_label_tests_20.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+binding_label_tests_26b.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+binding_label_tests_35.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+block_11.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+block_12.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+block_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+block_end_error_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+blockdata_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+blockdata_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+blockdata_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+blockdata_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+blocks_nested_incomplete_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bound_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bound_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bound_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bound_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bound_simplification_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bound_simplification_4.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+bound_simplification_5.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+bound_simplification_6.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bounds_check_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_19.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_22.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_23.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_24.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bounds_check_25.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bounds_check_26.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_28.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_array_ctor_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_array_ctor_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_array_ctor_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_array_ctor_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_array_ctor_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_array_ctor_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_array_io.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bounds_check_fail_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_fail_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_fail_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_fail_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_fail_5.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bounds_check_fail_6.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bounds_check_fail_7.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bounds_check_fail_8.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bounds_check_strlen_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_strlen_10.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bounds_check_strlen_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_strlen_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_strlen_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_strlen_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_strlen_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_strlen_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_strlen_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+bounds_check_strlen_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+boz_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+boz_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+boz_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+boz_15.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+boz_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+boz_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+boz_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+boz_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+boz_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+boz_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+boz_complex_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+boz_complex_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+boz_float_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+boz_float_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+byte_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+byte_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+byte_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_assoc.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+c_by_val_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_by_val_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_by_val_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_char_tests_3.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+c_char_tests_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_f_pointer_shape_tests_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_f_pointer_shape_tests_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_f_pointer_shape_tests_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_f_pointer_tests.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+c_f_pointer_tests_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_f_pointer_tests_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_funloc_tests_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_funloc_tests_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_funloc_tests_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_funptr_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+c_funptr_1_mod.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+c_kind_params.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+c_loc_pure_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_loc_test.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+c_loc_test_19.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_loc_test_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_loc_test_22.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_loc_tests_16.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+c_ptr_tests_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_ptr_tests_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_ptr_tests_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_sizeof_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+c_sizeof_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+c_sizeof_4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+c_sizeof_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char4-subscript.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+char4_decl-2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+char4_decl.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+char_array_constructor_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_assign_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_bounds_check_fail_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_cast_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_cast_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_component_initializer_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_decl_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_eoshift_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_initialiser_actual.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_length_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_length_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_length_20.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_length_22.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_length_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_pointer_assign.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_pointer_assign_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_pointer_assign_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_pointer_dependency.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_pointer_dummy.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_pointer_func.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_result_11.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+char_result_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+char_result_19.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+char_result_mod_19.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+character_comparison_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+character_comparison_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+character_comparison_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+character_comparison_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+character_comparison_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+character_comparison_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+character_comparison_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+character_comparison_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+character_comparison_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+charlen_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+check_bits_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+check_bits_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+chmod_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+chmod_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+chmod_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_51.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_52.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_62.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_64.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_76.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+class_77.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+class_alias.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_allocate_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_allocate_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_allocate_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_allocate_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_allocate_24.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_allocate_25.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_array_13.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+class_array_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_array_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_array_24.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+class_assign_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+class_assign_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+class_optional_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+class_optional_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+class_result_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+class_result_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+co_reduce_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+co_reduce_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_10.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_11.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_12.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_13.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_14.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_15.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_16.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_17.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_18.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_19.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_20.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_21.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_22.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_23.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_24.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_25.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_26.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_27.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_28.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_29_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_29_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_30.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_31.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_32.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_33.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_34.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_35.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_35a.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_37.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_38.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_39.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_4.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_40.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_41.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_42.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_43.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_44.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_45.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_46.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_47.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_48.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_49.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_5.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_50.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_6.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_7.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_8.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_9.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_alloc_with_implicit_sync_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_alloc_with_implicit_sync_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_allocate_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_allocate_12.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_args_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_args_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_atomic_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_atomic_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_atomic_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_atomic_4.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_atomic_5.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_atomic_6.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_class_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_class_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_10.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_11.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_12.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_13.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_14.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_15.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_16.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_17.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_18.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_4.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_5.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_6.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_8.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_collectives_9.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_critical_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_critical_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_data_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_dependency_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_fail_st.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lib_alloc_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lib_alloc_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lib_alloc_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lib_alloc_4.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lib_comm_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lib_move_alloc_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lib_realloc_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lib_this_image_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lib_this_image_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lib_token_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lib_token_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lib_token_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lib_token_4.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lock_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lock_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lock_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lock_4.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lock_5.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lock_6.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_lock_7.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_poly_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_poly_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_poly_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_poly_4.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_poly_5.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_poly_6.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_poly_7.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_poly_8.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_poly_9.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_stat_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_stat_function.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_stat_whitespace.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_subobject_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_sync.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_sync_memory.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_this_image_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_this_image_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coarray_this_image_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+coindexed_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+comma_IO_extension_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+common_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+common_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+common_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+common_18.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+common_19.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+common_20.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+common_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+common_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+common_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+common_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+common_align_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+common_align_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+complex_intrinsic_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+complex_intrinsic_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+complex_intrinsic_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+complex_intrinsic_8.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+complex_parameter_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+conditional_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+conditional_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+conditional_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+conditional_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+conditional_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+conditional_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+conditional_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+conditional_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+conditional_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+constructor_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+constructor_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+constructor_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+constructor_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+contains.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+contiguous_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+contiguous_10.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+contiguous_15.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+contiguous_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+contiguous_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+contiguous_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+continuation_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+continuation_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+continuation_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+continuation_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+continuation_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+continuation_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+continuation_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+continuation_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+continuation_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+continuation_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+continuation_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+continuation_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+convert_implied_open.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+coshape_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+cr_lf.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cray_pointers_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cray_pointers_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cray_pointers_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cray_pointers_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cray_pointers_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cray_pointers_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cray_pointers_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cray_pointers_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cray_pointers_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cray_pointers_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cray_pointers_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cshift_bounds_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cshift_bounds_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cshift_bounds_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cshift_bounds_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+cshift_large_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+data_bounds_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+data_bounds_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+data_char_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+data_char_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+data_char_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+data_char_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+data_constraints_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+data_initialized.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+data_invalid.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+data_pointer_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+date_and_time_4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+deallocate_error_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+deallocate_error_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+debug_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec-comparison-character_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec-comparison-character_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec-comparison-complex_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec-comparison-complex_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec-comparison-int_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec-comparison-int_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec-comparison-real_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec-comparison-real_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec-comparison.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_bitwise_ops_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_bitwise_ops_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_bitwise_ops_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_assignment_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_assignment_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_assignment_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_assignment_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_assignment_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_assignment_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_assignment_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_assignment_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_data_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_data_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_data_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_data_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_data_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_data_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_char_conversion_in_data_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_exp_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_exp_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_exp_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_init_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_init_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_init_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_init_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_intrinsic_ints.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_io_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_io_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_io_2a.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_io_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_io_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_io_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_io_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_loc_rval_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_loc_rval_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_logical_xor_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_logical_xor_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_math.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_math_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_math_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_math_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_math_5.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+dec_math_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_parameter_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_parameter_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_parameter_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_static_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_static_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_static_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_19.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_20.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_22.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_23.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_25.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_26.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_27.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_28.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_structure_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_type_print.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_type_print_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_union_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_union_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_union_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_union_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_union_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_union_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_union_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_union_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_union_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_union_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_union_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dec_union_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+default_format_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+default_format_denormal_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+default_format_denormal_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+default_initialization_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+default_initialization_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+default_numeric_type_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+deferred_character_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+deferred_character_33.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+deferred_character_40.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+deferred_type_param_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+deferred_type_param_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+defined_operators_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_20.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_26.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_27.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_28.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_29.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_30.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_31.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_32.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_33.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_34.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_35.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_36.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_37.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_38.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_41.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_42.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_43.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_45.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_47.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_48.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_49.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_54.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+dependency_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dependency_generation_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+der_array_io_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+der_array_io_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+der_array_io_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+der_charlen_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+der_io_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+derived_array_intrinisics_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+derived_constructor_char_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+derived_constructor_char_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+derived_constructor_comps_6.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+derived_pointer_null_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+derived_pointer_recursion.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+derived_recursion.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+diagnostic-format-sarif-pr105916.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dim_sum_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+dim_sum_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+dim_sum_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+direct_io_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+directive_unroll_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+directive_unroll_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+directive_unroll_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+directive_unroll_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_check_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_check_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_check_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_check_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_check_19.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+do_check_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_check_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_check_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_check_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_concurrent_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+do_concurrent_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_concurrent_11.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+do_concurrent_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_concurrent_6.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+do_concurrent_7.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+do_concurrent_8_f2018.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_concurrent_8_f2023.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_concurrent_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_concurrent_constraints.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+do_concurrent_local_init.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_concurrent_typespec_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_corner_warn.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_iterator_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_subscript_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+do_subscript_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dollar_sym_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+dollar_sym_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dot_product_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dot_product_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+double_complex_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dtio_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dummy_procedure_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+dup_save_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+duplicate_type_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+duplicate_type_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+e_d_fmt.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+elemental_args_check_5.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+elemental_args_check_6.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+elemental_dependency_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+elemental_dependency_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+elemental_dependency_4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+elemental_dependency_5.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+elemental_optional_args_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+elemental_optional_args_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+empty_format_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+end_subroutine_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+end_subroutine_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+endfile_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+endfile_4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+entry_19.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+entry_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+enum_10.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+enum_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+eof_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+eor_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+eoshift_bounds_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+eoshift_large_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+equiv_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+equiv_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+equiv_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+equiv_constraint_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+equiv_constraint_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+equiv_constraint_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+equiv_constraint_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+equiv_constraint_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+equiv_constraint_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+equiv_substr.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+errnocheck_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+error_format.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+error_stop_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+error_stop_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+exponent_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+extends_type_of_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+external_procedures_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+f2018_obs.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+f2c_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+f2c_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+f2c_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+f2c_4.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+f2c_5.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+f2c_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+f2c_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+f2c_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+f2c_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+feed_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+feed_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fimplicit_none_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fimplicit_none_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+finalize_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+finalize_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+finalize_12.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+finalize_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+finalize_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+finalize_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+finalize_28.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+finalize_30.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+finalize_33.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+finalize_34.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+finalize_35.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+finalize_36.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+finalize_37.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+finalize_38a.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+finalize_49.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+finalize_57.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+finalize_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+findloc_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+findloc_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_en_rd.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+fmt_en_rn.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+fmt_en_ru.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+fmt_en_rz.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+fmt_error_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_error_4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+fmt_error_5.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+fmt_f_default_field_width_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_f_default_field_width_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_f_default_field_width_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_fw_d.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_g_default_field_width_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_g_default_field_width_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_g_default_field_width_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_i_default_field_width_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_i_default_field_width_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_i_default_field_width_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_int_sign.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_l.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_l0.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_read_bz_bn.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_tab_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+fmt_tab_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+forall_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+forall_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+forall_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+forall_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+forall_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+forall_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+func_decl_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+func_decl_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+func_derived_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+func_result_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+function_charlen_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+function_kinds_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+function_kinds_5.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+function_optimize_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+function_optimize_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+function_optimize_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+function_optimize_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+function_optimize_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+function_optimize_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+function_optimize_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+function_optimize_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+function_optimize_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+function_optimize_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+function_optimize_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+gamma_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+gamma_4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+generic_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+generic_26.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+generic_36-2.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+global_references_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+global_vars_c_init.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+global_vars_f90_init.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+goto_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+hollerith3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+hollerith5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+hollerith8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+hollerith_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+hollerith_character_array_constructor.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+hollerith_f95.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+hollerith_legacy.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+hollerith_to_char_parameter_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+host_assoc_variable_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+iall_iany_iparity_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+iargc.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+ibits.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+ichar_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+illegal_boz_arg_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+implicit_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+implicit_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+implicit_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+implicit_class_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+implicit_pure_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+implicit_pure_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+implicit_pure_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+implicit_pure_4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+implicit_pure_5.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+implied_do_io_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+implied_do_io_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+implied_do_io_4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+implied_do_io_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+implied_shape_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+import2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+import3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+impure_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+include_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+include_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+include_15.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+include_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+include_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+include_19.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+include_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+include_20.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+include_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+include_23.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+include_24.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+include_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+include_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+include_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+include_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+include_9.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+index_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+index_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+index_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_20.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+init_flag_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+initialization_10.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+initialization_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+initialization_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+initialization_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+initialization_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+initialization_30.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+initialization_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+initialization_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+initialization_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_11.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+inline_matmul_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_19.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_23.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_24.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_25.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_26.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_product_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_sum_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_sum_bounds_check_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_sum_bounds_check_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_transpose_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inquire.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inquire_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inquire_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inquire_iolength.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inquiry_type_ref_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inquiry_type_ref_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inquiry_type_ref_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inquiry_type_ref_7.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+inquiry_type_ref_8.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+int_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+int_conv_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+int_range_io_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+integer_exponentiation_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+integer_exponentiation_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intent_optimize_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intent_optimize_10.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intent_optimize_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intent_optimize_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intent_optimize_4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intent_optimize_5.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intent_optimize_6.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intent_optimize_7.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intent_optimize_8.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intent_optimize_9.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intent_out_11.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+intent_out_15.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intent_out_7.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+intent_out_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intent_out_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+interface_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+interface_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+interface_35.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+interface_42.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+interface_50.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+interface_57.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+interface_60.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+interface_61.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+interface_abstract_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+interface_abstract_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+internal_dummy_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+internal_pack_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+internal_pack_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+internal_pack_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+internal_pack_16.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+internal_pack_17.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+internal_pack_18.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+internal_pack_19.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+internal_pack_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+internal_pack_20.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+internal_pack_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+internal_pack_22.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+internal_pack_24.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+internal_pack_25.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+internal_pack_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+internal_pack_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+internal_pack_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+internal_pack_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+internal_pack_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+internal_write_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intrinsic.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_actual_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_optional_char_arg_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_pack_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intrinsic_pack_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intrinsic_shadow_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_size_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_spread_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intrinsic_spread_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intrinsic_std_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_std_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_std_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_std_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_std_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+intrinsic_unpack_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intrinsic_unpack_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+invalid_interface_assignment.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_constraints_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_constraints_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_constraints_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_constraints_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_constraints_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_constraints_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_constraints_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_constraints_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_err_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+io_real_boz2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_real_boz_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_real_boz_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_real_boz_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_tags_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_tags_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_tags_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_tags_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_tags_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_tags_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_tags_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_tags_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_tags_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+io_tags_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+iostat_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+ipa-sra-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+ipcp-array-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+ipcp-array-2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+is_contiguous_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+ishft_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+isnan_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+isnan_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+iso_c_binding_compiler_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+iso_c_binding_compiler_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+iso_c_binding_compiler_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+iso_c_binding_param_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+iso_c_binding_param_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+iso_fortran_binding_uint8_array.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+iso_fortran_env_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+iso_fortran_env_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+iso_fortran_env_7.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+iso_fortran_env_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+label_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+label_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+large_integer_kind_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+large_integer_kind_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+large_real_kind_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+large_real_kind_form_io_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+large_real_kind_form_io_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+large_unit_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+ldist-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+ldist-pr43023.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+leadz_trailz_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+leadz_trailz_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+len_trim.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+line_length_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+line_length_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+line_length_12.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+line_length_13.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+line_length_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+line_length_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+line_length_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+line_length_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+line_length_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+line_length_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+line_length_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+linefile.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+list_directed_large.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+list_read_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+list_read_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+literal_constants.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+loc_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+logical_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+logical_temp_io_kind8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+loop_versioning_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+loop_versioning_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+loop_versioning_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+loop_versioning_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+loop_versioning_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+loop_versioning_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+loop_versioning_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+loop_versioning_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+loop_versioning_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+loop_versioning_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+lrshift_1.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+ltime_gmtime_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+ltime_gmtime_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_19.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_blas_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_blas_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_bounds_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_bounds_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_bounds_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_bounds_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_bounds_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_bounds_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_bounds_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_bounds_7.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+matmul_bounds_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_bounds_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+matmul_const.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+max_expr.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+maxerrors.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+maxloc_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+maxloc_bounds_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+maxloc_bounds_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+maxloc_bounds_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+maxloc_bounds_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+maxloc_bounds_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+maxloc_bounds_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+maxloc_bounds_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+maxloc_bounds_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+maxlocval_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+maxlocval_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+mclock.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+merge_char_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+merge_char_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+merge_char_const.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+merge_init_expr_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+min0_max0_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+min0_max0_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+min_expr.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+min_max_conformance.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+min_max_kind.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+minloc_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+minlocval_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+minlocval_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+minmax_char_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+minmax_integer.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+minmaxloc_15.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+minmaxloc_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+minmaxloc_18.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+minmaxloc_18a.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+minmaxloc_18b.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+minmaxloc_18c.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+minmaxloc_18d.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+minmaxloc_19.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+minmaxloc_20.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+minmaxloc_21.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+minmaxloc_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+minmaxloc_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+minmaxloc_integer_kinds_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+minmaxloc_zerosize_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+missing_optional_dummy_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+missing_optional_dummy_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+missing_optional_dummy_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+missing_optional_dummy_6a.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+mixed_io_1.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+module_implicit_conversion.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+module_naming_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+module_nan.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+module_parameter_array_refs_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+module_private_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+module_private_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+module_procedure_double_colon_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+module_procedure_double_colon_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+module_procedure_double_colon_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+module_read_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+module_variable_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+module_variable_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+module_variable_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+module_widestring_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+move_alloc_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+move_alloc_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+mvbits_7.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+namelist_100.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+namelist_101.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+namelist_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_19.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_22.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_24.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_34.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_35.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_37.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_42.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_43.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_48.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_49.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_54.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_55.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_63.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_65.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_67.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_83.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+namelist_85.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_86.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_87.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_args.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_assumed_char.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_char_only.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_empty.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_internal.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+namelist_use_only.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nan_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nan_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nan_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nan_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nan_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nan_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nan_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nearest_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nearest_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nearest_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+negative_automatic_size.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nested_array_constructor_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nested_modules_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nested_modules_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+newunit_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nint_p7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+no-automatic.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+no_arg_check_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+no_arg_check_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+no_char_conversion_in_array_constructor.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+no_char_to_numeric_assign.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+no_overwrite_recursive_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+no_overwrite_recursive_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+no_range_check_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+no_range_check_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+no_unit_error_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+noinline.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+non_lvalue_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+nonreturning_statements.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+noreturn-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+noreturn-2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+noreturn-4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+noreturn-5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+norm2_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+norm2_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+norm2_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nosigned_zero_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nosigned_zero_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+null_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+null_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+null_actual.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+null_actual_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+nullify_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+num_images_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+o_fast_stacksize.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+oldstyle_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+open_errors_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+open_errors_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+open_new_segv.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+openacc-define-1.f90 # scope=OpenACC; reason=excluded OpenACC syntax or runtime dependency
+openacc-define-2.f90 # scope=OpenACC; reason=excluded OpenACC syntax or runtime dependency
+openacc-define-3.f90 # scope=OpenACC; reason=excluded OpenACC syntax or runtime dependency
+openmp-define-1.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp-define-2.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp-define-3.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+operator_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+optional_absent_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+optional_absent_7.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+out_of_range_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+output_exponents_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+overload_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pack_bounds_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+parameter_array_element_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+parameter_array_element_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+parameter_array_init_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+parameter_array_section_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+parameter_unused.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+parens_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+parens_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+parity_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+parity_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_assign_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_15.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pointer_check_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_check_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_function_actual_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_init_10.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pointer_init_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_intent_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_intent_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_intent_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_intent_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_remapping_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_remapping_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pointer_target_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+power_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+power_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+power_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+power_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+power_7.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+power_8.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr100154.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr100950.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr100988.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr101158.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr101264.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr101267.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr101399_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr101399_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr102180.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr102366.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr102458.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr102458b.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr102532.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr102860.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr103286.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr103367.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr103475.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr103504.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr103505.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr103607.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr103608.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr103628.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr103691.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr103692.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr103715.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr103779.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr104210.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr104330.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr104466.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr104571.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr104649.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr104908.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr105456-nmlr.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr105456-nmlw.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr105456-ruf.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr105456-wf.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr105456-wuf.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr105456.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr105954.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr106331.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr106556.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr106557.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr106934.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr106945.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr107423.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr107559.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr107680.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr107681.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr107899.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr108131.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr108193.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr108501.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr108502.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr108527.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr108592.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr108889.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr109265.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr109662-a.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr109662.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr109788.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr111880.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr111891.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr112404.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr112406.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr112407b.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr112459.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr112877-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr113503_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr114883.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr114959.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr115281.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr115348.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr117060.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr117730_b.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+pr117763.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr117901.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr119136.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr119273.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr120049_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr120049_a.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+pr121743.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr122957.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr123947_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr124543.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr125117.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr15129.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr15140.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr16597.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr17143.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr17164.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr17706.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr18210.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr20086.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr20124.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr20865.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr25623-2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr25623.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr25923.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr26246_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr26246_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr28158.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr29713.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr30391-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr31025.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr32136.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr32242.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr32533.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr32535.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr33074.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr33449.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr33794.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr34163.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr35662.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr35944-2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr36006-2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr36192_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr36680.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr37286.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr37287-1.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+pr38722.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr39666-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr39666-2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr41043.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr41212.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr41225.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr41229.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr41347.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr41922.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr41928.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr42108.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr42166.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr43229.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr43475.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr43688.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr43796.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr43808.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr43866.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr43984.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr44491.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr44592.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr44882.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr45636.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr46190.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr46519-2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr46588.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr46665.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr46804.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr46945.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr46985.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr47054_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr47054_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr48636-2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr48636.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr48958.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr49179.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr49308.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr49472.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr49494.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr49675.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr50769.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr50875.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr52370.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr52621.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr52701.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr52835.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr53217.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr53787.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr54889.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr55086_1_tfat.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr55086_2_tfat.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr55086_aliasing_dummy_4_tfat.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr55330.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr56015.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr56049.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr57393-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr57393-2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr57904.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr57987.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr58290.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr59107.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr59440-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr59440-2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr59440-3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr61209.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr61335.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr61921.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr62135.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr62695.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr63331.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr63821.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr64528.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr65903.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr66545_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr66545_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr67170.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr67460.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr67614.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr67615.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr67740.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr68078.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+pr68251.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr68318_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr68318_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr68379-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr68817.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr69055.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr69395.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr69419.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr69603.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr69955.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr69962.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr69987.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr70754.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr70870_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr70931.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr70937.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr71204.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr71230-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr71230-2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr71252.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr71523_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr71523_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr71526.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr71642.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr71688.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr71706.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr77260_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr77260_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr77380.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr77406.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr77420_3.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+pr77694.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr77719.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr77763.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr77959.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr77978_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr77978_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr77978_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr78240.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr78259.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr78278.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr78279.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr78571.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr78619.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr78739.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr78758.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr79315.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr79886.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr79966.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr80012.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr80494.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr80668.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr81464.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr81529.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr81735.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr81889.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr82004.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr82253.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr82973.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr83149_1.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+pr83149_b.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+pr83246.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr84117.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr84245.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr84565.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr84784.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr85082.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr85357.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr85543.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr85780.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr85895.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr86551.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr87117.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr87360.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr87907.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr87991.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr88138.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr88148.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+pr88169_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr88169_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr88228.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr88248.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr88299.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr88357_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr88379.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr88611.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr88624.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr88833.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr88902.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr88932.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr88934.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr88964.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr89092.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr89451.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr89462.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr89664.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr89956.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr90002.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr90021.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr90290.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr90385.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr91003.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr91296.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr91372.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr91496.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr91497.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr91497_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr91650_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr91802.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr91913.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr91945.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr92050.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr92094.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr92537.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr92613.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr92613_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr92629.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr92874.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr92897.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr93263_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr93364.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr93473.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr93524.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+pr93715.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr93792.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr94285.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr94329.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr94708.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr94978.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95088.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95089.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr95090.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr95091.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95373_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95373_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95398.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95446.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95687.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95688.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95689.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95707.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95709.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95826.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95827.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr95828.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95879.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr95881.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr96085.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96102b.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr96312.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96319.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96436_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96436_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96436_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96436_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96436_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96436_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96436_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96436_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96436_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96436_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96613.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr96711.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr96737.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+pr96986.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr97036.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr97505.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr97673.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr98076.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr98411.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr99112.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr99139.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr99204.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr99545.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr99602.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr99602a.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr99602b.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr99602c.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr99602d.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr99853.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+predict-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+predict-2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+predict-3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+print_parentheses_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+private_type_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+private_type_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+private_type_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+private_type_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+private_type_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+private_type_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+private_type_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+private_type_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+proc_assign_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+proc_decl_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+proc_decl_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+proc_ptr_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+proc_ptr_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+proc_ptr_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+proc_ptr_24.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+proc_ptr_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+proc_ptr_35.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+proc_ptr_39.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+proc_ptr_56.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+proc_ptr_7.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+proc_ptr_8.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+proc_ptr_common_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+proc_ptr_comp_51.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+proc_ptr_comp_pass_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+proc_ptr_result_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+promotion.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+promotion_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+promotion_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+promotion_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+protected_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+protected_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+protected_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+protected_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+protected_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+protected_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+ptr-func-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+ptr-func-2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+ptr-func-4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+public_private_module_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+public_private_module_3.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+public_private_module_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+public_private_module_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+public_private_module_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+public_private_module_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pure_formal_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+quad_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+quad_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+random_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+random_5.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+random_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+random_init_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+random_init_4.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+random_init_5.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+random_init_6.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+rank_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+rank_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+rank_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+rank_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+read_dir.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+read_eor.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+read_float_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+read_infnan_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+read_legacy_comma.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+read_logical.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+real4-10-real8-16.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+real4-16-real8-10.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+real4-16-real8-16.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+real4-16-real8-4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+real4-16.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+real4-8-real8-16.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+real8-16.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+real_compare_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+real_const_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+realloc_on_assign_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+realloc_on_assign_16a.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+realloc_on_assign_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+realloc_on_assign_19.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+realloc_on_assign_20.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+realloc_on_assign_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+realloc_on_assign_22.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+reassoc_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+reassoc_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+reassoc_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+reassoc_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+reassoc_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+record_marker_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+record_marker_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+recursive_check_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+recursive_check_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+recursive_check_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+recursive_check_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+recursive_check_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+recursive_check_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+recursive_check_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+recursive_check_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+recursive_check_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+recursive_reference_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+recursive_stack.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+recursive_statement_functions.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+repack_arrays_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+repeat_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+reshape_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+reshape_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+reshape_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+reshape_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+reshape_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+reshape_order_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+reshape_order_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+reshape_order_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+reshape_order_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+restricted_expression_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+restricted_expression_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+result_default_init_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+result_in_spec_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+return_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+rewind_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+round_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+runtime_warning_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+same_name_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+save_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+save_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+save_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+save_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+save_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+save_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+scalar_pointer_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+scalar_return_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+scan_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+select_char_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+select_char_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+select_contiguous.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+select_type_20.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+select_type_25.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+select_type_41.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+select_type_49.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+selected_char_kind_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+selected_kind_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+selected_logical_kind_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+selected_logical_kind_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+selected_real_kind_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+selected_real_kind_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+semicolon_free.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+semicolon_free_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+shape_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+shape_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+shape_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+short_circuiting_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+short_circuiting_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+simd-builtins-1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+simd-builtins-2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+simd-builtins-6.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+simd-builtins-7.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+simd-builtins-8.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+simd-builtins-9.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+single_char_string.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+size_kind_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+size_optional_dim_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+size_optional_dim_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+sizeof_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+sms-1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+sms-2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+spec_statement_in_exec.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+specifics_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+split_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+split_4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+spread_bounds_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+spread_init_expr_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+spread_scalar_source.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+spread_size_limit.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+spread_size_limit_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+stat_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+stat_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+stat_4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+statement_function_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+statement_function_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+statement_function_5.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+stfunc_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+stfunc_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+stfunc_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+stfunc_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+stfunc_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+stop_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+stop_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+stop_4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+stop_shouldfail.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+storage_size_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+storage_size_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+str_comp_optimize_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+streamio_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+streamio_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+string_1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+string_1_lp64.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+string_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+string_3_lp64.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+string_assign_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+string_assign_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+string_compare_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+string_ctor_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+string_length_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+string_length_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+string_length_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+structure_constructor_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+structure_constructor_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+subnormal_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+substr_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+substr_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+system_clock_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+system_clock_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+system_clock_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+team_change_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+team_change_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+team_end_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+team_end_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+team_form_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+team_form_3.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+team_get_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+team_number_1.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+team_sync_2.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+temporary_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+test_only_clause.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+tl_editing.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+trans-mem-skel.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_array_intrinsic_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_array_subref.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+transfer_array_subref_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+transfer_check_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_check_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_check_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_check_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_check_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_class_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_hollerith_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_intrinsic_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_intrinsic_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_resolve_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_simplify_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_simplify_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_simplify_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_simplify_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_simplify_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_simplify_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transfer_simplify_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transpose_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transpose_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transpose_optimization_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transpose_optimization_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+transpose_reshape_r10.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+trim_optimize_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+trim_optimize_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+trim_optimize_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+trim_optimize_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+trim_optimize_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+trim_optimize_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+type_decl_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+type_decl_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+typebound_proc_19.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+typebound_proc_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unexpected_eof_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unf_io_convert_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unf_io_convert_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+unf_io_convert_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unformatted_subrecord_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unlimited_polymorphic_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unlimited_polymorphic_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unpack_bounds_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unpack_bounds_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unpack_bounds_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_15.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_16.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_19.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_20.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_21_be.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_22.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_23.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_25.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_26.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_29.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_30.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_31.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_32.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_33.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_34.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_35.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_36.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_38.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_39.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_40.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_41.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_42.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_43.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_44.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_kiss.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+unsigned_write.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+unused_artificial_dummies_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+use_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+use_12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+use_21.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+use_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+use_only_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+use_rename_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+use_rename_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+use_without_only_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+used_before_typed_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+used_before_typed_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+used_before_typed_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+used_before_typed_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+used_before_typed_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+used_before_typed_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+used_types_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+value_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+value_10.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+value_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+value_4.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+vax_structure_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+vector_subscript_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+vector_subscript_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+volatile10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+volatile11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+volatile12.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+volatile2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+volatile3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+volatile4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+volatile5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+volatile6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+volatile7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_alias.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_align_commons.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_conversion.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_conversion_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_conversion_11.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_conversion_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_conversion_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_conversion_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_conversion_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_conversion_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_conversion_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_conversion_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_conversion_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_function_without_result.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_function_without_result_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_implicit_procedure_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_intent_out_not_set.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_std_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_std_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_std_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_target_lifetime_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_target_lifetime_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_target_lifetime_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_target_lifetime_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_undefined_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_dummy_argument_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_dummy_argument_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_dummy_argument_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_dummy_argument_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_dummy_argument_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_function.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_function_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_function_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_var.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_var_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_var_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warnings_are_errors_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+weak-1.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+weak-2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+weak-3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+where_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+where_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+where_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+whole_file_14.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+whole_file_17.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+whole_file_18.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+whole_file_21.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+whole_file_22.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+whole_file_25.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+whole_file_26.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+whole_file_29.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+whole_file_31.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+whole_file_32.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+whole_file_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+whole_file_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+whole_file_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_11.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+widechar_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_IO_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_intrinsics_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_intrinsics_10.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_intrinsics_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_intrinsics_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_intrinsics_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_intrinsics_5.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_intrinsics_6.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_intrinsics_7.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_intrinsics_8.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_intrinsics_9.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+widechar_select_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+winapi.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+write_check.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+wtruncate.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+wunused-parameter.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+wunused-parameter_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+zero_sized_13.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+zero_sized_8.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bounds_check_20.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+implied_do_io_5.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+inline_matmul_20.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+unsigned_write_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+always_inline_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+binding_label_tests_34.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+binding_label_tests_36.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+coarray_51.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+do_concurrent_assoc_default_none.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+f_c_string3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+f_c_string4.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+inline_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+inline_matmul_27.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pdt_86_reduced.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+power_10.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+pr105594.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+pr84622.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+submodule_35_aux.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+submodule_37.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+submodule_host_assoc_1.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+submodule_host_assoc_1_aux.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+submodule_private_host.f90 # scope=harness; reason=requires unmodeled DejaGNU additional-source handling
+submodule_private_host_aux.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+warn_undefined_vars_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_undefined_vars_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_undefined_vars_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_undefined_vars_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_but_set_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_but_set_error_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
+warn_unused_intent_out_2.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics

--- a/test/conformance/skip_lfortran.txt
+++ b/test/conformance/skip_lfortran.txt
@@ -1,2 +1,2 @@
 # lfortran integration_tests entries skipped by the gauntlet.
-# Format: basename.f90 # reason
+# Format: path # owner=ORG/REPO#N; reason=text or path # scope=TAG; reason=text

--- a/test/conformance/xfail_fortfront_f90.txt
+++ b/test/conformance/xfail_fortfront_f90.txt
@@ -1,119 +1,119 @@
 # Known-unsupported files for the fortfront-f90 suite.
-# One basename or suite-relative path per line.
+# Format: path # owner=ORG/REPO#N; reason=text or path # scope=TAG; reason=text
 # Lines starting with '#' and blank lines are ignored.
 #
 # Promote entries by removing them from this file when ffc starts passing.
-ast_coverage_control_flow.f90
-ast_coverage_literals_calls.f90
-ast_forall_pointer.f90
-call_graph_internal_procedures.f90
-control_flow_associate_construct.f90
-data_statement_scalar_upgrade.f90
-docs_character_arrays_out.f90
-docs_unsigned_integers_out.f90
-dtio_interface_basic.f90
-dtio_interface_read_write.f90
-dtio_interface_unformatted.f90
-external_tool_example.f90
-f2003_abstract_interface.f90
-f2003_block_construct.f90
-f2003_type_bound_array_call.f90
-issue_1324_if_inside_do_loop.f90
-issue_1353_class_pointer_declaration.f90
-issue_1570_pure_elemental_preservation.f90
-issue_1607_final_procedures.f90
-issue_1611_allocate_no_typespec.f90
-issue_1614_character_module_variable.f90
-issue_1615_target_attribute.f90
-issue_1619_nested_types_complex.f90
-issue_1621_intent_out_array_shape.f90
-issue_1738_derived_type_allocatable.f90
-issue_1740_optional_keyword_arguments.f90
-issue_1744_operator_interface.f90
-issue_1771_module_parameter_types.f90
-issue_1782_procedure_pointer.f90
-issue_1827_submodule_simple.f90
-issue_1827_submodule_with_contents.f90
-issue_1960_pointer_assignment_if.f90
-issue_2014_elemental_function_lost.f90
-issue_2017_assumed_shape_duplicate_monomorph.f90
-issue_2024_char_function_duplicate_and_missing.f90
-issue_2070_entry_loses_argument_declarations.f90
+ast_coverage_control_flow.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+ast_coverage_literals_calls.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+ast_forall_pointer.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+call_graph_internal_procedures.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+control_flow_associate_construct.f90 # owner=lazy-fortran/ffc#331; reason=bind BLOCK and ASSOCIATE storage scopes
+data_statement_scalar_upgrade.f90 # scope=harness; reason=FortFront semantic rejection fixture
+docs_character_arrays_out.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+docs_unsigned_integers_out.f90 # scope=vendor; reason=nonstandard UNSIGNED extension
+dtio_interface_basic.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_interface_read_write.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_interface_unformatted.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+external_tool_example.f90 # scope=harness; reason=requires a companion module outside this suite invocation
+f2003_abstract_interface.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+f2003_block_construct.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+f2003_type_bound_array_call.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+issue_1324_if_inside_do_loop.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+issue_1353_class_pointer_declaration.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+issue_1570_pure_elemental_preservation.f90 # owner=lazy-fortran/ffc#405; reason=lower elemental procedures through array expressions
+issue_1607_final_procedures.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+issue_1611_allocate_no_typespec.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_1614_character_module_variable.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+issue_1615_target_attribute.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+issue_1619_nested_types_complex.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_1621_intent_out_array_shape.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+issue_1738_derived_type_allocatable.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+issue_1740_optional_keyword_arguments.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_1744_operator_interface.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_1771_module_parameter_types.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+issue_1782_procedure_pointer.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+issue_1827_submodule_simple.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+issue_1827_submodule_with_contents.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+issue_1960_pointer_assignment_if.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+issue_2014_elemental_function_lost.f90 # owner=lazy-fortran/ffc#405; reason=lower elemental procedures through array expressions
+issue_2017_assumed_shape_duplicate_monomorph.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+issue_2024_char_function_duplicate_and_missing.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+issue_2070_entry_loses_argument_declarations.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
 # Source INCLUDE expansion is unsupported; ffc now rejects instead of silently
 # dropping the include line.
-issue_2078_include_statement_silently_dropped.f90
-issue_2162_entry_wrapping.f90
-issue_2236_optional_assumed_rank_bridge.f90
-issue_2238_select_rank_performance.f90
-issue_2248_read_keyword.f90
-issue_2250_pure_interface.f90
-issue_2416_io_format_variable.f90
-issue_2416_io_formats_comprehensive.f90
-issue_2416_io_namelist_read.f90
-issue_2417_minloc_with_mask.f90
-issue_2418_intrinsic_keywords_declared.f90
-issue_2419_data_variable_in_allocate.f90
-issue_2450_procedure_interfaces.f90
-issue_2452_roundtrip_timeout.f90
-issue_2453_character_array_constructor.f90
-issue_2455_array_constructor_arg.f90
-issue_2455_nested_array_constructor.f90
-issue_2455_nested_function_args.f90
-issue_2458_multi_array_declaration.f90
-issue_2486_class_type_multidecl.f90
-issue_2487_parameter_statement.f90
-issue_2489_interface_in_procedure.f90
-issue_2490_hollerith_format.f90
-issue_2493_char_array_constructor.f90
-issue_2495_data_null_intrinsic.f90
-issue_2497_include_line_standalone.f90
-issue_2520_doubled_quotes_format_string.f90
-issue_2559_select_type_case_variations.f90
-issue_2562_where_invalid_if.f90
-issue_256_fix_suggestion.f90
-issue_256_incomplete_expression.f90
-issue_256_invalid_syntax_missing_then.f90
-issue_2591_unsigned_declarations.f90
-issue_2591_unsigned_mixing_error.f90
-issue_2592_interface_block_explicit_interface_ok.f90
-issue_2592_missing_explicit_interface_function.f90
-issue_2592_missing_explicit_interface_subroutine.f90
-issue_2639_intrinsic_subroutine_calls_ok.f90
-issue_2644_strict_arg_checker_scope_lookup.f90
-issue_2737_lfortran_template_instantiate.f90
-issue_2738_lfortran_traits_requirements_implements.f90
-issue_2753_unsigned_argument_mixing_error.f90
-issue_2753_unsigned_assignment_mixing_error.f90
-issue_playtest5_array_parameter_rank_lost.f90
-library_usage_ast_node_counter.f90
-library_usage_ast_node_position.f90
-tmp_goto_ast.f90
-tooling_lightweight_ast.f90
-undefined_var_recursive_type.f90
+issue_2078_include_statement_silently_dropped.f90 # owner=lazy-fortran/ffc#354; reason=expand Fortran INCLUDE lines
+issue_2162_entry_wrapping.f90 # owner=lazy-fortran/ffc#416; reason=compile procedure-only translation units
+issue_2236_optional_assumed_rank_bridge.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_2238_select_rank_performance.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+issue_2248_read_keyword.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+issue_2250_pure_interface.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_2416_io_format_variable.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+issue_2416_io_formats_comprehensive.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+issue_2416_io_namelist_read.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+issue_2417_minloc_with_mask.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+issue_2418_intrinsic_keywords_declared.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+issue_2419_data_variable_in_allocate.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+issue_2450_procedure_interfaces.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_2452_roundtrip_timeout.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+issue_2453_character_array_constructor.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+issue_2455_array_constructor_arg.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+issue_2455_nested_array_constructor.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+issue_2455_nested_function_args.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+issue_2458_multi_array_declaration.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+issue_2486_class_type_multidecl.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+issue_2487_parameter_statement.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+issue_2489_interface_in_procedure.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+issue_2490_hollerith_format.f90 # scope=legacy; reason=deleted Hollerith FORMAT descriptor
+issue_2493_char_array_constructor.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+issue_2495_data_null_intrinsic.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+issue_2497_include_line_standalone.f90 # owner=lazy-fortran/ffc#354; reason=expand Fortran INCLUDE lines
+issue_2520_doubled_quotes_format_string.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_2559_select_type_case_variations.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+issue_2562_where_invalid_if.f90 # scope=harness; reason=FortFront semantic rejection fixture
+issue_256_fix_suggestion.f90 # scope=harness; reason=FortFront parser rejection fixture
+issue_256_incomplete_expression.f90 # scope=harness; reason=FortFront parser rejection fixture
+issue_256_invalid_syntax_missing_then.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+issue_2591_unsigned_declarations.f90 # scope=vendor; reason=nonstandard UNSIGNED extension
+issue_2591_unsigned_mixing_error.f90 # scope=vendor; reason=nonstandard UNSIGNED extension
+issue_2592_interface_block_explicit_interface_ok.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+issue_2592_missing_explicit_interface_function.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+issue_2592_missing_explicit_interface_subroutine.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+issue_2639_intrinsic_subroutine_calls_ok.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+issue_2644_strict_arg_checker_scope_lookup.f90 # owner=lazy-fortran/ffc#327; reason=key lowering symbols by FortFront binding identity
+issue_2737_lfortran_template_instantiate.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+issue_2738_lfortran_traits_requirements_implements.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_2753_unsigned_argument_mixing_error.f90 # scope=vendor; reason=nonstandard UNSIGNED extension
+issue_2753_unsigned_assignment_mixing_error.f90 # scope=vendor; reason=nonstandard UNSIGNED extension
+issue_playtest5_array_parameter_rank_lost.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+library_usage_ast_node_counter.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+library_usage_ast_node_position.f90 # scope=harness; reason=requires a companion module outside this suite invocation
+tmp_goto_ast.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+tooling_lightweight_ast.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+undefined_var_recursive_type.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 # C interoperability: c_funloc/c_funptr/c_f_procpointer and bind(c) procedure
 # pointers are not yet lowered by the direct LIRIC session.
-issue_2814_c_funloc.f90
-issue_2814_c_f_procpointer.f90
-issue_2820_c_interop_pointers.f90
+issue_2814_c_funloc.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_2814_c_f_procpointer.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_2820_c_interop_pointers.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
 # Inline generic instantiation caret syntax name^(T)(...) is unsupported.
-issue_2817_inline_instantiate_caret.f90
+issue_2817_inline_instantiate_caret.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
 # Implied-do upper bound references its own (out-of-scope) index; not lowered.
-issue_2819_implied_do_index_out_of_scope.f90
+issue_2819_implied_do_index_out_of_scope.f90 # scope=harness; reason=FortFront semantic rejection fixture
 # FortFront parser rejects these (semicolon in interface block; type() return
 # in interface body). Blocked on a FortFront fix, not an ffc lowering gap.
-issue_2837_interface_type_return.f90
+issue_2837_interface_type_return.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 # Unary user-defined operator: FortFront emits a dangling operand index
 # ("argument index does not reference an AST node"). Blocked on FortFront.
-issue_2838_unary_defined_operator.f90
+issue_2838_unary_defined_operator.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
 # VALUE attribute on dummy args mis-declared as a symbol named "value".
 # New corpus examples added by the fortfront update for features ffc does not
 # yet lower (expression/keyword I/O formats, PURE-with-print body checks,
 # implied-DO index shadow, procedure-only units). Never passed; not regressions.
-issue_2819_implied_do_index_shadow.f90
-issue_2819_pure_with_print.f90
-issue_2836_io_expression_format.f90
-issue_2836_io_keyword_unit_format.f90
-issue_2848_dimension_statement.f90  # ff#2848 DIMENSION statement -> unsupported scalar type
-issue_2850_bare_function_interface.f90  # ff#2850 bare interface: duplicate decl
-issue_2850_bare_subroutine_interface.f90  # ff#2850 bare interface
-issue_2855_external_intrinsic_conflict.f90  # ff#2855 external/intrinsic conflict
+issue_2819_implied_do_index_shadow.f90 # scope=harness; reason=FortFront semantic rejection fixture
+issue_2819_pure_with_print.f90 # scope=harness; reason=FortFront semantic rejection fixture
+issue_2836_io_expression_format.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+issue_2836_io_keyword_unit_format.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+issue_2848_dimension_statement.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+issue_2850_bare_function_interface.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+issue_2850_bare_subroutine_interface.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+issue_2855_external_intrinsic_conflict.f90 # scope=harness; reason=FortFront semantic rejection fixture

--- a/test/conformance/xfail_fortfront_lf.txt
+++ b/test/conformance/xfail_fortfront_lf.txt
@@ -1,68 +1,68 @@
 # Known-unsupported files for the fortfront-lf suite.
-# One basename or suite-relative path per line.
+# Format: path # owner=ORG/REPO#N; reason=text or path # scope=TAG; reason=text
 # Lines starting with '#' and blank lines are ignored.
 #
 # Promote entries by removing them from this file when ffc starts passing.
-array_index_brackets_multi.lf
-array_index_brackets_simple.lf
-array_slice_basic.lf
-array_slice_empty_bounds.lf
-array_slice_stride.lf
-boolean_assign_bare_false.lf
-boolean_assign_bare_true.lf
-debug_mixed_constructs.lf
-docs_character_arrays.lf
-docs_unsigned_integers.lf
-error_missing_then.lf
-implicit_do_print.lf
-intrinsic_functions.lf
-issue_1330_missing_declarations.lf
-issue_1410_pointer_null.lf
-issue_1414_implied_do.lf
-issue_1534_multi_dimension_allocatable.lf
-issue_1775_intent_in_preserved.lf
-issue_1784_subroutine_wrapping.lf
-issue_1814_nested_lazy_function.lf
-issue_1816_multiple_return_values.lf
-issue_1816_multiple_returns.lf
-issue_1968_lazy_function_result.lf
-issue_2012_subroutine_local_not_inferred.lf
-issue_2062_nested_do_missing_var_type_mismatch.lf
-issue_2063_deferred_char_function_syntax.lf
-issue_2066_array_function_rank_mismatch.lf
-issue_2067_implied_do_array_return_rank_mismatch.lf
-issue_2069_allocate_not_inferred_allocatable.lf
-issue_2071_function_param_string_inferred_as_real.lf
-issue_2072_pointer_not_declared.lf
-issue_2075_stop_keyword_collision_in_function_param.lf
-issue_2106_missing_intent_monomorphization.lf
-issue_2110_array_param_hardcoded.lf
-issue_2147_mono_name_collision_wrong_types.lf
-issue_2150_reshape_variable_vs_literal_shape.lf
-issue_2151_array_function_broken.lf
-issue_2153_array_call_scalar_param.lf
-issue_2163_character_substring_lengths.lf
-issue_2165_undeclared_argument.lf
-issue_2691_implied_do_static_size_known.lf
-issue_2691_implied_do_static_size_unknown.lf
-issue_2694_strict_zero_iter_implied_do.lf
-issue_2694_strict_zero_sized_array_constructor.lf
-issue_652_multi_var_allocatable.lf
-issue_nested_internal_procedures.lf
-issue_playtest5_function_no_return_type.lf
-issue_playtest5_nested_function_chaos.lf
-issue_playtest5_reshape_allocatable_never_allocated.lf
-issue_playtest5_subroutine_name_collision.lf
-monomorphization_add_three_types.lf
-test_209_mixed.lf
-test_209_none.lf
-test_sem_scope.lf
-test_subroutine_monomorphization.lf
+array_index_brackets_multi.lf # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+array_index_brackets_simple.lf # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+array_slice_basic.lf # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_slice_empty_bounds.lf # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_slice_stride.lf # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+boolean_assign_bare_false.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+boolean_assign_bare_true.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+debug_mixed_constructs.lf # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+docs_character_arrays.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+docs_unsigned_integers.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+error_missing_then.lf # scope=harness; reason=FortFront Lazy parser rejection fixture
+implicit_do_print.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsic_functions.lf # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+issue_1330_missing_declarations.lf # owner=lazy-fortran/ffc#438; reason=apply Lazy Fortran default type and intent policy
+issue_1410_pointer_null.lf # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+issue_1414_implied_do.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_1534_multi_dimension_allocatable.lf # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+issue_1775_intent_in_preserved.lf # owner=lazy-fortran/ffc#408; reason=reorder keyword actual arguments by public dummy names
+issue_1784_subroutine_wrapping.lf # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+issue_1814_nested_lazy_function.lf # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+issue_1816_multiple_return_values.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_1816_multiple_returns.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_1968_lazy_function_result.lf # owner=lazy-fortran/ffc#425; reason=infer Lazy Fortran array declarations
+issue_2012_subroutine_local_not_inferred.lf # owner=lazy-fortran/ffc#438; reason=apply Lazy Fortran default type and intent policy
+issue_2062_nested_do_missing_var_type_mismatch.lf # owner=lazy-fortran/ffc#425; reason=infer Lazy Fortran array declarations
+issue_2063_deferred_char_function_syntax.lf # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+issue_2066_array_function_rank_mismatch.lf # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+issue_2067_implied_do_array_return_rank_mismatch.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_2069_allocate_not_inferred_allocatable.lf # owner=lazy-fortran/ffc#425; reason=infer Lazy Fortran array declarations
+issue_2071_function_param_string_inferred_as_real.lf # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+issue_2072_pointer_not_declared.lf # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+issue_2075_stop_keyword_collision_in_function_param.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_2106_missing_intent_monomorphization.lf # owner=lazy-fortran/ffc#437; reason=emit one-unit Lazy procedure specializations
+issue_2110_array_param_hardcoded.lf # owner=lazy-fortran/ffc#437; reason=emit one-unit Lazy procedure specializations
+issue_2147_mono_name_collision_wrong_types.lf # owner=lazy-fortran/ffc#437; reason=emit one-unit Lazy procedure specializations
+issue_2150_reshape_variable_vs_literal_shape.lf # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+issue_2151_array_function_broken.lf # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+issue_2153_array_call_scalar_param.lf # owner=lazy-fortran/ffc#437; reason=emit one-unit Lazy procedure specializations
+issue_2163_character_substring_lengths.lf # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+issue_2165_undeclared_argument.lf # owner=lazy-fortran/ffc#438; reason=apply Lazy Fortran default type and intent policy
+issue_2691_implied_do_static_size_known.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_2691_implied_do_static_size_unknown.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_2694_strict_zero_iter_implied_do.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+issue_2694_strict_zero_sized_array_constructor.lf # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+issue_652_multi_var_allocatable.lf # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+issue_nested_internal_procedures.lf # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+issue_playtest5_function_no_return_type.lf # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+issue_playtest5_nested_function_chaos.lf # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+issue_playtest5_reshape_allocatable_never_allocated.lf # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+issue_playtest5_subroutine_name_collision.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+monomorphization_add_three_types.lf # owner=lazy-fortran/ffc#437; reason=emit one-unit Lazy procedure specializations
+test_209_mixed.lf # owner=lazy-fortran/ffc#425; reason=infer Lazy Fortran array declarations
+test_209_none.lf # owner=lazy-fortran/ffc#425; reason=infer Lazy Fortran array declarations
+test_sem_scope.lf # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+test_subroutine_monomorphization.lf # owner=lazy-fortran/ffc#437; reason=emit one-unit Lazy procedure specializations
 
 # IEEE arithmetic intrinsic module (ieee_is_nan/ieee_is_finite/...) unsupported.
-issue_2815_ieee_arithmetic.lf
+issue_2815_ieee_arithmetic.lf # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
 # Walrus declaration ':=' produces a dangling AST target index in FortFront.
-issue_2816_walrus_redeclaration.lf
+issue_2816_walrus_redeclaration.lf # scope=harness; reason=FortFront Lazy semantic rejection fixture
 # Derived-type constructor in lazy mode lowered as a real function call.
-issue_2142_mono_wrong_return_types.lf  # generic add() monomorphized to module+interface; ffc lacks mixed-kind generic dispatch
-monomorphization_simple.lf  # generic add() monomorphized to module+interface; ffc lacks mixed-kind generic dispatch
+issue_2142_mono_wrong_return_types.lf # owner=lazy-fortran/ffc#437; reason=emit one-unit Lazy procedure specializations
+monomorphization_simple.lf # owner=lazy-fortran/ffc#437; reason=emit one-unit Lazy procedure specializations

--- a/test/conformance/xfail_gfortran_dg.txt
+++ b/test/conformance/xfail_gfortran_dg.txt
@@ -1,2146 +1,2141 @@
 # Known-unsupported files for the gfortran-dg testsuite suite.
-# One basename or suite-relative path per line.
+# Format: path # owner=ORG/REPO#N; reason=text or path # scope=TAG; reason=text
 # Lines starting with '#' and blank lines are ignored.
 #
 # Promote entries by removing them from this file when ffc starts passing.
-ISO_Fortran_binding_14.f90
-ISO_Fortran_binding_19.f90
-ISO_Fortran_binding_4.f90
-PR100029.f90
-PR100040.f90
-PR100094.f90
-PR100103.f90
-PR100120.f90
-PR100132.f90
-PR100245.f90
-PR19754_2.f90
-PR85868A.f90
-PR85868B.f90
-PR90350.f90
-PR93308.f90
-PR94022.f90
-PR94289.f90
-PR95196.f90
-PR95214.f90
-PR95331.f90
-PR95352.f90
-PR96726.f90
-PR96727.f90
-PR96728.f90
-PR97046.f90
-access_spec_3.f90
-achar_1.f90
-achar_2.f90
-actual_array_constructor_1.f90
-actual_array_constructor_2.f90
-actual_array_constructor_3.f90
-actual_array_interface_1.f90
-actual_array_offset_1.f90
-actual_array_result_1.f90
-actual_array_subref.f90
-actual_array_substr_1.f90
-actual_array_substr_2.f90
-actual_pointer_function_1.f90
-actual_procedure_1.f90
-adjustl_1.f90
-advance_1.f90
-advance_4.f90
-advance_5.f90
-advance_6.f90
-aint_anint_1.f90
-aliasing_array_result_1.f90
-aliasing_complex_pointer.f90
-aliasing_dummy_2.f90
-aliasing_dummy_4.f90
-aliasing_dummy_5.f90
-alloc_alloc_expr_2.f90
-alloc_comp_assign_1.f90
-alloc_comp_assign_10.f90
-alloc_comp_assign_11.f90
-alloc_comp_assign_17.f90
-alloc_comp_assign_4.f90
-alloc_comp_assign_6.f90
-alloc_comp_assign_7.f90
-alloc_comp_assign_8.f90
-alloc_comp_auto_array_1.f90
-alloc_comp_auto_array_2.f90
-alloc_comp_auto_array_4.f90
-alloc_comp_basics_2.f90
-alloc_comp_basics_3.f90
-alloc_comp_basics_4.f90
-alloc_comp_basics_5.f90
-alloc_comp_basics_7.f90
-alloc_comp_bounds_1.f90
-alloc_comp_class_1.f90
-alloc_comp_class_2.f90
-alloc_comp_constraint_6.f90
-alloc_comp_constructor_3.f90
-alloc_comp_constructor_4.f90
-alloc_comp_constructor_7.f90
-alloc_comp_deep_copy_5.f90
-alloc_comp_deep_copy_6.f90
-alloc_comp_deep_copy_7.f90
-alloc_comp_default_init_1.f90
-alloc_comp_default_init_2.f90
-alloc_comp_initializer_1.f90
-alloc_comp_initializer_3.f90
-alloc_comp_optional_1.f90
-alloc_comp_result_1.f90
-alloc_comp_result_2.f90
-alloc_comp_result_3.f90
-alloc_comp_scalar_1.f90
-alloc_comp_transformational_1.f90
-alloc_deferred_comp_1.f90
-allocatable_dummy_1.f90
-allocatable_dummy_3.f90
-allocatable_function_10.f90
-allocatable_function_3.f90
-allocatable_function_5.f90
-allocatable_function_6.f90
-allocatable_function_7.f90
-allocatable_function_9.f90
-allocatable_length_2.f90
-allocatable_scalar_10.f90
-allocatable_scalar_12.f90
-allocatable_scalar_14.f90
-allocatable_scalar_4.f90
-allocatable_scalar_7.f90
-allocatable_scalar_8.f90
-allocate_alloc_opt_10.f90
-allocate_alloc_opt_12.f90
-allocate_alloc_opt_13.f90
-allocate_alloc_opt_3.f90
-allocate_alloc_opt_6.f90
-allocate_alloc_opt_7.f90
-allocate_assumed_charlen_1.f90
-allocate_assumed_charlen_4.f90
-allocate_char_star_scalar_1.f90
-allocate_class_3.f90
-allocate_class_4.f90
-allocate_derived_2.f90
-allocate_derived_3.f90
-allocate_derived_4.f90
-allocate_derived_5.f90
-allocate_with_mold_1.f90
-allocate_with_mold_3.f90
-allocate_with_mold_4.f90
-allocate_with_source_1.f90
-allocate_with_source_2.f90
-allocate_with_source_24.f90
-allocate_with_source_26.f90
-allocate_with_source_27.f90
-allocate_with_source_28.f90
-allocate_with_source_3.f90
-allocate_with_source_31.f90
-allocate_with_source_32.f90
-allocate_with_source_5.f90
-allocate_with_typespec_1.f90
-allocate_zerosize_1.f90
-allocate_zerosize_2.f90
-allocated_1.f90
-allocated_4.f90
-ambiguous_specific_2.f90
-and_or_xor.f90
-anint_1.f90
-any_all_2.f90
-anyallcount_1.f90
-append_1.f90
-argument_checking_1.f90
-argument_checking_17.f90
-argument_checking_19.f90
-argument_checking_8.f90
-array_1.f90
-array_2.f90
-array_3.f90
-array_5.f90
-array_alloc_1.f90
-array_alloc_2.f90
-array_alloc_3.f90
-array_constructor_10.f90
-array_constructor_12.f90
-array_constructor_16.f90
-array_constructor_17.f90
-array_constructor_19.f90
-array_constructor_21.f90
-array_constructor_3.f90
-array_constructor_31.f90
-array_constructor_32.f90
-array_constructor_33.f90
-array_constructor_34.f90
-array_constructor_35.f90
-array_constructor_36.f90
-array_constructor_37.f90
-array_constructor_4.f90
-array_constructor_42.f90
-array_constructor_45.f90
-array_constructor_50.f90
-array_constructor_52.f90
-array_constructor_53.f90
-array_constructor_55.f90
-array_constructor_56.f90
-array_constructor_57.f90
-array_constructor_58.f90
-array_constructor_6.f90
-array_constructor_7.f90
-array_constructor_8.f90
-array_constructor_9.f90
-array_constructor_typespec_1.f90
-array_function_1.f90
-array_function_3.f90
-array_function_4.f90
-array_function_5.f90
-array_function_6.f90
-array_initializer_1.f90
-array_initializer_2.f90
-array_memcpy_5.f90
-array_reference_1.f90
-array_reference_2.f90
-array_return_value_1.f90
-array_simplify_1.f90
-array_simplify_2.f90
-array_simplify_3.f90
-array_temporaries_3.f90
-arrayio_1.f90
-arrayio_10.f90
-arrayio_11.f90
-arrayio_12.f90
-arrayio_13.f90
-arrayio_14.f90
-arrayio_15.f90
-arrayio_16.f90
-arrayio_2.f90
-arrayio_3.f90
-arrayio_5.f90
-arrayio_6.f90
-arrayio_9.f90
-arrayio_derived_1.f90
-arrayio_derived_2.f90
-assign_12.f90
-assign_13.f90
-assign_9.f90
-associate_12.f90
-associate_13.f90
-associate_14.f90
-associate_15.f90
-associate_16.f90
-associate_17.f90
-associate_22.f90
-associate_23.f90
-associate_25.f90
-associate_27.f90
-associate_28.f90
-associate_29.f90
-associate_34.f90
-associate_35.f90
-associate_38.f90
-associate_41.f90
-associate_42.f90
-associate_44.f90
-associate_45.f90
-associate_46.f90 # re-listed: ffc lowering gap exposed by fortfront bare-end unit split
-associate_47.f90
-associate_48.f90
-associate_49.f90
-associate_58.f90
-associate_60.f90
-associate_61.f90
-associate_62.f90
-associate_63.f90
-associate_65.f90
-associate_67.f90
-associate_68.f90
-associate_71.f90
-associate_74.f90
-associate_75.f90
-associate_77.f90
-associated_1.f90
-associated_2.f90
-associated_4.f90
-associated_5.f90
-associated_6.f90
-associated_8.f90
-associated_assumed_rank.f90
-associated_target_2.f90
-associated_target_3.f90
-associated_target_4.f90
-associated_target_7.f90
-associated_target_8.f90
-assumed_charlen_arg_1.f90
-assumed_charlen_arg_2.f90
-assumed_charlen_function_2.f90
-assumed_charlen_needed_1.f90
-assumed_charlen_parameter.f90
-assumed_charlen_sharing.f90
-assumed_dummy_1.f90
-assumed_len.f90
-assumed_present.f90
-assumed_rank_13.f90
-assumed_rank_16.f90
-assumed_rank_17.f90
-assumed_rank_19.f90
-assumed_rank_20.f90
-assumed_rank_21.f90
-assumed_rank_24.f90
-assumed_rank_25.f90
-assumed_rank_7.f90
-assumed_rank_bounds_1.f90
-assumed_rank_bounds_2.f90
-assumed_rank_bounds_3.f90
-assumed_shape_ranks_2.f90
-assumed_size_2.f90
-assumed_size_refs_3.f90
-assumed_type_1.f90
-assumed_type_18.f90
-assumed_type_2a.f90
-assumed_type_9.f90
-auto_array_1.f90
-auto_char_dummy_array_1.f90
-auto_char_dummy_array_2.f90
-auto_char_dummy_array_3.f90
-auto_char_len_3.f90
-auto_char_pointer_array_result_1.f90
-auto_pointer_array_result_1.f90
-auto_save_1.f90
-backslash_1.f90
-backspace_10.f90
-backspace_11.f90
-backspace_7.f90
-backtrace_1.f90
-bessel_1.f90
-bessel_2.f90
-besxy.f90
-bind-c-char-descr.f90
-bind_c_char_11.f90
-bind_c_char_2.f90
-bind_c_char_3.f90
-bind_c_dts_5.f90
-bind_c_optional-1.f90 # re-listed: ffc lowering gap exposed by fortfront bare-end unit split
-bind_c_optional-2.f90
-bind_c_procs_2.f90
-bind_c_procs_3.f90
-bind_c_usage_19.f90
-bind_c_usage_21.f90
-bind_c_usage_29.f90
-bind_c_usage_30.f90
-binding_label_tests_26a.f90
-binding_label_tests_32.f90
-binding_label_tests_33.f90
-block_14.f90
-block_name_1.f90
-blockdata_7.f90
-bound_1.f90
-bound_10.f90
-bound_11.f90
-bound_3.f90
-bound_4.f90
-bound_5.f90
-bound_6.f90
-bounds_check_20.f90
-bounds_check_27.f90
-bounds_check_29.f90
-boz_11.f90
-boz_12.f90
-boz_13.f90
-boz_5.f90
-boz_bge.f90
-boz_dshift_2.f90
-boz_iand_2.f90
-boz_int.f90
-c_assoc_3.f90
-c_assoc_5.f90
-c_char_tests_4.f90
-c_f_pointer_shape_tests_5.f90
-c_f_pointer_shape_tests_6.f90
-c_f_pointer_tests_4.f90
-c_funloc_tests_10.f90
-c_loc_test_18.f90
-c_loc_test_20.f90
-c_loc_tests_13.f90
-c_loc_tests_14.f90
-c_ptr_tests_17.f90
-c_ptr_tests_18.f90
-c_ptr_tests_19.f90
-c_sizeof_1.f90
-c_sizeof_6.f90
-c_sizeof_8.f90
-change_symbol_attributes_1.f90
-char_allocation_1.f90
-char_array_arg_1.f90
-char_array_constructor.f90
-char_array_constructor_2.f90
-char_array_constructor_3.f90
-char_array_structure_constructor.f90
-char_associated_1.f90
-char_component_initializer_1.f90
-char_component_initializer_3.f90
-char_cons_len.f90
-char_cshift_1.f90
-char_cshift_2.f90
-char_cshift_3.f90
-char_decl_2.f90
-char_eoshift_1.f90
-char_eoshift_2.f90
-char_eoshift_3.f90
-char_eoshift_4.f90
-char_expr_1.f90
-char_expr_3.f90
-char_length_10.f90
-char_length_11.f90
-char_length_12.f90
-char_length_13.f90
-char_length_14.f90
-char_length_15.f90
-char_length_16.f90
-char_length_18.f90
-char_length_19.f90
-char_length_2.f90
-char_length_21.f90
-char_length_23.f90
-char_length_5.f90
-char_length_6.f90
-char_length_7.f90
-char_length_8.f90
-char_pack_1.f90
-char_pack_2.f90
-char_pointer_assign_3.f90
-char_pointer_assign_icb_1.f90
-char_pointer_comp_assign.f90
-char_reshape_1.f90
-char_result_1.f90
-char_result_10.f90
-char_result_12.f90
-char_result_13.f90
-char_result_14.f90
-char_result_15.f90
-char_result_17.f90
-char_result_2.f90
-char_result_3.f90
-char_result_4.f90
-char_result_5.f90
-char_result_6.f90
-char_result_7.f90
-char_result_8.f90
-char_result_9.f90
-char_spread_1.f90
-char_transpose_1.f90
-char_type_len.f90
-char_unpack_1.f90
-char_unpack_2.f90
-character_array_constructor_1.f90
-character_array_dummy_1.f90
-character_workout_1.f90
-character_workout_4.f90
-charlen_15.f90
-charlen_16.f90
-charlen_17.f90
-chkbits.f90
-class_35.f90
-class_48.f90
-class_49.f90
-class_63.f90
-class_66.f90
-class_67.f90
-class_68.f90
-class_74.f90
-class_75.f90
-class_79.f90
-class_allocate_12.f90
-class_allocate_13.f90
-class_allocate_18.f90
-class_allocate_20.f90
-class_allocate_21.f90
-class_allocate_22.f90
-class_allocate_5.f90
-class_array_14.f90
-class_array_18.f90
-class_assign_4.f90
-class_dummy_11.f90
-class_dummy_6.f90
-class_dummy_7.f90 # re-listed: ffc lowering gap exposed by fortfront bare-end unit split
-class_dummy_8.f90
-class_dummy_9.f90
-class_elemental_1.f90
-class_nameclash.f90
-class_result_10.f90
-class_result_2.f90
-class_result_3.f90
-class_result_5.f90
-class_result_6.f90
-class_result_9.f90
-class_to_type_2.f90
-class_to_type_4.f90
-class_transformational_1.f90
-class_transformational_2.f90
-cmplx_intrinsic_1.f90
-common_1.f90
-common_12.f90
-common_2.f90
-common_pointer_1.f90
-complex_int_1.f90
-complex_intrinsic_1.f90
-complex_intrinsic_3.f90
-complex_intrinsic_5.f90
-complex_read.f90
-complex_write.f90
-constructor_1.f90
-constructor_2.f90
-constructor_3.f90
-constructor_6.f90
-contained_1.f90
-contained_3.f90
-contained_module_proc_1.f90
-contiguous_13.f90
-contiguous_14.f90
-contiguous_5.f90
-contiguous_6.f90
-contiguous_8.f90
-continuation_12.f90
-continuation_8.f90
-count_mask_1.f90
-coverage.f90
-cray_pointers_13.f90
-cshift_1.f90
-cshift_2.f90
-cshift_nan_1.f90
-data_array_1.f90
-data_array_4.f90
-data_array_7.f90
-data_components_1.f90
-data_implied_do_1.f90
-data_initialized_3.f90
-data_initialized_4.f90
-data_namelist_conflict.f90
-data_pointer_3.f90
-data_stmt_pointer.f90
-data_vector_section.f90
-date_and_time_1.f90
-date_and_time_3.f90
-deallocate_alloc_opt_3.f90
-deallocate_stat.f90
-deallocate_stat_2.f90
-default_format_1.f90
-default_initialization_2.f90
-default_initialization_3.f90
-default_initialization_6.f90
-deferred_character_1.f90
-deferred_character_10.f90
-deferred_character_11.f90
-deferred_character_12.f90
-deferred_character_13.f90
-deferred_character_14.f90
-deferred_character_16.f90
-deferred_character_17.f90
-deferred_character_19.f90
-deferred_character_2.f90
-deferred_character_20.f90
-deferred_character_22.f90
-deferred_character_23.f90
-deferred_character_24.f90
-deferred_character_26.f90
-deferred_character_27.f90
-deferred_character_28.f90
-deferred_character_29.f90
-deferred_character_3.f90
-deferred_character_30.f90
-deferred_character_31.f90
-deferred_character_32.f90
-deferred_character_34.f90
-deferred_character_35.f90
-deferred_character_36.f90
-deferred_character_37.f90
-deferred_character_38.f90
-deferred_character_39.f90
-deferred_character_4.f90
-deferred_character_5.f90
-deferred_character_6.f90
-deferred_character_7.f90
-deferred_character_8.f90
-deferred_character_9.f90
-deferred_character_assignment_1.f90
-deferred_type_component_1.f90
-deferred_type_component_2.f90
-deferred_type_component_3.f90
-deferred_type_param_4.f90
-deferred_type_param_5.f90
-deferred_type_param_6.f90
-deferred_type_param_8.f90
-deferred_type_proc_pointer_1.f90
-deferred_type_proc_pointer_2.f90
-defined_assignment_1.f90
-defined_assignment_10.f90
-defined_assignment_11.f90
-defined_assignment_12.f90
-defined_assignment_13.f90
-defined_assignment_2.f90
-defined_assignment_3.f90
-defined_assignment_4.f90
-defined_assignment_6.f90
-defined_assignment_7.f90
-defined_assignment_9.f90
-dependency_1.f90
-dependency_19.f90
-dependency_2.f90
-dependency_21.f90
-dependency_22.f90
-dependency_23.f90
-dependency_24.f90
-dependency_25.f90
-dependency_3.f90
-dependency_39.f90
-dependency_40.f90
-dependency_44.f90
-dependency_46.f90
-dependency_50.f90
-dependency_51.f90
-dependency_52.f90
-dependency_53.f90
-dependency_55.f90
-dependency_56.f90
-dependency_57.f90
-dependency_58.f90
-dependency_59.f90
-dependency_60.f90
-dependent_decls_1.f90
-dependent_decls_2.f90
-dependent_decls_3.f90
-der_array_1.f90
-der_pointer_1.f90
-der_pointer_2.f90
-der_pointer_3.f90
-der_pointer_4.f90
-der_ptr_component_1.f90
-der_ptr_component_2.f90
-derived_comp_array_ref_1.f90
-derived_comp_array_ref_2.f90
-derived_comp_array_ref_3.f90
-derived_comp_array_ref_4.f90
-derived_comp_array_ref_5.f90
-derived_comp_array_ref_7.f90
-derived_constructor_char_3.f90
-derived_constructor_comps_1.f90
-derived_constructor_comps_3.f90
-derived_constructor_comps_4.f90
-derived_constructor_comps_5.f90
-derived_constructor_comps_7.f90
-derived_external_function_1.f90 # re-listed: ffc lowering gap exposed by fortfront bare-end unit split
-derived_init_1.f90
-derived_init_2.f90
-derived_init_3.f90
-derived_init_4.f90
-derived_init_5.f90
-derived_init_6.f90
-derived_init_7.f90
-derived_pointer_recursion_2.f90
-derived_result_3.f90
-derived_result_5.f90
-direct_io_1.f90
-direct_io_11.f90
-direct_io_12.f90
-direct_io_3.f90
-direct_io_4.f90
-direct_io_5.f90
-direct_io_6.f90
-direct_io_7.f90
-direct_io_8.f90
-do_check_14.f90
-do_check_15.f90
-do_check_17.f90
-do_check_7.f90
-do_concurrent_13.f90
-do_concurrent_14.f90
-do_concurrent_2.f90
-do_pointer_1.f90
-dot_product_4.f90
-dtio_1.f90
-dtio_10.f90
-dtio_12.f90
-dtio_14.f90
-dtio_15.f90
-dtio_16.f90
-dtio_17.f90
-dtio_19.f90
-dtio_2.f90
-dtio_22.f90
-dtio_23.f90
-dtio_24.f90
-dtio_25.f90
-dtio_27.f90
-dtio_3.f90
-dtio_33.f90
-dtio_34.f90
-dtio_35.f90
-dtio_36.f90
-dtio_37.f90
-dtio_4.f90
-dtio_7.f90
-dtio_8.f90
-dtio_9.f90
-dummy_functions_1.f90
-dummy_procedure_3.f90
-dummy_procedure_7.f90
-dynamic_dispatch_12.f90
-edit_real_1.f90
-elemental_assignment_1.f90
-elemental_by_value_1.f90
-elemental_dependency_2.f90
-elemental_dependency_6.f90
-elemental_function_1.f90
-elemental_function_2.f90
-elemental_function_3.f90
-elemental_initializer_1.f90
-elemental_optional_args_2.f90
-elemental_optional_args_3.f90
-elemental_optional_args_4.f90
-elemental_optional_args_7.f90
-elemental_scalar_args_1.f90
-elemental_scalar_args_2.f90
-elemental_subroutine_1.f90
-elemental_subroutine_10.f90
-elemental_subroutine_11.f90
-elemental_subroutine_3.f90
-elemental_subroutine_7.f90
-elemental_subroutine_9.f90
-empty_type.f90
-endfile.f90
-endfile_2.f90
-endfile_5.f90
-entry_1.f90
-entry_10.f90
-entry_11.f90
-entry_12.f90
-entry_13.f90
-entry_14.f90
-entry_16.f90
-entry_2.f90
-entry_20.f90
-entry_26.f90
-entry_27.f90
-entry_3.f90
-entry_6.f90
-entry_8.f90
-entry_9.f90
-entry_array_specs_3.f90
-entry_dummy_ref_3.f90
-eof_1.f90
-eof_3.f90
-eof_4.f90
-eof_5.f90
-eor_handling_1.f90
-eor_handling_3.f90
-eor_handling_4.f90
-eor_handling_5.f90
-eoshift.f90
-eoshift_2.f90
-eoshift_3.f90
-eoshift_4.f90
-eoshift_5.f90
-eoshift_6.f90
-equiv_6.f90
-equiv_9.f90
-erfc_scaled_2.f90
-error_format_2.f90
-error_recovery_5.f90
-execute_command_line_1.f90
-execute_command_line_2.f90
-execute_command_line_3.f90
-exponent_1.f90
-external_procedures_2.f90
-external_procedures_3.f90
-external_procedures_4.f90
-f_c_string1.f90
-f_c_string2.f90
-fgetc_1.f90
-fgetc_2.f90
-filename_null.f90
-filepos1.f90
-finalize_13.f90
-finalize_14.f90
-finalize_15.f90
-finalize_17.f90
-finalize_25.f90
-finalize_31.f90
-finalize_38.f90
-finalize_39.f90
-finalize_40.f90
-finalize_41.f90
-finalize_42.f90
-finalize_43.f90
-finalize_44.f90
-finalize_45.f90
-finalize_46.f90
-finalize_47.f90
-finalize_48.f90
-finalize_50.f90
-finalize_51.f90
-finalize_52.f90
-finalize_53.f90
-finalize_54.f90
-finalize_55.f90
-finalize_56.f90
-finalize_58.f90
-finalize_59.f90
-finalize_60.f90
-finalize_61.f90
-finalizer_recursive_alloc_1.f90
-finalizer_recursive_alloc_2.f90
-finalizer_self_assign.f90
-findloc_2.f90
-findloc_3.f90
-findloc_4.f90
-findloc_5.f90
-findloc_6.f90
-findloc_8.f90
-flush_1.f90
-fmt_cache_3.f90
-fmt_colon.f90
-fmt_e.f90
-fmt_en.f90
-fmt_exhaust.f90
-fmt_f0_1.f90
-fmt_f0_2.f90
-fmt_f0_3.f90
-fmt_float.f90
-fmt_g_1.f90
-fmt_huge.f90
-fmt_p_1.f90
-fmt_pf.f90
-fmt_read.f90
-fmt_read_3.f90
-fmt_t_1.f90
-fmt_t_3.f90
-fmt_t_4.f90
-fmt_t_5.f90
-fmt_t_8.f90
-fmt_unlimited.f90
-fmt_zero_digits.f90
-fmt_zero_precision.f90
-fmt_zero_width.f90
-fold_nearest.f90
-forall_1.f90
-forall_12.f90
-forall_19.f90
-forall_20.f90
-forall_3.f90
-forall_4.f90
-forall_6.f90
-forall_7.f90
-forall_char_dependencies_1.f90
-fraction.f90
-fseek.f90
-ftell_1.f90
-ftell_2.f90
-ftell_3.f90
-func_assign_2.f90
-func_assign_3.f90
-func_decl_2.f90
-func_derived_2.f90
-func_derived_3.f90
-func_derived_4.f90
-func_result_1.f90
-func_result_5.f90
-func_result_6.f90
-function_charlen_1.f90
-function_charlen_2.f90
-function_kinds_1.f90
-function_kinds_3.f90
-function_optimize_10.f90
-function_types_2.f90
-gamma_1.f90
-gamma_5.f90
-generic_10.f90
-generic_12.f90
-generic_15.f90
-generic_20.f90
-generic_21.f90
-generic_24.f90
-generic_25.f90
-generic_27.f90
-generic_28.f90
-generic_3.f90
-generic_30.f90
-generic_31.f90
-generic_33.f90
-generic_36-1.f90
-generic_4.f90
-generic_8.f90
-generic_stmt_1.f90
-generic_stmt_4.f90
-getenv_1.f90
-goto_4.f90
-hollerith_9.f90
-host_assoc_call_4.f90
-host_assoc_call_5.f90
-host_assoc_function_1.f90
-host_assoc_function_2.f90
-host_assoc_function_5.f90
-host_assoc_function_6.f90
-host_assoc_function_7.f90
-host_assoc_function_9.f90
-host_assoc_types_2.f90
-host_dummy_index_1.f90
-iall_iany_iparity_1.f90
-iall_masked.f90
-ibits_2.f90
-ichar_2.f90
-ichar_3.f90
-impl_do_var_data.f90
-implicit_10.f90
-implicit_12.f90
-implicit_2.f90
-implicit_derived_type_1.f90
-implied_do_1.f90
-implied_do_3.f90
-implied_do_io_2.f90
-implied_do_io_5.f90
-implied_do_io_7.f90
-implied_do_io_8.f90
-implied_do_io_9.f90
-implied_shape_4.f90
-import.f90
-import11.f90 # re-listed: ffc lowering gap exposed by fortfront bare-end unit split
-import4.f90
-import6.f90
-import7.f90 # re-listed: ffc lowering gap exposed by fortfront bare-end unit split
-import9.f90
-in_pack_rank7.f90
-include_4.f90
-index.f90
-index_3.f90
-index_5.f90
-initialization_11.f90
-initialization_12.f90
-initialization_14.f90
-initialization_2.f90
-initialization_20.f90
-initialization_22.f90
-initialization_26.f90
-initialization_27.f90
-initialization_29.f90
-inline_matmul_20.f90
-inline_matmul_21.f90
-inline_matmul_22.f90
-inline_sum_3.f90
-inline_sum_4.f90
-inline_sum_5.f90
-inquire-complex.f90
-inquire_10.f90
-inquire_15.f90
-inquire_16.f90
-inquire_17.f90
-inquire_19.f90
-inquire_5.f90
-inquire_7.f90
-inquire_9.f90
-inquire_internal.f90
-inquire_pre.f90
-inquire_recl_f2018.f90
-inquire_size.f90
-inquiry_type_ref_5.f90 # re-listed: ffc lowering gap exposed by fortfront bare-end unit split
-int_2.f90
-int_3.f90
-integer_plus.f90
-intent_decl_1.f90
-intent_out_14.f90
-intent_out_16.f90
-intent_out_17.f90
-intent_out_18.f90
-intent_out_19.f90
-intent_out_2.f90
-intent_out_20.f90
-intent_out_21.f90
-intent_out_22.f90
-intent_out_5.f90
-intent_out_6.f90
-interface_10.f90
-interface_12.f90
-interface_13.f90
-interface_16.f90
-interface_25.f90
-interface_32.f90
-interface_4.f90
-interface_41.f90
-interface_49.f90
-interface_53.f90
-interface_54.f90
-interface_59.f90
-interface_62.f90
-interface_63.f90
-interface_9.f90
-interface_abstract_5.f90
-interface_assignment_1.f90
-interface_assignment_2.f90
-interface_assignment_3.f90
-interface_assignment_4.f90
-interface_assignment_7.f90
-interface_proc_end.f90
-internal_pack_1.f90
-internal_pack_10.f90
-internal_pack_13.f90
-internal_pack_14.f90
-internal_pack_23.f90
-internal_pack_4.f90
-internal_pack_6a.f90
-internal_pack_8.f90
-internal_readwrite_1.f90
-internal_readwrite_2.f90
-internal_readwrite_3.f90
-internal_readwrite_4.f90
-intrinsic_1.f90
-intrinsic_8.f90
-intrinsic_9.f90
-intrinsic_actual_2.f90
-intrinsic_bounds_1.f90
-intrinsic_char_1.f90
-intrinsic_ifunction_1.f90
-intrinsic_ifunction_2.f90
-intrinsic_intkinds_1.f90
-intrinsic_modulo_1.f90
-intrinsic_pack_1.f90
-intrinsic_pack_4.f90
-intrinsic_pack_5.f90
-intrinsic_pack_6.f90
-intrinsic_product_1.f90
-intrinsic_sign_2.f90
-intrinsic_signal.f90
-intrinsic_size_2.f90
-intrinsic_spread_1.f90
-intrinsic_unpack_1.f90
-intrinsic_verify_1.f90
-intrinsics_kind_argument_1.f90
-io_constraints_13.f90
-io_real_boz.f90
-iostat_1.f90
-iostat_4.f90
-iostat_5.f90
-is_contiguous_1.f90
-is_contiguous_2.f90
-is_contiguous_4.f90
-is_contiguous_5.f90
-is_iostat_end_eor_1.f90
-ishft_1.f90
-ishft_2.f90
-ishftc_optional_size_1.f90
-iso_c_binding_rename_3.f90
-iso_fortran_env_1.f90
-iso_fortran_env_2.f90
-iso_fortran_env_3.f90
-iso_fortran_env_8.f90
-large_recl.f90
-large_unit_2.f90
-largeequiv_1.f90
-leadz_trailz_1.f90
-linked_list_1.f90
-list_read_1.f90
-list_read_10.f90
-list_read_12.f90
-list_read_14.f90
-list_read_3.f90
-list_read_4.f90
-list_read_5.f90
-list_read_6.f90
-list_read_7.f90
-list_read_8.f90
-list_read_9.f90
-loc_1.f90
-logical_dot_product.f90
-logical_temp_io.f90
-longnames.f90
-make_unit.f90
-malloc_free_1.f90
-mapping_1.f90
-mapping_2.f90
-mapping_3.f90
-maskl_1.f90
-maskr_1.f90
-matmul_1.f90
-matmul_12.f90
-matmul_17.f90
-matmul_18.f90
-matmul_2.f90
-matmul_20.f90
-matmul_21.f90
-matmul_3.f90
-matmul_4.f90
-matmul_6.f90
-matmul_7.f90
-matmul_bounds_12.f90
-matmul_bounds_6.f90
-maxloc_1.f90
-maxloc_3.f90
-maxloc_4.f90
-maxloc_5.f90
-maxloc_6.f90
-maxloc_7.f90
-maxloc_8.f90
-maxloc_string_1.f90
-maxloc_with_dim_1.f90
-maxloc_with_dim_and_mask_1.f90
-maxloc_with_mask_1.f90
-maxlocval_3.f90
-maxval_arg_eval_count.f90
-maxval_char_1.f90
-maxval_char_2.f90
-maxval_char_3.f90
-maxval_char_4.f90
-maxval_parameter_1.f90
-merge_1.f90
-merge_bits_4.f90
-merge_init_expr.f90
-min_max_optional_1.f90
-min_max_optional_5.f90
-min_max_type.f90
-min_max_type_2.f90
-minloc_2.f90
-minloc_3.f90
-minloc_4.f90
-minloc_5.f90
-minloc_7.f90
-minloc_8.f90
-minloc_9.f90
-minloc_string_1.f90
-minloc_with_dim_1.f90
-minloc_with_dim_and_mask_1.f90
-minloc_with_mask_1.f90
-minlocval_2.f90
-minlocval_3.f90
-minmax_char_1.f90
-minmaxloc_1.f90
-minmaxloc_10.f90
-minmaxloc_11.f90
-minmaxloc_12.f90
-minmaxloc_13.f90
-minmaxloc_14.f90
-minmaxloc_17.f90
-minmaxloc_2.f90
-minmaxloc_22.f90
-minmaxloc_4.f90
-minmaxloc_5.f90
-minmaxloc_6.f90
-minmaxloc_7.f90
-minmaxval_1.f90
-minval_char_1.f90
-minval_char_2.f90
-minval_char_3.f90
-minval_char_4.f90
-minval_char_5.f90
-minval_parameter_1.f90
-missing_derived_type_1.f90
-missing_optional_dummy_1.f90
-missing_optional_dummy_2.f90
-missing_optional_dummy_3.f90
-missing_optional_dummy_7.f90
-missing_parens_2.f90
-mod_large_1.f90
-mod_sign0_1.f90
-module_blank_common.f90
-module_commons_1.f90
-module_commons_3.f90
-module_double_reuse.f90
-module_equivalence_1.f90
-module_equivalence_2.f90
-module_equivalence_3.f90
-module_equivalence_4.f90
-module_equivalence_5.f90
-module_error_1.f90
-module_interface_1.f90
-module_interface_2.f90
-module_private_array_refs_1.f90
-module_proc_external_dummy.f90
-module_procedure_1.f90
-module_procedure_3.f90
-module_procedure_5.f90
-module_procedure_6.f90
-module_read_2.f90
-module_write_1.f90
-move_alloc.f90
-move_alloc_10.f90
-move_alloc_12.f90
-move_alloc_13.f90
-move_alloc_14.f90
-move_alloc_16.f90
-move_alloc_19.f90
-move_alloc_2.f90
-move_alloc_6.f90
-multiple_allocation_1.f90
-multiple_allocation_2.f90
-multiple_allocation_3.f90
-mvbits_1.f90
-mvbits_2.f90
-mvbits_3.f90
-mvbits_4.f90
-mvbits_5.f90
-mvbits_6.f90
-namelist_102.f90
-namelist_13.f90
-namelist_15.f90
-namelist_16.f90
-namelist_17.f90
-namelist_20.f90
-namelist_23.f90
-namelist_26.f90
-namelist_27.f90
-namelist_28.f90
-namelist_29.f90
-namelist_30.f90
-namelist_31.f90
-namelist_38.f90
-namelist_39.f90
-namelist_40.f90
-namelist_41.f90
-namelist_44.f90
-namelist_45.f90
-namelist_46.f90
-namelist_47.f90
-namelist_50.f90
-namelist_51.f90
-namelist_52.f90
-namelist_53.f90
-namelist_56.f90
-namelist_57.f90
-namelist_58.f90
-namelist_59.f90
-namelist_60.f90
-namelist_61.f90
-namelist_62.f90
-namelist_64.f90
-namelist_66.f90
-namelist_68.f90
-namelist_69.f90
-namelist_70.f90
-namelist_71.f90
-namelist_73.f90
-namelist_74.f90
-namelist_76.f90
-namelist_77.f90
-namelist_78.f90
-namelist_79.f90
-namelist_80.f90
-namelist_81.f90
-namelist_82.f90
-namelist_84.f90
-namelist_88.f90
-namelist_89.f90
-namelist_95.f90
-namelist_96.f90
-namelist_97.f90
-namelist_99.f90
-namelist_utf8.f90
-nearest_4.f90
-nearest_6.f90
-negative-z-descriptor.f90
-negative_stride_1.f90
-negative_unit2.f90
-nested_allocatables_1.f90
-nested_array_constructor_1.f90
-nested_array_constructor_3.f90
-nested_array_constructor_4.f90
-nested_array_constructor_5.f90
-nested_array_constructor_6.f90
-nested_modules_1.f90
-nested_modules_2.f90
-nested_modules_3.f90
-nested_modules_6.f90
-nested_reshape.f90
-nesting_1.f90
-new_line.f90
-newunit_1.f90
-newunit_3.f90
-newunit_5.f90
-nint_1.f90
-nint_2.f90
-no_arg_check_1.f90
-no_arg_check_2a.f90
-no_range_check_3.f90
-noadv_size.f90
-noreturn-3.f90
-norm2_1.f90
-nosigned_zero_1.f90
-null_10.f90
-null_11.f90
-null_4.f90
-null_9.f90
-null_actual_2.f90
-null_actual_5.f90
-null_actual_6.f90
-null_actual_7.f90
-open_errors.f90
-open_negative_unit_1.f90
-open_new.f90
-open_readonly_1.f90
-operator_1.f90
-operator_7.f90
-optional_absent_10.f90
-optional_absent_11.f90
-optional_absent_12.f90
-optional_absent_13.f90
-optional_absent_2.f90
-optional_absent_3.f90
-optional_absent_4.f90
-optional_absent_5.f90
-optional_absent_6.f90
-optional_absent_8.f90
-optional_absent_9.f90
-optional_assumed_charlen_2.f90
-optional_class_1.f90
-optional_deferred_char_1.f90
-optional_dim_2.f90
-optional_dim_3.f90
-optional_mask.f90
-out_of_range_1.f90
-out_of_range_2.f90
-overload_1.f90
-overload_4.f90
-overload_5.f90
-pack_mask_1.f90
-pad_no.f90
-parameter_array_dummy.f90
-parameter_array_element_2.f90
-parameter_array_format.f90
-parameter_array_init_1.f90
-parameter_array_init_4.f90
-parameter_array_init_5.f90
-parameter_array_init_6.f90
-parameter_array_init_8.f90
-parameter_array_ref_1.f90
-parameter_array_ref_2.f90
-parameter_array_section_1.f90
-parens_3.f90
-parens_4.f90
-parens_7.f90
-parent_result_ref_1.f90
-parent_result_ref_3.f90
-parent_result_ref_4.f90
-parity_1.f90
-past_eor.f90
-pdt_generic_1.f90
-pointer_array_1.f90
-pointer_array_10.f90
-pointer_array_11.f90
-pointer_array_2.f90
-pointer_array_3.f90
-pointer_array_4.f90
-pointer_array_5.f90
-pointer_array_7.f90
-pointer_array_9.f90
-pointer_array_component_1.f90
-pointer_array_component_2.f90
-pointer_array_component_3.f90
-pointer_assign_10.f90
-pointer_assign_11.f90
-pointer_assign_14.f90
-pointer_assign_15.f90
-pointer_assign_16.f90
-pointer_assign_3.f90
-pointer_assign_4.f90
-pointer_assign_8.f90
-pointer_assign_9.f90
-pointer_comp_init_1.f90
-pointer_function_actual_2.f90
-pointer_function_result_1.f90
-pointer_init_1.f90
-pointer_init_12.f90
-pointer_init_3.f90
-pointer_init_4.f90
-pointer_init_5.f90
-pointer_init_8.f90
-pointer_intent_5.f90
-pointer_intent_6.f90
-pointer_remapping_9.f90
-pointer_target_1.f90
-pointer_to_substring.f90
-power.f90
-power1.f90
-power2.f90
-pr100155.f90
-pr100194.f90
-pr100273.f90
-pr100949.f90
-pr102109.f90
-pr102112.f90
-pr102190.f90
-pr102333.f90
-pr102619.f90
-pr102817.f90
-pr103139.f90
-pr103312.f90
-pr103366.f90
-pr103389.f90
-pr103506_1.f90
-pr103716.f90
-pr103898.f90
-pr104349.f90
-pr104429.f90
-pr104555.f90
-pr105168.f90
-pr105205.f90
-pr105361.f90
-pr105473.f90
-pr105847.f90
-pr106731.f90
-pr106918.f90
-pr107068.f90
-pr107872.f90
-pr107900.f90
-pr108010.f90
-pr108420.f90
-pr108961.f90
-pr109209.f90
-pr109345.f90
-pr109358.f90
-pr109948.f90
-pr110224.f90
-pr110415.f90
-pr110877.f90
-pr111022.f90
-pr111853.f90
-pr112316.f90
-pr112407a.f90
-pr113363.f90
-pr113503_2.f90
-pr113956.f90
-pr114012.f90
-pr114021.f90
-pr114304-2.f90
-pr114304.f90
-pr114535d.f90
-pr114739.f90
-pr114874_1.f90
-pr117077.f90
-pr117730_a.f90
-pr117768.f90
-pr117797.f90
-pr117819.f90
-pr117820.f90
-pr119502.f90
-pr119836_1.f90
-pr119836_3.f90
-pr119856.f90
-pr119948.f90
-pr120152_1.f90
-pr120152_2.f90
-pr120153.f90
-pr120158.f90
-pr120191_1.f90
-pr120191_2.f90
-pr120191_3.f90
-pr120196.f90
-pr120743.f90
-pr121234.f90
-pr121472.f90
-pr121475.f90
-pr122513.f90
-pr122936.f90
-pr122949.f90
-pr123868.f90
-pr123947_1.f90
-pr123949.f90
-pr124161.f90
-pr124208.f90
-pr124235.f90
-pr124450.f90
-pr124567.f90
-pr124780.f90
-pr15164.f90
-pr15324.f90
-pr15957.f90
-pr15959.f90
-pr16861.f90
-pr16938.f90
-pr17090.f90
-pr17285.f90
-pr17286.f90
-pr17612.f90
-pr17615.f90
-pr18025.f90
-pr18122.f90
-pr18392.f90
-pr19467.f90
-pr19926.f90
-pr19928-1.f90
-pr19928-2.f90
-pr20480.f90
-pr21177.f90
-pr32222.f90
-pr32238.f90
-pr33646.f90
-pr35944-1.f90
-pr35983.f90
-pr36006-1.f90
-pr39865.f90
-pr41126.f90
-pr42119.f90
-pr43505.f90
-pr43793.f90
-pr44735.f90
-pr45578.f90
-pr47574.f90
-pr47757-1.f90
-pr47757-2.f90
-pr47757-3.f90
-pr47878.f90
-pr49103.f90
-pr49213.f90
-pr49540-1.f90
-pr49698.f90
-pr50069_1.f90
-pr51434.f90
-pr51993.f90
-pr53298.f90
-pr55086_1.f90
-pr55086_2.f90
-pr57910.f90
-pr59700.f90
-pr59706.f90
-pr60126.f90
-pr61454.f90
-pr61765.f90
-pr61775.f90
-pr61960.f90
-pr62125.f90
-pr63797.f90
-pr63883.f90
-pr64124.f90
-pr64230.f90
-pr64530.f90
-pr64589.f90
-pr65429.f90
-pr65450.f90
-pr65996.f90
-pr66311.f90
-pr67140.f90
-pr67219.f90
-pr67524.f90
-pr67805_2.f90
-pr67987.f90
-pr68053.f90
-pr68154.f90
-pr68155.f90
-pr68227.f90
-pr68566.f90
-pr68864.f90
-pr69155.f90
-pr69455_1.f90
-pr69455_2.f90
-pr69514_1.f90
-pr69514_2.f90
-pr69739.f90
-pr70040.f90
-pr70409.f90
-pr70673.f90
-pr70673_2.f90
-pr71085.f90
-pr71764.f90
-pr77420_4.f90
-pr77632_1.f90
-pr77942.f90
-pr78092.f90
-pr78719_1.f90
-pr81509_1.f90
-pr81849.f90
-pr81978.f90
-pr82314.f90
-pr82774.f90
-pr83149.f90
-pr83149_a.f90
-pr83864.f90
-pr83874.f90
-pr84088.f90
-pr84155.f90
-pr84523.f90
-pr84674.f90
-pr84779.f90
-pr84868.f90
-pr84869.f90
-pr84957.f90
-pr85138_1.f90
-pr85138_2.f90
-pr85352.f90
-pr85520.f90
-pr85521_1.f90
-pr85521_2.f90
-pr85786.f90
-pr85816.f90
-pr85938.f90
-pr85975.f90
-pr85996.f90
-pr86322_3.f90
-pr86328.f90
-pr86760.f90
-pr87045.f90
-pr87946.f90
-pr87992.f90
-pr87993.f90
-pr87994_1.f90
-pr87994_2.f90
-pr87994_3.f90
-pr88052.f90
-pr88116_2.f90
-pr88169_2.f90
-pr88688.f90
-pr89077.f90
-pr89084.f90
-pr89266.f90
-pr89647.f90
-pr89943_2.f90
-pr90344.f90
-pr91553.f90
-pr91566.f90
-pr91577.f90
-pr91660_2.f90
-pr91661.f90
-pr91784.f90
-pr91862.f90
-pr92208.f90
-pr92277.f90
-pr92586.f90
-pr93263_2.f90
-pr93365.f90
-pr93600_2.f90
-pr93678.f90
-pr93685_1.f90
-pr93814.f90
-pr94377.f90
-pr94380.f90
-pr95053_2.f90
-pr95104.f90
-pr95338.f90 # re-listed: ffc lowering gap exposed by fortfront bare-end unit split
-pr95342.f90
-pr95500.f90
-pr95611.f90
-pr95614_1.f90
-pr95614_2.f90
-pr95614_4.f90
-pr95829.f90
-pr95880.f90
-pr95882_1.f90
-pr95882_2.f90
-pr95882_3.f90
-pr96486.f90
-pr96859.f90
-pr97272.f90
-pr97500.f90
-pr97768_1.f90
-pr98016.f90
-pr98017.f90
-pr98408.f90
-pr99036.f90
-pr99210.f90
-pr99326.f90
-print_c_kinds.f90
-print_fmt_1.f90
-private_type_13.f90
-private_type_14.f90
-private_type_7.f90
-private_type_8.f90
-proc_decl_12.f90
-proc_decl_13.f90
-proc_decl_14.f90
-proc_decl_15.f90
-proc_decl_16.f90
-proc_decl_17.f90
-proc_decl_18.f90
-proc_decl_19.f90
-proc_decl_2.f90
-proc_decl_20.f90
-proc_decl_22.f90
-proc_decl_23.f90
-proc_decl_24.f90
-proc_decl_27.f90
-proc_decl_28.f90
-proc_decl_9.f90
-proc_ptr_1.f90
-proc_ptr_10.f90
-proc_ptr_12.f90
-proc_ptr_18.f90
-proc_ptr_19.f90
-proc_ptr_20.f90
-proc_ptr_22.f90
-proc_ptr_23.f90
-proc_ptr_25.f90
-proc_ptr_26.f90
-proc_ptr_27.f90
-proc_ptr_29.f90
-proc_ptr_34.f90
-proc_ptr_36.f90
-proc_ptr_41.f90
-proc_ptr_42.f90
-proc_ptr_43.f90
-proc_ptr_47.f90
-proc_ptr_48.f90
-proc_ptr_49.f90
-proc_ptr_5.f90
-proc_ptr_50.f90
-proc_ptr_51.f90
-proc_ptr_52.f90
-proc_ptr_53.f90
-proc_ptr_54.f90
-proc_ptr_57.f90
-proc_ptr_6.f90
-proc_ptr_9.f90
-proc_ptr_comp_1.f90
-proc_ptr_comp_10.f90
-proc_ptr_comp_12.f90
-proc_ptr_comp_13.f90
-proc_ptr_comp_14.f90
-proc_ptr_comp_15.f90
-proc_ptr_comp_16.f90
-proc_ptr_comp_17.f90
-proc_ptr_comp_18.f90
-proc_ptr_comp_19.f90
-proc_ptr_comp_2.f90
-proc_ptr_comp_21.f90
-proc_ptr_comp_23.f90
-proc_ptr_comp_26.f90
-proc_ptr_comp_27.f90
-proc_ptr_comp_28.f90
-proc_ptr_comp_29.f90
-proc_ptr_comp_34.f90
-proc_ptr_comp_36.f90
-proc_ptr_comp_37.f90
-proc_ptr_comp_38.f90
-proc_ptr_comp_4.f90
-proc_ptr_comp_40.f90
-proc_ptr_comp_44.f90
-proc_ptr_comp_45.f90
-proc_ptr_comp_47.f90
-proc_ptr_comp_49.f90
-proc_ptr_comp_50.f90
-proc_ptr_comp_52.f90
-proc_ptr_comp_53.f90
-proc_ptr_comp_54.f90
-proc_ptr_comp_6.f90
-proc_ptr_comp_7.f90
-proc_ptr_comp_pass_1.f90
-proc_ptr_comp_pass_2.f90
-proc_ptr_comp_pass_3.f90
-proc_ptr_comp_pass_5.f90
-proc_ptr_result_1.f90
-proc_ptr_result_4.f90
-proc_ptr_result_6.f90
-proc_ptr_result_7.f90
-proc_target_1.f90
-ptr-func-3.f90
-ptr-func-5.f90
-public_private_module_10.f90
-public_private_module_4.f90
-pure_byref_1.f90
-pure_formal_proc_2.f90
-pure_formal_proc_4.f90
-pure_initializer_3.f90
-quad_3.f90
-random_4.f90
-random_init_2.f90
-random_seed_2.f90
-random_seed_3.f90
-read_1.f90
-read_2.f90
-read_3.f90
-read_4.f90
-read_5.f90
-read_bad_advance.f90
-read_bang.f90
-read_bang4.f90
-read_eof_1.f90
-read_eof_2.f90
-read_eof_3.f90
-read_eof_4.f90
-read_eof_5.f90
-read_eof_7.f90
-read_eof_8.f90
-read_eof_all.f90
-read_float_3.f90
-read_list_eof_1.f90
-read_no_eor.f90
-read_noadvance.f90
-read_repeat.f90
-read_repeat_2.f90
-read_size_noadvance.f90
-read_x_eof.f90
-read_x_eor.f90
-readwrite_unf_direct_eor_1.f90
-real4-10-real8-10.f90
-real4-10-real8-4.f90
-real4-10.f90
-real4-8-real8-10.f90
-real4-8-real8-4.f90
-real4-8.f90
-real8-10.f90
-real8-4.f90
-real_const_2.f90
-realloc_on_assign_10.f90
-realloc_on_assign_11.f90
-realloc_on_assign_12.f90
-realloc_on_assign_13.f90
-realloc_on_assign_15.f90
-realloc_on_assign_17.f90
-realloc_on_assign_23.f90
-realloc_on_assign_24.f90
-realloc_on_assign_25.f90
-realloc_on_assign_26.f90
-realloc_on_assign_28.f90
-realloc_on_assign_29.f90
-realloc_on_assign_30.f90
-realloc_on_assign_31.f90
-realloc_on_assign_32.f90
-realloc_on_assign_9.f90
-recursive_alloc_comp_5.f90
-recursive_alloc_comp_6.f90
-recursive_interface_1.f90
-recursive_interface_2.f90
-recursive_reference_2.f90
-reduce_1.f90
-reduce_3.f90
-reduce_4.f90
-reduction.f90
-repeat_2.f90
-repeat_3.f90
-repeat_5.f90
-repeat_6.f90
-repeat_8.f90
-reshape-alloc.f90
-reshape-complex.f90
-reshape.f90
-reshape_2.f90
-reshape_6.f90
-reshape_pad_1.f90
-reshape_rank7.f90
-reshape_zerosize_1.f90
-reshape_zerosize_3.f90
-reshape_zerosize_4.f90
-result_in_spec_1.f90
-result_in_spec_2.f90
-result_in_spec_4.f90
-ret_array_1.f90
-ret_pointer_1.f90
-ret_pointer_2.f90
-rrspacing_1.f90
-save_8.f90
-save_alloc_character_1.f90
-scalar_mask_1.f90
-scalar_mask_2.f90
-scalarize_parameter_array_1.f90
-scalarize_parameter_array_2.f90
-scale_1.f90
-scan_3.f90
-scratch_1.f90
-select_rank_1.f90
-select_rank_5.f90
-select_type_4.f90
-select_type_42.f90
-select_type_43.f90
-select_type_44.f90
-select_type_45.f90
-select_type_46.f90
-select_type_47.f90
-select_type_48.f90
-select_type_50.f90
-select_type_51.f90
-selected_char_kind_1.f90
-selected_char_kind_4.f90
-selected_logical_kind_1.f90
-selected_logical_kind_4.f90
-set_exponent_1.f90
-shape_12.f90
-shape_2.f90
-shape_3.f90
-shape_4.f90
-shape_5.f90
-shape_6.f90
-shape_8.f90
-shift-alloc.f90
-shift-kind.f90
-shift-kind_2.f90
-shiftalr_3.f90
-simpleif_1.f90
-simplify_argN_1.f90
-simplify_cshift_1.f90
-simplify_cshift_2.f90
-simplify_cshift_3.f90
-simplify_cshift_4.f90
-simplify_eoshift_1.f90
-simplify_modulo.f90
-size_dim.f90
-size_kind.f90
-sizeof.f90
-sizeof_4.f90
-sizeof_5.f90
-sizeof_6.f90
-slash_1.f90
-spec_expr_10.f90
-spec_expr_4.f90
-spec_expr_5.f90
-spec_expr_8.f90
-spec_expr_9.f90
-specification_type_resolution_1.f90
-specification_type_resolution_2.f90
-specifics_2.f90
-split_1.f90
-split_2.f90
-spread_scalar_zerosize.f90
-spread_shape_1.f90
-spread_simplify_1.f90
-spread_zerosize_1.f90
-storage_size_7.f90
-streamio_1.f90
-streamio_10.f90
-streamio_11.f90
-streamio_12.f90
-streamio_13.f90
-streamio_14.f90
-streamio_15.f90
-streamio_16.f90
-streamio_17.f90
-streamio_18.f90
-streamio_3.f90
-streamio_4.f90
-streamio_5.f90
-streamio_6.f90
-streamio_7.f90
-streamio_8.f90
-string_5.f90
-string_array_constructor_1.f90
-string_array_constructor_2.f90
-string_array_constructor_3.f90
-string_array_constructor_4.f90
-string_compare_1.f90
-string_compare_2.f90
-string_compare_3.f90
-string_length_1.f90
-string_length_5.f90
-string_pad_trunc.f90
-structure_constructor_10.f90
-structure_constructor_14.f90
-submodule_23.f90
-submodule_34.f90
-subref_array_pointer_1.f90
-subref_array_pointer_2.f90
-subref_array_pointer_3.f90
-substr_1.f90
-substr_5.f90
-substr_7.f90
-substr_8.f90
-substr_alloc_string_comp_1.f90
-substr_simplify.f90
-substring_equivalence.f90
-substring_integer_index.f90
-sum_zero_array_1.f90
-temporary_1.f90
-tiny_1.f90
-tiny_2.f90
-transfer_array_intrinsic_1.f90
-transfer_array_intrinsic_2.f90
-transfer_array_intrinsic_3.f90
-transfer_assumed_size_1.f90
-transfer_char_kind4.f90
-transfer_class_2.f90
-transfer_class_3.f90
-transfer_class_4.f90
-transfer_class_5.f90
-transfer_intrinsic_2.f90
-transfer_intrinsic_3.f90
-transfer_intrinsic_5.f90
-transfer_null_1.f90
-transfer_resolve_1.f90
-transfer_resolve_2.f90
-transfer_resolve_4.f90
-transfer_simplify_10.f90
-transfer_simplify_11.f90
-transfer_simplify_4.f90
-transfer_simplify_5.f90
-transfer_simplify_6.f90
-transfer_simplify_9.f90
-transpose_1.f90
-transpose_4.f90
-transpose_conjg_1.f90
-transpose_intrinsic_func_call_1.f90
-trim_1.f90
-trim_optimize_4.f90
-trim_optimize_6.f90
-typebound_assignment_7.f90
-typebound_assignment_8.f90
-typebound_call_26.f90
-typebound_call_28.f90
-typebound_call_30.f90
-typebound_call_32.f90
-typebound_deferred_1.f90
-typebound_generic_15.f90
-typebound_operator_11.f90
-typebound_operator_15.f90
-typebound_operator_17.f90
-typebound_operator_20.f90
-typebound_proc_20.f90
-typebound_proc_21.f90
-typebound_proc_23.f90
-typebound_proc_25.f90
-typebound_proc_30.f90
-typebound_proc_32.f90
-typebound_proc_33.f90
-typebound_proc_35.f90
-typebound_proc_36.f90
-ubound_1.f90
-unf_read_corrupted_1.f90
-unf_read_corrupted_2.f90
-unf_short_record_1.f90
-unit_1.f90
-unlimited_polymorphic_12.f90
-unlimited_polymorphic_13.f90
-unlimited_polymorphic_15.f90
-unlimited_polymorphic_16.f90
-unlimited_polymorphic_17.f90
-unlimited_polymorphic_18.f90
-unlimited_polymorphic_19.f90
-unlimited_polymorphic_20.f90
-unlimited_polymorphic_21.f90
-unlimited_polymorphic_22.f90
-unlimited_polymorphic_23.f90
-unlimited_polymorphic_25.f90
-unlimited_polymorphic_26.f90
-unlimited_polymorphic_29.f90
-unlimited_polymorphic_32.f90
-unlimited_polymorphic_5.f90
-unlimited_polymorphic_6.f90
-unlimited_polymorphic_7.f90
-unpack_mask_1.f90
-unpack_zerosize_1.f90
-unreferenced_use_assoc_1.f90
-unsigned_write_2.f90
-use_10.f90
-use_13.f90
-use_17.f90
-use_18.f90
-use_2.f90
-use_24.f90
-use_25.f90
-use_27.f90
-use_28.f90
-use_5.f90
-use_8.f90
-use_allocated_1.f90
-use_only_2.f90
-use_only_3.f90
-use_only_5.f90
-use_rename_12.f90
-use_rename_13.f90
-use_rename_14.f90 # re-listed: ffc lowering gap exposed by fortfront bare-end unit split
-use_rename_7.f90
-use_rename_9.f90
-used_dummy_types_1.f90
-used_dummy_types_2.f90
-used_dummy_types_5.f90
-used_dummy_types_6.f90
-used_dummy_types_7.f90
-used_dummy_types_8.f90
-used_interface_ref.f90
-used_types_1.f90
-used_types_10.f90
-used_types_11.f90
-used_types_12.f90 # re-listed: ffc lowering gap exposed by fortfront bare-end unit split
-used_types_13.f90
-used_types_15.f90
-used_types_16.f90
-used_types_2.f90
-used_types_20.f90
-used_types_22.f90
-used_types_3.f90
-used_types_4.f90
-used_types_5.f90
-used_types_6.f90
-used_types_9.f90
-userdef_operator_1.f90
-value_9.f90
-value_optional_1.f90
-value_optional_2.f90
-value_optional_3.f90
-value_test.f90
-value_tests_f03.f90
-vector_subscript_1.f90
-vector_subscript_2.f90
-vector_subscript_3.f90
-vector_subscript_5.f90
-vector_subscript_8.f90
-vector_subscript_9.f90
-verify_2.f90
-verify_3.f90
-warn_unused_dummy_argument_5.f90
-where_1.f90
-where_2.f90
-where_4.f90
-where_nested_1.f90
-where_operator_assign_1.f90
-where_operator_assign_2.f90
-where_operator_assign_3.f90
-whole_file_10.f90
-whole_file_11.f90
-whole_file_12.f90
-whole_file_13.f90
-whole_file_23.f90
-whole_file_27.f90
-whole_file_35.f90
-whole_file_8.f90
-whole_file_9.f90
-widechar_6.f90
-widechar_9.f90
-widechar_IO_1.f90
-widechar_IO_2.f90
-widechar_IO_3.f90
-widechar_compare_1.f90
-write_0_pe_format.f90
-write_check3.f90
-write_direct_eor.f90
-write_fmt_trim.f90
-write_recursive.f90
-write_zero_array.f90
-zero_array_components_1.f90
-zero_length_1.f90
-zero_length_2.f90
-zero_sized_1.f90
-zero_sized_11.f90
-zero_sized_12.f90
-zero_sized_14.f90
-zero_sized_15.f90
-zero_sized_2.f90
-zero_sized_3.f90
-zero_sized_4.f90
-zero_sized_5.f90
-zero_sized_7.f90
-zero_sized_9.f90
-associate_contained_func_typebound.f90
-associate_contained_func_typebound_2.f90
-associate_infer_program_type.f90
-assumed_charlen_dummy.f90
-auto_char_len_1.f90
-auto_char_len_2.f90
-automatic_char_len_1.f90
-bind_c_usage_32.f90
-bound_simplification_1.f90
-dec_exp_3.f90
-dec_io_3.f90
-dec_static_3.f90
-erfc_scaled_1.f90
-fmt_error_6.f90
-fmt_t_2.f90
-implicit_16.f90
-initialization_9.f90
-integer_exponentiation_2.f90
-intrinsic_actual_4.f90
-oldstyle_3.f90
-stfunc_8.f90
-stmt_func_1.f90
-string_4.f90
-associate_80.f90 # new corpus file since 2026-06 seed
-associate_81.f90 # new corpus file since 2026-06 seed
-associate_82.f90 # new corpus file since 2026-06 seed
-contiguous_17.f90 # new corpus file since 2026-06 seed
-do_concurrent_assoc_iter_1.f90 # new corpus file since 2026-06 seed
-fmt_t_10.f90 # new corpus file since 2026-06 seed
-fmt_t_11.f90 # new corpus file since 2026-06 seed
-implied_do_alloc_comp_1.f90 # new corpus file since 2026-06 seed
-loc_3.f90 # new corpus file since 2026-06 seed
-namelist_103.f90 # new corpus file since 2026-06 seed
-pdt_array_alloc_1.f90 # new corpus file since 2026-06 seed
-select_type_53.f90 # new corpus file since 2026-06 seed
-stop_function_code_1.f90 # new corpus file since 2026-06 seed
-submodule_38.f90 # new corpus file since 2026-06 seed
-warn_unused_but_set_variable_2.f90 # new corpus file since 2026-06 seed
-warn_unused_intent_out_1.f90 # new corpus file since 2026-06 seed
-warn_unused_read_1.f90 # new corpus file since 2026-06 seed
+ISO_Fortran_binding_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+ISO_Fortran_binding_19.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+ISO_Fortran_binding_4.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+PR100029.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+PR100040.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+PR100094.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+PR100103.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+PR100120.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+PR100132.f90 # owner=lazy-fortran/ffc#452; reason=lower the scalar data-pointer association query
+PR100245.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+PR19754_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+PR85868A.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+PR85868B.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+PR90350.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+PR93308.f90 # owner=lazy-fortran/ffc#334; reason=lower the BIND(C) assumed-shape dummy descriptor
+PR94022.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+PR94289.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+PR95196.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+PR95214.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+PR95331.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+PR95352.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+PR96726.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+PR96727.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+PR96728.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+PR97046.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+access_spec_3.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+achar_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+achar_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+actual_array_constructor_1.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+actual_array_constructor_2.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+actual_array_constructor_3.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+actual_array_interface_1.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+actual_array_offset_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+actual_array_result_1.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+actual_array_subref.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+actual_array_substr_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+actual_array_substr_2.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+actual_pointer_function_1.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+actual_procedure_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+adjustl_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+advance_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+advance_4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+advance_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+advance_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+aint_anint_1.f90 # owner=lazy-fortran/ffc#431; reason=lower AINT and ANINT kind conversions
+aliasing_array_result_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+aliasing_complex_pointer.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+aliasing_dummy_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+aliasing_dummy_4.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+aliasing_dummy_5.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+alloc_alloc_expr_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_assign_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+alloc_comp_assign_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_assign_11.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+alloc_comp_assign_17.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+alloc_comp_assign_4.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+alloc_comp_assign_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_assign_7.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_assign_8.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+alloc_comp_auto_array_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_auto_array_2.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+alloc_comp_auto_array_4.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+alloc_comp_basics_2.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+alloc_comp_basics_3.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+alloc_comp_basics_4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_basics_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_basics_7.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_bounds_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_class_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_class_2.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+alloc_comp_constraint_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_constructor_3.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+alloc_comp_constructor_4.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+alloc_comp_constructor_7.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+alloc_comp_deep_copy_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_deep_copy_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_deep_copy_7.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_default_init_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_default_init_2.f90 # owner=lazy-fortran/ffc#365; reason=preserve allocatable-component ownership
+alloc_comp_initializer_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+alloc_comp_initializer_3.f90 # owner=lazy-fortran/ffc#463; reason=lower structured DATA initialization
+alloc_comp_optional_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+alloc_comp_result_1.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+alloc_comp_result_2.f90 # owner=lazy-fortran/ffc#327; reason=preserve distinct declaration bindings
+alloc_comp_result_3.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+alloc_comp_scalar_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+alloc_comp_transformational_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+alloc_deferred_comp_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+allocatable_dummy_1.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+allocatable_dummy_3.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+allocatable_function_10.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+allocatable_function_3.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+allocatable_function_5.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+allocatable_function_6.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+allocatable_function_7.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+allocatable_function_9.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocatable_length_2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+allocatable_scalar_10.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocatable_scalar_12.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+allocatable_scalar_14.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+allocatable_scalar_4.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+allocatable_scalar_7.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocatable_scalar_8.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_alloc_opt_10.f90 # owner=lazy-fortran/ffc#358; reason=lower multi-object ALLOCATE
+allocate_alloc_opt_12.f90 # owner=lazy-fortran/ffc#404; reason=fold typed component default initializers
+allocate_alloc_opt_13.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+allocate_alloc_opt_3.f90 # owner=lazy-fortran/ffc#428; reason=return allocation status and release descriptor storage
+allocate_alloc_opt_6.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_alloc_opt_7.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_assumed_charlen_1.f90 # owner=lazy-fortran/ffc#358; reason=lower multi-object ALLOCATE
+allocate_assumed_charlen_4.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+allocate_char_star_scalar_1.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+allocate_class_3.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+allocate_class_4.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+allocate_derived_2.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+allocate_derived_3.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_derived_4.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+allocate_derived_5.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+allocate_with_mold_1.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+allocate_with_mold_3.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+allocate_with_mold_4.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+allocate_with_source_1.f90 # owner=lazy-fortran/ffc#358; reason=lower multi-object ALLOCATE
+allocate_with_source_2.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+allocate_with_source_24.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+allocate_with_source_26.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+allocate_with_source_27.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+allocate_with_source_28.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+allocate_with_source_3.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+allocate_with_source_31.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+allocate_with_source_32.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+allocate_with_source_5.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+allocate_with_typespec_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+allocate_zerosize_1.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_zerosize_2.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+allocated_1.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+allocated_4.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+ambiguous_specific_2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+and_or_xor.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+anint_1.f90 # owner=lazy-fortran/ffc#431; reason=lower AINT and ANINT kind conversions
+any_all_2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+anyallcount_1.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+append_1.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+argument_checking_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+argument_checking_17.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+argument_checking_19.f90 # owner=lazy-fortran/ffc#448; reason=validate and lower the scalar procedure call
+argument_checking_8.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+array_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+array_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_5.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+array_alloc_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+array_alloc_2.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+array_alloc_3.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+array_constructor_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_constructor_12.f90 # owner=lazy-fortran/ffc#447; reason=preserve the INTEGER(8) implied-do iterator kind
+array_constructor_16.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+array_constructor_17.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+array_constructor_19.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_constructor_21.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+array_constructor_3.f90 # owner=lazy-fortran/ffc#388; reason=reject incompatible array constructor types
+array_constructor_31.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_constructor_32.f90 # owner=lazy-fortran/ffc#463; reason=lower nested constructors in DATA initialization
+array_constructor_33.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_constructor_34.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+array_constructor_35.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+array_constructor_36.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+array_constructor_37.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+array_constructor_4.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+array_constructor_42.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_constructor_45.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+array_constructor_50.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+array_constructor_52.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_constructor_53.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_constructor_55.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_constructor_56.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_constructor_57.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+array_constructor_58.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+array_constructor_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_constructor_7.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_constructor_8.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+array_constructor_9.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+array_constructor_typespec_1.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+array_function_1.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+array_function_3.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+array_function_4.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+array_function_5.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_function_6.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+array_initializer_1.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+array_initializer_2.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+array_memcpy_5.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+array_reference_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+array_reference_2.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+array_return_value_1.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_simplify_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+array_simplify_2.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+array_simplify_3.f90 # owner=lazy-fortran/ffc#412; reason=fold the named array initialization expression
+array_temporaries_3.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+arrayio_1.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+arrayio_10.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+arrayio_11.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+arrayio_12.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+arrayio_13.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+arrayio_14.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+arrayio_15.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+arrayio_16.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+arrayio_2.f90 # owner=lazy-fortran/ffc#423; reason=lower formatted output to internal character storage
+arrayio_3.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+arrayio_5.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+arrayio_6.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+arrayio_9.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+arrayio_derived_1.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+arrayio_derived_2.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+assign_12.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+assign_13.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+assign_9.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_12.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+associate_13.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+associate_14.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+associate_15.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+associate_16.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+associate_17.f90 # owner=lazy-fortran/ffc#432; reason=lower NORM2 over descriptor arrays
+associate_22.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_23.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+associate_25.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+associate_27.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+associate_28.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+associate_29.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+associate_34.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+associate_35.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_38.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_41.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+associate_42.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_44.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_45.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+associate_46.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+associate_47.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+associate_48.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+associate_49.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_58.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+associate_60.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_61.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+associate_62.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+associate_63.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+associate_65.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+associate_67.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+associate_68.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+associate_71.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_74.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+associate_75.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_77.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+associated_1.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+associated_2.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+associated_4.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+associated_5.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+associated_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associated_8.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+associated_assumed_rank.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+associated_target_2.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+associated_target_3.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+associated_target_4.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+associated_target_7.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+associated_target_8.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+assumed_charlen_arg_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+assumed_charlen_arg_2.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+assumed_charlen_function_2.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+assumed_charlen_needed_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+assumed_charlen_parameter.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+assumed_charlen_sharing.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+assumed_dummy_1.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+assumed_len.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+assumed_present.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+assumed_rank_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+assumed_rank_16.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+assumed_rank_17.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+assumed_rank_19.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+assumed_rank_20.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+assumed_rank_21.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+assumed_rank_24.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+assumed_rank_25.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+assumed_rank_7.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+assumed_rank_bounds_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+assumed_rank_bounds_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+assumed_rank_bounds_3.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+assumed_size_2.f90 # owner=lazy-fortran/ffc#386; reason=reject invalid array indexing and shape expressions
+assumed_size_refs_3.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+assumed_type_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+assumed_type_18.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+assumed_type_2a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+assumed_type_9.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+auto_array_1.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+auto_char_dummy_array_1.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+auto_char_dummy_array_2.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+auto_char_dummy_array_3.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+auto_char_len_3.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+auto_char_pointer_array_result_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+auto_pointer_array_result_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+auto_save_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+backslash_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+backspace_10.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+backspace_11.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+backspace_7.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+backtrace_1.f90 # scope=vendor; reason=GNU BACKTRACE extension
+bessel_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+bessel_2.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+besxy.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+bind-c-char-descr.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+bind_c_char_11.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+bind_c_char_2.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+bind_c_char_3.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+bind_c_dts_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bind_c_optional-1.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+bind_c_optional-2.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+bind_c_procs_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bind_c_procs_3.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+bind_c_usage_19.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+bind_c_usage_21.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bind_c_usage_29.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bind_c_usage_30.f90 # owner=lazy-fortran/fortfront#2886; reason=enforce BIND(C) interoperability contracts
+binding_label_tests_26a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+binding_label_tests_32.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+binding_label_tests_33.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+block_14.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+block_name_1.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+blockdata_7.f90 # owner=lazy-fortran/ffc#463; reason=lower structured DATA initialization
+bound_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+bound_10.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+bound_11.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+bound_3.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+bound_4.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+bound_5.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+bound_6.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+bounds_check_20.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+bounds_check_27.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+bounds_check_29.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+boz_11.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+boz_12.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+boz_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+boz_5.f90 # owner=lazy-fortran/ffc#393; reason=reject BOZ literals outside permitted contexts
+boz_bge.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+boz_dshift_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+boz_iand_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+boz_int.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+c_assoc_3.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+c_assoc_5.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+c_char_tests_4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+c_f_pointer_shape_tests_5.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+c_f_pointer_shape_tests_6.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+c_f_pointer_tests_4.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+c_funloc_tests_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+c_loc_test_18.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+c_loc_test_20.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+c_loc_tests_13.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+c_loc_tests_14.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+c_ptr_tests_17.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+c_ptr_tests_18.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+c_ptr_tests_19.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+c_sizeof_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+c_sizeof_6.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+c_sizeof_8.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+change_symbol_attributes_1.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+char_allocation_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_array_arg_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+char_array_constructor.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_array_constructor_2.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+char_array_constructor_3.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_array_structure_constructor.f90 # owner=lazy-fortran/ffc#358; reason=lower multi-object ALLOCATE
+char_associated_1.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+char_component_initializer_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_component_initializer_3.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_cons_len.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_cshift_1.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+char_cshift_2.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+char_cshift_3.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+char_decl_2.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+char_eoshift_1.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+char_eoshift_2.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+char_eoshift_3.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+char_eoshift_4.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+char_expr_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_expr_3.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_length_10.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_length_11.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_length_12.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+char_length_13.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_length_14.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_length_15.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+char_length_16.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_length_18.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_length_19.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+char_length_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_length_21.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_length_23.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_length_5.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_length_6.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_length_7.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_length_8.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+char_pack_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+char_pack_2.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+char_pointer_assign_3.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+char_pointer_assign_icb_1.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+char_pointer_comp_assign.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_reshape_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_result_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_result_10.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+char_result_12.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+char_result_13.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+char_result_14.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+char_result_15.f90 # owner=lazy-fortran/ffc#410; reason=preserve fixed-length character function results
+char_result_17.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_result_2.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+char_result_3.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+char_result_4.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+char_result_5.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+char_result_6.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+char_result_7.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+char_result_8.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+char_result_9.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+char_spread_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+char_transpose_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_type_len.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_unpack_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+char_unpack_2.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+character_array_constructor_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+character_array_dummy_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+character_workout_1.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+character_workout_4.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+charlen_15.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+charlen_16.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+charlen_17.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+chkbits.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_35.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+class_48.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_49.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_63.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_66.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+class_67.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_68.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_74.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+class_75.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+class_79.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+class_allocate_12.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_allocate_13.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_allocate_18.f90 # owner=lazy-fortran/ffc#403; reason=invoke the scalar finalization path
+class_allocate_20.f90 # owner=lazy-fortran/ffc#403; reason=invoke the scalar finalization path
+class_allocate_21.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_allocate_22.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+class_allocate_5.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+class_array_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_array_18.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_assign_4.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+class_dummy_11.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+class_dummy_6.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_dummy_7.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+class_dummy_8.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_dummy_9.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_elemental_1.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_nameclash.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_result_10.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_result_2.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_result_3.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_result_5.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_result_6.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_result_9.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_to_type_2.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_to_type_4.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_transformational_1.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+class_transformational_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+cmplx_intrinsic_1.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+common_1.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_12.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_2.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_pointer_1.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+complex_int_1.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+complex_intrinsic_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+complex_intrinsic_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+complex_intrinsic_5.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+complex_read.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+complex_write.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+constructor_1.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+constructor_2.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+constructor_3.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+constructor_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+contained_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+contained_3.f90 # owner=lazy-fortran/ffc#456; reason=lower procedure ENTRY points
+contained_module_proc_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+contiguous_13.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+contiguous_14.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+contiguous_5.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+contiguous_6.f90 # owner=lazy-fortran/ffc#381; reason=enforce data and procedure pointer target contracts
+contiguous_8.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+continuation_12.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+continuation_8.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+count_mask_1.f90 # owner=lazy-fortran/ffc#463; reason=lower structured DATA initialization
+coverage.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+cray_pointers_13.f90 # scope=vendor; reason=nonstandard Cray pointer extension
+cshift_1.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+cshift_2.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+cshift_nan_1.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+data_array_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+data_array_4.f90 # owner=lazy-fortran/ffc#463; reason=lower structured DATA initialization
+data_array_7.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+data_components_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+data_implied_do_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+data_initialized_3.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+data_initialized_4.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+data_namelist_conflict.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+data_pointer_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+data_stmt_pointer.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+data_vector_section.f90 # owner=lazy-fortran/ffc#463; reason=lower DATA initialization over array sections
+date_and_time_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+date_and_time_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+deallocate_alloc_opt_3.f90 # owner=lazy-fortran/ffc#428; reason=return allocation status and release descriptor storage
+deallocate_stat.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+deallocate_stat_2.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+default_format_1.f90 # owner=lazy-fortran/ffc#354; reason=expand Fortran INCLUDE lines
+default_initialization_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+default_initialization_3.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+default_initialization_6.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+deferred_character_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+deferred_character_10.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+deferred_character_11.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+deferred_character_12.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+deferred_character_13.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+deferred_character_14.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+deferred_character_16.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+deferred_character_17.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+deferred_character_19.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+deferred_character_2.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+deferred_character_20.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+deferred_character_22.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+deferred_character_23.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+deferred_character_24.f90 # owner=lazy-fortran/ffc#349; reason=migrate deferred scalar character storage
+deferred_character_26.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+deferred_character_27.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+deferred_character_28.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+deferred_character_29.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+deferred_character_3.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+deferred_character_30.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+deferred_character_31.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+deferred_character_32.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+deferred_character_34.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+deferred_character_35.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+deferred_character_36.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+deferred_character_37.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+deferred_character_38.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+deferred_character_39.f90 # owner=lazy-fortran/ffc#356; reason=resolve leading-dimension dummies
+deferred_character_4.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+deferred_character_5.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+deferred_character_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+deferred_character_7.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+deferred_character_8.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+deferred_character_9.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+deferred_character_assignment_1.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+deferred_type_component_1.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+deferred_type_component_2.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+deferred_type_component_3.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+deferred_type_param_4.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+deferred_type_param_5.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+deferred_type_param_6.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+deferred_type_param_8.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+deferred_type_proc_pointer_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+deferred_type_proc_pointer_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+defined_assignment_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+defined_assignment_10.f90 # owner=lazy-fortran/ffc#462; reason=recurse through defined assignment components
+defined_assignment_11.f90 # owner=lazy-fortran/ffc#462; reason=recurse through defined assignment components
+defined_assignment_12.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+defined_assignment_13.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+defined_assignment_2.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+defined_assignment_3.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+defined_assignment_4.f90 # owner=lazy-fortran/ffc#462; reason=recurse through defined assignment components
+defined_assignment_6.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+defined_assignment_7.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+defined_assignment_9.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+dependency_1.f90 # owner=lazy-fortran/ffc#344; reason=preserve overlapping array-section assignment
+dependency_19.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dependency_2.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+dependency_21.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+dependency_22.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dependency_23.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+dependency_24.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+dependency_25.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+dependency_3.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+dependency_39.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+dependency_40.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dependency_44.f90 # owner=lazy-fortran/ffc#344; reason=make overlapping array assignment alias-safe
+dependency_46.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+dependency_50.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+dependency_51.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+dependency_52.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dependency_53.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+dependency_55.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+dependency_56.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+dependency_57.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+dependency_58.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+dependency_59.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+dependency_60.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+dependent_decls_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+dependent_decls_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+dependent_decls_3.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+der_array_1.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+der_pointer_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+der_pointer_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+der_pointer_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+der_pointer_4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+der_ptr_component_1.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+der_ptr_component_2.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+derived_comp_array_ref_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_comp_array_ref_2.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_comp_array_ref_3.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+derived_comp_array_ref_4.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+derived_comp_array_ref_5.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_comp_array_ref_7.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+derived_constructor_char_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_constructor_comps_1.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_constructor_comps_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_constructor_comps_4.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_constructor_comps_5.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+derived_constructor_comps_7.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+derived_external_function_1.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+derived_init_1.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+derived_init_2.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_init_3.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+derived_init_4.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+derived_init_5.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_init_6.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+derived_init_7.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+derived_pointer_recursion_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_result_3.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+derived_result_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+direct_io_1.f90 # owner=lazy-fortran/ffc#396; reason=preserve direct-access file-unit state
+direct_io_11.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted direct-file input
+direct_io_12.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+direct_io_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+direct_io_4.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+direct_io_5.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+direct_io_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+direct_io_7.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+direct_io_8.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+do_check_14.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+do_check_15.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+do_check_17.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+do_check_7.f90 # owner=lazy-fortran/ffc#448; reason=validate and lower the scalar procedure call
+do_concurrent_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+do_concurrent_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+do_concurrent_2.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+do_pointer_1.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+dot_product_4.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+dtio_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dtio_10.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_12.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+dtio_14.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_15.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_16.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_17.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dtio_19.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+dtio_2.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_22.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_23.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_24.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_25.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+dtio_27.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dtio_33.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_34.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_35.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_36.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_37.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+dtio_4.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+dtio_7.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+dtio_8.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dtio_9.f90 # owner=lazy-fortran/ffc#427; reason=return stable defined-I/O status values
+dummy_functions_1.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+dummy_procedure_3.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+dummy_procedure_7.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+dynamic_dispatch_12.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+edit_real_1.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+elemental_assignment_1.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+elemental_by_value_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+elemental_dependency_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+elemental_dependency_6.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+elemental_function_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+elemental_function_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+elemental_function_3.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+elemental_initializer_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+elemental_optional_args_2.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+elemental_optional_args_3.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+elemental_optional_args_4.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+elemental_optional_args_7.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+elemental_scalar_args_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+elemental_scalar_args_2.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+elemental_subroutine_1.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+elemental_subroutine_10.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+elemental_subroutine_11.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+elemental_subroutine_3.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+elemental_subroutine_7.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+elemental_subroutine_9.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+empty_type.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+endfile.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+endfile_2.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+endfile_5.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+entry_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+entry_10.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+entry_11.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+entry_12.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+entry_13.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+entry_14.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+entry_16.f90 # owner=lazy-fortran/ffc#456; reason=lower procedure ENTRY points
+entry_2.f90 # owner=lazy-fortran/ffc#416; reason=compile procedure-only translation units
+entry_20.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+entry_26.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+entry_27.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+entry_3.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+entry_6.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+entry_8.f90 # owner=lazy-fortran/ffc#456; reason=lower procedure ENTRY points
+entry_9.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+entry_array_specs_3.f90 # owner=lazy-fortran/ffc#416; reason=compile procedure-only translation units
+entry_dummy_ref_3.f90 # owner=lazy-fortran/ffc#416; reason=compile procedure-only translation units
+eof_1.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+eof_3.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+eof_4.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+eof_5.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+eor_handling_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+eor_handling_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+eor_handling_4.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+eor_handling_5.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+eoshift.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+eoshift_2.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+eoshift_3.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+eoshift_4.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+eoshift_5.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+eoshift_6.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+equiv_6.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equiv_9.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+erfc_scaled_2.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+error_format_2.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+error_recovery_5.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+execute_command_line_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+execute_command_line_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+execute_command_line_3.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+exponent_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+external_procedures_2.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+external_procedures_3.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+external_procedures_4.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+f_c_string1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+f_c_string2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+fgetc_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+fgetc_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+filename_null.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+filepos1.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
+finalize_13.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+finalize_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+finalize_15.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_17.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_25.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_31.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_38.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+finalize_39.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_40.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_41.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_42.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_43.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_44.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_45.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_46.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_47.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_48.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_50.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+finalize_51.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_52.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+finalize_53.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+finalize_54.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_55.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_56.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+finalize_58.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_59.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+finalize_60.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalize_61.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+finalizer_recursive_alloc_1.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalizer_recursive_alloc_2.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalizer_self_assign.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+findloc_2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+findloc_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+findloc_4.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+findloc_5.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+findloc_6.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+findloc_8.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+flush_1.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+fmt_cache_3.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+fmt_colon.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+fmt_e.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+fmt_en.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+fmt_exhaust.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+fmt_f0_1.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+fmt_f0_2.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+fmt_f0_3.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+fmt_float.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+fmt_g_1.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+fmt_huge.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+fmt_p_1.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+fmt_pf.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+fmt_read.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+fmt_read_3.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+fmt_t_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+fmt_t_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+fmt_t_4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+fmt_t_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+fmt_t_8.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+fmt_unlimited.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+fmt_zero_digits.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+fmt_zero_precision.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+fmt_zero_width.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+fold_nearest.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+forall_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+forall_12.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+forall_19.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+forall_20.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+forall_3.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+forall_4.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+forall_6.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+forall_char_dependencies_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+fraction.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+fseek.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+ftell_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+ftell_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+ftell_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+func_assign_2.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+func_assign_3.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+func_decl_2.f90 # owner=lazy-fortran/ffc#379; reason=enforce function-result and ENTRY rules
+func_derived_2.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+func_derived_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+func_derived_4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+func_result_1.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+func_result_5.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+func_result_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+function_charlen_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+function_charlen_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+function_kinds_1.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+function_kinds_3.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+function_optimize_10.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+function_types_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+gamma_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+gamma_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+generic_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+generic_12.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+generic_15.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+generic_20.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+generic_21.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+generic_24.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+generic_25.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+generic_27.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+generic_28.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+generic_3.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+generic_30.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+generic_31.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+generic_33.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+generic_36-1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+generic_4.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+generic_8.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+generic_stmt_1.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+generic_stmt_4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+getenv_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+goto_4.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+hollerith_9.f90 # scope=vendor; reason=nonstandard Hollerith literal extension
+host_assoc_call_4.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+host_assoc_call_5.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+host_assoc_function_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+host_assoc_function_2.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+host_assoc_function_5.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+host_assoc_function_6.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+host_assoc_function_7.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+host_assoc_function_9.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+host_assoc_types_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+host_dummy_index_1.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+iall_iany_iparity_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+iall_masked.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+ibits_2.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+ichar_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+ichar_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+impl_do_var_data.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+implicit_10.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+implicit_12.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+implicit_2.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+implicit_derived_type_1.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+implied_do_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+implied_do_3.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+implied_do_io_2.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+implied_do_io_5.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+implied_do_io_7.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+implied_do_io_8.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_io_9.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+implied_shape_4.f90 # owner=lazy-fortran/ffc#356; reason=resolve leading-dimension dummies
+import.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+import11.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+import4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+import6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+import7.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+import9.f90 # owner=lazy-fortran/ffc#357; reason=preserve executable/interface bodies
+in_pack_rank7.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+include_4.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+index.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+index_3.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+index_5.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+initialization_11.f90 # owner=lazy-fortran/ffc#404; reason=apply the component default on INTENT(OUT) entry
+initialization_12.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+initialization_14.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+initialization_2.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+initialization_20.f90 # scope=compiler-flags; reason=diagnostic depends on compiler constructor-size limit
+initialization_22.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+initialization_26.f90 # owner=lazy-fortran/ffc#412; reason=fold the named array initialization expression
+initialization_27.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+initialization_29.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+inline_matmul_20.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+inline_matmul_21.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+inline_matmul_22.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+inline_sum_3.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+inline_sum_4.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+inline_sum_5.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+inquire-complex.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+inquire_10.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+inquire_15.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+inquire_16.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+inquire_17.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+inquire_19.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+inquire_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+inquire_7.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+inquire_9.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+inquire_internal.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+inquire_pre.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+inquire_recl_f2018.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+inquire_size.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+inquiry_type_ref_5.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+int_2.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+int_3.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+integer_plus.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+intent_decl_1.f90 # owner=lazy-fortran/fortfront#2895; reason=reject incompatible declaration attributes
+intent_out_14.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+intent_out_16.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intent_out_17.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intent_out_18.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intent_out_19.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+intent_out_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intent_out_20.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+intent_out_21.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+intent_out_22.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+intent_out_5.f90 # owner=lazy-fortran/ffc#365; reason=preserve allocatable-component ownership
+intent_out_6.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+interface_10.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+interface_12.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+interface_13.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+interface_16.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+interface_25.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+interface_32.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+interface_4.f90 # owner=lazy-fortran/ffc#415; reason=resolve generic specifics by declared signature
+interface_41.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+interface_49.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+interface_53.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+interface_54.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+interface_59.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+interface_62.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+interface_63.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+interface_9.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+interface_abstract_5.f90 # owner=lazy-fortran/ffc#378; reason=reject malformed or ambiguous generic interfaces
+interface_assignment_1.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+interface_assignment_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+interface_assignment_3.f90 # owner=lazy-fortran/ffc#462; reason=recurse through defined assignment components
+interface_assignment_4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+interface_assignment_7.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+interface_proc_end.f90 # owner=lazy-fortran/ffc#357; reason=preserve executable/interface bodies
+internal_pack_1.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+internal_pack_10.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+internal_pack_13.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+internal_pack_14.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+internal_pack_23.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+internal_pack_4.f90 # owner=lazy-fortran/ffc#334; reason=preserve absent assumed-shape dummy descriptors
+internal_pack_6a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+internal_pack_8.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+internal_readwrite_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+internal_readwrite_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+internal_readwrite_3.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+internal_readwrite_4.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+intrinsic_1.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+intrinsic_8.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsic_9.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsic_actual_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsic_bounds_1.f90 # owner=lazy-fortran/ffc#343; reason=lower reductions through descriptor iteration
+intrinsic_char_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsic_ifunction_1.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsic_ifunction_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsic_intkinds_1.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+intrinsic_modulo_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsic_pack_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsic_pack_4.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsic_pack_5.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsic_pack_6.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsic_product_1.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsic_sign_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsic_signal.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsic_size_2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsic_spread_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsic_unpack_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsic_verify_1.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_kind_argument_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+io_constraints_13.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+io_real_boz.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+iostat_1.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+iostat_4.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+iostat_5.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+is_contiguous_1.f90 # owner=lazy-fortran/ffc#358; reason=lower multi-object ALLOCATE
+is_contiguous_2.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+is_contiguous_4.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+is_contiguous_5.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+is_iostat_end_eor_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+ishft_1.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+ishft_2.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+ishftc_optional_size_1.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+iso_c_binding_rename_3.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+iso_fortran_env_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+iso_fortran_env_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+iso_fortran_env_3.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+iso_fortran_env_8.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+large_recl.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+large_unit_2.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+largeequiv_1.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+leadz_trailz_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+linked_list_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+list_read_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+list_read_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+list_read_12.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+list_read_14.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+list_read_3.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+list_read_4.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+list_read_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+list_read_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+list_read_7.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+list_read_8.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+list_read_9.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+loc_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+logical_dot_product.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+logical_temp_io.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+longnames.f90 # owner=lazy-fortran/ffc#327; reason=preserve distinct declaration bindings
+make_unit.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+malloc_free_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+mapping_1.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+mapping_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+mapping_3.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+maskl_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+maskr_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+matmul_1.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+matmul_12.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+matmul_17.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+matmul_18.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+matmul_2.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+matmul_20.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+matmul_21.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+matmul_3.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+matmul_4.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+matmul_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+matmul_7.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+matmul_bounds_12.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+matmul_bounds_6.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+maxloc_1.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+maxloc_3.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+maxloc_4.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+maxloc_5.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+maxloc_6.f90 # owner=lazy-fortran/ffc#343; reason=lower reductions through descriptor iteration
+maxloc_7.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+maxloc_8.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+maxloc_string_1.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+maxloc_with_dim_1.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+maxloc_with_dim_and_mask_1.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+maxloc_with_mask_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+maxlocval_3.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+maxval_arg_eval_count.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+maxval_char_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+maxval_char_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+maxval_char_3.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+maxval_char_4.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+maxval_parameter_1.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+merge_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+merge_bits_4.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+merge_init_expr.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+min_max_optional_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+min_max_optional_5.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+min_max_type.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+min_max_type_2.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+minloc_2.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+minloc_3.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+minloc_4.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+minloc_5.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+minloc_7.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+minloc_8.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+minloc_9.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+minloc_string_1.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+minloc_with_dim_1.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+minloc_with_dim_and_mask_1.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+minloc_with_mask_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+minlocval_2.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+minlocval_3.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+minmax_char_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+minmaxloc_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+minmaxloc_10.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+minmaxloc_11.f90 # owner=lazy-fortran/ffc#343; reason=lower reductions through descriptor iteration
+minmaxloc_12.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+minmaxloc_13.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+minmaxloc_14.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+minmaxloc_17.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+minmaxloc_2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+minmaxloc_22.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+minmaxloc_4.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+minmaxloc_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+minmaxloc_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+minmaxloc_7.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+minmaxval_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+minval_char_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+minval_char_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+minval_char_3.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+minval_char_4.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+minval_char_5.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+minval_parameter_1.f90 # owner=lazy-fortran/ffc#343; reason=lower reductions through descriptor iteration
+missing_derived_type_1.f90 # owner=lazy-fortran/ffc#390; reason=enforce derived-type definition constraints
+missing_optional_dummy_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+missing_optional_dummy_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+missing_optional_dummy_3.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+missing_optional_dummy_7.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+missing_parens_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+mod_large_1.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+mod_sign0_1.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+module_blank_common.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+module_commons_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+module_commons_3.f90 # owner=lazy-fortran/ffc#351; reason=preserve CHARACTER storage in COMMON
+module_double_reuse.f90 # owner=lazy-fortran/ffc#371; reason=distinguish valid and ambiguous USE renames
+module_equivalence_1.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+module_equivalence_2.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON and EQUIVALENCE layout
+module_equivalence_3.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON and EQUIVALENCE layout
+module_equivalence_4.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+module_equivalence_5.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+module_error_1.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+module_interface_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+module_interface_2.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+module_private_array_refs_1.f90 # owner=lazy-fortran/ffc#358; reason=lower multi-object ALLOCATE
+module_proc_external_dummy.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+module_procedure_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+module_procedure_3.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+module_procedure_5.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+module_procedure_6.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+module_read_2.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+module_write_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+move_alloc.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+move_alloc_10.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+move_alloc_12.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+move_alloc_13.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+move_alloc_14.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+move_alloc_16.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+move_alloc_19.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+move_alloc_2.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+move_alloc_6.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+multiple_allocation_1.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+multiple_allocation_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+multiple_allocation_3.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+mvbits_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+mvbits_2.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+mvbits_3.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+mvbits_4.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+mvbits_5.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+mvbits_6.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+namelist_102.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_13.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_15.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_16.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_17.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_20.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_23.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_26.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_27.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_28.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_29.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+namelist_30.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_31.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+namelist_38.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+namelist_39.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_40.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_41.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_44.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_45.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_46.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_47.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_50.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_51.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_52.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_53.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+namelist_56.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_57.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+namelist_58.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_59.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_60.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_61.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_62.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_64.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_66.f90 # owner=lazy-fortran/ffc#404; reason=fold typed component default initializers
+namelist_68.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_69.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+namelist_70.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+namelist_71.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_73.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_74.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member constraints
+namelist_76.f90 # owner=lazy-fortran/ffc#460; reason=write scalar NAMELIST groups
+namelist_77.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+namelist_78.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_79.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_80.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_81.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_82.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+namelist_84.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_88.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+namelist_89.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_95.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+namelist_96.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_97.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_99.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_utf8.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+nearest_4.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+nearest_6.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+negative-z-descriptor.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+negative_stride_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+negative_unit2.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+nested_allocatables_1.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+nested_array_constructor_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+nested_array_constructor_3.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+nested_array_constructor_4.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+nested_array_constructor_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+nested_array_constructor_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+nested_modules_1.f90 # owner=lazy-fortran/ffc#447; reason=preserve typed complex module values
+nested_modules_2.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+nested_modules_3.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+nested_modules_6.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_reshape.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+nesting_1.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+new_line.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+newunit_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+newunit_3.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+newunit_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+nint_1.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+nint_2.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+no_arg_check_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+no_arg_check_2a.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+no_range_check_3.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+noadv_size.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+noreturn-3.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+norm2_1.f90 # owner=lazy-fortran/ffc#432; reason=lower NORM2 over descriptor arrays
+nosigned_zero_1.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+null_10.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+null_11.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+null_4.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+null_9.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+null_actual_2.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+null_actual_5.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+null_actual_6.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+null_actual_7.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+open_errors.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+open_negative_unit_1.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+open_new.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+open_readonly_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+operator_7.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+optional_absent_10.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+optional_absent_11.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+optional_absent_12.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+optional_absent_13.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+optional_absent_2.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+optional_absent_3.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+optional_absent_4.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+optional_absent_5.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+optional_absent_6.f90 # owner=lazy-fortran/ffc#409; reason=support OPTIONAL scalar dummies across kinds
+optional_absent_8.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+optional_absent_9.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+optional_assumed_charlen_2.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+optional_class_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+optional_deferred_char_1.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+optional_dim_2.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+optional_dim_3.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+optional_mask.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+out_of_range_1.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+out_of_range_2.f90 # scope=vendor; reason=nonstandard UNSIGNED extension
+overload_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+overload_4.f90 # owner=lazy-fortran/ffc#364; reason=register PROCEDURE declarations in the generic
+overload_5.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+pack_mask_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+pad_no.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+parameter_array_dummy.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+parameter_array_element_2.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+parameter_array_format.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+parameter_array_init_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+parameter_array_init_4.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+parameter_array_init_5.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+parameter_array_init_6.f90 # scope=compiler-flags; reason=diagnostic depends on compiler object-size limit
+parameter_array_init_8.f90 # owner=lazy-fortran/ffc#356; reason=resolve leading-dimension dummies
+parameter_array_ref_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+parameter_array_ref_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+parameter_array_section_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+parens_3.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+parens_4.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+parens_7.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+parent_result_ref_1.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+parent_result_ref_3.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+parent_result_ref_4.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+parity_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+past_eor.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+pdt_generic_1.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+pointer_array_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pointer_array_10.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+pointer_array_11.f90 # owner=lazy-fortran/ffc#432; reason=lower NORM2 over descriptor arrays
+pointer_array_2.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+pointer_array_3.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+pointer_array_4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pointer_array_5.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+pointer_array_7.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pointer_array_9.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+pointer_array_component_1.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+pointer_array_component_2.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+pointer_array_component_3.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+pointer_assign_10.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+pointer_assign_11.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+pointer_assign_14.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+pointer_assign_15.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+pointer_assign_16.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+pointer_assign_3.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+pointer_assign_4.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+pointer_assign_8.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+pointer_assign_9.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+pointer_comp_init_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pointer_function_actual_2.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+pointer_function_result_1.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+pointer_init_1.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+pointer_init_12.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+pointer_init_3.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+pointer_init_4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pointer_init_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pointer_init_8.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+pointer_intent_5.f90 # owner=lazy-fortran/ffc#338; reason=lower pointer-array association and indexing
+pointer_intent_6.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+pointer_remapping_9.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+pointer_target_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pointer_to_substring.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+power.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+power1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+power2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr100155.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+pr100194.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+pr100273.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr100949.f90 # owner=lazy-fortran/ffc#416; reason=compile procedure-only translation units
+pr102109.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pr102112.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pr102190.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr102333.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr102619.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pr102817.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+pr103139.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr103312.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+pr103366.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+pr103389.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+pr103506_1.f90 # owner=lazy-fortran/fortfront#2888; reason=reject local and global name collisions
+pr103716.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr103898.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+pr104349.f90 # owner=lazy-fortran/ffc#384; reason=require valid character length expressions
+pr104429.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+pr104555.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+pr105168.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+pr105205.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr105361.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+pr105473.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+pr105847.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+pr106731.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+pr106918.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr107068.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+pr107872.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+pr107900.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+pr108010.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+pr108420.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+pr108961.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+pr109209.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+pr109345.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr109358.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+pr109948.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr110224.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+pr110415.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+pr110877.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+pr111022.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+pr111853.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr112316.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+pr112407a.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+pr113363.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+pr113503_2.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+pr113956.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+pr114012.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+pr114021.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pr114304-2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr114304.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+pr114535d.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr114739.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr114874_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr117077.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+pr117730_a.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+pr117768.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+pr117797.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr117819.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr117820.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr119502.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+pr119836_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pr119836_3.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+pr119856.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+pr119948.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+pr120152_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pr120152_2.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+pr120153.f90 # scope=vendor; reason=nonstandard UNSIGNED extension
+pr120158.f90 # scope=vendor; reason=nonstandard UNSIGNED extension
+pr120191_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pr120191_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr120191_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr120196.f90 # owner=lazy-fortran/ffc#358; reason=lower multi-object ALLOCATE
+pr120743.f90 # owner=lazy-fortran/ffc#349; reason=store the deferred-length allocatable character scalar
+pr121234.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+pr121472.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+pr121475.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+pr122513.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+pr122936.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+pr122949.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr123868.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+pr123947_1.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+pr123949.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr124161.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+pr124208.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+pr124235.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr124450.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+pr124567.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+pr124780.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+pr15164.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr15324.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr15957.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+pr15959.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr16861.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr16938.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pr17090.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr17285.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+pr17286.f90 # owner=lazy-fortran/ffc#463; reason=lower structured DATA initialization
+pr17612.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr17615.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+pr18025.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+pr18122.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr18392.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr19467.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+pr19926.f90 # owner=lazy-fortran/ffc#448; reason=validate and lower the scalar procedure call
+pr19928-1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr19928-2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array component element expressions
+pr20480.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+pr21177.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+pr32222.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pr32238.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+pr33646.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr35944-1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pr35983.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+pr36006-1.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+pr39865.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr41126.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr42119.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr43505.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr43793.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+pr44735.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+pr45578.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+pr47574.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+pr47757-1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pr47757-2.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+pr47757-3.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+pr47878.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+pr49103.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pr49213.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+pr49540-1.f90 # owner=lazy-fortran/ffc#463; reason=lower repeated DATA initialization
+pr49698.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr50069_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr51434.f90 # owner=lazy-fortran/ffc#404; reason=fold typed component default initializers
+pr51993.f90 # owner=lazy-fortran/ffc#390; reason=enforce derived-type definition constraints
+pr53298.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr55086_1.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+pr55086_2.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+pr57910.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr59700.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+pr59706.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+pr60126.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pr61454.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+pr61765.f90 # owner=lazy-fortran/ffc#456; reason=lower procedure ENTRY points
+pr61775.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr61960.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr62125.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+pr63797.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr63883.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr64124.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr64230.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+pr64530.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+pr64589.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+pr65429.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr65450.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+pr65996.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr66311.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+pr67140.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+pr67219.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr67524.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+pr67805_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr67987.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+pr68053.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pr68154.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr68155.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr68227.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+pr68566.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+pr68864.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+pr69155.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+pr69455_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pr69455_2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pr69514_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr69514_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr69739.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr70040.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+pr70409.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr70673.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr70673_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr71085.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+pr71764.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+pr77420_4.f90 # scope=harness; reason=requires a companion module outside this suite invocation
+pr77632_1.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+pr77942.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+pr78092.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+pr78719_1.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+pr81509_1.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+pr81849.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pr81978.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+pr82314.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+pr82774.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+pr83149.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pr83149_a.f90 # owner=lazy-fortran/ffc#410; reason=lower the fixed-length character function result
+pr83864.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr83874.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+pr84088.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr84155.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+pr84523.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+pr84674.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+pr84779.f90 # owner=lazy-fortran/ffc#416; reason=compile procedure-only translation units
+pr84868.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr84869.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+pr84957.f90 # owner=lazy-fortran/ffc#456; reason=lower procedure ENTRY points
+pr85138_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+pr85138_2.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+pr85352.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pr85520.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr85521_1.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+pr85521_2.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+pr85786.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+pr85816.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+pr85938.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pr85975.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+pr85996.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr86322_3.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+pr86328.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+pr86760.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+pr87045.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+pr87946.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+pr87992.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr87993.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+pr87994_1.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+pr87994_2.f90 # owner=lazy-fortran/ffc#463; reason=lower named values in DATA initialization
+pr87994_3.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+pr88052.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+pr88116_2.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+pr88169_2.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+pr88688.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+pr89077.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr89084.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+pr89266.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+pr89647.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr89943_2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pr90344.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr91553.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr91566.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+pr91577.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+pr91660_2.f90 # owner=lazy-fortran/ffc#390; reason=reject the malformed derived type specification
+pr91661.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+pr91784.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr91862.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+pr92208.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr92277.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+pr92586.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+pr93263_2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pr93365.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+pr93600_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr93678.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+pr93685_1.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+pr93814.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+pr94377.f90 # owner=lazy-fortran/ffc#411; reason=support constant integer kind and length type parameters
+pr94380.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+pr95053_2.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+pr95104.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+pr95338.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+pr95342.f90 # owner=lazy-fortran/ffc#378; reason=reject malformed or ambiguous generic interfaces
+pr95500.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pr95611.f90 # owner=lazy-fortran/ffc#378; reason=reject malformed or ambiguous generic interfaces
+pr95614_1.f90 # owner=lazy-fortran/ffc#392; reason=enforce COMMON EQUIVALENCE SAVE and BLOCK DATA restrictions
+pr95614_2.f90 # owner=lazy-fortran/ffc#392; reason=enforce COMMON EQUIVALENCE SAVE and BLOCK DATA restrictions
+pr95614_4.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+pr95829.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr95880.f90 # owner=lazy-fortran/ffc#392; reason=enforce COMMON EQUIVALENCE SAVE and BLOCK DATA restrictions
+pr95882_1.f90 # owner=lazy-fortran/ffc#384; reason=require valid character length expressions
+pr95882_2.f90 # owner=lazy-fortran/ffc#384; reason=require valid character length expressions
+pr95882_3.f90 # owner=lazy-fortran/ffc#384; reason=require valid character length expressions
+pr96486.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+pr96859.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pr97272.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+pr97500.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+pr97768_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pr98016.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pr98017.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+pr98408.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pr99036.f90 # owner=lazy-fortran/ffc#378; reason=reject malformed or ambiguous generic interfaces
+pr99210.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+pr99326.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+print_c_kinds.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+print_fmt_1.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+private_type_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+private_type_14.f90 # owner=lazy-fortran/ffc#404; reason=fold typed component default initializers
+private_type_7.f90 # owner=lazy-fortran/ffc#327; reason=preserve distinct declaration bindings
+private_type_8.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+proc_decl_12.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_decl_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_decl_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_decl_15.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+proc_decl_16.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_decl_17.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+proc_decl_18.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_decl_19.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+proc_decl_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_decl_20.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_decl_22.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_decl_23.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+proc_decl_24.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_decl_27.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+proc_decl_28.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_decl_9.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+proc_ptr_10.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+proc_ptr_12.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_18.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+proc_ptr_19.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+proc_ptr_20.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+proc_ptr_22.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_23.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+proc_ptr_25.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+proc_ptr_26.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_27.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_29.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+proc_ptr_34.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+proc_ptr_36.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_41.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_42.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_43.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+proc_ptr_47.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+proc_ptr_48.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+proc_ptr_49.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_5.f90 # owner=lazy-fortran/ffc#461; reason=complete scalar procedure-pointer state
+proc_ptr_50.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+proc_ptr_51.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_52.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+proc_ptr_53.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_54.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+proc_ptr_57.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+proc_ptr_6.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+proc_ptr_9.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_12.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+proc_ptr_comp_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_15.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_16.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_17.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+proc_ptr_comp_18.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+proc_ptr_comp_19.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+proc_ptr_comp_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_21.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_23.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+proc_ptr_comp_26.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_27.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_28.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_29.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_34.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_36.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_37.f90 # owner=lazy-fortran/ffc#357; reason=preserve bodies after interface blocks
+proc_ptr_comp_38.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_40.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_44.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+proc_ptr_comp_45.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+proc_ptr_comp_47.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+proc_ptr_comp_49.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+proc_ptr_comp_50.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_52.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_53.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+proc_ptr_comp_54.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+proc_ptr_comp_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_comp_7.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+proc_ptr_comp_pass_1.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+proc_ptr_comp_pass_2.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+proc_ptr_comp_pass_3.f90 # owner=lazy-fortran/ffc#357; reason=preserve bodies after interface blocks
+proc_ptr_comp_pass_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_result_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_result_4.f90 # owner=lazy-fortran/ffc#461; reason=return scalar procedure pointers from functions
+proc_ptr_result_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_result_7.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_target_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+ptr-func-3.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+ptr-func-5.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+public_private_module_10.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+public_private_module_4.f90 # scope=harness; reason=requires a companion module outside this suite invocation
+pure_byref_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pure_formal_proc_2.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+pure_formal_proc_4.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+pure_initializer_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+quad_3.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+random_4.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+random_init_2.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+random_seed_2.f90 # owner=lazy-fortran/fortfront#2882; reason=reject procedure-call signature mismatches
+random_seed_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_1.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+read_3.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+read_4.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_5.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+read_bad_advance.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_bang.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_bang4.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_eof_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+read_eof_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+read_eof_3.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+read_eof_4.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_eof_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_eof_7.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_eof_8.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_eof_all.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_float_3.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+read_list_eof_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+read_no_eor.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_noadvance.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_repeat.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_repeat_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_size_noadvance.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+read_x_eof.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_x_eor.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+readwrite_unf_direct_eor_1.f90 # owner=lazy-fortran/ffc#427; reason=report the direct-record error boundary
+real4-10-real8-10.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+real4-10-real8-4.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+real4-10.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+real4-8-real8-10.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+real4-8-real8-4.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+real4-8.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+real8-10.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+real8-4.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+real_const_2.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+realloc_on_assign_10.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+realloc_on_assign_11.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+realloc_on_assign_12.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+realloc_on_assign_13.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+realloc_on_assign_15.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+realloc_on_assign_17.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+realloc_on_assign_23.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+realloc_on_assign_24.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+realloc_on_assign_25.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+realloc_on_assign_26.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+realloc_on_assign_28.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+realloc_on_assign_29.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+realloc_on_assign_30.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+realloc_on_assign_31.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+realloc_on_assign_32.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+realloc_on_assign_9.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+recursive_alloc_comp_5.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+recursive_alloc_comp_6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+recursive_interface_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+recursive_interface_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+recursive_reference_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+reduce_1.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+reduce_3.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+reduce_4.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+reduction.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+repeat_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+repeat_3.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+repeat_5.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+repeat_6.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+repeat_8.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+reshape-alloc.f90 # owner=lazy-fortran/ffc#358; reason=lower multi-object ALLOCATE
+reshape-complex.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+reshape.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+reshape_2.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+reshape_6.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+reshape_pad_1.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+reshape_rank7.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+reshape_zerosize_1.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+reshape_zerosize_3.f90 # owner=lazy-fortran/ffc#367; reason=accept zero-sized RESHAPE expressions
+reshape_zerosize_4.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+result_in_spec_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+result_in_spec_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+result_in_spec_4.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+ret_array_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+ret_pointer_1.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+ret_pointer_2.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+rrspacing_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+save_8.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+save_alloc_character_1.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+scalar_mask_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+scalar_mask_2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+scalarize_parameter_array_1.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+scalarize_parameter_array_2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+scale_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+scan_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+scratch_1.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+select_rank_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+select_rank_5.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+select_type_4.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_type_42.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+select_type_43.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_44.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+select_type_45.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_46.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+select_type_47.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_48.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_type_50.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_type_51.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+selected_char_kind_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+selected_char_kind_4.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+selected_logical_kind_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+selected_logical_kind_4.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+set_exponent_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+shape_12.f90 # owner=lazy-fortran/ffc#358; reason=lower multi-object ALLOCATE
+shape_2.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+shape_3.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+shape_4.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+shape_5.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+shape_6.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+shape_8.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+shift-alloc.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+shift-kind.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+shift-kind_2.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+shiftalr_3.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+simpleif_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+simplify_argN_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+simplify_cshift_1.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+simplify_cshift_2.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+simplify_cshift_3.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+simplify_cshift_4.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+simplify_eoshift_1.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+simplify_modulo.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+size_dim.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+size_kind.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+sizeof.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+sizeof_4.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+sizeof_5.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+sizeof_6.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+slash_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+spec_expr_10.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+spec_expr_4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+spec_expr_5.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+spec_expr_8.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+spec_expr_9.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+specification_type_resolution_1.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+specification_type_resolution_2.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+specifics_2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+split_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+split_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+spread_scalar_zerosize.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+spread_shape_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+spread_simplify_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+spread_zerosize_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+storage_size_7.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+streamio_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+streamio_10.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+streamio_11.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+streamio_12.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+streamio_13.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+streamio_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+streamio_15.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+streamio_16.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+streamio_17.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+streamio_18.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+streamio_3.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+streamio_4.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+streamio_5.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+streamio_6.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+streamio_7.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+streamio_8.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+string_5.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_array_constructor_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+string_array_constructor_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+string_array_constructor_3.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+string_array_constructor_4.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_compare_1.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_compare_2.f90 # owner=lazy-fortran/ffc#347; reason=lower character-array section storage
+string_compare_3.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_length_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_length_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+string_pad_trunc.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+structure_constructor_10.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+structure_constructor_14.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+submodule_23.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+submodule_34.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+subref_array_pointer_1.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+subref_array_pointer_2.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+subref_array_pointer_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+substr_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+substr_5.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+substr_7.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+substr_8.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+substr_alloc_string_comp_1.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+substr_simplify.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+substring_equivalence.f90 # owner=lazy-fortran/ffc#351; reason=preserve substring EQUIVALENCE layout
+substring_integer_index.f90 # owner=lazy-fortran/ffc#386; reason=reject invalid array and substring indexes
+sum_zero_array_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+temporary_1.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+tiny_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+tiny_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_array_intrinsic_1.f90 # owner=lazy-fortran/ffc#435; reason=lower sized and array-valued TRANSFER
+transfer_array_intrinsic_2.f90 # owner=lazy-fortran/ffc#435; reason=lower sized and array-valued TRANSFER
+transfer_array_intrinsic_3.f90 # owner=lazy-fortran/ffc#435; reason=lower sized and array-valued TRANSFER
+transfer_assumed_size_1.f90 # owner=lazy-fortran/ffc#435; reason=lower sized and array-valued TRANSFER
+transfer_char_kind4.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+transfer_class_2.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+transfer_class_3.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+transfer_class_4.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+transfer_class_5.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+transfer_intrinsic_2.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+transfer_intrinsic_3.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+transfer_intrinsic_5.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+transfer_null_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+transfer_resolve_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+transfer_resolve_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+transfer_resolve_4.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+transfer_simplify_10.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+transfer_simplify_11.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_simplify_4.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+transfer_simplify_5.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+transfer_simplify_6.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_simplify_9.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+transpose_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+transpose_4.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+transpose_conjg_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+transpose_intrinsic_func_call_1.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+trim_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+trim_optimize_4.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+trim_optimize_6.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+typebound_assignment_7.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+typebound_assignment_8.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+typebound_call_26.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+typebound_call_28.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+typebound_call_30.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+typebound_call_32.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+typebound_deferred_1.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+typebound_generic_15.f90 # owner=lazy-fortran/ffc#378; reason=reject malformed or ambiguous generic interfaces
+typebound_operator_11.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+typebound_operator_15.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+typebound_operator_17.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+typebound_operator_20.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+typebound_proc_20.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+typebound_proc_21.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+typebound_proc_23.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+typebound_proc_25.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+typebound_proc_30.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+typebound_proc_32.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+typebound_proc_33.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+typebound_proc_35.f90 # owner=lazy-fortran/ffc#420; reason=dispatch the overridden type-bound procedure
+typebound_proc_36.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+ubound_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+unf_read_corrupted_1.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+unf_read_corrupted_2.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+unf_short_record_1.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+unit_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+unlimited_polymorphic_12.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+unlimited_polymorphic_13.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+unlimited_polymorphic_15.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+unlimited_polymorphic_16.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+unlimited_polymorphic_17.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+unlimited_polymorphic_18.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+unlimited_polymorphic_19.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+unlimited_polymorphic_20.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+unlimited_polymorphic_21.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+unlimited_polymorphic_22.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+unlimited_polymorphic_23.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+unlimited_polymorphic_25.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+unlimited_polymorphic_26.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+unlimited_polymorphic_29.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+unlimited_polymorphic_32.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+unlimited_polymorphic_5.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+unlimited_polymorphic_6.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+unlimited_polymorphic_7.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+unpack_mask_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+unpack_zerosize_1.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+unreferenced_use_assoc_1.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+unsigned_write_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+use_10.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+use_13.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+use_17.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+use_18.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+use_2.f90 # owner=lazy-fortran/fortfront#2897; reason=reject unclassifiable execution expressions
+use_24.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+use_25.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+use_27.f90 # owner=lazy-fortran/ffc#420; reason=dispatch overridden type-bound procedures through vtables
+use_28.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+use_5.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+use_8.f90 # owner=lazy-fortran/ffc#390; reason=enforce derived-type definition constraints
+use_allocated_1.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+use_only_2.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+use_only_3.f90 # scope=harness; reason=requires a companion module outside this suite invocation
+use_only_5.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+use_rename_12.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+use_rename_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+use_rename_14.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+use_rename_7.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+use_rename_9.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+used_dummy_types_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+used_dummy_types_2.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+used_dummy_types_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+used_dummy_types_7.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+used_dummy_types_8.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+used_interface_ref.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+used_types_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+used_types_10.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+used_types_11.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+used_types_12.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+used_types_13.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+used_types_15.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+used_types_16.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+used_types_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+used_types_20.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+used_types_22.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+used_types_3.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+used_types_4.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+used_types_5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+used_types_6.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+used_types_9.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+userdef_operator_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+value_9.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+value_optional_1.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+value_optional_2.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+value_optional_3.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+value_test.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+value_tests_f03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+vector_subscript_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+vector_subscript_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+vector_subscript_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+vector_subscript_5.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+vector_subscript_8.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+vector_subscript_9.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+verify_2.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+verify_3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+warn_unused_dummy_argument_5.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+where_1.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+where_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+where_4.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+where_nested_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+where_operator_assign_1.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+where_operator_assign_2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+where_operator_assign_3.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+whole_file_10.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+whole_file_11.f90 # owner=lazy-fortran/ffc#328; reason=resolve same-unit USE export identity
+whole_file_12.f90 # owner=lazy-fortran/ffc#409; reason=support OPTIONAL scalar dummies across kinds
+whole_file_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+whole_file_23.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+whole_file_27.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+whole_file_35.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+whole_file_8.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+whole_file_9.f90 # owner=lazy-fortran/ffc#456; reason=lower procedure ENTRY points
+widechar_6.f90 # owner=lazy-fortran/ffc#415; reason=resolve generic specifics by declared signature
+widechar_9.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+widechar_IO_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+widechar_IO_2.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+widechar_IO_3.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+widechar_compare_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+write_0_pe_format.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_check3.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+write_direct_eor.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+write_fmt_trim.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_recursive.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+write_zero_array.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+zero_array_components_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+zero_length_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+zero_length_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+zero_sized_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+zero_sized_11.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+zero_sized_12.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+zero_sized_14.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+zero_sized_15.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+zero_sized_2.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+zero_sized_3.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+zero_sized_4.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+zero_sized_5.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+zero_sized_7.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+zero_sized_9.f90 # owner=lazy-fortran/ffc#432; reason=lower NORM2 over descriptor arrays
+associate_contained_func_typebound.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+associate_contained_func_typebound_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_infer_program_type.f90 # owner=lazy-fortran/ffc#404; reason=fold typed component default initializers
+assumed_charlen_dummy.f90 # owner=lazy-fortran/ffc#384; reason=require valid character length expressions
+auto_char_len_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+auto_char_len_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+automatic_char_len_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+bind_c_usage_32.f90 # owner=lazy-fortran/ffc#384; reason=reject invalid interoperable character result length
+bound_simplification_1.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+dec_exp_3.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+dec_io_3.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
+dec_static_3.f90 # scope=vendor; reason=DEC AUTOMATIC and STATIC extensions
+erfc_scaled_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+fmt_error_6.f90 # owner=lazy-fortran/ffc#391; reason=reject malformed FORMAT descriptors
+fmt_t_2.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+implicit_16.f90 # owner=lazy-fortran/fortfront#2892; reason=reject unresolved symbols under IMPLICIT NONE
+initialization_9.f90 # owner=lazy-fortran/ffc#384; reason=require valid character length expressions
+integer_exponentiation_2.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+intrinsic_actual_4.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+oldstyle_3.f90 # owner=lazy-fortran/ffc#383; reason=enforce DATA object and initializer restrictions
+stfunc_8.f90 # scope=legacy; reason=obsolete statement-function semantics
+stmt_func_1.f90 # scope=legacy; reason=obsolete statement-function semantics
+string_4.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+associate_80.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_81.f90 # owner=lazy-fortran/ffc#410; reason=preserve fixed-length character function results
+associate_82.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+contiguous_17.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+do_concurrent_assoc_iter_1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+fmt_t_10.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+fmt_t_11.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+implied_do_alloc_comp_1.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+loc_3.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+namelist_103.f90 # owner=lazy-fortran/ffc#404; reason=fold typed component default initializers
+pdt_array_alloc_1.f90 # owner=lazy-fortran/ffc#411; reason=support constant integer kind and length type parameters
+select_type_53.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+stop_function_code_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+submodule_38.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+warn_unused_but_set_variable_2.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values

--- a/test/conformance/xfail_lfortran.txt
+++ b/test/conformance/xfail_lfortran.txt
@@ -1,3429 +1,3425 @@
 # Known-unsupported files for the lfortran integration_tests suite.
-# One basename or suite-relative path per line.
+# Format: path # owner=ORG/REPO#N; reason=text or path # scope=TAG; reason=text
 # Lines starting with # and blank lines are ignored.
 # Promote entries by removing them when ffc starts passing.
-abs_04.f90
-abs_06.f90
-allocatable_cchar_01.f90
-allocatable_component_assign_recursive_01.f90
-allocatable_component_reshape_unallocated_01.f90
-allocatable_component_struct_array_01.f90
-allocatable_component_struct_array_02.f90
-allocatable_component_unnamed_unallocated_01.f90
-allocatable_derived_array_01.f90
-allocatable_dummy_descriptor_01.f90
-allocatable_lhs_finalization_01.f90
-allocatable_oob_01.f90
-allocatable_polymorphic_assign_01.f90
-allocatable_polymorphic_assign_02.f90
-allocatable_polymorphic_assign_03.f90
-allocatable_polymorphic_mold_01.f90
-allocatble_c_ptr.f90
-allocate_01.f90
-allocate_02.f90
-allocate_03.f90
-allocate_04.f90
-allocate_05.f90
-allocate_06.f90
-allocate_07.f90
-allocate_08.f90
-allocate_10.f90
-allocate_11.f90
-allocate_12.f90
-allocate_14.f90
-allocate_15.f90
-allocate_16.f90
-allocate_17.f90
-allocate_18.f90
-allocate_19.f90
-allocate_20.f90
-allocate_21.f90
-allocate_22.f90
-allocate_23.f90
-allocate_24.f90
-allocate_26.f90
-allocate_27.f90
-allocate_29.f90
-allocate_30.f90
-allocate_31.f90
-allocate_32.f90
-allocate_33.f90
-allocate_35.f90
-allocate_36.f90
-allocate_38.f90
-allocate_39.f90
-allocate_40.f90
-allocate_41.f90
-allocate_42.f90
-allocate_43.f90
-allocate_44.f90
-allocate_45.f90
-allocate_46.f90
-allocate_48.f90
-allocate_49.f90
-allocate_51.f90
-allocate_52.f90
-allocate_53.f90
-allocate_54.f90
-allocate_55.f90
-allocate_56.f90
-allocate_57.f90
-allocate_58.f90
-allocate_59.f90
-allocate_60.f90
-allocate_61.f90
-allocate_61_mod2.f90
-allocate_62.f90
-allocate_63.f90
-allocate_66.f90
-allocate_67.f90
-allocate_69.f90
-allocate_70.f90
-allocate_72.f90
-allocate_73.f90
-allocated_01.f90
-allocated_04.f90
-allocated_05.f90
-allocate_source_ptr_01.f90
-any_01.f90
-any_02.f90
-array_01_pack.f90
-array_01_transfer.f90
-array_02_pack.f90
-array_02_transfer.f90
-array_03.f90
-array_03_pack.f90
-array_04_all.f90
-array_04_pack.f90
-array_04_transfer.f90
-array_05_transfer.f90
-array_06_transfer.f90
-array_07_transfer.f90
-array_08_transfer.f90
-array_bound_3.f90
-array_bound_6.f90
-array_bound_7.f90
-array_concat.f90
-array_constructor_02.f90
-array_constructor_03.f90
-array_constructor_04.f90
-array_constructor_05.f90
-array_constructor_06.f90
-array_constructor_07.f90
-array_indices_array_item_assignment_1.f90
-array_indices_array_item_assignment_2.f90
-array_indices_array_item_assignment_3.f90
-array_indices_array_item_assignment_4.f90
-array_indices_array_item_assignment.f90
-array_indices_array_item.f90
-array_indices_array_section_assignment.f90
-array_indices_array_section.f90
-array_init.f90
-arrayitem_01.f90
-array_neg_extent_01.f90
-array_op_03.f90
-array_op_04.f90
-array_op_05.f90
-array_op_06.f90
-array_op_07.f90
-array_op_08.f90
-array_op_09.f90
-array_op_10.f90
-array_op_12.f90
-array_op_13.f90
-array_reshape_pad_01.f90
-arrays_01_complex.f90
-arrays_01_logical.f90
-arrays_01_multi_dim.f90
-arrays_01_size.f90
-arrays_02_size.f90
-arrays_03_size.f90
-arrays_04_func.f90
-arrays_04_func_pass_arr_dims.f90
-arrays_04_size.f90
-arrays_05_size.f90
-arrays_06.f90
-arrays_07.f90
-arrays_08_size.f90
-arrays_09.f90
-arrays_100.f90
-arrays_101.f90
-arrays_102.f90
-arrays_103.f90
-arrays_104.f90
-arrays_105.f90
-arrays_106.f90
-arrays_107.f90
-arrays_108.f90
-arrays_10.f90
-arrays_10_size.f90
-arrays_110.f90
-arrays_111.f90
-arrays_112.f90
-arrays_113.f90
-arrays_114.f90
-arrays_115.f90
-arrays_116.f90
-arrays_117.f90
-arrays_118.f90
-arrays_119.f90
-arrays_120.f90
-arrays_123.f90
-arrays_125.f90
-arrays_126.f90
-arrays_12.f90
-arrays_12_size.f90
-arrays_13.f90
-arrays_13_size.f90
-arrays_14.f90
-arrays_15.f90
-arrays_20.f90
-arrays_21.f90
-arrays_23.f90
-arrays_25.f90
-arrays_26.f90
-arrays_28.f90
-arrays_29.f90
-arrays_30.f90
-arrays_32.f90
-arrays_33.f90
-arrays_34.f90
-arrays_36.f90
-arrays_37.f90
-arrays_38.f90
-arrays_39.f90
-arrays_40.f90
-arrays_41.f90
-arrays_42.f90
-arrays_43.f90
-arrays_44.f90
-arrays_49.f90
-arrays_51.f90
-arrays_52.f90
-arrays_54.f90
-arrays_55.f90
-arrays_56.f90
-arrays_57.f90
-arrays_58.f90
-arrays_59.f90
-arrays_60.f90
-arrays_61.f90
-arrays_62.f90
-arrays_63.f90
-arrays_64.f90
-arrays_65.f90
-arrays_66.f90
-arrays_67.f90
-arrays_68.f90
-arrays_69.f90
-arrays_70.f90
-arrays_71.f90
-arrays_72.f90
-arrays_73.f90
-arrays_74.f90
-arrays_75.f90
-arrays_76.f90
-arrays_77.f90
-arrays_78.f90
-arrays_79.f90
-arrays_80.f90
-arrays_81.f90
-arrays_82.f90
-arrays_83.f90
-arrays_84.f90
-arrays_85.f90
-arrays_86.f90
-arrays_87.f90
-arrays_88.f90
-arrays_89.f90
-arrays_91.f90
-arrays_92.f90
-arrays_93.f90
-arrays_94.f90
-arrays_95.f90
-arrays_96.f90
-arrays_97.f90
-arrays_98.f90
-arrays_99.f90
-arrays_constructor_01.f90
-array_section_01.f90
-array_section_02.f90
-array_section_03.f90
-array_section_04.f90
-array_section_05.f90
-array_section_06.f90
-array_section_07.f90
-array_section_08.f90
-array_section_10.f90
-array_section_11.f90
-array_section_12.f90
-array_section_13.f90
-array_section_14.f90
-array_section_15.f90
-array_section_16.f90
-array_section_17.f90
-array_section_18b.f90
-array_section_18.f90
-array_section_19.f90
-array_section_20.f90
-array_section_21.f90
-array_section_22.f90
-array_section_23.f90
-array_section_26.f90
-array_section_27.f90
-array_section_27_mod.f90
-array_section_28.f90
-array_section_29.f90
-array_section_assign_01.f90
-array_section_is_non_allocatable.f90
-arrays_elemental_15.f90
-array_shape_func_call.f90
-arrays_intrin_02.f90
-arrays_intrin_03.f90
-arrays_intrin_05.f90
-arrays_intrin_06.f90
-arrays_intrin_07.f90
-arrays_intrin_08.f90
-arrays_intrin_09.f90
-array_slice_01.f90
-array_slice_02.f90
-array_slice_04.f90
-arrays_op_10.f90
-arrays_op_11.f90
-arrays_op_12.f90
-arrays_op_13.f90
-arrays_op_14.f90
-arrays_op_15.f90
-arrays_op_16.f90
-arrays_op_17.f90
-arrays_op_18.f90
-arrays_op_19.f90
-arrays_op_1.f90
-arrays_op_20.f90
-arrays_op_21.f90
-arrays_op_22.f90
-arrays_op_23.f90
-arrays_op_24.f90
-arrays_op_25.f90
-arrays_op_26.f90
-arrays_op_27.f90
-arrays_op_28.f90
-arrays_op_29.f90
-arrays_op_30.f90
-arrays_op_31.f90
-arrays_op_3.f90
-arrays_op_4.f90
-arrays_op_5.f90
-arrays_op_6.f90
-arrays_op_8.f90
-arrays_op_9.f90
-arrays_reshape_14.f90
-arrays_reshape_15.f90
-arrays_reshape_16.f90
-arrays_reshape_17.f90
-arrays_reshape_18.f90
-arrays_reshape_19.f90
-arrays_reshape_20.f90
-arrays_reshape_21.f90
-arrays_reshape_22.f90
-arrays_reshape_23.f90
-arrays_reshape_24.f90
-arrays_reshape_27.f90
-arrays_reshape_28.f90
-arrays_reshape_29.f90
-arrays_reshape_30.f90
-arrays_reshape_31.f90
-arrays_reshape_32.f90
-arrays_reshape_33.f90
-arrays_reshape_34.f90
-arrays_reshape_35.f90
-arrays_reshape_36.f90
-arrays_reshape_37.f90
-arrays_reshape_38.f90
-arrays_reshape_39.f90
-arrays_reshape_40.f90
-arrays_reshape_41.f90
-arrays_reshape_42.f90
-arrays_reshape_43.f90
-arrays_reshape_44.f90
-array_unbounded_01.f90
-array_unbounded_02.f90
-assign_allocatable_array_of_struct_instances.f90
-assign_to1.f90
-assign_to2.f90
-associate_01.f90
-associate_02.f90
-associate_04.f90
-associate_05.f90
-associate_06_module.f90
-associate_08.f90
-associate_09.f90
-associate_10.f90
-associate_12.f90
-associate_13.f90
-associate_14.f90
-associate_15.f90
-associate_16.f90
-associate_17.f90
-associate_19.f90
-associate_20.f90
-associate_21.f90
-associate_21_mod.f90
-associate_22.f90
-associate_23.f90
-associate_24.f90
-associate_25.f90
-associate_26.f90
-associate_27.f90
-associate_28.f90
-associate_29.f90
-associate_30.f90
-associate_31.f90
-associate_32.f90
-associate_33.f90
-associate_34.f90
-associate_36.f90
-associate_37.f90
-associate_38.f90
-associate_39.f90
-associate_40.f90
-associate_41.f90
-associate_42.f90
-associate_43.f90
-associate_45.f90
-associate_46.f90
-associate_47.f90
-associate_48.f90
-associate_49.f90
-associate_50.f90
-associate_52.f90
-associate_53.f90
-associate_54.f90
-assumed_length_return_01.f90
-assumed_rank_01.f90
-assumed_rank_02.f90
-assumed_rank_03.f90
-assumed_rank_04.f90
-assumed_rank_05.f90
-assumed_rank_06.f90
-assumed_rank_07.f90
-assumed_rank_08.f90
-assumed_rank_09.f90
-assumed_rank_10.f90
-assumed_type_01.f90
-assumed_type_02.f90
-assumed_type_03.f90
-assumed_type_04.f90
-assumed_type_05.f90
-assume_rank_shape_product_01.f90
-attr_dim_01.f90
-attr_dim_03.f90
-attr_intrinsic.f90
-automatic_allocation_02.f90
-bindc_01.f90
-bindc_02b.f90
-bindc_02.f90
-bindc_03.f90
-bindc_04.f90
-bindc_05.f90
-bindc_06.f90
-bindc_07.f90
-bindc_08.f90
-bindc_09.f90
-bindc_10.f90
-bindc_11.f90
-bindc_12.f90
-bindc_14.f90
-bindc_15.f90
-bindc_17.f90
-bindc_18.f90
-bindc_19.f90
-bindc2.f90
-bindc_35.f90
-bindc_38.f90
-bindc_39.f90
-bindc3.f90
-bindc_43.f90
-bindc_45.f90
-bindc_46.f90
-bindc_47.f90
-bindc_49.f90
-bindc4.f90
-bindc_51.f90
-bindc5.f90
-bindc6.f90
-bindc_assumed_rank_01.f90
-bindc_iso_fb_01.f90
-bindc_iso_fb_02.f90
-bindc_iso_fb_03.f90
-bindc_iso_fb_04.f90
-bindc_iso_fb_05.f90
-bindc_iso_fb_06.f90
-bindc_iso_fb_07.f90
-bindc_iso_fb_08.f90
-binop_01.f90
-binop_02.f90
-binop_03.f90
-bin_op_complex_dp.f90
-binop_of_struct_instance_in_function_call.f90
-bin_op_real_01.f90
-bin_op_real_02.f90
-bin_op_real_dp.f90
-bits_02.f90
-bits_03.f90
-bits_04.f90
-bits_05.f90
-bits_07.f90
-block_01.f90
-block_02.f90
-block_03.f90
-block_04.f90
-block_05.f90
-block_07.f90
-block_08.f90
-block_10.f90
-block_11.f90
-block_12.f90
-block_13.f90
-block_14.f90
-block_15.f90
-block_17.f90
-block_data_04.f90
-block_data_string_01.f90
-block_data_string_02.f90
-block_data_string_03.f90
-block_data_string_04.f90
-boz_02.f90
-callback_01.f90
-callback_02.f90
-callback_03.f90
-callback_04.f90
-callback_05.f90
-callback_06.f90
-call_subroutine_without_type_01.f90
-call_subroutine_without_type.f90
-case_01.f90
-case_05.f90
-case_06.f90
-case_08.f90
-c_f_proc_ptr_01.f90
-character_01.f90
-character_02.f90
-character_06.f90
-character_08.f90
-character_09.f90
-character_10.f90
-character_11.f90
-character_12.f90
-character_13.f90
-character_14.f90
-character_16.f90
-character_17.f90
-character_18.f90
-character_20.f90
-character_21.f90
-character_22.f90
-character_23.f90
-character_24.f90
-character_25.f90
-character_26.f90
-character_27.f90
-character_28.f90
-character_29.f90
-character_30.f90
-character_31.f90
-character_32.f90
-character_array_block_padding.f90
-character_assignment_01.f90
-character_max_parameter_01.f90
-char_array_01.f90
-char_array_indexing_02.f90
-char_array_indexing.f90
-char_array_initialization_declaration_02.f90
-char_array_initialization_declaration.f90
-char_param_reshape_01.f90
-class_01.f90
-class_02.f90
-class_03.f90
-class_05.f90
-class_08.f90
-class_09.f90
-class_100.f90
-class_101.f90
-class_102.f90
-class_103.f90
-class_104.f90
-class_105.f90
-class_106a.f90
-class_106b.f90
-class_106.f90
-class_107.f90
-class_109.f90
-class_10.f90
-class_110.f90
-class_110_module.f90
-class_111.f90
-class_112.f90
-class_113.f90
-class_114.f90
-class_115.f90
-class_116.f90
-class_117.f90
-class_118.f90
-class_11.f90
-class_120.f90
-class_121.f90
-class_122.f90
-class_123.f90
-class_124.f90
-class_127.f90
-class_128.f90
-class_129.f90
-class_12.f90
-class_130.f90
-class_131.f90
-class_132.f90
-class_133.f90
-class_134.f90
-class_135.f90
-class_137.f90
-class_138.f90
-class_139.f90
-class_13.f90
-class_140.f90
-class_141.f90
-class_142.f90
-class_143.f90
-class_144.f90
-class_147.f90
-class_148.f90
-class_149.f90
-class_14.f90
-class_15.f90
-class_16.f90
-class_17.f90
-class_18.f90
-class_19.f90
-class_21.f90
-class_23.f90
-class_24.f90
-class_25.f90
-class_26.f90
-class_27.f90
-class_28.f90
-class_29.f90
-class_31.f90
-class_32.f90
-class_34.f90
-class_35.f90
-class_36.f90
-class_37.f90
-class_38.f90
-class_39.f90
-class_40.f90
-class_41.f90
-class_42.f90
-class_43.f90
-class_44.f90
-class_45.f90
-class_46.f90
-class_47.f90
-class_48.f90
-class_49.f90
-class_50.f90
-class_51.f90
-class_52.f90
-class_53.f90
-class_54.f90
-class_55.f90
-class_56.f90
-class_57.f90
-class_58.f90
-class_59.f90
-class_60.f90
-class_61.f90
-class_62.f90
-class_63_module_2.f90
-class_64.f90
-class_65.f90
-class_66.f90
-class_67.f90
-class_68.f90
-class_69.f90
-class_70.f90
-class_71.f90
-class_72.f90
-class_73.f90
-class_74.f90
-class_75.f90
-class_76.f90
-class_77.f90
-class_78.f90
-class_79.f90
-class_80.f90
-class_81.f90
-class_82.f90
-class_83.f90
-class_84.f90
-class_85.f90
-class_86.f90
-class_87.f90
-class_88.f90
-class_89.f90
-class_90.f90
-class_91.f90
-class_92.f90
-class_93.f90
-class_94.f90
-class_95.f90
-class_96.f90
-class_97.f90
-class_allocate_01.f90
-class_allocate_02.f90
-class_allocate_03.f90
-class_allocate_04.f90
-class_allocate_05.f90
-class_allocate_06.f90
-class_allocate_07.f90
-class_allocate_08.f90
-class_array_deepcopy_01.f90
-class_optional_01.f90
-class_procedure_args_01.f90
-class_star_pointer_01.f90
-cmake_minimal_test_01.f90
-cmd_01.f90
-cmd_02.f90
-cmd_03.f90
-coarray_01.f90
-common_03.f90
-common_07.f90
-common_16.f90
-common_19.f90
-common_21.f90
-common_24.f90
-common_28.f90
-common_31.f90
-common_32.f90
-common_36.f90
-common_37.f90
-common_38.f90
-common_40.f90
-common_substring_01.f90
-compiler_version_01.f90
-compiler_version_02.f90
-compiler_version_03.f90
-complex_03.f90
-complex_06.f90
-complex_07.f90
-complex_08.f90
-complex_09.f90
-complex_10.f90
-complex_11.f90
-complex_15.f90
-complex_16.f90
-complex_17.f90
-complex_18.f90
-complex_19.f90
-complex_21.f90
-complex_22.f90
-complex_23.f90
-complex_24.f90
-complex_25.f90
-complex_26.f90
-complex_28.f90
-complex_29.f90
-complex_31.f90
-complex_33.f90
-complex_34.f90
-complex_35.f90
-complex_36.f90
-complex_array_member_access.f90
-complex_cloc_01.f90
-complex_div_test.f90
-complex_implicit_cast.f90
-complex_pow_test.f90
-complex_solutions.f90
-complex_unary_minus_03.f90
-concat_char_arrays_01.f90
-cond_02.f90
-cond_04.f90
-cond_05.f90
-contig_stmt_01.f90
-conv_complex2real.f90
-count_param_01.f90
-cpp_pre_01.f90
-cpp_pre_06.f90
-cpp_pre_07.f90
-cpp_pre_08.f90
-cpp_pre_12.f90
-cpp_pre_14.f90
-cpp_pre_15.f90
-c_ptr_01.f90
-c_ptr_02.f90
-c_ptr_03.f90
-c_ptr_04.f90
-c_ptr_05.f90
-c_ptr_06.f90
-c_ptr_07.f90
-c_ptr_08.f90
-c_ptr_10.f90
-c_ptr_11.f90
-c_ptr_12.f90
-c_ptr_13.f90
-c_ptr_14.f90
-c_ptr_15.f90
-c_ptr_16.f90
-c_ptr_16_module.f90
-c_ptr_17.f90
-c_ptr_17_module.f90
-cpu_time_01.f90
-c_sizeof_02.f90
-c_sizeof_03.f90
-c_sizeof_04.f90
-c_sizeof_05.f90
-c_sizeof_06.f90
-custom_operator_01.f90
-custom_operator_02.f90
-custom_operator_03.f90
-custom_operator_04.f90
-custom_operator_05.f90
-custom_operator_06.f90
-custom_operator_07.f90
-custom_operator_08.f90
-custom_operator_09.f90
-custom_operator_10.f90
-custom_operator_11.f90
-custom_operator_12.f90
-custom_operator_13.f90
-custom_operator_14.f90
-custom_operator_15.f90
-custom_operator_16.f90
-custom_operator_17.f90
-custom_operator_18.f90
-custom_operator_19.f90
-custom_unary_operator_01.f90
-custom_unary_operator_02.f90
-cycle_and_exit1.f90
-cycle_and_exit2.f90
-cycle_and_exit4.f90
-cycle_and_exit5.f90
-dabs_01.f90
-data_02.f90
-data_03.f90
-data_05.f90
-data_06.f90
-data_07.f90
-data_11.f90
-data_12.f90
-data_14.f90
-data_16.f90
-data_17.f90
-data_18.f90
-data_19.f90
-data_20.f90
-data_21.f90
-data_22.f90
-data_23.f90
-data_implied_do_07.f90
-data_implied_do_08.f90
-data_implied_do_09.f90
-datastmt_01.f90
-dealloc_01.f90
-dealloc_02.f90
-dealloc_03.f90
-dealloc_04.f90
-dealloc_05.f90
-dealloc_06.f90
-deallocate_01.f90
-deallocate_02.f90
-declaration_01.f90
-declaration_04.f90
-deferred_shape_01.f90
-defined_op_match_01.f90
-derived_component_section_01.f90
-derived_component_section_02.f90
-derived_type_c_funptr_array_01.f90
-derived_type_member_procedure_call_01.f90
-derived_type_member_procedure_call_02.f90
-derived_types_01.f90
-derived_types_02.f90
-derived_types_03.f90
-derived_types_05.f90
-derived_types_09b.f90
-derived_types_09.f90
-derived_types_100.f90
-derived_types_101.f90
-derived_types_102.f90
-derived_types_103.f90
-derived_types_104.f90
-derived_types_105.f90
-derived_types_106.f90
-derived_types_107.f90
-derived_types_108.f90
-derived_types_109.f90
-derived_types_10.f90
-derived_types_110.f90
-derived_types_111.f90
-derived_types_112.f90
-derived_types_113.f90
-derived_types_114.f90
-derived_types_114_module.f90
-derived_types_115.f90
-derived_types_116.f90
-derived_types_117.f90
-derived_types_118.f90
-derived_types_119.f90
-derived_types_11.f90
-derived_types_120.f90
-derived_types_121.f90
-derived_types_122.f90
-derived_types_124.f90
-derived_types_125.f90
-derived_types_126.f90
-derived_types_127.f90
-derived_types_128.f90
-derived_types_129.f90
-derived_types_12.f90
-derived_types_130.f90
-derived_types_131.f90
-derived_types_132.f90
-derived_types_134.f90
-derived_types_134_module.f90
-derived_types_135.f90
-derived_types_137.f90
-derived_types_138.f90
-derived_types_139.f90
-derived_types_13.f90
-derived_types_140.f90
-derived_types_141.f90
-derived_types_142.f90
-derived_types_143.f90
-derived_types_144.f90
-derived_types_145.f90
-derived_types_146.f90
-derived_types_147.f90
-derived_types_148.f90
-derived_types_14.f90
-derived_types_15.f90
-derived_types_17.f90
-derived_types_18.f90
-derived_types_19.f90
-derived_types_19_module.f90
-derived_types_20.f90
-derived_types_20_module1.f90
-derived_types_21.f90
-derived_types_24.f90
-derived_types_25.f90
-derived_types_26.f90
-derived_types_27.f90
-derived_types_28.f90
-derived_types_29.f90
-derived_types_30.f90
-derived_types_31.f90
-derived_types_32.f90
-derived_types_33.f90
-derived_types_34.f90
-derived_types_35.f90
-derived_types_36.f90
-derived_types_37.f90
-derived_types_38.f90
-derived_types_39.f90
-derived_types_40.f90
-derived_types_41.f90
-derived_types_42.f90
-derived_types_43.f90
-derived_types_44.f90
-derived_types_46.f90
-derived_types_50.f90
-derived_types_51.f90
-derived_types_52.f90
-derived_types_53.f90
-derived_types_55.f90
-derived_types_56.f90
-derived_types_60.f90
-derived_types_61.f90
-derived_types_62.f90
-derived_types_63.f90
-derived_types_64.f90
-derived_types_65.f90
-derived_types_67.f90
-derived_types_69.f90
-derived_types_70.f90
-derived_types_71.f90
-derived_types_72.f90
-derived_types_73.f90
-derived_types_74.f90
-derived_types_75.f90
-derived_types_76.f90
-derived_types_77.f90
-derived_types_78.f90
-derived_types_79.f90
-derived_types_80.f90
-derived_types_81.f90
-derived_types_82.f90
-derived_types_83.f90
-derived_types_84.f90
-derived_types_85.f90
-derived_types_86.f90
-derived_types_87.f90
-derived_types_88.f90
-derived_types_89.f90
-derived_types_90.f90
-derived_types_91.f90
-derived_types_92.f90
-derived_types_93.f90
-derived_types_94.f90
-derived_types_95.f90
-derived_types_96.f90
-derived_types_97.f90
-derived_types_97_mod2.f90
-derived_types_98.f90
-derived_types_99.f90
-derived_types_apply_clip_01.f90
-derived_type_shape_pointer_01.f90
-derived_type_shape_pointer_02.f90
-derived_type_shape_pointer_03.f90
-derived_type_target_arg_01.f90
-derived_type_target_arg_02.f90
-dfloat_01.f90
-dict_test_01.f90
-dict_test_01_.f90
-dict_test_02_.f90
-dict_test_03_.f90
-dict_test_04_.f90
-dict_test_07_.f90
-dict_test_13_.f90
-dlaswap.f90
-do_concurrent_03.f90
-do_concurrent_04.f90
-do_concurrent_05.f90
-do_concurrent_06.f90
-do_concurrent_07.f90
-do_concurrent_08.f90
-do_concurrent_09.f90
-do_concurrent_10.f90
-do_concurrent_11.f90
-do_concurrent_12.f90
-do_concurrent_13.f90
-doconcurrentloop_02.f90
-do_loop_01.f90
-do_loop_02.f90
-doloop_03.f90
-do_loop_04.f90
-doloop_04.f90
-do_loop_05.f90
-do_loop_07.f90
-doloop_07.f90
-do_loop_08.f90
-doloop_08.f90
-do_loop_09.f90
-doloop_10.f90
-doloop_13.f90
-doloop_18.f90
-doloop_19.f90
-elemental_01.f90
-elemental_02.f90
-elemental_03.f90
-elemental_04.f90
-elemental_05.f90
-elemental_06.f90
-elemental_07.f90
-elemental_08.f90
-elemental_09.f90
-elemental_10.f90
-elemental_11.f90
-elemental_12.f90
-elemental_13.f90
-elemental_14.f90
-elemental_15.f90
-elemental_16.f90
-elemental_17.f90
-elemental_18.f90
-elemental_19.f90
-elemental_20.f90
-elemental_21.f90
-elemental_22.f90
-elemental_23.f90
-elemental_function_overloaded_compare.f90
-elemental_function_scalar_array_arg.f90
-empty_array_01.f90
-empty_array_02.f90
-empty_array_03.f90
-entry_01.f90
-entry_02.f90
-entry_03.f90
-entry_04.f90
-entry_05.f90
-entry_06.f90
-entry_07.f90
-entry_08.f90
-entry_09.f90
-entry_10.f90
-entry_11.f90
-entry_12.f90
-entry_13.f90
-entry_14.f90
-entry_15.f90
-entry_16.f90
-entry_17.f90
-entry_18.f90
-entry_19.f90
-entry_20.f90
-entry_21.f90
-enum_02.f90
-enum_03.f90
-enum_04.f90
-enum_06.f90
-enum_07.f90
-enum_07_submodule.f90
-equivalence_01.f90
-equivalence_02.f90
-equivalence_03.f90
-equivalence_04.f90
-equivalence_05.f90
-equivalence_06.f90
-equivalence_07.f90
-equivalence_08.f90
-equivalence_09.f90
-equivalence_10.f90
-equivalence_11.f90
-equivalence_12.f90
-equivalence_13.f90
-equivalence_14.f90
-equivalence_15.f90
-equivalence_16.f90
-equivalence_17.f90
-equivalence_18.f90
-equivalence_20.f90
-equivalence_21.f90
-equivalence_22.f90
-equivalence_23.f90
-equivalence_24.f90
-equivalence_25.f90
-equivalence_28.f90
-equivalence_29.f90
-equivalence_30.f90
-equivalence_31.f90
-equivalence_32.f90
-equivalence_33.f90
-equivalence_34.f90
-equivalence_35.f90
-equivalence_36.f90
-equivalence_37.f90
-error_stop_01.f90
-error_stop_02.f90
-error_stop_03.f90
-error_stop_04.f90
-exit_01.f90
-exponent_inf_01.f90
-expr_01.f90
-expr_05.f90
-expr_09.f90
-expr_13.f90
-expr_17.f90
-expr_19.f90
-expr_21.f90
-external_05.f90
-external_07.f90
-external_08.f90
-external_12.f90
-external_12_module.f90
-external_13.f90
-external_14.f90
-external_14_module.f90
-external_15.f90
-external_16.f90
-external_string_arg_01.f90
-file_01.f90
-file_02.f90
-file_03.f90
-file_04.f90
-file_05.f90
-file_06.f90
-file_07.f90
-file_08.f90
-file_09.f90
-file_10.f90
-file_11.f90
-file_12.f90
-file_13.f90
-file_14.f90
-file_15.f90
-file_16.f90
-file_17.f90
-file_18.f90
-file_19.f90
-file_20.f90
-file_21.f90
-file_22.f90
-file_23.f90
-file_24.f90
-file_25.f90
-file_26.f90
-file_27.f90
-file_28.f90
-file_29.f90
-file_30.f90
-file_31.f90
-file_32.f90
-file_33.f90
-file_34.f90
-file_35.f90
-file_36.f90
-file_38.f90
-file_39.f90
-file_40.f90
-file_41.f90
-file_42.f90
-file_43.f90
-file_44.f90
-file_45.f90
-file_46.f90
-file_47.f90
-file_48.f90
-file_49.f90
-file_50.f90
-file_51.f90
-file_52.f90
-file_53.f90
-file_54.f90
-file_55.f90
-file_56.f90
-file_57.f90
-file_58.f90
-file_59.f90
-file_60.f90
-file_61.f90
-file_62.f90
-file_63.f90
-file_65.f90
-file_66.f90
-file_67.f90
-file_69.f90
-file_70.f90
-file_71.f90
-file_72.f90
-file_73.f90
-file_close_01.f90
-file_close_02.f90
-file_open_01.f90
-file_open_05.f90
-file_open_07.f90
-file_open_08.f90
-file_open_09.f90
-file_open_10.f90
-file_overwrite.f90
-finalization_02.f90
-finalization_03.f90
-finalization_04.f90
-finalization_05.f90
-finalization_06.f90
-finalization_07.f90
-fixed_form_do_name_01.f90
-fixed_form_goto.f90
-fixed_form_io_keyword_02.f90
-fixed_form_select_case_01.f90
-fixed_form_select_case_02.f90
-fixed_form_select_rank_01.f90
-fixed_form_stmt_func_01.f90
-fixed_form_where_01.f90
-floor_01.f90
-floor_02.f90
-flush_02.f90
-flush_05.f90
-fma_03.f90
-fma.f90
-forall_04.f90
-format_01.f90
-format_02.f90
-format_04.f90
-format_05.f90
-format_06.f90
-format_07.f90
-format_08.f90
-format_08s.f90
-format_09.f90
-format_100.f90
-format_101.f90
-format_102.f90
-format_103.f90
-format_104.f90
-format_105.f90
-format_10.f90
-format_11.f90
-format_12.f90
-format_14.f90
-format_15.f90
-format_16.f90
-format_17.f90
-format_18.f90
-format_19.f90
-format_20.f90
-format_21.f90
-format_22.f90
-format_23.f90
-format_24.f90
-format_25.f90
-format_26.f90
-format_27.f90
-format_28.f90
-format_29.f90
-format_30.f90
-format_31.f90
-format_32.f90
-format_33.f90
-format_34.f90
-format_35.f90
-format_36.f90
-format_37.f90
-format_38.f90
-format_39.f90
-format_41.f90
-format_42.f90
-format_43.f90
-format_44.f90
-format_45.f90
-format_46.f90
-format_47.f90
-format_48.f90
-format_49.f90
-format_50.f90
-format_51.f90
-format_52.f90
-format_53.f90
-format_54.f90
-format_56.f90
-format_57.f90
-format_58.f90
-format_59.f90
-format_60.f90
-format_61.f90
-format_62.f90
-format_63.f90
-format_64.f90
-format_65.f90
-format_66.f90
-format_67.f90
-format_68.f90
-format_69.f90
-format_70.f90
-format_71.f90
-format_72.f90
-format_73.f90
-format_74.f90
-format_75.f90
-format_76.f90
-format_77.f90
-format_78.f90
-format_79.f90
-format_80.f90
-format_81.f90
-format_82.f90
-format_83.f90
-format_84.f90
-format_85.f90
-format_86.f90
-format_87.f90
-format_88.f90
-format_89.f90
-format_90.f90
-format_91.f90
-format_92.f90
-format_93.f90
-format_98.f90
-format_99.f90
-format_before_read_01.f90
-format_quotes_01.f90
-formatted_read_01.f90
-formatted_read_02.f90
-formatted_read_03.f90
-formatted_read_04.f90
-formatted_read_05.f90
-formatted_read_06.f90
-formatted_read_07.f90
-fortran_primes_01.f90
-fortuno_01.f90
-func_call_in_decl_01.f90
-func_parameter_type_02.f90
-functions_03.f90
-functions_06.f90
-functions_09.f90
-functions_10.f90
-functions_11.f90
-functions_12.f90
-functions_13.f90
-functions_15.f90
-functions_16.f90
-functions_18.f90
-functions_19.f90
-functions_20.f90
-functions_21.f90
-functions_22.f90
-functions_23.f90
-functions_24.f90
-functions_25.f90
-functions_26.f90
-functions_27.f90
-functions_28.f90
-functions_29.f90
-functions_30.f90
-functions_31.f90
-functions_32.f90
-functions_33.f90
-functions_34.f90
-functions_35.f90
-functions_36.f90
-functions_37.f90
-functions_38.f90
-functions_40.f90
-functions_42.f90
-functions_43.f90
-functions_44.f90
-functions_45.f90
-functions_46.f90
-functions_47.f90
-functions_48.f90
-functions_49.f90
-functions_50.f90
-functions_51.f90
-functions_52.f90
-functions_54.f90
-functions_55.f90
-functions_56.f90
-functions_56_mod.f90
-functions_57.f90
-functions_58.f90
-functions_59.f90
-functions_61.f90
-generic_interface_function_call_of_function_call.f90
-generic_name_01.f90
-generic_name_02.f90
-generic_name_03.f90
-generic_name_04.f90
-generic_name_05.f90
-generic_name_06.f90
-generic_name_07.f90
-generic_name_08.f90
-global_allocatable_01.f90
-global_allocatable_02.f90
-global_array_pointer_01.f90
-global_array_pointer_02.f90
-goto_03.f90
-goto_05.f90
-goto_06.f90
-goto_gototarget_return_01.f90
-gpu_metal_100.f90
-gpu_metal_101.f90
-gpu_metal_102.f90
-gpu_metal_103.f90
-gpu_metal_104.f90
-gpu_metal_105.f90
-gpu_metal_106.f90
-gpu_metal_109.f90
-gpu_metal_110.f90
-gpu_metal_112.f90
-gpu_metal_113.f90
-gpu_metal_114.f90
-gpu_metal_115.f90
-gpu_metal_116.f90
-gpu_metal_118.f90
-gpu_metal_119.f90
-gpu_metal_120.f90
-gpu_metal_121.f90
-gpu_metal_122.f90
-gpu_metal_123.f90
-gpu_metal_124.f90
-gpu_metal_125.f90
-gpu_metal_127.f90
-gpu_metal_128.f90
-gpu_metal_133.f90
-gpu_metal_134.f90
-gpu_metal_135.f90
-gpu_metal_136.f90
-gpu_metal_137.f90
-gpu_metal_139.f90
-gpu_metal_13.f90
-gpu_metal_140.f90
-gpu_metal_142.f90
-gpu_metal_142_mod.f90
-gpu_metal_143.f90
-gpu_metal_144.f90
-gpu_metal_147.f90
-gpu_metal_147_neural_network.f90
-gpu_metal_148.f90
-gpu_metal_150.f90
-gpu_metal_151.f90
-gpu_metal_152.f90
-gpu_metal_154.f90
-gpu_metal_157.f90
-gpu_metal_158.f90
-gpu_metal_159.f90
-gpu_metal_160.f90
-gpu_metal_162.f90
-gpu_metal_163.f90
-gpu_metal_164.f90
-gpu_metal_165.f90
-gpu_metal_166.f90
-gpu_metal_167.f90
-gpu_metal_168.f90
-gpu_metal_170.f90
-gpu_metal_171.f90
-gpu_metal_172.f90
-gpu_metal_174.f90
-gpu_metal_175.f90
-gpu_metal_176.f90
-gpu_metal_177.f90
-gpu_metal_179.f90
-gpu_metal_180.f90
-gpu_metal_181.f90
-gpu_metal_182.f90
-gpu_metal_183.f90
-gpu_metal_184.f90
-gpu_metal_185.f90
-gpu_metal_188.f90
-gpu_metal_190.f90
-gpu_metal_191.f90
-gpu_metal_192.f90
-gpu_metal_193.f90
-gpu_metal_194.f90
-gpu_metal_195.f90
-gpu_metal_23.f90
-gpu_metal_26.f90
-gpu_metal_27.f90
-gpu_metal_28.f90
-gpu_metal_29.f90
-gpu_metal_30.f90
-gpu_metal_31.f90
-gpu_metal_33.f90
-gpu_metal_35.f90
-gpu_metal_36.f90
-gpu_metal_37.f90
-gpu_metal_38.f90
-gpu_metal_39.f90
-gpu_metal_40.f90
-gpu_metal_41.f90
-gpu_metal_43.f90
-gpu_metal_44.f90
-gpu_metal_46.f90
-gpu_metal_47.f90
-gpu_metal_49.f90
-gpu_metal_50.f90
-gpu_metal_51.f90
-gpu_metal_52.f90
-gpu_metal_53.f90
-gpu_metal_54.f90
-gpu_metal_55.f90
-gpu_metal_56.f90
-gpu_metal_57.f90
-gpu_metal_58.f90
-gpu_metal_60.f90
-gpu_metal_61.f90
-gpu_metal_62.f90
-gpu_metal_63.f90
-gpu_metal_64.f90
-gpu_metal_65.f90
-gpu_metal_67.f90
-gpu_metal_68.f90
-gpu_metal_69.f90
-gpu_metal_70.f90
-gpu_metal_71.f90
-gpu_metal_73.f90
-gpu_metal_74.f90
-gpu_metal_75.f90
-gpu_metal_76.f90
-gpu_metal_77.f90
-gpu_metal_78.f90
-gpu_metal_80.f90
-gpu_metal_81.f90
-gpu_metal_84.f90
-gpu_metal_85.f90
-gpu_metal_86.f90
-gpu_metal_87.f90
-gpu_metal_90.f90
-gpu_metal_91.f90
-gpu_metal_92.f90
-gpu_metal_94.f90
-gpu_metal_95.f90
-gpu_metal_96.f90
-gpu_metal_97.f90
-gpu_metal_98.f90
-gpu_metal_99.f90
-hashmap_derived_pointer_associated.f90
-hashmap_nested_dealloc_derived_pointer.f90
-huge_string_read.f90
-if_02.f90
-if_03.f90
-if_06.f90
-if_label_01.f90
-ilp64_complex_literal_01.f90
-ilp64_file_ops_01.f90
-ilp64_kind_arg_01.f90
-ilp64_logical_read_01.f90
-implicit_argument_casting_01.f90
-implicit_argument_casting_02.f90
-implicit_argument_casting_03.f90
-implicit_argument_casting_04.f90
-implicit_interface_01.f90
-implicit_interface_02.f90
-implicit_interface_03.f90
-implicit_interface_04.f90
-implicit_interface_08.f90
-implicit_interface_12.f90
-implicit_interface_13.f90
-implicit_interface_15b.f90
-implicit_interface_15.f90
-implicit_interface_16.f90
-implicit_interface_17.f90
-implicit_interface_19.f90
-implicit_interface_22.f90
-implicit_interface_23.f90
-implicit_interface_25.f90
-implicit_interface_26.f90
-implicit_interface_27.f90
-implicit_interface_28.f90
-implicit_interface_29b.f90
-implicit_interface_29.f90
-implicit_interface_30.f90
-implicit_interface_31.f90
-implicit_interface_32.f90
-implicit_interface_34.f90
-implicit_interface_35.f90
-implicit_interface_36.f90
-implicit_interface_37.f90
-implicit_interface_38.f90
-implicit_interface_40.f90
-implicit_interface_41.f90
-implicit_typing_01.f90
-implicit_typing_03.f90
-implicit_typing_05.f90
-implicit_typing_08.f90
-implicit_typing_10.f90
-implicit_typing_11.f90
-implicit_typing_12.f90
-implied_do_loops10.f90
-implied_do_loops11.f90
-implied_do_loops12.f90
-implied_do_loops13.f90
-implied_do_loops14.f90
-implied_do_loops15.f90
-implied_do_loops16.f90
-implied_do_loops18.f90
-implied_do_loops19.f90
-implied_do_loops1.f90
-implied_do_loops20.f90
-implied_do_loops21.f90
-implied_do_loops22.f90
-implied_do_loops23.f90
-implied_do_loops24.f90
-implied_do_loops25.f90
-implied_do_loops26.f90
-implied_do_loops27.f90
-implied_do_loops28.f90
-implied_do_loops29.f90
-implied_do_loops2.f90
-implied_do_loops30.f90
-implied_do_loops31.f90
-implied_do_loops32.f90
-implied_do_loops33.f90
-implied_do_loops34.f90
-implied_do_loops35.f90
-implied_do_loops36.f90
-implied_do_loops37.f90
-implied_do_loops38.f90
-implied_do_loops39.f90
-implied_do_loops3.f90
-implied_do_loops40.f90
-implied_do_loops41.f90
-implied_do_loops42.f90
-implied_do_loops43.f90
-implied_do_loops4.f90
-implied_do_loops5.f90
-implied_do_loops6.f90
-implied_do_loops7.f90
-implied_do_loops8.f90
-implied_do_loops9.f90
-implied_do_loops_print.f90
-implied_do_loops_strings.f90
-include_01.f90
-include_02.f90
-include_04.f90
-infer_walrus_shadow_01.f90
-infer_walrus_shadow_02.f90
-infer_walrus_struct_02.f90
-init_values.f90
-inquire_02.f90
-inquire_03.f90
-inquire_04.f90
-inquire_05.f90
-inquire_06.f90
-inquire_07.f90
-inquire_08.f90
-inquire_09.f90
-inquire_10.f90
-inquire_11.f90
-inquire_12.f90
-inquire_13.f90
-inquire_14.f90
-inquire_unit_exist.f90
-insertion_sort_01.f90
-int_02.f90
-int_03.f90
-integer_boz_01.f90
-intent_02.f90
-intent_03.f90
-intent_out_allocatable_component_dealloc.f90
-intent_out_allocatable_struct_with_components.f90
-intent_out_array_01.f90
-intent_out_array_of_struct_dealloc.f90
-intent_out_array_structs_01.f90
-intent_out_finalize_01.f90
-intent_out_finalize_02.f90
-intent_out_finalize_03.f90
-intent_out_finalize_04.f90
-intent_out_module_dealloc.f90
-intent_out_nested_allocatable_01.f90
-intent_out_struct_member_no_dealloc.f90
-interface_01.f90
-interface_03.f90
-interface_04.f90
-interface_05.f90
-interface_07.f90
-interface_09.f90
-interface_11.f90
-interface_12a.f90
-interface_13.f90
-interface_14.f90
-interface_15.f90
-interface_16.f90
-interface_17.f90
-interface_18.f90
-interface_19.f90
-interface_30.f90
-interface_31.f90
-interface_32.f90
-interface_32_module.f90
-interface_33.f90
-internal_subr_assumed_size_01.f90
-intrinsic_reduce_01.f90
-intrinsic_reduce_derived_type_01.f90
-intrinsics_01.f90
-intrinsics_02.f90
-intrinsics_03.f90
-intrinsics_04.f90
-intrinsics_04s.f90
-intrinsics_06.f90
-intrinsics_07.f90
-intrinsics_100.f90
-intrinsics_102.f90
-intrinsics_103.f90
-intrinsics_104.f90
-intrinsics_105.f90
-intrinsics_106.f90
-intrinsics_107.f90
-intrinsics_108.f90
-intrinsics_109.f90
-intrinsics_110.f90
-intrinsics_111.f90
-intrinsics_112.f90
-intrinsics_113.f90
-intrinsics_114.f90
-intrinsics_115.f90
-intrinsics_116.f90
-intrinsics_117.f90
-intrinsics_118.f90
-intrinsics_119.f90
-intrinsics_120.f90
-intrinsics_121.f90
-intrinsics_122.f90
-intrinsics_123.f90
-intrinsics_124.f90
-intrinsics_125.f90
-intrinsics_126.f90
-intrinsics_127.f90
-intrinsics_128.f90
-intrinsics_129.f90
-intrinsics_12.f90
-intrinsics_130.f90
-intrinsics_131.f90
-intrinsics_132.f90
-intrinsics_133.f90
-intrinsics_134.f90
-intrinsics_135.f90
-intrinsics_136.f90
-intrinsics_137.f90
-intrinsics_138.f90
-intrinsics_139.f90
-intrinsics_140.f90
-intrinsics_141.f90
-intrinsics_142.f90
-intrinsics_143.f90
-intrinsics_144.f90
-intrinsics_145.f90
-intrinsics_146.f90
-intrinsics_147.f90
-intrinsics_148.f90
-intrinsics_149.f90
-intrinsics_14.f90
-intrinsics_150.f90
-intrinsics_151.f90
-intrinsics_152.f90
-intrinsics_153.f90
-intrinsics_154.f90
-intrinsics_155.f90
-intrinsics_156.f90
-intrinsics_157.f90
-intrinsics_158.f90
-intrinsics_159.f90
-intrinsics_15.f90
-intrinsics_160.f90
-intrinsics_161.f90
-intrinsics_162.f90
-intrinsics_163.f90
-intrinsics_164.f90
-intrinsics_165.f90
-intrinsics_166.f90
-intrinsics_167.f90
-intrinsics_168.f90
-intrinsics_169.f90
-intrinsics_16.f90
-intrinsics_170.f90
-intrinsics_171.f90
-intrinsics_172.f90
-intrinsics_173.f90
-intrinsics_174.f90
-intrinsics_175.f90
-intrinsics_176.f90
-intrinsics_177.f90
-intrinsics_178.f90
-intrinsics_179.f90
-intrinsics_17.f90
-intrinsics_180.f90
-intrinsics_181.f90
-intrinsics_182.f90
-intrinsics_183.f90
-intrinsics_184.f90
-intrinsics_185.f90
-intrinsics_187.f90
-intrinsics_188.f90
-intrinsics_189.f90
-intrinsics_18c.f90
-intrinsics_190.f90
-intrinsics_191.f90
-intrinsics_192.f90
-intrinsics_193.f90
-intrinsics_194.f90
-intrinsics_195.f90
-intrinsics_196.f90
-intrinsics_197.f90
-intrinsics_198.f90
-intrinsics_199.f90
-intrinsics_19c.f90
-intrinsics_19.f90
-intrinsics_200.f90
-intrinsics_201.f90
-intrinsics_202.f90
-intrinsics_203.f90
-intrinsics_204.f90
-intrinsics_205.f90
-intrinsics_206.f90
-intrinsics_207.f90
-intrinsics_208.f90
-intrinsics_209.f90
-intrinsics_210.f90
-intrinsics_211.f90
-intrinsics_212.f90
-intrinsics_213.f90
-intrinsics_214.f90
-intrinsics_215.f90
-intrinsics_216.f90
-intrinsics_217.f90
-intrinsics_218.f90
-intrinsics_219.f90
-intrinsics_21.f90
-intrinsics_220.f90
-intrinsics_221.f90
-intrinsics_222.f90
-intrinsics_223.f90
-intrinsics_224.f90
-intrinsics_225.f90
-intrinsics_226.f90
-intrinsics_227.f90
-intrinsics_228.f90
-intrinsics_229.f90
-intrinsics_22.f90
-intrinsics_230.f90
-intrinsics_231.f90
-intrinsics_232.f90
-intrinsics_233.f90
-intrinsics_234.f90
-intrinsics_235.f90
-intrinsics_236.f90
-intrinsics_237.f90
-intrinsics_238.f90
-intrinsics_239.f90
-intrinsics_23.f90
-intrinsics_240.f90
-intrinsics_241.f90
-intrinsics_242.f90
-intrinsics_243.f90
-intrinsics_244.f90
-intrinsics_245.f90
-intrinsics_246.f90
-intrinsics_247.f90
-intrinsics_248.f90
-intrinsics_249.f90
-intrinsics_24.f90
-intrinsics_250.f90
-intrinsics_251.f90
-intrinsics_252.f90
-intrinsics_253.f90
-intrinsics_254.f90
-intrinsics_255.f90
-intrinsics_256.f90
-intrinsics_257.f90
-intrinsics_258.f90
-intrinsics_259.f90
-intrinsics_25.f90
-intrinsics_260.f90
-intrinsics_261.f90
-intrinsics_262.f90
-intrinsics_263.f90
-intrinsics_264.f90
-intrinsics_265.f90
-intrinsics_266.f90
-intrinsics_267.f90
-intrinsics_268.f90
-intrinsics_269.f90
-intrinsics_270.f90
-intrinsics_271.f90
-intrinsics_272.f90
-intrinsics_273.f90
-intrinsics_274.f90
-intrinsics_275.f90
-intrinsics_276.f90
-intrinsics_277.f90
-intrinsics_278.f90
-intrinsics_279.f90
-intrinsics_27.f90
-intrinsics_280.f90
-intrinsics_281.f90
-intrinsics_282.f90
-intrinsics_283.f90
-intrinsics_284.f90
-intrinsics_285.f90
-intrinsics_286.f90
-intrinsics_288.f90
-intrinsics_289.f90
-intrinsics_290.f90
-intrinsics_291.f90
-intrinsics_293.f90
-intrinsics_294.f90
-intrinsics_295.f90
-intrinsics_296.f90
-intrinsics_297.f90
-intrinsics_298.f90
-intrinsics_29.f90
-intrinsics_300.f90
-intrinsics_301.f90
-intrinsics_302.f90
-intrinsics_303.f90
-intrinsics_304.f90
-intrinsics_305.f90
-intrinsics_306.f90
-intrinsics_307.f90
-intrinsics_308.f90
-intrinsics_309.f90
-intrinsics_30.f90
-intrinsics_311.f90
-intrinsics_312.f90
-intrinsics_313.f90
-intrinsics_314.f90
-intrinsics_315.f90
-intrinsics_316.f90
-intrinsics_317.f90
-intrinsics_319.f90
-intrinsics_31.f90
-intrinsics_320.f90
-intrinsics_321.f90
-intrinsics_322.f90
-intrinsics_323.f90
-intrinsics_325.f90
-intrinsics_326.f90
-intrinsics_327.f90
-intrinsics_328.f90
-intrinsics_329.f90
-intrinsics_330.f90
-intrinsics_331.f90
-intrinsics_332.f90
-intrinsics_333.f90
-intrinsics_334.f90
-intrinsics_335.f90
-intrinsics_336.f90
-intrinsics_337.f90
-intrinsics_338.f90
-intrinsics_339.f90
-intrinsics_33.f90
-intrinsics_340.f90
-intrinsics_341.f90
-intrinsics_342.f90
-intrinsics_343.f90
-intrinsics_344.f90
-intrinsics_345.f90
-intrinsics_346.f90
-intrinsics_347.f90
-intrinsics_348.f90
-intrinsics_349.f90
-intrinsics_34.f90
-intrinsics_350.f90
-intrinsics_351.f90
-intrinsics_352.f90
-intrinsics_353.f90
-intrinsics_354.f90
-intrinsics_355.f90
-intrinsics_356.f90
-intrinsics_357.f90
-intrinsics_358.f90
-intrinsics_359.f90
-intrinsics_35.f90
-intrinsics_360.f90
-intrinsics_361.f90
-intrinsics_362.f90
-intrinsics_363.f90
-intrinsics_365.f90
-intrinsics_366.f90
-intrinsics_367.f90
-intrinsics_368.f90
-intrinsics_369.f90
-intrinsics_36.f90
-intrinsics_370.f90
-intrinsics_371.f90
-intrinsics_372.f90
-intrinsics_373.f90
-intrinsics_374.f90
-intrinsics_375.f90
-intrinsics_376.f90
-intrinsics_377.f90
-intrinsics_378.f90
-intrinsics_379.f90
-intrinsics_37.f90
-intrinsics_380.f90
-intrinsics_381.f90
-intrinsics_382.f90
-intrinsics_383.f90
-intrinsics_384.f90
-intrinsics_385.f90
-intrinsics_386.f90
-intrinsics_387.f90
-intrinsics_388.f90
-intrinsics_389.f90
-intrinsics_38.f90
-intrinsics_390.f90
-intrinsics_391.f90
-intrinsics_392.f90
-intrinsics_393.f90
-intrinsics_394.f90
-intrinsics_395.f90
-intrinsics_396.f90
-intrinsics_397.f90
-intrinsics_398.f90
-intrinsics_39.f90
-intrinsics_400.f90
-intrinsics_401.f90
-intrinsics_402.f90
-intrinsics_403.f90
-intrinsics_405.f90
-intrinsics_406.f90
-intrinsics_409.f90
-intrinsics_40.f90
-intrinsics_410.f90
-intrinsics_411.f90
-intrinsics_412.f90
-intrinsics_413.f90
-intrinsics_414.f90
-intrinsics_415.f90
-intrinsics_416.f90
-intrinsics_417.f90
-intrinsics_418.f90
-intrinsics_419.f90
-intrinsics_420.f90
-intrinsics_421.f90
-intrinsics_422.f90
-intrinsics_423.f90
-intrinsics_424.f90
-intrinsics_425.f90
-intrinsics_426.f90
-intrinsics_427.f90
-intrinsics_428.f90
-intrinsics_429.f90
-intrinsics_430.f90
-intrinsics_431.f90
-intrinsics_433.f90
-intrinsics_435.f90
-intrinsics_436.f90
-intrinsics_437.f90
-intrinsics_438.f90
-intrinsics_439.f90
-intrinsics_43.f90
-intrinsics_440.f90
-intrinsics_441.f90
-intrinsics_442.f90
-intrinsics_443.f90
-intrinsics_444.f90
-intrinsics_446.f90
-intrinsics_447.f90
-intrinsics_448.f90
-intrinsics_449.f90
-intrinsics_44.f90
-intrinsics_450.f90
-intrinsics_451.f90
-intrinsics_452.f90
-intrinsics_453.f90
-intrinsics_454.f90
-intrinsics_456.f90
-intrinsics_457.f90
-intrinsics_459.f90
-intrinsics_45.f90
-intrinsics_460.f90
-intrinsics_461.f90
-intrinsics_462.f90
-intrinsics_463.f90
-intrinsics_464.f90
-intrinsics_466.f90
-intrinsics_467.f90
-intrinsics_468.f90
-intrinsics_469.f90
-intrinsics_46.f90
-intrinsics_48.f90
-intrinsics_49.f90
-intrinsics_50.f90
-intrinsics_51.f90
-intrinsics_52.f90
-intrinsics_53.f90
-intrinsics_54.f90
-intrinsics_55.f90
-intrinsics_56.f90
-intrinsics_57.f90
-intrinsics_58.f90
-intrinsics_59.f90
-intrinsics_60.f90
-intrinsics_61.f90
-intrinsics_62.f90
-intrinsics_63.f90
-intrinsics_64.f90
-intrinsics_65.f90
-intrinsics_67.f90
-intrinsics_68.f90
-intrinsics_69.f90
-intrinsics_70.f90
-intrinsics_72.f90
-intrinsics_73.f90
-intrinsics_74.f90
-intrinsics_75.f90
-intrinsics_76.f90
-intrinsics_77.f90
-intrinsics_78.f90
-intrinsics_79.f90
-intrinsics_81.f90
-intrinsics_83.f90
-intrinsics_84.f90
-intrinsics_85.f90
-intrinsics_86.f90
-intrinsics_87.f90
-intrinsics_88.f90
-intrinsics_90.f90
-intrinsics_91.f90
-intrinsics_92.f90
-intrinsics_93.f90
-intrinsics_96.f90
-intrinsics_97.f90
-intrinsics_98.f90
-intrinsics_99.f90
-intrinsics_open_close_read_write.f90
-io_direct_slash.f90
-ip_01.f90
-iso_c_binding_01.f90
-iso_c_binding_02.f90
-iso_c_binding_04.f90
-iso_c_binding_05.f90
-iso_c_binding_07.f90
-iso_fortran_env_01.f90
-iso_fortran_env_02.f90
-iso_fortran_env_03.f90
-iso_fortran_env_04.f90
-kinds_01.f90
-kinds_02.f90
-kinds_03.f90
-kwargs_01.f90
-kwargs_02.f90
-label_01.f90
-la_constants.f90
-lapack_01.f90
-lapack_02.f90
-lapack_06.f90
-lapack_07.f90
-lapack_08.f90
-lapack_10.f90
-lbound_01.f90
-lbound_02.f90
-legacy_array_sections_02.f90
-legacy_array_sections_04.f90
-legacy_array_sections_05.f90
-legacy_array_sections_06.f90
-legacy_array_sections_07.f90
-legacy_array_sections_08.f90
-legacy_array_sections_09.f90
-legacy_array_sections_10.f90
-legacy_array_sections_11.f90
-legacy_array_sections_12.f90
-legacy_array_sections_14.f90
-legacy_array_sections_15.f90
-legacy_array_sections_18.f90
-legacy_array_sections_19.f90
-legacy_array_sections_21.f90
-lfortran_intrinsic_sin.f90
-line_continuation_02.f90
-line_continuation_03.f90
-line_continuation_04.f90
-line_continuation_05.f90
-list_directed_stdin_eof_01.f90
-list_of_lists_test.f90
-list_of_tuples_test.f90
-list_test_01.f90
-list_test_01_.f90
-list_test_02_.f90
-list_test_03_.f90
-list_test_04_.f90
-list_test_06_.f90
-list_test_08_.f90
-list_test_09_.f90
-logical3.f90
-logical4.f90
-logical_arrays_logical_binop_01.f90
-logical_casting_01.f90
-logical_kind_01.f90
-logical_kind_02.f90
-logical_kind_04.f90
-logical_kind_05.f90
-logical_kind_06.f90
-logical_kind_07.f90
-logical_not_01.f90
-logical_testing.f90
-logical_to_integer_cast.f90
-matmul_01.f90
-matmul_02.f90
-matmul_03.f90
-matmul_04.f90
-matmul_05.f90
-matmul_06.f90
-matrix_01_transpose.f90
-matrix_03_transpose_param.f90
-max_02.f90
-merge_str_01.f90
-min_01.f90
-min_02.f90
-minmax_01.f90
-minpack_01.f90
-minpack_01_func.f90
-minpack_03.f90
-module_array_init.f90
-module_function_with_nopass.f90
-module_function_without_nopass.f90
-modules_03.f90
-modules_05.f90
-modules_08_b.f90
-modules_08.f90
-modules_09_a.f90
-modules_09.f90
-modules_15b.f90
-modules_15.f90
-modules_18b.f90
-modules_18.f90
-modules_19b.f90
-modules_19.f90
-modules_20.f90
-modules_22.f90
-modules_22_module.f90
-modules_23.f90
-modules_23_module.f90
-modules_24.f90
-modules_25.f90
-modules_25_module1.f90
-modules_25_module.f90
-modules_26.f90
-modules_27_module1.f90
-modules_27_module2.f90
-modules_28.f90
-modules_28_module1.f90
-modules_28_module2.f90
-modules_29.f90
-modules_29_module1.f90
-modules_29_module2.f90
-modules_29_module3.f90
-modules_30.f90
-modules_30_module1.f90
-modules_30_module2.f90
-modules_30_module3.f90
-modules_31.f90
-modules_31_module1.f90
-modules_31_module2.f90
-modules_32.f90
-modules_33_module1.f90
-modules_33_module3.f90
-modules_34_module1a.f90
-modules_34_module3.f90
-modules_35.f90
-modules_36.f90
-modules_37.f90
-modules_38.f90
-modules_39.f90
-modules_39_module.f90
-modules_40.f90
-modules_41.f90
-modules_42.f90
-modules_43.f90
-modules_44.f90
-modules_44_module.f90
-modules_45.f90
-modules_47.f90
-modules_48.f90
-modules_49.f90
-modules_50.f90
-modules_51.f90
-modules_52.f90
-modules_52_module1.f90
-modules_53.f90
-modules_55.f90
-modules_56.f90
-modules_57.f90
-modules_58.f90
-modules_59.f90
-modules_60.f90
-modules_61.f90
-modules_62.f90
-modules_62_parser.f90
-modules_62_terminal.f90
-modules_63.f90
-modules_63_module.f90
-modules_64.f90
-modules_65.f90
-modules_65_worker.f90
-modules_66.f90
-modules_66_worker.f90
-modules_67_consumer.f90
-modules_67.f90
-modules_68.f90
-modules_69.f90
-modules_71.f90
-modules_72.f90
-modulo_01.f90
-modulo_02.f90
-move_alloc_derived_01.f90
-move_alloc_pointer_alias.f90
-multi_file_member_access_01.f90
-multi_file_member_access_01_mod.f90
-multiple_objects_args.f90
-multiple_procs_in_bin_op.f90
-namelist_03.f90
-namelist_04.f90
-namelist_05.f90
-namelist_06.f90
-namelist_07.f90
-namelist_08.f90
-namelist_09.f90
-namelist_10.f90
-namelist_11.f90
-namelist_12.f90
-namelist_13.f90
-namelist_14.f90
-namelist_15.f90
-namelist_16.f90
-namelist_17.f90
-namelist_18.f90
-namelist_19.f90
-namelist_20.f90
-namelist_21.f90
-namelist_22.f90
-namelist_23.f90
-namelist_24.f90
-namelist_25.f90
-namelist_26.f90
-namelist_27.f90
-namelist_28.f90
-namelist_29.f90
-namelist_30.f90
-namelist_31.f90
-nbody.f90
-nested_03.f90
-nested_04.f90
-nested_05.f90
-nested_06.f90
-nested_07.f90
-nested_09.f90
-nested_10.f90
-nested_12.f90
-nested_13.f90
-nested_14.f90
-nested_15.f90
-nested_16.f90
-nested_17.f90
-nested_18.f90
-nested_20.f90
-nested_21.f90
-nested_22.f90
-nested_23.f90
-nested_24.f90
-nested_26.f90
-nested_27.f90
-nested_array_intrinsics_01.f90
-nested_callback_arrays.f90
-nested_callback_interface_01.f90
-nested_call_filter_01.f90
-nested_external_dedup_01.f90
-nested_namelist_01.f90
-nested_struct_proc_01.f90
-nested_vars_01.f90
-nested_vars_02.f90
-nested_vars_03.f90
-nested_vars_04.f90
-nested_vars_05.f90
-nested_vars_06.f90
-nested_vars1.f90
-nested_vars2.f90
-nested_vars3.f90
-nested_vars_allocatable_call.f90
-no_explicit_return_type_01.f90
-nullify_03.f90
-nullify_04.f90
-nullify_05.f90
-nullify_06.f90
-nullify_07.f90
-openmp_02.f90
-openmp_04.f90
-openmp_05.f90
-openmp_06.f90
-openmp_07.f90
-openmp_08.f90
-openmp_09.f90
-openmp_10.f90
-openmp_11.f90
-openmp_12.f90
-openmp_13.f90
-openmp_14.f90
-openmp_15.f90
-openmp_16.f90
-openmp_17.f90
-openmp_18.f90
-openmp_19.f90
-openmp_20.f90
-openmp_21.f90
-openmp_22.f90
-openmp_23.f90
-openmp_24.f90
-openmp_25.f90
-openmp_26.f90
-openmp_27.f90
-openmp_28.f90
-openmp_30.f90
-openmp_32.f90
-openmp_33.f90
-openmp_34.f90
-openmp_35.f90
-openmp_40.f90
-openmp_41.f90
-openmp_44.f90
-openmp_46.f90
-openmp_47.f90
-openmp_48.f90
-openmp_49.f90
-openmp_50.f90
-openmp_51.f90
-openmp_53.f90
-openmp_54.f90
-openmp_55.f90
-openmp_56.f90
-openmp_59.f90
-openmp_60.f90
-openmp_62.f90
-openmp_63.f90
-openmp_64.f90
-openmp_65.f90
-openmp_67.f90
-openmp_68.f90
-openmp_69.f90
-openmp_70.f90
-openmp_71.f90
-openmp_72.f90
-openmp_73.f90
-openmp_bindc_01.f90
-openmp_bindc_02.f90
-openmp_bindc_03.f90
-openmp_bindc_04.f90
-operator_overloading_01.f90
-operator_overloading_02.f90
-operator_overloading_03.f90
-operator_overloading_04.f90
-operator_overloading_05_module1.f90
-operator_overloading_05_module3.f90
-operator_overloading_06.f90
-operator_overloading_07.f90
-operator_overloading_08.f90
-operator_overloading_09.f90
-operator_overloading_10.f90
-operator_overloading_11.f90
-operator_overloading_12.f90
-operator_overloading_13.f90
-operator_overloading_14.f90
-operator_overloading_15.f90
-operator_overloading_16.f90
-operator_overloading_17.f90
-operator_overloading_18.f90
-operator_overloading_19.f90
-operator_overloading_20.f90
-operator_overloading_21.f90
-operator_overloading_22.f90
-operator_overloading_23.f90
-operator_overloading_24.f90
-operator_overloading_25.f90
-operator_overloading_26.f90
-operator_overloading_27.f90
-operator_overloading_28.f90
-operator_overloading_29.f90
-operator_overloading_30.f90
-operator_overloading_31.f90
-operator_overloading_32.f90
-operator_overloading_33.f90
-operator_overloading_34.f90
-operator_overloading_34_mod.f90
-operator_overloading_35.f90
-operator_overloading_36.f90
-operator_overloading_36_mod_base_sub.f90
-operator_overloading_37.f90
-operator_overloading_38.f90
-operator_overloading_39.f90
-optional_01.f90
-optional_02.f90
-optional_03.f90
-optional_04.f90
-optional_05.f90
-optional_06.f90
-optional_07.f90
-optional_08.f90
-optional_09.f90
-optional_10.f90
-optional_11.f90
-optional_12.f90
-optional_13.f90
-parameter_01.f90
-parameter_02.f90
-parameter_05.f90
-parameter_06.f90
-parameter_08.f90
-parameter_09.f90
-parameter_10.f90
-parameter_11.f90
-parameter_12.f90
-parameter_13.f90
-parameter_15.f90
-parameter_16.f90
-parsing_01.f90
-parsing_02.f90
-pass_array_by_data_01.f90
-pass_array_by_data_02.f90
-pass_array_by_data_03.f90
-pass_array_by_data_05.f90
-pass_array_by_data_07.f90
-pass_array_by_data_08.f90
-pass_array_by_data_09.f90
-pass_array_by_data_10.f90
-pass_array_by_data_11.f90
-pass_array_by_data_12.f90
-pass_array_by_data_13.f90
-pass_array_by_data_14.f90
-pass_array_by_data_extname_01.f90
-passing_array_01.f90
-passing_array_02.f90
-passing_array_04.f90
-passing_array_05.f90
-pdt_01.f90
-pdt_02.f90
-pdt_03.f90
-pdt_04.f90
-pdt_05.f90
-pdt_06.f90
-pdt_07.f90
-pdt_09.f90
-pdt_10.f90
-pdt_11.f90
-pdt_11_module.f90
-pdt_12.f90
-pdt_14.f90
-pdt_15.f90
-pdt_16.f90
-pointer_01.f90
-pointer_02.f90
-pointer_03.f90
-pointer_04.f90
-pointer_05.f90
-pointer_06.f90
-pointer_07.f90
-pointer_09.f90
-pointer_10.f90
-pointer_11.f90
-pointer_12.f90
-pointer_14.f90
-pointer_15.f90
-pointer_16.f90
-pointer_17.f90
-pointer_to_cptr.f90
-polymorphic_arguments_01.f90
-polymorphic_arguments_02.f90
-polymorphic_class_compare.f90
-polymorphic_select_type_01.f90
-polymorphic_select_type_02.f90
-precision_02.f90
-present_02.f90
-present_03.f90
-present_04.f90
-present_05.f90
-present_06.f90
-present_07.f90
-present_08.f90
-print_02.f90
-print_04.f90
-print_06.f90
-print_07.f90
-print_10.f90
-print_11.f90
-print_12.f90
-print_13.f90
-print_14.f90
-print_15.f90
-print_arr_03.f90
-print_arr_06.f90
-print_arr_08.f90
-print_arr_09.f90
-procedure_01.f90
-procedure_02.f90
-procedure_03.f90
-procedure_04.f90
-procedure_05.f90
-procedure_06.f90
-procedure_07.f90
-procedure_08.f90
-procedure_09_b.f90
-procedure_11.f90
-procedure_12.f90
-procedure_13.f90
-procedure_14.f90
-procedure_15.f90
-procedure_16.f90
-procedure_17.f90
-procedure_18.f90
-procedure_19.f90
-procedure_20.f90
-procedure_21.f90
-procedure_22_a.f90
-procedure_22.f90
-procedure_23.f90
-procedure_24.f90
-procedure_25.f90
-procedure_26.f90
-procedure_27.f90
-procedure_28.f90
-procedure_29.f90
-procedure_30.f90
-procedure_31.f90
-procedure_32.f90
-procedure_33.f90
-procedure_34.f90
-procedure_35.f90
-procedure_36.f90
-procedure_37.f90
-procedure_38.f90
-procedure_39.f90
-procedure_40.f90
-procedure_41.f90
-procedure_42.f90
-procedure_43.f90
-procedure_43_module.f90
-procedure_44.f90
-procedure_45.f90
-procedure_46.f90
-procedure_47.f90
-procedure_48.f90
-procedure_49.f90
-procedure_50.f90
-procedure_decl_01_a.f90
-procedure_decl_01_b.f90
-procedure_pointer_12.f90
-procedure_pointer_13.f90
-procedure_pointer_14.f90
-procedure_pointer_16.f90
-procedure_pointer_17.f90
-procedure_pointer_18.f90
-procedure_pointer_19.f90
-procedure_pointer_20.f90
-procedure_pointer_21.f90
-procedure_pointer_22.f90
-procedure_pointer_23.f90
-procedure_pointer_24.f90
-procedure_pointer_25.f90
-procedure_pointer_abstract_01.f90
-procedure_pointer_abstract_02.f90
-procedure_pointer_keyword_01.f90
-procedure_pointer_keyword_02.f90
-procedure_pointer_keyword_03.f90
-proc_ptr_14.f90
-proc_ptr_15.f90
-proc_ptr_17.f90
-proc_ptr_18.f90
-proc_ptr_nopass_01.f90
-product_01.f90
-product_02.f90
-program_01.f90
-program_03.f90
-pure_side_effects_03.f90
-random_init_01.f90
-random_init_02.f90
-random_number_01.f90
-random_number_complex_part_01.f90
-random_seed_01.f90
-read_01.f90
-read_02.f90
-read_03.f90
-read_04.f90
-read_05.f90
-read_06.f90
-read_07.f90
-read_08.f90
-read_09.f90
-read_10.f90
-read_11.f90
-read_12.f90
-read_13.f90
-read_14.f90
-read_16.f90
-read_19.f90
-read_20.f90
-read_21.f90
-read_22.f90
-read_23.f90
-read_24.f90
-read_25.f90
-read_26.f90
-read_27.f90
-read_28.f90
-read_29.f90
-read_30.f90
-read_31.f90
-read_32.f90
-read_33.f90
-read_34.f90
-read_35.f90
-read_36.f90
-read_37.f90
-read_38.f90
-read_39.f90
-read_40.f90
-read_41.f90
-read_42.f90
-read_43.f90
-read_44.f90
-read_45.f90
-read_47.f90
-read_48.f90
-read_49.f90
-read_50.f90
-read_51.f90
-read_52.f90
-read_53.f90
-read_54.f90
-read_55.f90
-read_56.f90
-read_57.f90
-read_58.f90
-read_59.f90
-read_60.f90
-read_61.f90
-read_62.f90
-read_63.f90
-read_64.f90
-read_65.f90
-read_66.f90
-read_67.f90
-read_68.f90
-read_69.f90
-read_70.f90
-read_71.f90
-read_72.f90
-read_73.f90
-read_74.f90
-read_75.f90
-read_76.f90
-read_77.f90
-read_78.f90
-read_80.f90
-read_81.f90
-read_82.f90
-read_83.f90
-read_85.f90
-read_86.f90
-read_87.f90
-read_88.f90
-read_89.f90
-read_90.f90
-read_91.f90
-read_92.f90
-read_93.f90
-read_94.f90
-read_95.f90
-read_96.f90
-real128_arith_01.f90
-real128_arith_02.f90
-real128_arith_03.f90
-real128_arith_04.f90
-real128_arith_05.f90
-real128_arith_06.f90
-real128_arith_07.f90
-real128_arith_08.f90
-real128_arith_09.f90
-real128_arith_10.f90
-real128_intrinsic_inquiry_01.f90
-real128_int_to_real_01.f90
-real128_literal_01.f90
-realloc_lhs_16.f90
-realloc_lhs_18.f90
-realloc_lhs_19.f90
-realloc_lhs_20.f90
-realloc_lhs_21.f90
-realloc_lhs_23.f90
-realloc_lhs_24.f90
-realloc_lhs_25.f90
-recursion_02.f90
-recursion_03.f90
-reserved_01.f90
-reserved_02.f90
-reserved_03.f90
-return_05.f90
-return_06.f90
-rewind_01.f90
-rewind_inquire_flush.f90
-save_04.f90
-save_05.f90
-save_07.f90
-save_08.f90
-save_10.f90
-save_11.f90
-save_13.f90
-save_14.f90
-select_case_01.f90
-select_case_02.f90
-select_case_03.f90
-selected_int_kind_01.f90
-select_label_01.f90
-select_rank_01.f90
-select_rank_02.f90
-select_rank_03.f90
-select_rank_04.f90
-select_rank_05.f90
-select_rank_06.f90
-select_rank_07.f90
-select_rank_08.f90
-select_rank_09.f90
-select_rank_10.f90
-select_rank_11.f90
-select_rank_12.f90
-select_rank_13.f90
-select_rank_14.f90
-select_rank_15.f90
-select_rank_16.f90
-select_rank_17.f90
-select_rank_19.f90
-select_rank_20.f90
-select_rank_21.f90
-select_rank_22.f90
-select_rank_23.f90
-select_rank_24.f90
-select_rank_25.f90
-select_rank_26.f90
-select_rank_27.f90
-select_rank_28.f90
-select_rank_29.f90
-select_rank_30.f90
-select_rank_31.f90
-select_rank_32.f90
-select_rank_33.f90
-select_rank_34.f90
-select_rank_35.f90
-select_rank_36.f90
-select_rank_37.f90
-select_rank_38.f90
-select_rank_pointer_01.f90
-select_type_01.f90
-select_type_02.f90
-select_type_03.f90
-select_type_05.f90
-select_type_06.f90
-select_type_07.f90
-select_type_08.f90
-select_type_09.f90
-select_type_10.f90
-select_type_11.f90
-select_type_12.f90
-select_type_13.f90
-select_type_14.f90
-select_type_15.f90
-select_type_16.f90
-select_type_17.f90
-select_type_18.f90
-select_type_19.f90
-select_type_20.f90
-select_type_21.f90
-select_type_22.f90
-select_type_23.f90
-select_type_24.f90
-select_type_25.f90
-select_type_26.f90
-select_type_27.f90
-select_type_28.f90
-select_type_29.f90
-select_type_30.f90
-select_type_31.f90
-select_type_32.f90
-select_type_33.f90
-select_type_34.f90
-select_type_36.f90
-select_type_37.f90
-select_type_38.f90
-select_type_39.f90
-select_type_40.f90
-select_type_41.f90
-select_type_42.f90
-select_type_43.f90
-select_type_44.f90
-select_type_45.f90
-select_type_46.f90
-select_type_47.f90
-select_type_48.f90
-select_type_49.f90
-select_type_50.f90
-select_type_51.f90
-select_type_52.f90
-separate_compilation_03a.f90
-separate_compilation_03b.f90
-separate_compilation_03.f90
-separate_compilation_04a.f90
-separate_compilation_04b.f90
-separate_compilation_04.f90
-separate_compilation_05a.f90
-separate_compilation_05b.f90
-separate_compilation_05.f90
-separate_compilation_06a.f90
-separate_compilation_06b.f90
-separate_compilation_06.f90
-separate_compilation_07b.f90
-separate_compilation_07.f90
-separate_compilation_08a.f90
-separate_compilation_08b.f90
-separate_compilation_08.f90
-separate_compilation_09b.f90
-separate_compilation_09.f90
-separate_compilation_10a.f90
-separate_compilation_10.f90
-separate_compilation_11.f90
-separate_compilation_12a.f90
-separate_compilation_12.f90
-separate_compilation_13a.f90
-separate_compilation_13.f90
-separate_compilation_15a.f90
-separate_compilation_15.f90
-separate_compilation_16b.f90
-separate_compilation_16.f90
-separate_compilation_17b.f90
-separate_compilation_17.f90
-separate_compilation_18b.f90
-separate_compilation_18.f90
-separate_compilation_19b.f90
-separate_compilation_19.f90
-separate_compilation_20b.f90
-separate_compilation_20.f90
-separate_compilation_21b.f90
-separate_compilation_21.f90
-separate_compilation_22b.f90
-separate_compilation_22.f90
-separate_compilation_23a.f90
-separate_compilation_23b.f90
-separate_compilation_23.f90
-separate_compilation_24b.f90
-separate_compilation_24.f90
-separate_compilation_25a.f90
-separate_compilation_25b.f90
-separate_compilation_25.f90
-separate_compilation_26b.f90
-separate_compilation_26.f90
-separate_compilation_27a.f90
-separate_compilation_27b.f90
-separate_compilation_27.f90
-separate_compilation_28a.f90
-separate_compilation_28b.f90
-separate_compilation_28.f90
-separate_compilation_29.f90
-separate_compilation_30a.f90
-separate_compilation_30b.f90
-separate_compilation_30.f90
-separate_compilation_31b.f90
-separate_compilation_31.f90
-separate_compilation_32b.f90
-separate_compilation_32.f90
-separate_compilation_33a.f90
-separate_compilation_33.f90
-separate_compilation_34a.f90
-separate_compilation_34.f90
-separate_compilation_35a.f90
-separate_compilation_35.f90
-separate_compilation_36.f90
-separate_compilation_37b.f90
-separate_compilation_37.f90
-separate_compilation_39b.f90
-separate_compilation_39.f90
-separate_compilation_40.f90
-separate_compilation_41a.f90
-separate_compilation_41b.f90
-separate_compilation_42.f90
-separate_compilation_43b.f90
-separate_compilation_43.f90
-separate_compilation_44b.f90
-separate_compilation_44.f90
-separate_compilation_45.f90
-separate_compilation_46a.f90
-separate_compilation_46.f90
-separate_compilation_47a.f90
-separate_compilation_47.f90
-separate_compilation_48.f90
-separate_compilation_49a.f90
-separate_compilation_49.f90
-separate_compilation_class_star_01.f90
-separate_compilation_class_star_02a.f90
-separate_compilation_class_star_02.f90
-separate_compilation_class_star_03a.f90
-separate_compilation_class_star_03.f90
-separate_compilation_class_star_04a.f90
-separate_compilation_class_star_04.f90
-separate_compilation_external_symbol_02a.f90
-separate_compilation_external_symbol_02.f90
-set_exponent_01.f90
-set_test_01.f90
-shifta_01.f90
-shifta_02.f90
-sign_from_value.f90
-simd_02.f90
-sin_01.f90
-sin_02.f90
-sizeof_01.f90
-slash_init_01.f90
-spec_expr_01.f90
-specfun_01.f90
-statement_01.f90
-statement_02.f90
-statement_03.f90
-statement_04.f90
-statement_05.f90
-statement_06.f90
-statement_07.f90
-statement1.f90
-stdlib_bitsets_01.f90
-string_03.f90
-string_04.f90
-string_06.f90
-string_07.f90
-string_08.f90
-string_100.f90
-string_101.f90
-string_102.f90
-string_103.f90
-string_104.f90
-string_105.f90
-string_106.f90
-string_107.f90
-string_108.f90
-string_109.f90
-string_10.f90
-string_110.f90
-string_112.f90
-string_113.f90
-string_114.f90
-string_115.f90
-string_116.f90
-string_117.f90
-string_118.f90
-string_12.f90
-string_13.f90
-string_14.f90
-string_15.f90
-string_16.f90
-string_17.f90
-string_19.f90
-string_20.f90
-string_21.f90
-string_22.f90
-string_23.f90
-string_24.f90
-string_27.f90
-string_29.f90
-string_30.f90
-string_31.f90
-string_32.f90
-string_34.f90
-string_36.f90
-string_37.f90
-string_38.f90
-string_39.f90
-string_40.f90
-string_42.f90
-string_43.f90
-string_45.f90
-string_46.f90
-string_47.f90
-string_48.f90
-string_49.f90
-string_50.f90
-string_52.f90
-string_53.f90
-string_54.f90
-string_56.f90
-string_57.f90
-string_58.f90
-string_59.f90
-string_60.f90
-string_61.f90
-string_62b.f90
-string_62.f90
-string_63.f90
-string_64.f90
-string_65.f90
-string_66.f90
-string_68.f90
-string_69.f90
-string_71.f90
-string_72.f90
-string_73.f90
-string_74.f90
-string_75.f90
-string_76.f90
-string_77.f90
-string_78.f90
-string_79.f90
-string_80.f90
-string_81.f90
-string_82.f90
-string_83.f90
-string_84.f90
-string_85.f90
-string_87.f90
-string_88.f90
-string_89.f90
-string_90.f90
-string_91.f90
-string_92.f90
-string_93.f90
-string_94.f90
-string_95.f90
-string_96.f90
-string_97.f90
-string_99.f90
-string_array_concat_01.f90
-string_concat_deferred_len.f90
-str_to_char.f90
-struct_allocate.f90
-struct_type_01.f90
-struct_type_02.f90
-struct_type_03.f90
-struct_type_04.f90
-struct_type_05.f90
-struct_type_06.f90
-struct_type_07.f90
-struct_type_08.f90
-struct_type_09.f90
-struct_type_10.f90
-struct_type_11.f90
-struct_type_12.f90
-struct_type_13.f90
-submodule_01.f90
-submodule_06.f90
-submodule_10.f90
-submodule_13.f90
-submodule_15.f90
-submodule_16.f90
-submodule_17.f90
-submodule_18a.f90
-submodule_18c.f90
-submodule_19a.f90
-submodule_19b.f90
-submodule_19c.f90
-submodule_20a.f90
-submodule_20c.f90
-submodule_21a.f90
-submodule_21c.f90
-submodule_22.f90
-submodule_23a.f90
-submodule_23c.f90
-submodule_24.f90
-submodule_25a.f90
-submodule_25c.f90
-submodule_27a.f90
-submodule_27c.f90
-submodule_29a.f90
-submodule_29c.f90
-submodule_29d.f90
-submodule_30a.f90
-submodule_30c.f90
-submodule_30d.f90
-submodule_31.f90
-submodule_32.f90
-submodule_33.f90
-submodule_34a.f90
-submodule_34b.f90
-submodule_37a.f90
-submodule_37c.f90
-submodule_37d.f90
-submodule_38a.f90
-submodule_38c.f90
-submodule_39a.f90
-submodule_39c.f90
-submodule_40a.f90
-submodule_40c.f90
-submodule_41.f90
-submodule_43.f90
-submodule_44a.f90
-submodule_44b.f90
-submodule_46.f90
-submodule_48.f90
-submodule_49.f90
-submodule_50a.f90
-submodule_50c.f90
-submodule_51a.f90
-submodule_51b.f90
-submodule_53a.f90
-submodule_53b.f90
-submodule_54.f90
-submodule_55.f90
-subroutines_03.f90
-subroutines_05.f90
-subroutines_06.f90
-subroutines_09.f90
-subroutines_10.f90
-subroutines_11.f90
-subroutines_13.f90
-subroutines_15.f90
-subroutines_16.f90
-subroutines_17.f90
-subroutines_18.f90
-subroutines_20.f90
-substring_read.f90
-sum_01.f90
-sum_03.f90
-symbol_table_jloop_01.f90
-sync_all_02.f90
-template_02.f90
-template_03b.f90
-template_03.f90
-template_04.f90
-template_05.f90
-template_07.f90
-template_add_01b.f90
-template_add_01c.f90
-template_add_01.f90
-template_add_02.f90
-template_add_03.f90
-template_add_04.f90
-template_array_01.f90
-template_array_02.f90
-template_array_03.f90
-template_array_04b.f90
-template_array_04.f90
-template_array_05.f90
-template_commutative.f90
-template_field.f90
-template_interface_01.f90
-template_intrinsic_func_01.f90
-template_intrinsic_op_01.f90
-template_lapack_01.f90
-template_matrix_01.f90
-template_matrix.f90
-template_matrix_test.f90
-template_monoid.f90
-template_nested.f90
-template_semigroup.f90
-template_simple_01.f90
-template_simple_02.f90
-template_simple_03.f90
-template_simple_04.f90
-template_sort_01.f90
-template_sort_02.f90
-template_struct_01.f90
-template_travel_01b.f90
-template_travel_01.f90
-template_travel_02.f90
-template_triple.f90
-template_unitring.f90
-template_vector.f90
-test_backspace_01.f90
-test_call_arg_structinstance_member.f90
-test_dshiftr.f90
-test_endfile_01.f90
-test_endfile_02.f90
-test_endfile_03.f90
-test_format_inf_nan.f90
-test_ieee_arithmetic_03.f90
-test_ieee_arithmetic_04.f90
-test_ieee_arithmetic.f90
-test_ieee_arithmetic_fast_01.f90
-test_ieee_copy_sign.f90
-test_ieee_inf_nan_01.f90
-test_ieee_infnan.f90
-test_ieee_int.f90
-test_ieee_is_finite.f90
-test_ieee_is_negative.f90
-test_ieee_is_normal.f90
-test_ieee_logb.f90
-test_ieee_nan_value.f90
-test_ieee_next_down.f90
-test_ieee_next.f90
-test_ieee_next_up.f90
-test_ieee_real.f90
-test_ieee_rem.f90
-test_ieee_rint.f90
-test_ieee_scalb.f90
-test_ieee_support.f90
-test_ieee_underflow_mode.f90
-test_ieee_unordered.f90
-test_ieee_value_01.f90
-test_inquire_size.f90
-test_iso_c_binding_constants.f90
-test_ord.f90
-test_rep.f90
-test_str.f90
-test_unsigned.f90
-transfer_01.f90
-transfer_02.f90
-transfer_03.f90
-transfer_04.f90
-transfer_05.f90
-transfer_06.f90
-transfer_07.f90
-transfer_08.f90
-transfer_09.f90
-transfer_10.f90
-transfer_11.f90
-transfer_12.f90
-transfer_13.f90
-transfer_14.f90
-transfer_15.f90
-transfer_16.f90
-transfer_17.f90
-transfer_18.f90
-transfer_19.f90
-transfer_20.f90
-transfer_21.f90
-transfer_22.f90
-transfer_23.f90
-transfer_24.f90
-transfer_25.f90
-transfer_26.f90
-transfer_27.f90
-transfer_28.f90
-transfer_29.f90
-transfer_assumed_shape_01.f90
-tsunami.f90
-tuple_test_01_.f90
-tuple_test_02_.f90
-tuple_test_03_.f90
-tuple_test_04_.f90
-tuple_test_concat_.f90
-tuple_test_nested_.f90
-type_bound_generic_member_access_01.f90
-type_bound_generic_member_access_02.f90
-type_bound_generic_member_access_03.f90
-type_parameter_inquiry_01.f90
-types_01.f90
-types_02.f90
-types_06.f90
-types_07.f90
-types_09.f90
-types_13.f90
-types_15.f90
-types_17.f90
-types_21.f90
-types_22.f90
-types_23.f90
-types_24.f90
-types_real_array_to_complex_array_cast.f90
-union_test_01.f90
-union_test_02.f90
-union_test_03.f90
-unpack_scalar_field_01.f90
-unpack_scalar_field_02.f90
-use_02.f90
-use_03.f90
-use_04.f90
-value_attribute_01.f90
-verify_intent_external_01.f90
-verify_intent_external_01_mod2.f90
-where_01.f90
-where_02.f90
-where_03.f90
-where_04.f90
-where_05.f90
-where_06.f90
-where_07.f90
-where_08.f90
-where_09.f90
-where_10.f90
-where_11.f90
-where_12.f90
-where_13.f90
-where_14.f90
-where_15.f90
-where_16.f90
-where_17.f90
-while_02.f90
-while_03.f90
-while_05.f90
-write_01.f90
-write_02.f90
-write_03.f90
-write_04.f90
-write_05.f90
-write_06.f90
-write_07.f90
-write_08.f90
-write_09.f90
-write_10.f90
-write_11.f90
-write_13.f90
-write_15.f90
-write_16.f90
-write_17.f90
-write_18.f90
-write_19.f90
-write_19_module.f90
-write_20.f90
-write_21.f90
-write_22.f90
-write_23.f90
-write_24.f90
-write_25.f90
-write_26.f90
-write_28.f90
-write_34.f90
-write_37.f90
-write_38.f90
-write_39.f90
-write_40.f90
-write_41.f90
-write_42.f90
-write_43.f90
-write_fortran_01.f90
-write_fortran_02.f90
-write_implied_do_1.f90
-write_substr_01.f90
+abs_04.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+abs_06.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+allocatable_cchar_01.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+allocatable_component_assign_recursive_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+allocatable_component_reshape_unallocated_01.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+allocatable_component_struct_array_01.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+allocatable_component_struct_array_02.f90 # owner=lazy-fortran/ffc#404; reason=fold typed component default initializers
+allocatable_component_unnamed_unallocated_01.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+allocatable_derived_array_01.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocatable_dummy_descriptor_01.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+allocatable_lhs_finalization_01.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+allocatable_oob_01.f90 # owner=lazy-fortran/ffc#349; reason=migrate deferred scalar character storage
+allocatable_polymorphic_assign_01.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+allocatable_polymorphic_assign_02.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+allocatable_polymorphic_assign_03.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+allocatable_polymorphic_mold_01.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+allocatble_c_ptr.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+allocate_01.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+allocate_02.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+allocate_03.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+allocate_04.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+allocate_05.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+allocate_06.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+allocate_07.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+allocate_08.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_10.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_11.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+allocate_12.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+allocate_14.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+allocate_15.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+allocate_16.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+allocate_17.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_18.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+allocate_19.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_20.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+allocate_21.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_22.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_23.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+allocate_24.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_26.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_27.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+allocate_29.f90 # owner=lazy-fortran/ffc#349; reason=migrate deferred scalar character storage
+allocate_30.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_31.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+allocate_32.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+allocate_33.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_35.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+allocate_36.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+allocate_38.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+allocate_39.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+allocate_40.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_41.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_42.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_43.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+allocate_44.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+allocate_45.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_46.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_48.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_49.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_51.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_52.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_53.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+allocate_54.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+allocate_55.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+allocate_56.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_57.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+allocate_58.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_59.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+allocate_60.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+allocate_61.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+allocate_61_mod2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+allocate_62.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+allocate_63.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_66.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_67.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+allocate_69.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_70.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+allocate_72.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+allocate_73.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+allocated_01.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+allocated_04.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+allocated_05.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+allocate_source_ptr_01.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+any_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+any_02.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_01_pack.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+array_01_transfer.f90 # owner=lazy-fortran/ffc#435; reason=lower sized and array-valued TRANSFER
+array_02_pack.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+array_02_transfer.f90 # owner=lazy-fortran/ffc#435; reason=lower sized and array-valued TRANSFER
+array_03.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+array_03_pack.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+array_04_all.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+array_04_pack.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+array_04_transfer.f90 # owner=lazy-fortran/ffc#435; reason=lower sized and array-valued TRANSFER
+array_05_transfer.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+array_06_transfer.f90 # owner=lazy-fortran/ffc#435; reason=lower sized and array-valued TRANSFER
+array_07_transfer.f90 # owner=lazy-fortran/ffc#435; reason=lower sized and array-valued TRANSFER
+array_08_transfer.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+array_bound_3.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+array_bound_6.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+array_bound_7.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+array_concat.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+array_constructor_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_constructor_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_constructor_04.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+array_constructor_05.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+array_constructor_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_constructor_07.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+array_indices_array_item_assignment_1.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_indices_array_item_assignment_2.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+array_indices_array_item_assignment_3.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+array_indices_array_item_assignment_4.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+array_indices_array_item_assignment.f90 # owner=lazy-fortran/ffc#418; reason=lower vector-subscript assignment as alias-safe scatter
+array_indices_array_item.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+array_indices_array_section_assignment.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_indices_array_section.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+array_init.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+arrayitem_01.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+array_neg_extent_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+array_op_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_op_04.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+array_op_05.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+array_op_06.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+array_op_07.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+array_op_08.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+array_op_09.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+array_op_10.f90 # owner=lazy-fortran/ffc#418; reason=lower vector-subscript assignment as alias-safe scatter
+array_op_12.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+array_op_13.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+array_reshape_pad_01.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_01_complex.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_01_logical.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_01_multi_dim.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_01_size.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+arrays_02_size.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+arrays_03_size.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+arrays_04_func.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_04_func_pass_arr_dims.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_04_size.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+arrays_05_size.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+arrays_06.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_07.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_08_size.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+arrays_09.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_100.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+arrays_101.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+arrays_102.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+arrays_103.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+arrays_104.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_105.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_106.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+arrays_107.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_108.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+arrays_10.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+arrays_10_size.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_110.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+arrays_111.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+arrays_112.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+arrays_113.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+arrays_114.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+arrays_115.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+arrays_116.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_117.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_118.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+arrays_119.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_120.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_123.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+arrays_125.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+arrays_126.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_12.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+arrays_12_size.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+arrays_13.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+arrays_13_size.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_14.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+arrays_15.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_20.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+arrays_21.f90 # owner=lazy-fortran/ffc#343; reason=lower reductions through descriptor iteration
+arrays_23.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_25.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_26.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+arrays_28.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+arrays_29.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_30.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_32.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_33.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+arrays_34.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+arrays_36.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+arrays_37.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_38.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_39.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+arrays_40.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_41.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+arrays_42.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+arrays_43.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_44.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+arrays_49.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+arrays_51.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+arrays_52.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_54.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_55.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_56.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+arrays_57.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_58.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_59.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_60.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_61.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+arrays_62.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_63.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_64.f90 # owner=lazy-fortran/ffc#418; reason=lower vector-subscript assignment as alias-safe scatter
+arrays_65.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_66.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+arrays_67.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_68.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_69.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_70.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+arrays_71.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+arrays_72.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+arrays_73.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+arrays_74.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+arrays_75.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_76.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_77.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+arrays_78.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_79.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+arrays_80.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+arrays_81.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_82.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_83.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+arrays_85.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+arrays_86.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+arrays_87.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+arrays_88.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+arrays_89.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_91.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_92.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+arrays_93.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+arrays_94.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+arrays_95.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+arrays_96.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+arrays_97.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+arrays_98.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+arrays_99.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_constructor_01.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+array_section_01.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_section_02.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+array_section_03.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+array_section_04.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+array_section_05.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+array_section_06.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+array_section_07.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_section_08.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_section_10.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_section_11.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+array_section_12.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_section_13.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+array_section_14.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_section_15.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_section_16.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+array_section_17.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_section_18b.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+array_section_18.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+array_section_19.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_section_20.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+array_section_21.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_section_22.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+array_section_23.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_section_26.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+array_section_27.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+array_section_27_mod.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_section_28.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+array_section_29.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+array_section_assign_01.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+array_section_is_non_allocatable.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_elemental_15.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+array_shape_func_call.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+arrays_intrin_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+arrays_intrin_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_intrin_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_intrin_06.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+arrays_intrin_07.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_intrin_08.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_intrin_09.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+array_slice_01.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+array_slice_02.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+array_slice_04.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_op_10.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+arrays_op_11.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_op_12.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_op_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_op_14.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_op_15.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+arrays_op_16.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_op_17.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_op_18.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+arrays_op_19.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_op_1.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+arrays_op_20.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_op_21.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_op_22.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_op_23.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_op_24.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_op_25.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_op_26.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+arrays_op_27.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+arrays_op_28.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+arrays_op_29.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_op_30.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+arrays_op_31.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+arrays_op_3.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+arrays_op_4.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+arrays_op_5.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+arrays_op_6.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+arrays_op_8.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_op_9.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+arrays_reshape_14.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_reshape_15.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_reshape_16.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+arrays_reshape_17.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_reshape_18.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_reshape_19.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_reshape_20.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_reshape_21.f90 # owner=lazy-fortran/ffc#356; reason=resolve leading-dimension dummies
+arrays_reshape_22.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+arrays_reshape_23.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+arrays_reshape_24.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+arrays_reshape_27.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_reshape_28.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_reshape_29.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_reshape_30.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_reshape_31.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+arrays_reshape_32.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_reshape_33.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+arrays_reshape_34.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+arrays_reshape_35.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+arrays_reshape_36.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+arrays_reshape_37.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+arrays_reshape_38.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+arrays_reshape_39.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_reshape_40.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_reshape_41.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+arrays_reshape_42.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+arrays_reshape_43.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+arrays_reshape_44.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+array_unbounded_01.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+array_unbounded_02.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+assign_allocatable_array_of_struct_instances.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+assign_to1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+assign_to2.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+associate_01.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+associate_02.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+associate_04.f90 # owner=lazy-fortran/ffc#331; reason=bind BLOCK and ASSOCIATE storage scopes
+associate_05.f90 # owner=lazy-fortran/ffc#331; reason=bind BLOCK and ASSOCIATE storage scopes
+associate_06_module.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+associate_08.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+associate_09.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_10.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+associate_12.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+associate_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_14.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+associate_15.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+associate_16.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+associate_17.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+associate_19.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_20.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_21.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+associate_21_mod.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+associate_22.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+associate_23.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+associate_24.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+associate_25.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+associate_26.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+associate_27.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+associate_28.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+associate_29.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+associate_30.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+associate_31.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+associate_32.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+associate_33.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+associate_34.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_36.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+associate_37.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+associate_38.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+associate_39.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+associate_40.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+associate_41.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+associate_42.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_43.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_45.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+associate_46.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+associate_47.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+associate_48.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_49.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+associate_50.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+associate_52.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+associate_53.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+associate_54.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+assumed_length_return_01.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+assumed_rank_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+assumed_rank_02.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+assumed_rank_03.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+assumed_rank_04.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+assumed_rank_05.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+assumed_rank_06.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+assumed_rank_07.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+assumed_rank_08.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+assumed_rank_09.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+assumed_rank_10.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+assumed_type_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+assumed_type_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+assumed_type_03.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+assumed_type_04.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+assumed_type_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+assume_rank_shape_product_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+attr_dim_01.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+attr_dim_03.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+attr_intrinsic.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+automatic_allocation_02.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+bindc_01.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+bindc_02b.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+bindc_02.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+bindc_03.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+bindc_04.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+bindc_05.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+bindc_06.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+bindc_07.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bindc_08.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bindc_09.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+bindc_10.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+bindc_11.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+bindc_12.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bindc_14.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+bindc_15.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+bindc_17.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+bindc_18.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bindc_19.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+bindc2.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+bindc_35.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+bindc_38.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bindc_39.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+bindc3.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+bindc_43.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bindc_45.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+bindc_46.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+bindc_47.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+bindc_49.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bindc4.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+bindc_51.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+bindc5.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+bindc6.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bindc_assumed_rank_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bindc_iso_fb_01.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+bindc_iso_fb_02.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+bindc_iso_fb_03.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+bindc_iso_fb_04.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+bindc_iso_fb_05.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+bindc_iso_fb_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bindc_iso_fb_07.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bindc_iso_fb_08.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+binop_01.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+binop_02.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+binop_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bin_op_complex_dp.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+binop_of_struct_instance_in_function_call.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+bin_op_real_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bin_op_real_02.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+bin_op_real_dp.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bits_02.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+bits_03.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+bits_04.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+bits_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+bits_07.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+block_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+block_02.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+block_03.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+block_04.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+block_05.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+block_07.f90 # owner=lazy-fortran/ffc#331; reason=bind BLOCK and ASSOCIATE storage scopes
+block_08.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+block_10.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+block_11.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+block_12.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+block_13.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+block_14.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+block_15.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+block_17.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+block_data_04.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+block_data_string_01.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+block_data_string_02.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+block_data_string_03.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+block_data_string_04.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+boz_02.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+callback_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+callback_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+callback_03.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+callback_04.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+callback_05.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+callback_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+call_subroutine_without_type_01.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+call_subroutine_without_type.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+case_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+case_05.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+case_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+case_08.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+c_f_proc_ptr_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+character_01.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+character_02.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+character_06.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+character_08.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+character_09.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+character_10.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+character_11.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+character_12.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+character_13.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+character_14.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+character_16.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+character_17.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+character_18.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+character_20.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+character_21.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+character_22.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+character_23.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+character_24.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+character_25.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+character_26.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+character_27.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+character_28.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+character_29.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+character_30.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+character_31.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+character_32.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+character_array_block_padding.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+character_assignment_01.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+character_max_parameter_01.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_array_01.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_array_indexing_02.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+char_array_indexing.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_array_initialization_declaration_02.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+char_array_initialization_declaration.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+char_param_reshape_01.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+class_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+class_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+class_03.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+class_05.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_08.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+class_09.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_100.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_101.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_102.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_103.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+class_104.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+class_105.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_106a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_106b.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_106.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_107.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_109.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_10.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_110.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+class_110_module.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_111.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_112.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_113.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_114.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_115.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_116.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_117.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+class_118.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+class_11.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+class_120.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+class_121.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+class_122.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_123.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_124.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+class_127.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_128.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_129.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_12.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_130.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_131.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_132.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_133.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_134.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_135.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+class_137.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_138.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_139.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+class_13.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+class_140.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+class_141.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_142.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_143.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+class_144.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_147.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_148.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+class_149.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_15.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_16.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+class_17.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_18.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_19.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+class_21.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+class_23.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_24.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_25.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_26.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+class_27.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_28.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_29.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+class_31.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_32.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+class_34.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_35.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_36.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_37.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_38.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+class_39.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_40.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_41.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_42.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_43.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_44.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+class_45.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_46.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+class_47.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_48.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+class_49.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_50.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_51.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+class_52.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+class_53.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_54.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_55.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_56.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_57.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_58.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+class_59.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_60.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+class_61.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_62.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_63_module_2.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_64.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_65.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_66.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_67.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_68.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_69.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_70.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_71.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_72.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+class_73.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_74.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+class_75.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_76.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_77.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_78.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_79.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_80.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_81.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+class_82.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_83.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+class_84.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+class_85.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_86.f90 # owner=lazy-fortran/ffc#365; reason=deep-copy allocatable derived components
+class_87.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_88.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+class_89.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_90.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+class_91.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_92.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+class_93.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+class_94.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+class_95.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_96.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_97.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_allocate_01.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+class_allocate_02.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_allocate_03.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_allocate_04.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+class_allocate_05.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_allocate_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_allocate_07.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+class_allocate_08.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+class_array_deepcopy_01.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+class_optional_01.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+class_procedure_args_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+class_star_pointer_01.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+cmake_minimal_test_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+cmd_01.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+cmd_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+cmd_03.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+coarray_01.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+common_03.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_07.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_16.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_19.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_21.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_24.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+common_28.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_31.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_32.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_36.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+common_37.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_38.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_40.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+common_substring_01.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+compiler_version_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+compiler_version_02.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+compiler_version_03.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+complex_03.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+complex_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+complex_07.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+complex_08.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+complex_09.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+complex_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+complex_11.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+complex_15.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+complex_16.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+complex_17.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+complex_18.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+complex_19.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+complex_21.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+complex_22.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+complex_23.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+complex_24.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+complex_25.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+complex_26.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+complex_28.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+complex_29.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+complex_31.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+complex_33.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+complex_34.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+complex_35.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+complex_36.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+complex_array_member_access.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+complex_cloc_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+complex_div_test.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+complex_implicit_cast.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+complex_pow_test.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+complex_solutions.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+complex_unary_minus_03.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+concat_char_arrays_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+cond_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+cond_04.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+cond_05.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+contig_stmt_01.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+conv_complex2real.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+count_param_01.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+cpp_pre_01.f90 # scope=legacy; reason=legacy or preprocessed source form
+cpp_pre_06.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+cpp_pre_07.f90 # scope=legacy; reason=legacy or preprocessed source form
+cpp_pre_08.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+cpp_pre_12.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+cpp_pre_14.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+cpp_pre_15.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+c_ptr_01.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+c_ptr_02.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+c_ptr_03.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+c_ptr_04.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+c_ptr_05.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+c_ptr_06.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+c_ptr_07.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+c_ptr_08.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+c_ptr_10.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+c_ptr_11.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+c_ptr_12.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+c_ptr_13.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+c_ptr_14.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+c_ptr_15.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+c_ptr_16.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+c_ptr_16_module.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+c_ptr_17.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+c_ptr_17_module.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+cpu_time_01.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+c_sizeof_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+c_sizeof_03.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+c_sizeof_04.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+c_sizeof_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+c_sizeof_06.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+custom_operator_01.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+custom_operator_02.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+custom_operator_03.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+custom_operator_04.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+custom_operator_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+custom_operator_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+custom_operator_07.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+custom_operator_08.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+custom_operator_09.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+custom_operator_10.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+custom_operator_11.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+custom_operator_12.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+custom_operator_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+custom_operator_14.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+custom_operator_15.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+custom_operator_16.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+custom_operator_17.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+custom_operator_18.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+custom_operator_19.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+custom_unary_operator_01.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+custom_unary_operator_02.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+cycle_and_exit1.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+cycle_and_exit2.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+cycle_and_exit4.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+cycle_and_exit5.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+dabs_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+data_02.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+data_03.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+data_05.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+data_06.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+data_07.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+data_11.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+data_12.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+data_14.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+data_16.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+data_17.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+data_18.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+data_19.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+data_20.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+data_21.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+data_22.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+data_23.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+data_implied_do_07.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+data_implied_do_08.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+data_implied_do_09.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+datastmt_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+dealloc_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dealloc_02.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+dealloc_03.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+dealloc_04.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+dealloc_05.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+dealloc_06.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+deallocate_01.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+deallocate_02.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+declaration_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+declaration_04.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+deferred_shape_01.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+defined_op_match_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+derived_component_section_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+derived_component_section_02.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+derived_type_c_funptr_array_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_type_member_procedure_call_01.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_type_member_procedure_call_02.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+derived_types_01.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_02.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+derived_types_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_09b.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_09.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+derived_types_100.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+derived_types_101.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+derived_types_102.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+derived_types_103.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+derived_types_104.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+derived_types_105.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+derived_types_106.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+derived_types_107.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+derived_types_108.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+derived_types_109.f90 # owner=lazy-fortran/ffc#371; reason=distinguish valid and ambiguous USE renames
+derived_types_10.f90 # owner=lazy-fortran/ffc#404; reason=fold typed component default initializers
+derived_types_110.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+derived_types_111.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+derived_types_112.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+derived_types_113.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+derived_types_114.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+derived_types_114_module.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+derived_types_115.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_116.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_117.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_118.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+derived_types_119.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_11.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_120.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+derived_types_121.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+derived_types_122.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_124.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+derived_types_125.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+derived_types_126.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_127.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_128.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_129.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_12.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_130.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_131.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_132.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+derived_types_134.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_134_module.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_135.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+derived_types_137.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_138.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_139.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+derived_types_13.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+derived_types_140.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_141.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_142.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+derived_types_143.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+derived_types_144.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_145.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+derived_types_146.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_147.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_148.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_14.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_15.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+derived_types_17.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+derived_types_18.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_19.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+derived_types_19_module.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+derived_types_20.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+derived_types_20_module1.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+derived_types_21.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_24.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_25.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+derived_types_26.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+derived_types_27.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+derived_types_28.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+derived_types_29.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_30.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_31.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+derived_types_32.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+derived_types_33.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_34.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+derived_types_35.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+derived_types_36.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+derived_types_37.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+derived_types_38.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+derived_types_39.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_40.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_41.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_42.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_43.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+derived_types_44.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+derived_types_46.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_50.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+derived_types_51.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+derived_types_52.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+derived_types_53.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_55.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_56.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+derived_types_60.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_61.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+derived_types_62.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+derived_types_63.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_64.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_65.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+derived_types_67.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+derived_types_69.f90 # owner=lazy-fortran/ffc#404; reason=fold typed component default initializers
+derived_types_70.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_71.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_72.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+derived_types_73.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_74.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+derived_types_75.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+derived_types_76.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_77.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+derived_types_78.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+derived_types_79.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_80.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+derived_types_81.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_82.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+derived_types_83.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_84.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_85.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+derived_types_86.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_87.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+derived_types_88.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_89.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+derived_types_90.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_91.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_92.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+derived_types_93.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+derived_types_94.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+derived_types_95.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+derived_types_96.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_97.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+derived_types_97_mod2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_types_98.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+derived_types_99.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+derived_types_apply_clip_01.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+derived_type_shape_pointer_01.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+derived_type_shape_pointer_02.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+derived_type_shape_pointer_03.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+derived_type_target_arg_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+derived_type_target_arg_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dfloat_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+dict_test_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+dict_test_01_.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+dict_test_02_.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+dict_test_03_.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dict_test_04_.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dict_test_07_.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dict_test_13_.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+dlaswap.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+do_concurrent_03.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+do_concurrent_04.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+do_concurrent_05.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+do_concurrent_06.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+do_concurrent_07.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+do_concurrent_08.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+do_concurrent_09.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+do_concurrent_10.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+do_concurrent_11.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+do_concurrent_12.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+do_concurrent_13.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+doconcurrentloop_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+do_loop_01.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+do_loop_02.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+doloop_03.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+do_loop_04.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+doloop_04.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+do_loop_05.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+do_loop_07.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+doloop_07.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+do_loop_08.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+doloop_08.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+do_loop_09.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+doloop_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+doloop_13.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+doloop_18.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+doloop_19.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+elemental_01.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+elemental_02.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+elemental_03.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+elemental_04.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+elemental_05.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+elemental_06.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+elemental_07.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+elemental_08.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+elemental_09.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+elemental_10.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+elemental_11.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+elemental_12.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+elemental_13.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+elemental_14.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+elemental_15.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+elemental_16.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+elemental_17.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+elemental_18.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+elemental_19.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+elemental_20.f90 # owner=lazy-fortran/ffc#405; reason=lower ELEMENTAL scalar procedure semantics
+elemental_21.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+elemental_22.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+elemental_23.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+elemental_function_overloaded_compare.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+elemental_function_scalar_array_arg.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+empty_array_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+empty_array_03.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+entry_01.f90 # owner=lazy-fortran/ffc#456; reason=lower procedure ENTRY points
+entry_02.f90 # owner=lazy-fortran/ffc#456; reason=lower procedure ENTRY points
+entry_03.f90 # owner=lazy-fortran/ffc#456; reason=lower procedure ENTRY points
+entry_04.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+entry_05.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+entry_06.f90 # owner=lazy-fortran/ffc#456; reason=lower procedure ENTRY points
+entry_07.f90 # owner=lazy-fortran/ffc#456; reason=lower procedure ENTRY points
+entry_08.f90 # owner=lazy-fortran/ffc#456; reason=lower procedure ENTRY points
+entry_09.f90 # owner=lazy-fortran/ffc#456; reason=lower procedure ENTRY points
+entry_10.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+entry_11.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+entry_12.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+entry_13.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+entry_14.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+entry_15.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+entry_16.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+entry_17.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+entry_18.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+entry_19.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+entry_20.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+entry_21.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+enum_02.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+enum_03.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+enum_04.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+enum_06.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+enum_07.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+enum_07_submodule.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+equivalence_01.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_02.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+equivalence_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+equivalence_04.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+equivalence_05.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_06.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+equivalence_07.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+equivalence_08.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_09.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_10.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_11.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_12.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_13.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_14.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_15.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_16.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_17.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_18.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+equivalence_20.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_21.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_22.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_23.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_24.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_25.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_28.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_29.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_30.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+equivalence_31.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+equivalence_32.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_33.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_34.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_35.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_36.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+equivalence_37.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+error_stop_01.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+error_stop_02.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+error_stop_03.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+error_stop_04.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+exit_01.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+exponent_inf_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+expr_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+expr_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+expr_09.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+expr_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+expr_17.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+expr_19.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+expr_21.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+external_05.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+external_07.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+external_08.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+external_12.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+external_12_module.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+external_13.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+external_14.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+external_14_module.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+external_15.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+external_16.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+external_string_arg_01.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+file_01.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_02.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_03.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_04.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_05.f90 # owner=lazy-fortran/ffc#343; reason=lower reductions through descriptor iteration
+file_06.f90 # owner=lazy-fortran/ffc#343; reason=lower reductions through descriptor iteration
+file_07.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+file_08.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_09.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+file_10.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_11.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_12.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_13.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_14.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+file_15.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_16.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_17.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_18.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_19.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_20.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_21.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_22.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_23.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+file_24.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_25.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_26.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+file_27.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_28.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+file_29.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_30.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_31.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_32.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_33.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_34.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_35.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_36.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_38.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_39.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_40.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_41.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_42.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_43.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_44.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+file_45.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+file_46.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_47.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_48.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+file_49.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_50.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_51.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+file_52.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_53.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+file_54.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_55.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_56.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_57.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+file_58.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+file_59.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_60.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_61.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_62.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_63.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_65.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_66.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+file_67.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_69.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_70.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+file_71.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_72.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_73.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_close_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+file_close_02.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_open_01.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_open_05.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+file_open_07.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_open_08.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+file_open_09.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+file_open_10.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+file_overwrite.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+finalization_02.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalization_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+finalization_04.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalization_05.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+finalization_06.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+finalization_07.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+fixed_form_do_name_01.f90 # scope=legacy; reason=legacy or preprocessed source form
+fixed_form_goto.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+fixed_form_io_keyword_02.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+fixed_form_select_case_01.f90 # scope=legacy; reason=legacy or preprocessed source form
+fixed_form_select_case_02.f90 # scope=legacy; reason=legacy or preprocessed source form
+fixed_form_select_rank_01.f90 # scope=legacy; reason=legacy or preprocessed source form
+fixed_form_stmt_func_01.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+fixed_form_where_01.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+floor_01.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+floor_02.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+flush_02.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+flush_05.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+fma_03.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+fma.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+forall_04.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+format_01.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_02.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_04.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_05.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_06.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_07.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_08.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+format_08s.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+format_09.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+format_100.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+format_101.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_102.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_103.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_104.f90 # owner=lazy-fortran/ffc#366; reason=implement internal E and X formatting
+format_105.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+format_10.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_11.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_12.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_14.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_15.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_16.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_17.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_18.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+format_19.f90 # owner=lazy-fortran/ffc#366; reason=implement internal E and X formatting
+format_20.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+format_21.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_22.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_23.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_24.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_25.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_26.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_27.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_28.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+format_29.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_30.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_31.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_32.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_33.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+format_34.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+format_35.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+format_36.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_37.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_38.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_39.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_41.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_42.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_43.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_44.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_45.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+format_46.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+format_47.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+format_48.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+format_49.f90 # owner=lazy-fortran/ffc#366; reason=implement internal E and X formatting
+format_50.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_51.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_52.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+format_53.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+format_54.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+format_56.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_57.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+format_58.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+format_59.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_60.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+format_61.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_62.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+format_63.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+format_64.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_65.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_66.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+format_67.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+format_68.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+format_69.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+format_70.f90 # owner=lazy-fortran/ffc#366; reason=implement internal E and X formatting
+format_71.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+format_72.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+format_73.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+format_74.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+format_75.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_76.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+format_77.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+format_78.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+format_79.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+format_80.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_81.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_82.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+format_83.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+format_84.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_85.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+format_86.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_87.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_88.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+format_89.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+format_90.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_91.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_92.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_93.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_98.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_99.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_before_read_01.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+format_quotes_01.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+formatted_read_01.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+formatted_read_02.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+formatted_read_03.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+formatted_read_04.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+formatted_read_05.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+formatted_read_06.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+formatted_read_07.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+fortran_primes_01.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+fortuno_01.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+func_call_in_decl_01.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+func_parameter_type_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+functions_03.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+functions_06.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+functions_09.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+functions_10.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+functions_11.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+functions_12.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+functions_13.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+functions_15.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+functions_16.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+functions_18.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+functions_19.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+functions_20.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+functions_21.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+functions_22.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+functions_23.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+functions_24.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+functions_25.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+functions_26.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+functions_27.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+functions_28.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+functions_29.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+functions_30.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+functions_31.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+functions_32.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+functions_33.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+functions_34.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+functions_35.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+functions_36.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+functions_37.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+functions_38.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+functions_40.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+functions_42.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+functions_43.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+functions_44.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+functions_45.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+functions_46.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+functions_47.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+functions_48.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+functions_49.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+functions_50.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+functions_51.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+functions_52.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+functions_54.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+functions_55.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+functions_56.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+functions_56_mod.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+functions_57.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+functions_58.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+functions_59.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+functions_61.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+generic_interface_function_call_of_function_call.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+generic_name_01.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+generic_name_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+generic_name_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+generic_name_04.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+generic_name_05.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+generic_name_06.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+generic_name_07.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+generic_name_08.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+global_allocatable_01.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+global_allocatable_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+global_array_pointer_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+global_array_pointer_02.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+goto_03.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+goto_05.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+goto_06.f90 # owner=lazy-fortran/ffc#354; reason=expand Fortran INCLUDE lines
+goto_gototarget_return_01.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+gpu_metal_100.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_101.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_102.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_103.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_104.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_105.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_106.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_109.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_110.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_112.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_113.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_114.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_115.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_116.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_118.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_119.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_120.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_121.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_122.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_123.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_124.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_125.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_127.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_128.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_133.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_134.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_135.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_136.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_137.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_139.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_13.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_140.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_142.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_142_mod.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_143.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_144.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_147.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_147_neural_network.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_148.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_150.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_151.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_152.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_154.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_157.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_158.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_159.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_160.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_162.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_163.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_164.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_165.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_166.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_167.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_168.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_170.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_171.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_172.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_174.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_175.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_176.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_177.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_179.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_180.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_181.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_182.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_183.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_184.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_185.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_188.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_190.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_191.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_192.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_193.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_194.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_195.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_23.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_26.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_27.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_28.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_29.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_30.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_31.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_33.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_35.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_36.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_37.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_38.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_39.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_40.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_41.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_43.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_44.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_46.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_47.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_49.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_50.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_51.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_52.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_53.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_54.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_55.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_56.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_57.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_58.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_60.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_61.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_62.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_63.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_64.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_65.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_67.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_68.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_69.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_70.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_71.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_73.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_74.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_75.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_76.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_77.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_78.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_80.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_81.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_84.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_85.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_86.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_87.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_90.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_91.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_92.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_94.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_95.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_96.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_97.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_98.f90 # scope=GPU; reason=excluded GPU or device-backend case
+gpu_metal_99.f90 # scope=GPU; reason=excluded GPU or device-backend case
+hashmap_derived_pointer_associated.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+hashmap_nested_dealloc_derived_pointer.f90 # owner=lazy-fortran/ffc#401; reason=lower scalar pointer components
+huge_string_read.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+if_02.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+if_03.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+if_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+if_label_01.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+ilp64_complex_literal_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+ilp64_file_ops_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+ilp64_kind_arg_01.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+ilp64_logical_read_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implicit_argument_casting_01.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+implicit_argument_casting_02.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+implicit_argument_casting_04.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+implicit_interface_01.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+implicit_interface_02.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+implicit_interface_03.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+implicit_interface_04.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+implicit_interface_08.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+implicit_interface_12.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implicit_interface_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implicit_interface_15b.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+implicit_interface_15.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+implicit_interface_16.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+implicit_interface_17.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+implicit_interface_19.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+implicit_interface_22.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+implicit_interface_23.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+implicit_interface_25.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+implicit_interface_26.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+implicit_interface_27.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+implicit_interface_28.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+implicit_interface_29b.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+implicit_interface_29.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+implicit_interface_30.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+implicit_interface_31.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+implicit_interface_32.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+implicit_interface_34.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+implicit_interface_35.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+implicit_interface_36.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+implicit_interface_37.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+implicit_interface_38.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implicit_interface_40.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+implicit_interface_41.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+implicit_typing_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+implicit_typing_03.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+implicit_typing_05.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+implicit_typing_08.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+implicit_typing_10.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+implicit_typing_11.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+implicit_typing_12.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+implied_do_loops10.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+implied_do_loops11.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+implied_do_loops12.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+implied_do_loops13.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+implied_do_loops14.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+implied_do_loops15.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+implied_do_loops16.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+implied_do_loops18.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+implied_do_loops19.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops20.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+implied_do_loops21.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops22.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+implied_do_loops23.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops24.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops25.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+implied_do_loops26.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops27.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops28.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops29.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops2.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+implied_do_loops30.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+implied_do_loops31.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+implied_do_loops32.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+implied_do_loops33.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops34.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+implied_do_loops35.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+implied_do_loops36.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+implied_do_loops37.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+implied_do_loops38.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops39.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+implied_do_loops3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops40.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+implied_do_loops41.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+implied_do_loops42.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+implied_do_loops43.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+implied_do_loops4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops5.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops6.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+implied_do_loops7.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+implied_do_loops8.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+implied_do_loops9.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+implied_do_loops_print.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+implied_do_loops_strings.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+include_01.f90 # owner=lazy-fortran/ffc#354; reason=expand Fortran INCLUDE lines
+include_02.f90 # owner=lazy-fortran/ffc#354; reason=expand Fortran INCLUDE lines
+include_04.f90 # owner=lazy-fortran/ffc#354; reason=expand Fortran INCLUDE lines
+infer_walrus_shadow_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+infer_walrus_shadow_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+infer_walrus_struct_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+init_values.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+inquire_02.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+inquire_03.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+inquire_04.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+inquire_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+inquire_06.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+inquire_07.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+inquire_08.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+inquire_09.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+inquire_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+inquire_11.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+inquire_12.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+inquire_13.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+inquire_14.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+inquire_unit_exist.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+insertion_sort_01.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+int_02.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+int_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+integer_boz_01.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intent_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intent_03.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intent_out_allocatable_component_dealloc.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+intent_out_allocatable_struct_with_components.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+intent_out_array_01.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+intent_out_array_of_struct_dealloc.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+intent_out_array_structs_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intent_out_finalize_01.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+intent_out_finalize_02.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+intent_out_finalize_03.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+intent_out_finalize_04.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+intent_out_module_dealloc.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+intent_out_nested_allocatable_01.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+intent_out_struct_member_no_dealloc.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+interface_01.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+interface_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+interface_04.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+interface_05.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+interface_07.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+interface_09.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+interface_11.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+interface_12a.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+interface_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+interface_14.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+interface_15.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+interface_16.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+interface_17.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+interface_18.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+interface_19.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+interface_30.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+interface_31.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+interface_32.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+interface_32_module.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+interface_33.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+internal_subr_assumed_size_01.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+intrinsic_reduce_01.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+intrinsic_reduce_derived_type_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_01.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+intrinsics_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_03.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_04.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_04s.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_06.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_07.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_100.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_102.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_103.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_104.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_105.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_106.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_107.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_108.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_109.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_110.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_111.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_112.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_113.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_114.f90 # owner=lazy-fortran/ffc#431; reason=lower AINT and ANINT kind conversions
+intrinsics_115.f90 # owner=lazy-fortran/ffc#431; reason=lower AINT and ANINT kind conversions
+intrinsics_116.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_117.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_118.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_119.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_120.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_121.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_122.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_123.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_124.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_125.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_126.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+intrinsics_127.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_128.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_129.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_12.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_130.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_131.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_132.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_133.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_134.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_135.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_136.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_137.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_138.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_139.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_140.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_141.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_142.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_143.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_144.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_145.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+intrinsics_146.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_147.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_148.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_149.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_14.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_150.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_151.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_152.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_153.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_154.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_155.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_156.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_157.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_158.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_159.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_15.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_160.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_161.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_162.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_163.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_164.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_165.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_166.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_167.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_168.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_169.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_16.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_170.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_171.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_172.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_173.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_174.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_175.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+intrinsics_176.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_177.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_178.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_179.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_17.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_180.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_181.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_182.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_183.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_184.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_185.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_187.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_188.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_189.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_18c.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_190.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_191.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_192.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_193.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+intrinsics_194.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_195.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_196.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_197.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_198.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_199.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+intrinsics_19c.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_19.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_200.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+intrinsics_201.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_202.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_203.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_204.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_205.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_206.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+intrinsics_207.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_208.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_209.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_210.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_211.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_212.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_213.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_214.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_215.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_216.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_217.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_218.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_219.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_21.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_220.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_221.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_222.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_223.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_224.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_225.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_226.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_227.f90 # owner=lazy-fortran/ffc#432; reason=lower NORM2 over descriptor arrays
+intrinsics_228.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_229.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_22.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_230.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_231.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_232.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_233.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_234.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_235.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_236.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+intrinsics_237.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_238.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_239.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_23.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_240.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_241.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_242.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_243.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_244.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+intrinsics_245.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_246.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_247.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_248.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+intrinsics_249.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_24.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_250.f90 # owner=lazy-fortran/ffc#343; reason=lower reductions through descriptor iteration
+intrinsics_251.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_252.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_253.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_254.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_255.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_256.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_257.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_258.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_259.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_25.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_260.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_261.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_262.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_263.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_264.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_265.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_266.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_267.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_268.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_269.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_270.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_271.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_272.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_273.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_274.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_275.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_276.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_277.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_278.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_279.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_27.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_280.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_281.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_282.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_283.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_284.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_285.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_286.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_288.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_289.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_290.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_291.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_293.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_294.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_295.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_296.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_297.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+intrinsics_298.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_29.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+intrinsics_300.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_301.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_302.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_303.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+intrinsics_304.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_305.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_306.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_307.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_308.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_309.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_30.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_311.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+intrinsics_312.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_313.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_314.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_315.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_316.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_317.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_319.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_31.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_320.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_321.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_322.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_323.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+intrinsics_325.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_326.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_327.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_328.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_329.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+intrinsics_330.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_331.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+intrinsics_332.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+intrinsics_333.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+intrinsics_334.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+intrinsics_335.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+intrinsics_336.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_337.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_338.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_339.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_33.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_340.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_341.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_342.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_343.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+intrinsics_344.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_345.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_346.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_347.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+intrinsics_348.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+intrinsics_349.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_34.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_350.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_351.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_352.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_353.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_354.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_355.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_356.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_357.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_358.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_359.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_35.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_360.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_361.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+intrinsics_362.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_363.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+intrinsics_365.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+intrinsics_366.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_367.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_368.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_369.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_36.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_370.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_371.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+intrinsics_372.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+intrinsics_373.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_374.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_375.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_376.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_377.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+intrinsics_378.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_379.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_37.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_380.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_381.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_382.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_383.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_384.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+intrinsics_385.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_386.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+intrinsics_387.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_388.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_389.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_38.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_390.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+intrinsics_391.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_392.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_393.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+intrinsics_394.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_395.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_396.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_397.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_398.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_39.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_400.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_401.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_402.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_403.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_405.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+intrinsics_406.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_409.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+intrinsics_40.f90 # owner=lazy-fortran/ffc#431; reason=lower AINT and ANINT kind conversions
+intrinsics_410.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_411.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_412.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_413.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_414.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_415.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_416.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_417.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_418.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+intrinsics_419.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+intrinsics_420.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_421.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_422.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+intrinsics_423.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+intrinsics_424.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+intrinsics_425.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+intrinsics_426.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_427.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_428.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_429.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_430.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+intrinsics_431.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_433.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_435.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_436.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_437.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_438.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_439.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_43.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_440.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_441.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_442.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_443.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+intrinsics_444.f90 # owner=lazy-fortran/ffc#431; reason=lower AINT and ANINT kind conversions
+intrinsics_446.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_447.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_448.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+intrinsics_449.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_44.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+intrinsics_450.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+intrinsics_451.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+intrinsics_452.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_453.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+intrinsics_454.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_456.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+intrinsics_457.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+intrinsics_459.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+intrinsics_45.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_460.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_461.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+intrinsics_462.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_463.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_464.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+intrinsics_466.f90 # owner=lazy-fortran/ffc#426; reason=lower CSHIFT and EOSHIFT
+intrinsics_467.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+intrinsics_468.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_469.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+intrinsics_46.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_48.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_49.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_50.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+intrinsics_51.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_52.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_53.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_54.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_55.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_56.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+intrinsics_57.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+intrinsics_58.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_59.f90 # owner=lazy-fortran/ffc#365; reason=deep-copy allocatable derived components
+intrinsics_60.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_61.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_62.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+intrinsics_63.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_64.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_65.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+intrinsics_67.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_68.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_69.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_70.f90 # owner=lazy-fortran/ffc#431; reason=lower AINT and ANINT kind conversions
+intrinsics_72.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_73.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_74.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+intrinsics_75.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+intrinsics_76.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+intrinsics_77.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+intrinsics_78.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_79.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_81.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+intrinsics_83.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_84.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_85.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_86.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_87.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+intrinsics_88.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+intrinsics_90.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+intrinsics_91.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+intrinsics_92.f90 # owner=lazy-fortran/ffc#431; reason=lower AINT and ANINT kind conversions
+intrinsics_93.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_96.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+intrinsics_97.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+intrinsics_98.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+intrinsics_99.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+intrinsics_open_close_read_write.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+io_direct_slash.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+ip_01.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+iso_c_binding_01.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+iso_c_binding_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+iso_c_binding_04.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+iso_c_binding_05.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+iso_c_binding_07.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+iso_fortran_env_01.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+iso_fortran_env_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+iso_fortran_env_03.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+iso_fortran_env_04.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+kinds_01.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+kinds_02.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+kinds_03.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+kwargs_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+kwargs_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+label_01.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
+la_constants.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+lapack_01.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+lapack_06.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+lapack_07.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+lapack_08.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+lapack_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+lbound_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+lbound_02.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+legacy_array_sections_02.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+legacy_array_sections_04.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+legacy_array_sections_05.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+legacy_array_sections_06.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+legacy_array_sections_07.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+legacy_array_sections_08.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+legacy_array_sections_09.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+legacy_array_sections_10.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+legacy_array_sections_11.f90 # scope=legacy; reason=legacy or preprocessed source form
+legacy_array_sections_12.f90 # scope=legacy; reason=legacy or preprocessed source form
+legacy_array_sections_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+legacy_array_sections_15.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+legacy_array_sections_18.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+legacy_array_sections_19.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+legacy_array_sections_21.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+lfortran_intrinsic_sin.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+line_continuation_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+line_continuation_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+line_continuation_04.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+line_continuation_05.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+list_directed_stdin_eof_01.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+list_of_lists_test.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+list_of_tuples_test.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+list_test_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+list_test_01_.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+list_test_02_.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+list_test_03_.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+list_test_04_.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+list_test_06_.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+list_test_08_.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+list_test_09_.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+logical3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+logical4.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+logical_arrays_logical_binop_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+logical_casting_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+logical_kind_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+logical_kind_02.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+logical_kind_04.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+logical_kind_05.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+logical_kind_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+logical_kind_07.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+logical_not_01.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+logical_testing.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+logical_to_integer_cast.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+matmul_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+matmul_02.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+matmul_03.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+matmul_04.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+matmul_05.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+matmul_06.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+matrix_01_transpose.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+matrix_03_transpose_param.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+max_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+merge_str_01.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+min_01.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+min_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+minmax_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+minpack_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+minpack_01_func.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+minpack_03.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+module_array_init.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+module_function_with_nopass.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+module_function_without_nopass.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+modules_03.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+modules_05.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_08_b.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+modules_08.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_09_a.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+modules_09.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_15b.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+modules_15.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_18b.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_18.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_19b.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+modules_19.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_20.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_22.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_22_module.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_23.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_23_module.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_24.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+modules_25.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+modules_25_module1.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+modules_25_module.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+modules_26.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+modules_27_module1.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+modules_27_module2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+modules_28.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_28_module1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_28_module2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_29.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_29_module1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_29_module2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_29_module3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_30.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_30_module1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_30_module2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_30_module3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_31.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_31_module1.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+modules_31_module2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_32.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_33_module1.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+modules_33_module3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_34_module1a.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+modules_34_module3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_35.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+modules_36.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+modules_37.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_38.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+modules_39.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+modules_39_module.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+modules_40.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_41.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_42.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+modules_43.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+modules_44.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_44_module.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+modules_45.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_47.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+modules_48.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_49.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+modules_50.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+modules_51.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_52.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_52_module1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_53.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+modules_55.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_56.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+modules_57.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_58.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_59.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_60.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+modules_61.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_62.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_62_parser.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_62_terminal.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+modules_63.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_63_module.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+modules_64.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+modules_65.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+modules_65_worker.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+modules_66.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_66_worker.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+modules_67_consumer.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_67.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+modules_68.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+modules_69.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+modules_71.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modules_72.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+modulo_01.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+modulo_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+move_alloc_derived_01.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+move_alloc_pointer_alias.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+multi_file_member_access_01.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+multi_file_member_access_01_mod.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+multiple_objects_args.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+multiple_procs_in_bin_op.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_03.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_04.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_05.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_06.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_07.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_08.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_09.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_11.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_12.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_13.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_14.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_15.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_16.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_17.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_18.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+namelist_19.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_20.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_21.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+namelist_22.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+namelist_23.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_24.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_25.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_26.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_27.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_28.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+namelist_29.f90 # owner=lazy-fortran/ffc#436; reason=read scalar NAMELIST groups
+namelist_30.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+namelist_31.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+nbody.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+nested_03.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_04.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_05.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_06.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_07.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_09.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_10.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_12.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+nested_13.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_14.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+nested_15.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+nested_16.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_17.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+nested_18.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+nested_20.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+nested_21.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+nested_22.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+nested_23.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+nested_24.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+nested_26.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_27.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+nested_array_intrinsics_01.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+nested_callback_arrays.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+nested_callback_interface_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_call_filter_01.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+nested_external_dedup_01.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+nested_namelist_01.f90 # owner=lazy-fortran/ffc#460; reason=write scalar NAMELIST groups
+nested_struct_proc_01.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+nested_vars_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_vars_02.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+nested_vars_03.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+nested_vars_04.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+nested_vars_05.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_vars_06.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+nested_vars1.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_vars2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_vars3.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+nested_vars_allocatable_call.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+no_explicit_return_type_01.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+nullify_03.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+nullify_04.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+nullify_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+nullify_06.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+nullify_07.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+openmp_02.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_04.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_05.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_06.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_07.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_08.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_09.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_10.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_11.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_12.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_13.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_14.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_15.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_16.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_17.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_18.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_19.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_20.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_21.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_22.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_23.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_24.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_25.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_26.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_27.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_28.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_30.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_32.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_33.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_34.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_35.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_40.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_41.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_44.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_46.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_47.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_48.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_49.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_50.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_51.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_53.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_54.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_55.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_56.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_59.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_60.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_62.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_63.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_64.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_65.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_67.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_68.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_69.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_70.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_71.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_72.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_73.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_bindc_01.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_bindc_02.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_bindc_03.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+openmp_bindc_04.f90 # scope=OpenMP; reason=excluded OpenMP syntax or runtime dependency
+operator_overloading_01.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+operator_overloading_02.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+operator_overloading_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_04.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_05_module1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_05_module3.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_07.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_08.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+operator_overloading_09.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_11.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_12.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_13.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+operator_overloading_14.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+operator_overloading_15.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_16.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+operator_overloading_17.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+operator_overloading_18.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+operator_overloading_19.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+operator_overloading_20.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+operator_overloading_21.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+operator_overloading_22.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+operator_overloading_23.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+operator_overloading_24.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+operator_overloading_25.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+operator_overloading_26.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+operator_overloading_27.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+operator_overloading_28.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_29.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+operator_overloading_30.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+operator_overloading_31.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+operator_overloading_32.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+operator_overloading_33.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+operator_overloading_34.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+operator_overloading_34_mod.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_35.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_36.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+operator_overloading_36_mod_base_sub.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+operator_overloading_37.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+operator_overloading_38.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+operator_overloading_39.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+optional_01.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+optional_02.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+optional_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+optional_04.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+optional_05.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+optional_06.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+optional_07.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+optional_08.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+optional_09.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+optional_10.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+optional_11.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+optional_12.f90 # owner=lazy-fortran/ffc#344; reason=make overlapping array assignment alias-safe
+optional_13.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+parameter_01.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+parameter_02.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+parameter_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+parameter_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+parameter_08.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+parameter_09.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+parameter_10.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+parameter_11.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+parameter_12.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+parameter_13.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+parameter_15.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+parameter_16.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+parsing_01.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+parsing_02.f90 # owner=lazy-fortran/ffc#378; reason=reject illegal interface bodies consistently
+pass_array_by_data_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pass_array_by_data_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pass_array_by_data_03.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+pass_array_by_data_05.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+pass_array_by_data_07.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+pass_array_by_data_08.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+pass_array_by_data_09.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+pass_array_by_data_10.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pass_array_by_data_11.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pass_array_by_data_12.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+pass_array_by_data_13.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+pass_array_by_data_14.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+pass_array_by_data_extname_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+passing_array_01.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+passing_array_02.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+passing_array_04.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+passing_array_05.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+pdt_01.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+pdt_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pdt_03.f90 # owner=lazy-fortran/ffc#411; reason=support constant integer kind and length type parameters
+pdt_04.f90 # owner=lazy-fortran/ffc#411; reason=support constant integer kind and length type parameters
+pdt_05.f90 # owner=lazy-fortran/ffc#411; reason=support constant integer kind and length type parameters
+pdt_06.f90 # owner=lazy-fortran/ffc#411; reason=support constant integer kind and length type parameters
+pdt_07.f90 # owner=lazy-fortran/ffc#411; reason=support constant integer kind and length type parameters
+pdt_09.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pdt_10.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+pdt_11.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+pdt_11_module.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+pdt_12.f90 # owner=lazy-fortran/ffc#357; reason=preserve bodies after interface blocks
+pdt_14.f90 # owner=lazy-fortran/ffc#411; reason=support constant integer kind and length type parameters
+pdt_15.f90 # owner=lazy-fortran/ffc#411; reason=support constant integer kind and length type parameters
+pdt_16.f90 # owner=lazy-fortran/ffc#411; reason=support constant integer kind and length type parameters
+pointer_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+pointer_02.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+pointer_03.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+pointer_04.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+pointer_05.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+pointer_06.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+pointer_07.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+pointer_09.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+pointer_10.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+pointer_11.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+pointer_12.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+pointer_14.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+pointer_15.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+pointer_16.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+pointer_17.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+pointer_to_cptr.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+polymorphic_arguments_01.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+polymorphic_arguments_02.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+polymorphic_class_compare.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+polymorphic_select_type_01.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+polymorphic_select_type_02.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+precision_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+present_02.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+present_03.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+present_04.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+present_05.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+present_06.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+present_07.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+present_08.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+print_02.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+print_04.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+print_06.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+print_07.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+print_10.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+print_11.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+print_12.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+print_13.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+print_14.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+print_15.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+print_arr_03.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+print_arr_06.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+print_arr_08.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+print_arr_09.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+procedure_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_03.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+procedure_04.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_05.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+procedure_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_07.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_08.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_09_b.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+procedure_11.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_12.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+procedure_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_15.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_16.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+procedure_17.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_18.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_19.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+procedure_20.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_21.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+procedure_22_a.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+procedure_22.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+procedure_23.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+procedure_24.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+procedure_25.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+procedure_26.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+procedure_27.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+procedure_28.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+procedure_29.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+procedure_30.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+procedure_31.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+procedure_32.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+procedure_33.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+procedure_34.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+procedure_35.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+procedure_36.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_37.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_38.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+procedure_39.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+procedure_40.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_41.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+procedure_42.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+procedure_43.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+procedure_43_module.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+procedure_44.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+procedure_45.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_46.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_47.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_48.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_49.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+procedure_50.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_decl_01_a.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+procedure_decl_01_b.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_pointer_12.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_pointer_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_pointer_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_pointer_16.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_pointer_17.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+procedure_pointer_18.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+procedure_pointer_19.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_pointer_20.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_pointer_21.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+procedure_pointer_22.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+procedure_pointer_23.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_pointer_24.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_pointer_25.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+procedure_pointer_abstract_01.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+procedure_pointer_abstract_02.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+procedure_pointer_keyword_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+procedure_pointer_keyword_02.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+procedure_pointer_keyword_03.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+proc_ptr_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+proc_ptr_15.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+proc_ptr_17.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+proc_ptr_18.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+proc_ptr_nopass_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+product_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+product_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+program_01.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+program_03.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+pure_side_effects_03.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+random_init_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+random_init_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+random_number_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+random_number_complex_part_01.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+random_seed_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_01.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+read_02.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_03.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_04.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_05.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_06.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_07.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_08.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_09.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+read_10.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+read_11.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+read_12.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_13.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+read_14.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+read_16.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_19.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_20.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_21.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_22.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_23.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+read_24.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_25.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+read_26.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+read_27.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_28.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_29.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_30.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_31.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_32.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_33.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+read_34.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_35.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_36.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_37.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_38.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+read_39.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_40.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_41.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+read_42.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_43.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_44.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+read_45.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_47.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_48.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_49.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+read_50.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_51.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_52.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_53.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_54.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_55.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_56.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+read_57.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_58.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+read_59.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_60.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_61.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_62.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_63.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+read_64.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_65.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_66.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_67.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_68.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_69.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_70.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+read_71.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+read_72.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_73.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+read_74.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_75.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_76.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_77.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_78.f90 # owner=lazy-fortran/ffc#349; reason=migrate deferred scalar character storage
+read_80.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_81.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+read_82.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_83.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_85.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_86.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+read_87.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_88.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+read_89.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+read_90.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_91.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_92.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_93.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+read_94.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+read_95.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+read_96.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+real128_arith_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+real128_arith_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+real128_arith_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+real128_arith_04.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+real128_arith_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+real128_arith_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+real128_arith_07.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+real128_arith_08.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+real128_arith_09.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+real128_arith_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+real128_intrinsic_inquiry_01.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+real128_int_to_real_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+real128_literal_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+realloc_lhs_16.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+realloc_lhs_18.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+realloc_lhs_19.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+realloc_lhs_20.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+realloc_lhs_21.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+realloc_lhs_23.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+realloc_lhs_24.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+realloc_lhs_25.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+recursion_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+recursion_03.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+reserved_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+reserved_02.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+reserved_03.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+return_05.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+return_06.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+rewind_01.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+rewind_inquire_flush.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+save_04.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+save_05.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+save_07.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+save_08.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+save_10.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+save_11.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+save_13.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+save_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+select_case_01.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+select_case_02.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+select_case_03.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+selected_int_kind_01.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+select_label_01.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+select_rank_01.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+select_rank_02.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+select_rank_03.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+select_rank_04.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_rank_05.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+select_rank_06.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_rank_07.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+select_rank_08.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+select_rank_09.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-backed RESHAPE
+select_rank_10.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_rank_11.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_rank_12.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+select_rank_13.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_rank_14.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_rank_15.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+select_rank_16.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+select_rank_17.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_rank_19.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_rank_20.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+select_rank_21.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_rank_22.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_rank_23.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_rank_24.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_rank_25.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_rank_26.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_rank_27.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_rank_28.f90 # owner=lazy-fortran/ffc#344; reason=make overlapping array assignment alias-safe
+select_rank_29.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_rank_30.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+select_rank_31.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_rank_32.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+select_rank_33.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_rank_34.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+select_rank_35.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+select_rank_36.f90 # owner=lazy-fortran/ffc#343; reason=lower reductions through descriptor iteration
+select_rank_37.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_rank_38.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_rank_pointer_01.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+select_type_01.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_02.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_03.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_05.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_type_06.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+select_type_07.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_08.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_09.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_10.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_11.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_type_12.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_13.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_14.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_15.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_16.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_17.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_18.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_type_19.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_type_20.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_type_21.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_22.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_23.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+select_type_24.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_25.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_26.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_27.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_28.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_29.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_30.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_31.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_32.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_33.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_34.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+select_type_36.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_37.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_type_38.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+select_type_39.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+select_type_40.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_type_41.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_type_42.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_type_43.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_type_44.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_45.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_46.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+select_type_47.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+select_type_48.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_type_49.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+select_type_50.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+select_type_51.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+select_type_52.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+separate_compilation_03a.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+separate_compilation_03b.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+separate_compilation_03.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_04a.f90 # owner=lazy-fortran/ffc#343; reason=lower reductions through descriptor iteration
+separate_compilation_04b.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+separate_compilation_04.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+separate_compilation_05a.f90 # owner=lazy-fortran/ffc#343; reason=lower reductions through descriptor iteration
+separate_compilation_05b.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+separate_compilation_05.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+separate_compilation_06a.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+separate_compilation_06b.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+separate_compilation_06.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_07b.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_07.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_08a.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+separate_compilation_08b.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+separate_compilation_08.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_09b.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+separate_compilation_09.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_10a.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+separate_compilation_10.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_11.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+separate_compilation_12a.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+separate_compilation_12.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_13a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+separate_compilation_13.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_15a.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+separate_compilation_15.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_16b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_16.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+separate_compilation_17b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_17.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+separate_compilation_18b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_18.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+separate_compilation_19b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_19.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+separate_compilation_20b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_20.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+separate_compilation_21b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_21.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+separate_compilation_22b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_22.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+separate_compilation_23a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+separate_compilation_23b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_23.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_24b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_24.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+separate_compilation_25a.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_25b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_25.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_26b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_26.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+separate_compilation_27a.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_27b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_27.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_28a.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+separate_compilation_28b.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+separate_compilation_28.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
+separate_compilation_29.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+separate_compilation_30a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+separate_compilation_30b.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+separate_compilation_30.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_31b.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+separate_compilation_31.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_32b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_32.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+separate_compilation_33a.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+separate_compilation_33.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_34a.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+separate_compilation_34.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_35a.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+separate_compilation_35.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_36.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+separate_compilation_37b.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+separate_compilation_37.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_39b.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+separate_compilation_39.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+separate_compilation_40.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+separate_compilation_41a.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+separate_compilation_41b.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+separate_compilation_42.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+separate_compilation_43b.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+separate_compilation_43.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_44b.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+separate_compilation_44.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_45.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+separate_compilation_46a.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
+separate_compilation_46.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_47a.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+separate_compilation_47.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+separate_compilation_48.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+separate_compilation_49a.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+separate_compilation_49.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+separate_compilation_class_star_01.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+separate_compilation_class_star_02a.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+separate_compilation_class_star_02.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_class_star_03a.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+separate_compilation_class_star_03.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_class_star_04a.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+separate_compilation_class_star_04.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+separate_compilation_external_symbol_02a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+separate_compilation_external_symbol_02.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+set_exponent_01.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+set_test_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+shifta_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+shifta_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+sign_from_value.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+simd_02.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+sin_01.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+sin_02.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+sizeof_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+slash_init_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+spec_expr_01.f90 # owner=lazy-fortran/ffc#329; reason=fold specification expressions in declaration context
+specfun_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+statement_01.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+statement_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+statement_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+statement_04.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+statement_05.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+statement_06.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+statement_07.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+statement1.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+stdlib_bitsets_01.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_03.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+string_04.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_06.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_07.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_08.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_100.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+string_101.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_102.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_103.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_104.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+string_105.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+string_106.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+string_107.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_108.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_109.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+string_10.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_110.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_112.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_113.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_114.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_115.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_116.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_117.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_118.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_12.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_13.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+string_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+string_15.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+string_16.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_17.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+string_19.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+string_20.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_21.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_22.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+string_23.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+string_24.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+string_27.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_29.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_30.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+string_31.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_32.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+string_34.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_36.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_37.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+string_38.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_39.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_40.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_42.f90 # owner=lazy-fortran/ffc#349; reason=migrate deferred scalar character storage
+string_43.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
+string_45.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_46.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+string_47.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+string_48.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_49.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_50.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+string_52.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_53.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_54.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+string_56.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+string_57.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+string_58.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+string_59.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+string_60.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_61.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_62b.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_62.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+string_63.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+string_64.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_65.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_66.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+string_68.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+string_69.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_71.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_72.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_73.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_74.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_75.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+string_76.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+string_77.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_78.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_79.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_80.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_81.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+string_82.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
+string_83.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_84.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+string_85.f90 # owner=lazy-fortran/ffc#330; reason=map procedure and host bindings to storage
+string_87.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_88.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+string_89.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+string_90.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_91.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_92.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_93.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+string_94.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_95.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+string_96.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_97.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_99.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+string_array_concat_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+string_concat_deferred_len.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+str_to_char.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+struct_allocate.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+struct_type_01.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+struct_type_02.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+struct_type_03.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+struct_type_04.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+struct_type_05.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+struct_type_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+struct_type_07.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+struct_type_08.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+struct_type_09.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+struct_type_10.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+struct_type_11.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+struct_type_12.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+struct_type_13.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+submodule_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_06.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+submodule_10.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+submodule_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_15.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+submodule_16.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_17.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_18a.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+submodule_18c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_19a.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+submodule_19b.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+submodule_19c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_20a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_20c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_21a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_21c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_22.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+submodule_23a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_23c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_24.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_25a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_25c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_27a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_27c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_29a.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+submodule_29c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_29d.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_30a.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+submodule_30c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_30d.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_31.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+submodule_32.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+submodule_33.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_34a.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+submodule_34b.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+submodule_37a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_37c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_37d.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_38a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_38c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_39a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_39c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_40a.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
+submodule_40c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_41.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+submodule_43.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+submodule_44a.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+submodule_44b.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+submodule_46.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+submodule_48.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+submodule_49.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
+submodule_50a.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+submodule_50c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
+submodule_51a.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+submodule_51b.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+submodule_53a.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+submodule_53b.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+submodule_54.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+submodule_55.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
+subroutines_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+subroutines_05.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
+subroutines_06.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+subroutines_09.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+subroutines_10.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+subroutines_11.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+subroutines_13.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+subroutines_15.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+subroutines_16.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+subroutines_17.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+subroutines_18.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
+subroutines_20.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
+substring_read.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+sum_01.f90 # owner=lazy-fortran/ffc#343; reason=lower reductions through descriptor iteration
+sum_03.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+symbol_table_jloop_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+sync_all_02.f90 # scope=coarray; reason=excluded coarray or image-control semantics
+template_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_03b.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_03.f90 # scope=vendor; reason=LFortran template language extension
+template_04.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_07.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_add_01b.f90 # scope=vendor; reason=LFortran template language extension
+template_add_01c.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_add_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_add_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_add_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_add_04.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_array_01.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+template_array_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_array_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_array_04b.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+template_array_04.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
+template_array_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_commutative.f90 # scope=vendor; reason=LFortran template language extension
+template_field.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_interface_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_intrinsic_func_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_intrinsic_op_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_lapack_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_matrix_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_matrix.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_matrix_test.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+template_monoid.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_nested.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_semigroup.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_simple_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_simple_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_simple_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_simple_04.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_sort_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_sort_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_struct_01.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+template_travel_01b.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_travel_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_travel_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_triple.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_unitring.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+template_vector.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+test_backspace_01.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+test_call_arg_structinstance_member.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+test_dshiftr.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+test_endfile_01.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+test_endfile_02.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+test_endfile_03.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+test_format_inf_nan.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
+test_ieee_arithmetic_03.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+test_ieee_arithmetic_04.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_arithmetic.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+test_ieee_arithmetic_fast_01.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_copy_sign.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_inf_nan_01.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_infnan.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_int.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+test_ieee_is_finite.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_is_negative.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+test_ieee_is_normal.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_logb.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_nan_value.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+test_ieee_next_down.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_next.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_next_up.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_real.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_rem.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_rint.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_scalb.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_support.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_underflow_mode.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
+test_ieee_unordered.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+test_ieee_value_01.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+test_inquire_size.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+test_iso_c_binding_constants.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+test_ord.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+test_rep.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+test_str.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+test_unsigned.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+transfer_01.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+transfer_02.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_03.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_04.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+transfer_05.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
+transfer_06.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+transfer_07.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+transfer_08.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+transfer_09.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+transfer_10.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+transfer_11.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_12.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+transfer_13.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+transfer_14.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_15.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_16.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_17.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_18.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from runtime expressions
+transfer_19.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+transfer_20.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+transfer_21.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_22.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+transfer_23.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+transfer_24.f90 # owner=lazy-fortran/ffc#338; reason=migrate pointer arrays to descriptors
+transfer_25.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+transfer_26.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+transfer_27.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_28.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_29.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+transfer_assumed_shape_01.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+tsunami.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+tuple_test_01_.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+tuple_test_02_.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+tuple_test_03_.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+tuple_test_04_.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+tuple_test_concat_.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+tuple_test_nested_.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+type_bound_generic_member_access_01.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+type_bound_generic_member_access_02.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
+type_bound_generic_member_access_03.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+type_parameter_inquiry_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+types_01.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+types_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+types_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+types_07.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+types_09.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
+types_13.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+types_15.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+types_17.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
+types_21.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+types_22.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+types_23.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+types_24.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
+types_real_array_to_complex_array_cast.f90 # owner=lazy-fortran/ffc#459; reason=lower typed array constructors
+union_test_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+union_test_02.f90 # scope=vendor; reason=DEC UNION and MAP language extension
+union_test_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+unpack_scalar_field_01.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+unpack_scalar_field_02.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
+use_02.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
+use_03.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
+use_04.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+value_attribute_01.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
+verify_intent_external_01.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+verify_intent_external_01_mod2.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
+where_01.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+where_02.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+where_03.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+where_04.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+where_05.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+where_06.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+where_07.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+where_08.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+where_09.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+where_10.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+where_11.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+where_12.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
+where_13.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+where_14.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+where_15.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+where_16.f90 # owner=lazy-fortran/ffc#345; reason=route WHERE and FORALL through array expressions
+where_17.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
+while_02.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+while_03.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
+while_05.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
+write_01.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_02.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
+write_03.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_04.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_05.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_06.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_07.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+write_08.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_09.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+write_10.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+write_11.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+write_13.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+write_15.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_16.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+write_17.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_18.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+write_19.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
+write_19_module.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+write_20.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+write_21.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
+write_22.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
+write_23.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_24.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
+write_25.f90 # owner=lazy-fortran/ffc#366; reason=implement internal E and X formatting
+write_26.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+write_28.f90 # owner=lazy-fortran/ffc#366; reason=implement internal E and X formatting
+write_34.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_37.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_38.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_39.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+write_40.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
+write_41.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+write_42.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+write_43.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+write_fortran_01.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
+write_fortran_02.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
+write_implied_do_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
+write_substr_01.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations

--- a/test/test_conformance_manifest_validation.f90
+++ b/test/test_conformance_manifest_validation.f90
@@ -1,0 +1,220 @@
+program test_conformance_manifest_validation
+    implicit none
+
+    character(len=*), parameter :: SCRIPT = &
+        'scripts/conformance_gauntlet.sh'
+    character(len=*), parameter :: FIXTURE_DIR = &
+        '/tmp/ffc_manifest_validation_fixtures'
+    character(len=*), parameter :: XFAIL_MANIFEST = &
+        '/tmp/ffc_manifest_validation_xfail.txt'
+    character(len=*), parameter :: SKIP_MANIFEST = &
+        '/tmp/ffc_manifest_validation_skip.txt'
+    character(len=*), parameter :: REPORT = &
+        '/tmp/ffc_manifest_validation.jsonl'
+    character(len=*), parameter :: FAILURE_LOG = &
+        '/tmp/ffc_manifest_validation_failure.log'
+    character(len=*), parameter :: AUDIT_MANIFEST = &
+        '/tmp/ffc_manifest_validation_audit.txt'
+    character(len=*), parameter :: FAKE_BIN_DIR = &
+        '/tmp/ffc_manifest_validation_bin'
+    character(len=64), parameter :: DIAGNOSTICS(7) = [character(len=64) :: &
+        'reason is required', &
+        'owner or scope is required', &
+        'owner and scope cannot both appear', &
+        'malformed owner', &
+        'duplicate path', &
+        'unknown scope', &
+        'malformed delimiter']
+    integer :: case_number
+    logical :: passed
+
+    passed = .true.
+    call write_fixture()
+    call write_valid_manifests()
+    if (.not. valid_manifest_runs()) passed = .false.
+
+    do case_number = 1, size(DIAGNOSTICS)
+        call write_invalid_manifest(case_number)
+        if (.not. invalid_manifest_fails(case_number, &
+            trim(DIAGNOSTICS(case_number)))) passed = .false.
+    end do
+    call write_fake_gh()
+    if (.not. audit_owner('378', .true., '')) passed = .false.
+    if (.not. audit_owner('445', .false., 'is CLOSED')) passed = .false.
+    if (.not. audit_owner('999999', .false., 'is MISSING')) passed = .false.
+
+    if (.not. passed) stop 1
+    print *, 'PASS: expected-disposition manifest validation'
+
+contains
+
+    subroutine write_fixture()
+        integer :: unit
+
+        call execute_command_line('rm -rf '//FIXTURE_DIR)
+        call execute_command_line('mkdir -p '//FIXTURE_DIR)
+        open(newunit=unit, file=FIXTURE_DIR//'/owned_failure.f90', &
+            status='replace', action='write')
+        write(unit, '(A)') 'subroutine owned_failure'
+        write(unit, '(A)') '! { dg-error "synthetic accepted case" }'
+        write(unit, '(A)') 'end subroutine owned_failure'
+        close(unit)
+    end subroutine write_fixture
+
+    subroutine write_valid_manifests()
+        integer :: unit
+
+        open(newunit=unit, file=XFAIL_MANIFEST, status='replace', &
+            action='write')
+        write(unit, '(A)') 'owned_failure.f90 # owner=lazy-fortran/ffc#445;'// &
+            ' reason=closed owners are offline-valid'
+        write(unit, '(A)') 'coarray.f90 # scope=coarray; reason=excluded'
+        write(unit, '(A)') 'openmp.f90 # scope=OpenMP; reason=excluded'
+        write(unit, '(A)') 'openacc.f90 # scope=OpenACC; reason=excluded'
+        write(unit, '(A)') 'vendor.f90 # scope=vendor; reason=excluded'
+        write(unit, '(A)') 'legacy.f90 # scope=legacy; reason=excluded'
+        write(unit, '(A)') &
+            'flags.f90 # scope=compiler-flags; reason=excluded'
+        close(unit)
+
+        open(newunit=unit, file=SKIP_MANIFEST, status='replace', &
+            action='write')
+        write(unit, '(A)') 'gpu.f90 # scope=GPU; reason=excluded'
+        write(unit, '(A)') 'harness.f90 # scope=harness; reason=excluded'
+        close(unit)
+    end subroutine write_valid_manifests
+
+    logical function valid_manifest_runs() result(ok)
+        character(len=:), allocatable :: command
+        integer :: exit_stat
+
+        command = environment_prefix()//' bash '//SCRIPT// &
+            ' --suite gfortran-dg --file owned_failure.f90'// &
+            ' --report '//REPORT//' > '//FAILURE_LOG//' 2>&1'
+        call execute_command_line(command, exitstat=exit_stat)
+        ok = exit_stat == 0 .and. file_contains(REPORT, &
+            '"file":"owned_failure.f90","status":"XFAIL"')
+        if (.not. ok) print *, 'FAIL: valid structured manifests were rejected'
+    end function valid_manifest_runs
+
+    subroutine write_invalid_manifest(case_number)
+        integer, intent(in) :: case_number
+        integer :: unit
+
+        open(newunit=unit, file=XFAIL_MANIFEST, status='replace', &
+            action='write')
+        select case (case_number)
+        case (1)
+            write(unit, '(A)') &
+                'owned_failure.f90 # owner=lazy-fortran/ffc#378'
+        case (2)
+            write(unit, '(A)') 'owned_failure.f90 # reason=missing owner'
+        case (3)
+            write(unit, '(A)') 'owned_failure.f90 # '// &
+                'owner=lazy-fortran/ffc#378; scope=coarray; reason=both'
+        case (4)
+            write(unit, '(A)') &
+                'owned_failure.f90 # owner=issue-378; reason=malformed'
+        case (5)
+            write(unit, '(A)') 'owned_failure.f90 # '// &
+                'owner=lazy-fortran/ffc#378; reason=first'
+            write(unit, '(A)') 'owned_failure.f90 # '// &
+                'owner=lazy-fortran/ffc#378; reason=second'
+        case (6)
+            write(unit, '(A)') &
+                'owned_failure.f90 # scope=threads; reason=unknown'
+        case (7)
+            write(unit, '(A)') 'owned_failure.f90# '// &
+                'owner=lazy-fortran/ffc#378; reason=no separator'
+        end select
+        close(unit)
+    end subroutine write_invalid_manifest
+
+    logical function invalid_manifest_fails(case_number, diagnostic) result(ok)
+        integer, intent(in) :: case_number
+        character(len=*), intent(in) :: diagnostic
+        character(len=:), allocatable :: command
+        character(len=32) :: line_text
+        integer :: exit_stat
+
+        write(line_text, '(I0)') merge(2, 1, case_number == 5)
+        command = environment_prefix()//' bash '//SCRIPT// &
+            ' --suite gfortran-dg --file owned_failure.f90'// &
+            ' --report '//REPORT//' > '//FAILURE_LOG//' 2>&1'
+        call execute_command_line(command, exitstat=exit_stat)
+        ok = exit_stat /= 0 .and. &
+            file_contains(FAILURE_LOG, XFAIL_MANIFEST//':'//trim(line_text)) &
+            .and. file_contains(FAILURE_LOG, diagnostic)
+        if (.not. ok) print *, 'FAIL: missing rejection: ', trim(diagnostic)
+    end function invalid_manifest_fails
+
+    function environment_prefix() result(prefix)
+        character(len=:), allocatable :: prefix
+
+        prefix = 'FFC_GFORTRAN_DG_DIR='//FIXTURE_DIR// &
+            ' FFC_XFAIL_MANIFEST='//XFAIL_MANIFEST// &
+            ' FFC_SKIP_MANIFEST='//SKIP_MANIFEST
+    end function environment_prefix
+
+    subroutine write_fake_gh()
+        integer :: unit
+
+        call execute_command_line('rm -rf '//FAKE_BIN_DIR)
+        call execute_command_line('mkdir -p '//FAKE_BIN_DIR)
+        open(newunit=unit, file=FAKE_BIN_DIR//'/gh', status='replace', &
+            action='write')
+        write(unit, '(A)') '#!/usr/bin/env bash'
+        write(unit, '(A)') 'case "$3" in'
+        write(unit, '(A)') '378) echo OPEN ;;'
+        write(unit, '(A)') '445) echo CLOSED ;;'
+        write(unit, '(A)') '*) exit 1 ;;'
+        write(unit, '(A)') 'esac'
+        close(unit)
+        call execute_command_line('chmod +x '//FAKE_BIN_DIR//'/gh')
+    end subroutine write_fake_gh
+
+    logical function audit_owner(issue_number, should_pass, diagnostic) &
+            result(ok)
+        character(len=*), intent(in) :: issue_number
+        logical, intent(in) :: should_pass
+        character(len=*), intent(in) :: diagnostic
+        character(len=:), allocatable :: command
+        integer :: exit_stat
+        integer :: unit
+
+        open(newunit=unit, file=AUDIT_MANIFEST, status='replace', &
+            action='write')
+        write(unit, '(A)') 'owned_failure.f90 # owner=lazy-fortran/ffc#'// &
+            issue_number//'; reason=audit fixture'
+        close(unit)
+        command = 'PATH='//FAKE_BIN_DIR//'/:$PATH '// &
+            'scripts/audit_manifest_owners.sh '//AUDIT_MANIFEST// &
+            ' > '//FAILURE_LOG//' 2>&1'
+        call execute_command_line(command, exitstat=exit_stat)
+        if (should_pass) then
+            ok = exit_stat == 0
+        else
+            ok = exit_stat /= 0 .and. file_contains(FAILURE_LOG, diagnostic)
+        end if
+        if (.not. ok) print *, 'FAIL: owner audit case ', issue_number
+    end function audit_owner
+
+    logical function file_contains(path, needle) result(found)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: needle
+        character(len=4096) :: line
+        integer :: io_stat
+        integer :: unit
+
+        found = .false.
+        open(newunit=unit, file=path, status='old', action='read', iostat=io_stat)
+        if (io_stat /= 0) return
+        do
+            read(unit, '(A)', iostat=io_stat) line
+            if (io_stat /= 0) exit
+            if (index(line, needle) > 0) found = .true.
+        end do
+        close(unit)
+    end function file_contains
+
+end program test_conformance_manifest_validation


### PR DESCRIPTION
Closes #395.

Require every xfail and skip entry to name an open implementation issue or an
allowed excluded scope, with a nonempty reason. Ordinary gauntlet runs validate
the grammar offline; the explicit audit checks issue liveness through `gh`.

Promote the nine verified external-corpus XPASS entries. All other normalized
manifest membership is unchanged.

Compiler lowering is untouched. Aliasing, storage lifetimes, dispatch,
descriptor and procedure ABI, and generated code are unchanged; this patch
only changes conformance metadata and harness parsing.

## Verification

Failing before implementation:

```text
FAIL: valid structured manifests were rejected
FAIL: missing rejection: reason is required
FAIL: missing rejection: owner or scope is required
FAIL: missing rejection: owner and scope cannot both appear
FAIL: missing rejection: malformed owner
FAIL: missing rejection: duplicate path
FAIL: missing rejection: unknown scope
FAIL: missing rejection: malformed delimiter
STOP 1
```

Passing after implementation:

```text
fo test test_conformance_manifest_validation
test_conformance_manifest_validation PASS 0.28s
1 passed, 0 failed, 0 skipped

scripts/audit_manifest_owners.sh
PASS: 101 open manifest owners

fo
Static analysis: OK (309 modules)
Builds: 377/377 twice
Tests: 247/247 passed
Lint: OK
```

Full external-corpus measurements:

```text
fortfront-f90: PASS=339 XFAIL=100 XPASS=0 FAIL=0 NOREF=94 TOTAL=439
fortfront-lf: PASS=205 XFAIL=59 XPASS=0 FAIL=0 NOREF=0 TOTAL=264
lfortran: PASS=848 XFAIL=3421 XPASS=0 FAIL=11 NOREF=145 TOTAL=4280
gfortran-dg: PASS=1175 XFAIL=2132 XPASS=0 FAIL=333 NOREF=1 SKIP=2298 WARNING_UNCHECKED=75 TOTAL=5938
```

The gfortran per-file status diff against the pre-change full report contains
only the five named `XPASS` to `PASS` promotions. The four LFortran promotions
also pass in an isolated selected run. Manifest path-set comparison contains
only those nine removals.
