### PR TITLE
[scope-04] Bind BLOCK and ASSOCIATE storage scopes by identity

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -47,7 +47,8 @@ module session_program_lowering
         declaration_binding_t, resolve_name_at_node, &
         resolve_identifier_binding, BINDING_DECLARATION, &
         BINDING_DUMMY_ARGUMENT, BINDING_FUNCTION_RESULT, &
-        BINDING_NAMED_CONSTANT, ASSOCIATION_DIRECT, ASSOCIATION_HOST
+        BINDING_NAMED_CONSTANT, ASSOCIATION_DIRECT, ASSOCIATION_HOST, &
+        BINDING_ASSOCIATE_NAME
     use liric_session_bindings, only: destroy, begin_i32_main, &
         liric_session_t, &
         begin_i32_function, begin_i64_function, begin_void_subroutine, &
@@ -391,9 +392,10 @@ contains
         integer, intent(in) :: node_index
         type(declaration_binding_t) :: binding
         character(len=:), allocatable :: resolve_error
-        integer :: symbol_index
+        integer :: symbol_index, binding_index
 
         if (len_trim(name) == 0) return
+        if (context%storage_scope_depth <= 0) return
         ! The declaration has just run, so the newest same-named slot is the
         ! one it produced. This is the last place text is used as a key.
         symbol_index = find_symbol(context, name)
@@ -404,8 +406,22 @@ contains
         if (.not. binding%found) return
         if (binding%declaration_node_index /= node_index) return
         if (binding%scope_node_index <= 0) return
-        symbol_index = find_symbol_for_binding(context, binding)
-        if (symbol_index <= 0) return
+        binding_index = find_symbol_for_binding(context, binding)
+        if (binding_index > 0) then
+            symbol_index = binding_index
+        else if (context%symbols(symbol_index)%has_binding) then
+            return
+        end if
+        call attach_symbol_binding(context, symbol_index, binding)
+    end subroutine register_declaration_binding
+
+    subroutine attach_symbol_binding(context, symbol_index, binding)
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        type(declaration_binding_t), intent(in) :: binding
+
+        if (symbol_index <= 0 .or. symbol_index > context%symbol_count) return
+        if (.not. binding%found) return
         context%symbols(symbol_index)%has_binding = .true.
         context%symbols(symbol_index)%binding_declaration_index = &
             binding%declaration_node_index
@@ -416,7 +432,29 @@ contains
         call context%binding_table%insert_binding( &
             binding%declaration_node_index, binding%declaration_entity_index, &
             binding%scope_node_index, symbol_index)
-    end subroutine register_declaration_binding
+    end subroutine attach_symbol_binding
+
+    subroutine push_storage_scope(context, saved_symbol_count, saved_floor)
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(out) :: saved_symbol_count
+        integer, intent(out) :: saved_floor
+
+        saved_symbol_count = context%symbol_count
+        saved_floor = context%block_scope_floor
+        context%block_scope_floor = saved_symbol_count
+        context%storage_scope_depth = context%storage_scope_depth + 1
+    end subroutine push_storage_scope
+
+    subroutine pop_storage_scope(context, saved_symbol_count, saved_floor)
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: saved_symbol_count
+        integer, intent(in) :: saved_floor
+
+        call context%binding_table%drop_bindings_from(saved_symbol_count + 1)
+        context%symbol_count = saved_symbol_count
+        context%block_scope_floor = saved_floor
+        context%storage_scope_depth = max(0, context%storage_scope_depth - 1)
+    end subroutine pop_storage_scope
 
     subroutine lower_declaration_entities(node_in, node_index, context, error_msg)
         type(declaration_node), intent(in) :: node_in

