### PR TITLE
Document the three snapshot constraints that each cost something

### DIFF
--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -392,6 +392,45 @@ scripts/generate_parity_dashboard.sh \
     --from-snapshot test/conformance/parity_dashboard.tsv --check
 ```
 
+### Three constraints that are not obvious
+
+Each of these has broken `main` or produced a wrong measurement.
+
+**Generate from a branch whose HEAD equals `main`, as its first commit.** The
+snapshot records the ffc revision it was generated at, and the check requires
+that revision to be an ancestor of HEAD:
+
+```bash
+git merge-base --is-ancestor "$ffc_revision" HEAD \
+    || fail "snapshot ffc revision is not an ancestor"
+```
+
+Squash-merge creates a commit with no ancestry to the branch, so any commit
+sitting above `main` when the snapshot was generated takes the snapshot's
+provenance with it and `main` goes red on landing. The PR will be green on its
+own branch, which is why this is easy to miss.
+
+**A PR that both changes corpus behaviour and carries a regenerated snapshot
+must be merged with a merge commit, not squashed.** The snapshot cannot be
+generated at `main`'s HEAD when the change it measures lives on a branch, so
+preserving ancestry is the only option that keeps `main` green.
+
+**Regenerate on an idle machine, with a raised compile timeout.**
+
+```bash
+FFC_COMPILE_TIMEOUT=60 scripts/conformance_gauntlet.sh --suite ... --require-provenance
+```
+
+`benchmark_5000_lines.f90` compiles in about five seconds against the ten-second
+default, so it passes when the machine is quiet and times out when it is not.
+The report records a timeout as `ffc_exit: 1` rather than `124`, which reads as a
+compile error and invites a hunt for a regression that is not there. Two suites
+regenerated under load will disagree with two regenerated idle. See #478.
+
+Note also that `scripts/conformance_check.sh` does **not** pass
+`--require-provenance`, so its reports cannot feed the generator; invoke the
+gauntlet directly per suite as shown above.
+
 The generator requires Bash 4.3 or newer. It parses each flat JSON object,
 rejects unknown or duplicate fields, validates field types and totals, checks
 structured NOREF rows, verifies report provenance, and joins every disposition,


### PR DESCRIPTION
Re-lands the documentation from #482, which had to be reverted by #483 because its branch was cut from the wrong base.

`docs/CONFORMANCE.md` explains how to regenerate the parity snapshot but omits three constraints that decide whether `main` stays green.

## 1. Ancestry versus squash-merge

```bash
git merge-base --is-ancestor "$ffc_revision" HEAD || fail "..."
```

Squash-merge creates a commit with no ancestry to the branch, so a snapshot generated on a branch with commits above `main` records a revision that ceases to exist on `main`'s history. #477 was green on its branch and red the moment it landed.

Generate from a branch whose HEAD equals `main`, as its first commit. And a PR that both changes corpus behaviour and carries a regenerated snapshot needs a **merge commit** — #480 was merged that way deliberately.

## 2. Only reproducible on an idle machine

`benchmark_5000_lines.f90`: 5.0s compile against a 10s default.

| load | compile | result |
|---|---:|---|
| ~8 | 5.0s | passes |
| ~257 | 48.8s | times out, reported FAIL |

And the report records a timeout as `ffc_exit: 1`, not `124` — which reads as a compile error and cost an afternoon suspecting a regression in unrelated dead-code removals. #478.

## 3. `conformance_check.sh` cannot feed the generator

It does not pass `--require-provenance`, so its reports are rejected with `report provenance is not verified`. Discovering that costs a full four-suite run.

## This diff is one file

`git log main..HEAD` was empty before branching, and `git diff --stat` is `docs/CONFORMANCE.md | 39 +++`. That check is the thing #482 skipped: a branch cut from the wrong base produces a green PR whose description and contents diverge entirely, and reviewing the description will not catch it.

## Verification

```
fo
Static: OK (314 modules)   Build: OK   Tests: OK   Lint: OK
All stages passed (98.1s)
```