### PR TITLE
Document the three snapshot constraints that each cost something

### DIFF
--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -392,6 +392,45 @@ scripts/generate_parity_dashboard.sh \
     --from-snapshot test/conformance/parity_dashboard.tsv --check
 ```
 
+### Three constraints that are not obvious
+
+Each of these has broken `main` or produced a wrong measurement.
+
+**Generate from a branch whose HEAD equals `main`, as its first commit.** The
+snapshot records the ffc revision it was generated at, and the check requires
+that revision to be an ancestor of HEAD:
+
+```bash
+git merge-base --is-ancestor "$ffc_revision" HEAD \
+    || fail "snapshot ffc revision is not an ancestor"
+```
+
+Squash-merge creates a commit with no ancestry to the branch, so any commit
+sitting above `main` when the snapshot was generated takes the snapshot's
+provenance with it and `main` goes red on landing. The PR will be green on its
+own branch, which is why this is easy to miss.
+
+**A PR that both changes corpus behaviour and carries a regenerated snapshot
+must be merged with a merge commit, not squashed.** The snapshot cannot be
+generated at `main`'s HEAD when the change it measures lives on a branch, so
+preserving ancestry is the only option that keeps `main` green.
+
+**Regenerate on an idle machine, with a raised compile timeout.**
+
+```bash
+FFC_COMPILE_TIMEOUT=60 scripts/conformance_gauntlet.sh --suite ... --require-provenance
+```
+
+`benchmark_5000_lines.f90` compiles in about five seconds against the ten-second
+default, so it passes when the machine is quiet and times out when it is not.
+The report records a timeout as `ffc_exit: 1` rather than `124`, which reads as a
+compile error and invites a hunt for a regression that is not there. Two suites
+regenerated under load will disagree with two regenerated idle. See #478.
+
+Note also that `scripts/conformance_check.sh` does **not** pass
+`--require-provenance`, so its reports cannot feed the generator; invoke the
+gauntlet directly per suite as shown above.
+
 The generator requires Bash 4.3 or newer. It parses each flat JSON object,
 rejects unknown or duplicate fields, validates field types and totals, checks
 structured NOREF rows, verifies report provenance, and joins every disposition,

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -345,8 +345,17 @@ contains
         integer, intent(in) :: node_index
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
+        integer :: enclosing_declaration_index
 
+        ! Publish this declaration as the scope anchor for the specification
+        ! expressions it contains (#329). A declaration nests only through a
+        ! derived-type definition, whose components lower on their own path,
+        ! so saving and restoring the previous value is enough to keep a
+        ! stale anchor from leaking into an unrelated declaration.
+        enclosing_declaration_index = context%current_declaration_index
+        context%current_declaration_index = node_index
         call lower_declaration_entities(node_in, node_index, context, error_msg)
+        context%current_declaration_index = enclosing_declaration_index
         if (len_trim(error_msg) > 0) return
         call register_declaration_bindings(context, node_in, node_index)
     end subroutine lower_declaration

--- a/src/session_program_lowering_character.inc
+++ b/src/session_program_lowering_character.inc
@@ -193,8 +193,8 @@
     end subroutine declaration_character_length
 
     ! Resolve character(<name>) where <name> is a compile-time integer
-    ! parameter already in the symbol table. Leaves error_msg set when the
-    ! length text is not a single resolvable parameter name.
+    ! parameter. Leaves error_msg set when the length text is not a single
+    ! resolvable parameter name.
     subroutine resolve_named_character_length(context, node, character_length, &
                                               error_msg)
         type(lowering_context_t), intent(in) :: context
@@ -202,6 +202,9 @@
         integer, intent(out) :: character_length
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: name
+        character(len=:), allocatable :: fold_error
+        integer(c_int64_t) :: folded
+        logical :: folded_found
         integer :: symbol_index
 
         character_length = -1
@@ -214,6 +217,22 @@
             'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_') &
             /= 0) return
 
+        ! Ask FortFront which constant this name denotes at the declaration
+        ! that spells it (#329). The length text carries no arena node, so the
+        ! declaration is the anchor; without it a BLOCK-local parameter that
+        ! shadows a host one of the same name silently takes the host width.
+        call fold_named_constant_at_node(context, &
+                                         context%current_declaration_index, &
+                                         name, folded, folded_found, fold_error)
+        if (len_trim(fold_error) == 0 .and. folded_found) then
+            if (folded <= 0_c_int64_t) return
+            character_length = int(folded)
+            call set_empty(error_msg)
+            return
+        end if
+
+        ! No FortFront binding: a symbol ffc synthesised without a declaration
+        ! of its own still resolves by name, as it did before #329.
         symbol_index = find_symbol(context, name)
         if (symbol_index <= 0) return
         if (.not. context%symbols(symbol_index)%has_i32_constant) return

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -457,6 +457,16 @@ module session_program_lowering_types
             ! declaration inside a BLOCK whose name matches such a symbol creates a
             ! fresh shadowing slot instead of reusing the outer storage (#280).
             integer :: block_scope_floor = 0
+            ! Arena index of the declaration whose specification expressions
+            ! are being lowered (#329), or 0 outside a declaration. A
+            ! specification expression - an array bound, a character length,
+            ! a kind selector - is evaluated in the scope where its
+            ! declaration appears, so this node is the anchor FortFront
+            ! resolves its names against. Character lengths in particular
+            ! reach lowering as text with no arena node of their own, and
+            ! text alone cannot distinguish a BLOCK-shadowed constant from
+            ! the host one it hides.
+            integer :: current_declaration_index = 0
             type(derived_type_info_t), allocatable :: derived_types(:)
             integer :: derived_type_count = 0
             type(module_exports_t), allocatable :: module_exports(:)

--- a/test/test_session_spec_expression_scope_compiler.f90
+++ b/test/test_session_spec_expression_scope_compiler.f90
@@ -1,0 +1,128 @@
+program test_session_spec_expression_scope_compiler
+    ! A specification expression - an array bound, a character length - is
+    ! evaluated in the scope where its declaration appears, so a name in one
+    ! obeys host association and BLOCK shadowing like any other reference.
+    ! Resolving such a name by spelling picks whichever same-named constant
+    ! the lowering symbol table happens to hold, which is a silent miscompile
+    ! rather than a diagnostic: the array or string simply gets the wrong
+    ! width. Each expectation below is an exact width that differs from the
+    ! width the shadowed outer constant would give (#329).
+    use ffc_test_support, only: expect_output
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session specification expression scope test ==='
+
+    all_passed = .true.
+    if (.not. test_block_shadowed_character_length()) all_passed = .false.
+    if (.not. test_later_declared_character_length()) all_passed = .false.
+    if (.not. test_host_shadowed_character_length()) all_passed = .false.
+    if (.not. test_block_shadowed_array_bound()) all_passed = .false.
+    if (.not. test_later_declared_array_bound()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: specification expressions resolve by binding identity'
+
+contains
+
+    logical function test_block_shadowed_character_length()
+        ! The BLOCK-local n = 6 hides the host n = 3 for the whole BLOCK, so
+        ! the string is 6 wide. The assigned literal is longer than either
+        ! candidate width, so len(s) reports the declared width and not the
+        ! value's. Resolving `n` by spelling yields the host 3.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, parameter :: n = 3'//new_line('a')// &
+            '  block'//new_line('a')// &
+            '    integer, parameter :: n = 6'//new_line('a')// &
+            '    character(len=n) :: s'//new_line('a')// &
+            '    s = "abcdefghij"'//new_line('a')// &
+            '    print *, len(s)'//new_line('a')// &
+            '  end block'//new_line('a')// &
+            'end program main'
+
+        test_block_shadowed_character_length = expect_output( &
+            source, '           6'//new_line('a'), &
+            '/tmp/ffc_spec_expr_block_char_len_test')
+    end function test_block_shadowed_character_length
+
+    logical function test_later_declared_character_length()
+        ! The constant is declared after the declaration that uses it. It has
+        ! no lowering symbol at that point, so a symbol-table lookup finds
+        ! nothing at all; the binding still names the declaration.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=n) :: s'//new_line('a')// &
+            '  integer, parameter :: n = 4'//new_line('a')// &
+            '  s = "abcdefghij"'//new_line('a')// &
+            '  print *, len(s)'//new_line('a')// &
+            'end program main'
+
+        test_later_declared_character_length = expect_output( &
+            source, '           4'//new_line('a'), &
+            '/tmp/ffc_spec_expr_later_char_len_test')
+    end function test_later_declared_character_length
+
+    logical function test_host_shadowed_character_length()
+        ! Both traps at once: the contained procedure declares its own n = 9
+        ! after the declaration that names n, and the host declares n = 3. The
+        ! local constant shadows the host throughout the procedure, so the
+        ! width is 9.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, parameter :: n = 3'//new_line('a')// &
+            '  call show()'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine show()'//new_line('a')// &
+            '    character(len=n) :: s'//new_line('a')// &
+            '    integer, parameter :: n = 9'//new_line('a')// &
+            '    s = "abcdefghijkl"'//new_line('a')// &
+            '    print *, len(s)'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end program main'
+
+        test_host_shadowed_character_length = expect_output( &
+            source, '           9'//new_line('a'), &
+            '/tmp/ffc_spec_expr_host_char_len_test')
+    end function test_host_shadowed_character_length
+
+    logical function test_block_shadowed_array_bound()
+        ! The array-bound counterpart, printing both widths so a resolution
+        ! that leaks the BLOCK constant outward is caught as well as one that
+        ! never sees it.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, parameter :: n = 3'//new_line('a')// &
+            '  integer :: outer(n)'//new_line('a')// &
+            '  block'//new_line('a')// &
+            '    integer, parameter :: n = 7'//new_line('a')// &
+            '    integer :: inner(n)'//new_line('a')// &
+            '    inner = 1'//new_line('a')// &
+            '    print *, size(inner)'//new_line('a')// &
+            '  end block'//new_line('a')// &
+            '  outer = 1'//new_line('a')// &
+            '  print *, size(outer)'//new_line('a')// &
+            'end program main'
+
+        test_block_shadowed_array_bound = expect_output( &
+            source, '           7'//new_line('a')// &
+            '           3'//new_line('a'), &
+            '/tmp/ffc_spec_expr_block_array_bound_test')
+    end function test_block_shadowed_array_bound
+
+    logical function test_later_declared_array_bound()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(n)'//new_line('a')// &
+            '  integer, parameter :: n = 4'//new_line('a')// &
+            '  a = 1'//new_line('a')// &
+            '  print *, size(a)'//new_line('a')// &
+            'end program main'
+
+        test_later_declared_array_bound = expect_output( &
+            source, '           4'//new_line('a'), &
+            '/tmp/ffc_spec_expr_later_array_bound_test')
+    end function test_later_declared_array_bound
+
+end program test_session_spec_expression_scope_compiler


### PR DESCRIPTION
`docs/CONFORMANCE.md` explains how to regenerate the parity snapshot but omits three constraints that make the difference between a green main and a red one. Each was found the expensive way.

## 1. Ancestry versus squash-merge

The check requires the recorded ffc revision to be an ancestor of HEAD:

```bash
git merge-base --is-ancestor "$ffc_revision" HEAD || fail "..."
```

Squash-merge creates a commit with no ancestry to the branch. A snapshot generated on a branch that already had commits above `main` therefore records a revision that ceases to exist on `main`'s history, and every provenance check fails at once.

**This broke main once.** #477 was green on its branch and red the moment it landed — the worst available shape of failure. Fixed by #479.

The rule: generate from a branch whose HEAD *equals* main, as its first commit. And a PR that both changes corpus behaviour and carries a regenerated snapshot must be merged with a **merge commit**, because the snapshot cannot be generated at main's HEAD when the change it measures lives on a branch. #480 was merged that way deliberately.

## 2. The snapshot is only reproducible on an idle machine

`benchmark_5000_lines.f90` compiles in about 5s against the 10s default:

| load | compile | result |
|---|---:|---|
| ~8 | 5.0s | passes |
| ~257 | 48.8s | times out, reported FAIL |

Worse, the report records a timeout as `ffc_exit: 1`, not `124`. That reads as a compile error, and it sent me looking for a regression in unrelated dead-code removals for a good while before I thought to time the compile. #478 tracks making this reproducible.

## 3. `conformance_check.sh` cannot feed the generator

It does not pass `--require-provenance`, so its reports are rejected with `report provenance is not verified`. Neither script's help says so, and discovering it costs a full four-suite run.

## Verification

Documentation only.

```
fo
Static: OK (315 modules)   Build: OK   Tests: OK   Lint: OK
All stages passed (96.0s)
```

The first `fo` run reported `Tests: FAIL` and the next two were clean — the load-dependent flake in #478 again, which is itself an argument for that issue.