--- a/src/session_program_lowering_associate.inc
+++ b/src/session_program_lowering_associate.inc
@@ -1,48 +1,64 @@
-    subroutine lower_associate(arena, node, context, error_msg)
+    subroutine lower_associate(arena, node, node_index, context, error_msg)
         ! Lower an ASSOCIATE construct over scalar selectors. Each associate
         ! name is bound, for the construct scope only, to the value of its
         ! selector expression. The body is then lowered, and the associate-name
         ! bindings are removed at the end of the construct.
         type(ast_arena_t), intent(in) :: arena
         type(associate_node), intent(in) :: node
+        integer, intent(in) :: node_index
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: i, saved_symbol_count
+        integer :: i, saved_symbol_count, saved_floor
         logical :: terminated
         type(lr_operand_desc_t) :: value
 
         call set_empty(error_msg)
+        terminated = .false.
         if (.not. allocated(node%associations)) then
             call set_empty(error_msg)
             return
         end if
-        saved_symbol_count = context%symbol_count
+        call push_storage_scope(context, saved_symbol_count, saved_floor)
         do i = 1, size(node%associations)
-            call bind_associate_name(arena, node%associations(i), context, &
-                                     error_msg)
-            if (len_trim(error_msg) > 0) return
+            call bind_associate_name(arena, node%associations(i), i, node_index, &
+                                     context, error_msg)
+            if (len_trim(error_msg) > 0) exit
         end do
-        if (allocated(node%body_indices)) then
+        if (len_trim(error_msg) == 0 .and. allocated(node%body_indices)) then
             call lower_statement_list(arena, node%body_indices, context, value, &
                                       terminated, error_msg)
-            if (len_trim(error_msg) > 0) return
         end if
-        ! Associate names are scoped to the construct: drop their bindings.
-        context%symbol_count = saved_symbol_count
+        ! Associate names are scoped to the construct: drop their storage and
+        ! binding identities even when body lowering reports an error.
+        call pop_storage_scope(context, saved_symbol_count, saved_floor)
+        if (len_trim(error_msg) > 0) return
+        if (terminated) context%current_block_terminated = terminated
     end subroutine lower_associate
 
-    subroutine bind_associate_name(arena, assoc, context, error_msg)
+    subroutine bind_associate_name(arena, assoc, association_index, scope_index, &
+                                   context, error_msg)
         type(ast_arena_t), intent(in) :: arena
         type(association_t), intent(in) :: assoc
+        integer, intent(in) :: association_index
+        integer, intent(in) :: scope_index
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: value_kind, idx, src_idx
         character(len=:), allocatable :: sel_name, name_err
         type(lr_operand_desc_t) :: value
+        type(declaration_binding_t) :: binding
 
         call set_empty(error_msg)
         if (.not. allocated(assoc%name)) then
             error_msg = 'associate name is missing'
+            return
+        end if
+        call resolve_name_at_node(arena, scope_index, assoc%name, binding, name_err)
+        if (len_trim(name_err) > 0 .or. .not. binding%found .or. &
+            binding%binding_kind /= BINDING_ASSOCIATE_NAME .or. &
+            binding%declaration_node_index /= scope_index .or. &
+            binding%declaration_entity_index /= association_index) then
+            error_msg = 'associate name has no FortFront binding: '//trim(assoc%name)
             return
         end if
         if (.not. node_exists(arena, assoc%expr_index)) then
@@ -56,11 +72,12 @@
         ! through reads under the associate name (Fortran 2018 11.1.3.3).
         if (is_identifier(arena, assoc%expr_index)) then
             call get_identifier_name(arena, assoc%expr_index, sel_name, name_err)
-            src_idx = find_symbol(context, sel_name)
+            src_idx = resolve_symbol_at_node(context, assoc%expr_index, sel_name)
             if (src_idx > 0) then
-                idx = associate_symbol_slot(context, assoc%name)
+                idx = associate_symbol_slot(context, binding)
                 context%symbols(idx) = context%symbols(src_idx)
                 context%symbols(idx)%name = trim(assoc%name)
+                call attach_symbol_binding(context, idx, binding)
                 return
             end if
         end if
@@ -71,15 +88,15 @@
         if (node_exists(arena, assoc%expr_index)) then
             select type (sel => arena%entries(assoc%expr_index)%node)
             type is (array_slice_node)
-                call bind_associate_array_section(arena, sel, assoc%name, &
+                call bind_associate_array_section(arena, sel, assoc%name, binding, &
                                                   context, error_msg)
                 return
             type is (component_access_node)
                 ! A derived-type component selector (associate(s => a%comp))
                 ! aliases the component's storage address, so reads and writes
                 ! through the associate name flow to the component.
-                call bind_associate_component(arena, sel, assoc%name, context, &
-                                              error_msg)
+                call bind_associate_component(arena, sel, assoc%name, binding, &
+                                              context, error_msg)
                 return
             end select
         end if
@@ -112,7 +129,7 @@
         end select
         if (len_trim(error_msg) > 0) return
 
-        idx = associate_symbol_slot(context, assoc%name)
+        idx = associate_symbol_slot(context, binding)
         context%symbols(idx)%name = trim(assoc%name)
         context%symbols(idx)%value_kind = value_kind
         context%symbols(idx)%value = value
@@ -123,6 +140,7 @@
         context%symbols(idx)%is_deferred_character = .false.
         context%symbols(idx)%is_array = .false.
         context%symbols(idx)%is_allocatable = .false.
+        call attach_symbol_binding(context, idx, binding)
     end subroutine bind_associate_name
 
     recursive logical function associate_selector_is_array(arena, node_index, &
@@ -150,18 +168,19 @@
 
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, id_err)
-            sym = find_symbol(context, id_name)
+            sym = resolve_symbol_at_node(context, node_index, id_name)
             if (sym > 0) is_arr = context%symbols(sym)%is_array
         end if
     end function associate_selector_is_array
 
-    integer function associate_symbol_slot(context, name) result(idx)
-        ! Find an existing symbol slot for an associate name, or append a fresh
-        ! one. Reuse keeps a same-named outer symbol shadowed for the construct.
+    integer function associate_symbol_slot(context, binding) result(idx)
+        ! Find an existing symbol slot for an associate binding, or append a
+        ! fresh one. The binding identity is what permits a same-named outer
+        ! symbol to remain untouched.
         type(lowering_context_t), intent(inout) :: context
-        character(len=*), intent(in) :: name
+        type(declaration_binding_t), intent(in) :: binding
 
-        idx = find_symbol(context, name)
+        idx = find_symbol_for_binding(context, binding)
         if (idx <= 0) then
             call grow_symbols(context)
             idx = context%symbol_count + 1
@@ -170,7 +189,7 @@
     end function associate_symbol_slot
 
     subroutine bind_associate_array_section(arena, slice_node, assoc_name, &
-                                            context, error_msg)
+                                            binding, context, error_msg)
         ! associate(x => a(lo:hi)): bind x to a rank-1, unit-stride view onto
         ! a(lo:hi)'s own storage (the associate name always starts at lower
         ! bound 1, Fortran 2018 11.1.3.3). Element access through x GEPs the
@@ -179,6 +198,7 @@
         type(ast_arena_t), intent(in) :: arena
         type(array_slice_node), intent(in) :: slice_node
         character(len=*), intent(in) :: assoc_name
+        type(declaration_binding_t), intent(in) :: binding
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
         type(array_section_info_t) :: info
@@ -231,7 +251,7 @@
         if (.not. ok) return
 
         extent = array_section_total_elements(info)
-        idx = associate_symbol_slot(context, assoc_name)
+        idx = associate_symbol_slot(context, binding)
         context%symbols(idx)%name = trim(assoc_name)
         context%symbols(idx)%value_kind = value_kind
         context%symbols(idx)%is_array = .true.
@@ -247,16 +267,18 @@
         context%symbols(idx)%is_parameter = .false.
         context%symbols(idx)%is_derived = .false.
         context%symbols(idx)%is_allocatable = .false.
+        call attach_symbol_binding(context, idx, binding)
         call set_empty(error_msg)
     end subroutine bind_associate_array_section
 
-    subroutine bind_associate_component(arena, comp_node, assoc_name, context, &
-                                        error_msg)
+    subroutine bind_associate_component(arena, comp_node, assoc_name, binding, &
+                                        context, error_msg)
         ! associate(s => a%comp): bind s to the component's own storage
         ! address, so reads and writes through s flow to a%comp.
         type(ast_arena_t), intent(in) :: arena
         type(component_access_node), intent(in) :: comp_node
         character(len=*), intent(in) :: assoc_name
+        type(declaration_binding_t), intent(in) :: binding
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t) :: component_address
@@ -274,7 +296,7 @@
             component_address, error_msg, 'associate component selector')
         if (len_trim(error_msg) > 0) return
 
-        idx = associate_symbol_slot(context, assoc_name)
+        idx = associate_symbol_slot(context, binding)
         context%symbols(idx)%name = trim(assoc_name)
         context%symbols(idx)%value_kind = comp_kind
         context%symbols(idx)%address = component_address
@@ -286,5 +308,6 @@
         context%symbols(idx)%is_deferred_character = .false.
         context%symbols(idx)%is_array = .false.
         context%symbols(idx)%is_allocatable = .false.
+        call attach_symbol_binding(context, idx, binding)
         call set_empty(error_msg)
     end subroutine bind_associate_component

--- a/src/session_program_lowering_block_concurrent.inc
+++ b/src/session_program_lowering_block_concurrent.inc
@@ -12,8 +12,8 @@
         integer :: saved_floor
 
         call set_empty(error_msg)
-        saved_symbol_count = context%symbol_count
-        saved_floor = context%block_scope_floor
+        terminated = .false.
+        call push_storage_scope(context, saved_symbol_count, saved_floor)
         ! Everything declared so far is an enclosing scope for this block. A
         ! BLOCK-local declaration that reuses an outer name then lands in a fresh
         ! slot above the floor, so its writes never touch the outer storage,
@@ -22,13 +22,12 @@
         if (allocated(node%body_indices)) then
             call lower_statement_list(arena, node%body_indices, context, value, &
                                       terminated, error_msg)
-            if (len_trim(error_msg) > 0) return
-            if (terminated) context%current_block_terminated = terminated
         end if
-        ! Discard BLOCK-local symbols so they are not visible outside; a shadowed
-        ! outer name reverts to its (untouched) outer slot automatically.
-        context%symbol_count = saved_symbol_count
-        context%block_scope_floor = saved_floor
+        ! Discard BLOCK-local symbols and their binding identities so neither a
+        ! shadowed name nor a later declaration can reuse stale construct state.
+        call pop_storage_scope(context, saved_symbol_count, saved_floor)
+        if (len_trim(error_msg) > 0) return
+        if (terminated) context%current_block_terminated = terminated
     end subroutine lower_block_construct
 
     subroutine lower_do_concurrent(arena, node, context, value, error_msg)

--- a/src/session_program_lowering_inferred.inc
+++ b/src/session_program_lowering_inferred.inc
@@ -209,6 +209,28 @@
                         context)
                 end do
             end if
+        type is (block_construct_node)
+            if (allocated(node%body_indices)) then
+                do i = 1, size(node%body_indices)
+                    call mark_explicit_declarations(arena, node%body_indices(i), &
+                        context)
+                end do
+            end if
+        type is (associate_node)
+            if (allocated(node%associations)) then
+                do i = 1, size(node%associations)
+                    if (allocated(node%associations(i)%name)) then
+                        call add_explicit_decl_name(context, &
+                            node%associations(i)%name)
+                    end if
+                end do
+            end if
+            if (allocated(node%body_indices)) then
+                do i = 1, size(node%body_indices)
+                    call mark_explicit_declarations(arena, node%body_indices(i), &
+                        context)
+                end do
+            end if
         end select
     end subroutine mark_explicit_declarations
 

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -900,7 +900,7 @@
         type is (select_rank_node)
             call lower_select_rank(arena, node, context, error_msg)
         type is (associate_node)
-            call lower_associate(arena, node, context, error_msg)
+            call lower_associate(arena, node, node_index, context, error_msg)
         type is (block_construct_node)
             call lower_block_construct(arena, node, context, error_msg)
         type is (where_node)

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -457,6 +457,10 @@ module session_program_lowering_types
         ! declaration inside a BLOCK whose name matches such a symbol creates a
         ! fresh shadowing slot instead of reusing the outer storage (#280).
         integer :: block_scope_floor = 0
+        ! Number of explicit BLOCK/ASSOCIATE storage scopes currently active.
+        ! Ordinary declaration registration stays out of this issue's scope;
+        ! construct-local declarations are the identities that must be popped.
+        integer :: storage_scope_depth = 0
         ! Arena index of the declaration whose specification expressions
         ! are being lowered (#329), or 0 outside a declaration. A
         ! specification expression - an array bound, a character length,

--- a/src/session_symbol_table.f90
+++ b/src/session_symbol_table.f90
@@ -44,10 +44,7 @@ module session_symbol_table
     contains
         procedure :: find_binding => table_find_binding
         procedure :: insert_binding => table_insert_binding
-        ! drop_from_symbol is deliberately not exposed. It is reachable only
-        ! from insert_binding, which is the sole point where a symbol slot can
-        ! be reused; see the note there.
-        procedure, private :: drop_from_symbol => table_drop_from_symbol
+        procedure :: drop_bindings_from => table_drop_from_symbol
     end type session_symbol_table_t
 
 contains
@@ -97,7 +94,7 @@ contains
         if (declaration_node_index <= 0) return
         if (scope_node_index <= 0) return
         if (symbol_index <= 0) return
-        call self%drop_from_symbol(symbol_index)
+        call self%drop_bindings_from(symbol_index)
         call grow_bindings(self)
         self%binding_count = self%binding_count + 1
         self%bindings(self%binding_count)%declaration_node_index = &
@@ -112,14 +109,8 @@ contains
         !! Forget every association whose symbol slot is `first_symbol_index`
         !! or above.
         !!
-        !! This does NOT track the lowering context truncating its symbol array
-        !! back to an enclosing scope. Roughly 40 sites assign
-        !! context%symbol_count downward and none of them notify this table, so
-        !! do not rely on it as a scope-exit hook. It exists solely so that
-        !! insert_binding cannot leave a stale identity attached to a slot it is
-        !! about to reuse.
-        !! or later. Called when the lowering context truncates its symbol
-        !! array back to an enclosing scope.
+        !! Called when the lowering context truncates its symbol array back to
+        !! an enclosing scope, and by insert_binding before a slot is reused.
         class(session_symbol_table_t), intent(inout) :: self
         integer, intent(in) :: first_symbol_index
         integer :: i

--- a/test/test_session_block_shadow_compiler.f90
+++ b/test/test_session_block_shadow_compiler.f90
@@ -2,7 +2,7 @@ program test_session_block_shadow_compiler
     ! #280: a variable declared inside a BLOCK shadows an identically named
     ! outer variable. Writes to the inner name must not touch the outer storage,
     ! and the outer value must be visible again after the block ends.
-    use ffc_test_support, only: expect_output
+    use ffc_test_support, only: expect_error_contains, expect_output
     implicit none
     logical :: all_passed
 
@@ -11,6 +11,8 @@ program test_session_block_shadow_compiler
 
     if (.not. test_shadow_restores_outer()) all_passed = .false.
     if (.not. test_outer_write_persists()) all_passed = .false.
+    if (.not. test_associate_shadow_restores_outer()) all_passed = .false.
+    if (.not. test_block_local_is_not_visible_after_end()) all_passed = .false.
 
     if (all_passed) then
         print *, 'PASS: BLOCK shadowing lowers through direct LIRIC session'
@@ -22,12 +24,14 @@ program test_session_block_shadow_compiler
 contains
 
     logical function test_shadow_restores_outer()
-        ! Inner BLOCK redeclares value, sets it to 2; outer value stays 1.
+        ! The outer value remains visible before and after the BLOCK while the
+        ! inner declaration shadows it only inside: 1, 2, 1.
         character(len=*), parameter :: source = &
             'program main'//new_line('a')// &
             '  implicit none'//new_line('a')// &
             '  integer :: value'//new_line('a')// &
             '  value = 1'//new_line('a')// &
+            '  print *, value'//new_line('a')// &
             '  block'//new_line('a')// &
             '    integer :: value'//new_line('a')// &
             '    value = 2'//new_line('a')// &
@@ -36,7 +40,8 @@ contains
             '  print *, value'//new_line('a')// &
             'end program main'
         test_shadow_restores_outer = expect_output( &
-            source, '           2'//new_line('a')//'           1'//new_line('a'), &
+            source, '           1'//new_line('a')//'           2'//new_line('a')// &
+            '           1'//new_line('a'), &
             '/tmp/ffc_block_shadow_test')
     end function test_shadow_restores_outer
 
@@ -58,5 +63,43 @@ contains
         test_outer_write_persists = expect_output( &
             source, '          16'//new_line('a'), '/tmp/ffc_block_outer_test2')
     end function test_outer_write_persists
+
+    logical function test_associate_shadow_restores_outer()
+        ! An ASSOCIATE name is a construct-local binding even when it has the
+        ! same spelling as the selector's host variable. The host storage must
+        ! be unchanged after END ASSOCIATE.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer :: value'//new_line('a')// &
+            '  value = 1'//new_line('a')// &
+            '  associate (value => 2)'//new_line('a')// &
+            '    print *, value'//new_line('a')// &
+            '  end associate'//new_line('a')// &
+            '  print *, value'//new_line('a')// &
+            'end program main'
+        test_associate_shadow_restores_outer = expect_output( &
+            source, '           2'//new_line('a')//'           1'//new_line('a'), &
+            '/tmp/ffc_associate_shadow_test')
+    end function test_associate_shadow_restores_outer
+
+    logical function test_block_local_is_not_visible_after_end()
+        ! A BLOCK declaration must be removed from storage lookup at the
+        ! construct boundary; FortFront therefore cannot be bypassed by a stale
+        ! text-keyed symbol after END BLOCK.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer :: outer'//new_line('a')// &
+            '  outer = 1'//new_line('a')// &
+            '  block'//new_line('a')// &
+            '    integer :: inside'//new_line('a')// &
+            '    inside = 2'//new_line('a')// &
+            '  end block'//new_line('a')// &
+            '  print *, inside'//new_line('a')// &
+            'end program main'
+        test_block_local_is_not_visible_after_end = expect_error_contains( &
+            source, 'was not declared', '/tmp/ffc_block_scope_error_test')
+    end function test_block_local_is_not_visible_after_end
 
 end program test_session_block_shadow_compiler


### PR DESCRIPTION
Closes #331.

## Summary

- bind BLOCK and ASSOCIATE construct-local storage to FortFront declaration identities;
- clean symbol slots and binding identities on every construct exit, including lowering errors;
- preserve outer storage for same-named BLOCK and ASSOCIATE locals;
- add independent output and diagnostic coverage for scope restoration and post-END BLOCK visibility.

## Validation

- `fo test test_session_block_shadow_compiler`
- `fo test test_session_associate_compiler`
- `fo test test_session_associate_selectors_compiler`
- `fo test test_session_structured_control_compiler`
- `fo test test_session_spec_expression_scope_compiler`
- `fo fmt --check`
- `FO_TEST_TIMEOUT=600 FO_BUILD_TIMEOUT=120 LIBRARY_PATH=../liric/build fo` (251 tests, lint, static checks, and build)