### PR TITLE
[decl-collect-01] register resolved declarations once

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -44,7 +44,7 @@ module session_program_lowering
         is_literal, get_literal_info, &
         is_identifier, get_identifier_name, &
         is_module_node, is_program_node, &
-        declaration_binding_t, resolve_name_at_node, &
+        declaration_binding_t, resolve_name_at_node, get_scope_bindings, &
         resolve_identifier_binding, BINDING_DECLARATION, &
         BINDING_DUMMY_ARGUMENT, BINDING_FUNCTION_RESULT, &
         BINDING_NAMED_CONSTANT, ASSOCIATION_DIRECT, ASSOCIATION_HOST, &
@@ -220,7 +220,7 @@ module session_program_lowering
         multi_unit_container_node, submodule_node
     use fortfront, only: get_node_line, get_node_column
     use session_program_lowering_types, only: lowering_context_t, &
-        branch_result_t, symbol_t, &
+        branch_result_t, symbol_t, declaration_record_t, &
         array_section_info_t, &
         reduction_operand_t, &
         derived_type_info_t, &
@@ -395,7 +395,6 @@ contains
         integer :: symbol_index, binding_index
 
         if (len_trim(name) == 0) return
-        if (context%storage_scope_depth <= 0) return
         ! The declaration has just run, so the newest same-named slot is the
         ! one it produced. This is the last place text is used as a key.
         symbol_index = find_symbol(context, name)
@@ -406,6 +405,9 @@ contains
         if (.not. binding%found) return
         if (binding%declaration_node_index /= node_index) return
         if (binding%scope_node_index <= 0) return
+        if (context%declaration_collection_complete) then
+            if (find_declaration_record(context, binding) <= 0) return
+        end if
         binding_index = find_symbol_for_binding(context, binding)
         if (binding_index > 0) then
             symbol_index = binding_index

--- a/src/session_program_lowering_arrays.inc
+++ b/src/session_program_lowering_arrays.inc
@@ -1884,6 +1884,9 @@
         integer(c_int64_t) :: extent
         logical :: is_dummy
         logical :: is_assumed
+        integer :: binding_index
+        type(declaration_binding_t) :: binding
+        character(len=:), allocatable :: binding_error
         type(lr_operand_desc_t) :: param_base
 
         is_assumed = present(assumed_extents)
@@ -1891,7 +1894,19 @@
         ! An array body declaration whose name matches a dummy argument binds
         ! the explicit-shape array view onto the parameter pointer instead of
         ! allocating fresh storage; the caller passes the actual's base address.
-        index = find_symbol(context, name)
+        binding_index = 0
+        if (context%current_declaration_index > 0) then
+            call resolve_name_at_node(context%arena, &
+                context%current_declaration_index, name, binding, binding_error)
+            if (len_trim(binding_error) == 0 .and. binding%found) then
+                binding_index = find_symbol_for_binding(context, binding)
+            end if
+        end if
+        if (binding_index > 0) then
+            index = binding_index
+        else
+            index = find_symbol(context, name)
+        end if
         is_dummy = .false.
         if (index > 0) then
             if (context%symbols(index)%is_common_bound) then
@@ -1900,6 +1915,17 @@
                 ! already set shape and element_address from this same
                 ! declaration node, so this occurrence is a benign redeclare.
                 call set_empty(error_msg)
+                return
+            end if
+            if (binding_index > 0 .and. context%symbols(index)%is_array .and. &
+                .not. context%symbols(index)%is_array_result .and. &
+                .not. context%symbols(index)%is_parameter) then
+                if (context%symbols(index)%value_kind /= value_kind) then
+                    error_msg = 'conflicting array declaration metadata: '// &
+                                trim(name)
+                else
+                    call set_empty(error_msg)
+                end if
                 return
             end if
             if (context%symbols(index)%is_parameter .and. &

--- a/src/session_program_lowering_declarations.inc
+++ b/src/session_program_lowering_declarations.inc
@@ -1,3 +1,502 @@
+    subroutine collect_resolved_declarations(arena, root_index, context, &
+                                             error_msg)
+        ! Build the declaration registry before any executable body is emitted.
+        ! FortFront owns the name-to-entity decision; this pass records the
+        ! binding returned at each declaration site, including a body
+        ! redeclaration that FortFront maps to a dummy or result identity. The
+        ! registry is metadata-only because storage operands can be created only
+        ! after a procedure's LIRIC function is active (#457).
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: root_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        call set_empty(error_msg)
+        context%declaration_record_count = 0
+        context%declaration_collection_complete = .false.
+        if (.not. allocated(context%declaration_records)) then
+            allocate(context%declaration_records(64))
+        end if
+        if (.not. node_exists(arena, root_index)) then
+            error_msg = 'declaration collection root is not an AST node'
+            return
+        end if
+
+        do i = 1, arena%size
+            if (.not. node_exists(arena, i)) cycle
+            select type (node => arena%entries(i)%node)
+            type is (declaration_node)
+                if (.not. declaration_is_collectable(arena, i, node)) cycle
+                call collect_declaration_node(arena, i, node, context, error_msg)
+                if (len_trim(error_msg) > 0) return
+            type is (parameter_declaration_node)
+                call collect_parameter_declaration_node(arena, i, node, context, &
+                                                        error_msg)
+                if (len_trim(error_msg) > 0) return
+            type is (function_def_node)
+                call collect_function_result_declaration(arena, i, node, &
+                                                         context, error_msg)
+                if (len_trim(error_msg) > 0) return
+            end select
+        end do
+        context%declaration_collection_complete = .true.
+    end subroutine collect_resolved_declarations
+
+    logical function declaration_is_collectable(arena, node_index, node) &
+        result(is_collectable)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(declaration_node), intent(in) :: node
+        integer :: parent_index
+
+        is_collectable = .false.
+        if (node_index <= 0) return
+        ! DIMENSION contributes shape to a later typed declaration, and EXTERNAL
+        ! contributes a procedure name. Neither introduces scalar/array storage.
+        if (declaration_is_bare_dimension(node)) return
+        if (node%is_external) return
+        ! Derived-type components are layout metadata, not procedure-local
+        ! entities. Their parent is not a lexical scope for name resolution.
+        parent_index = arena%entries(node_index)%parent_index
+        if (parent_index > 0 .and. node_exists(arena, parent_index)) then
+            select type (parent => arena%entries(parent_index)%node)
+            type is (derived_type_node)
+                return
+            end select
+        end if
+        if (node%is_multi_declaration) then
+            is_collectable = allocated(node%var_names) .and. &
+                             size(node%var_names) > 0
+        else
+            is_collectable = allocated(node%var_name) .and. &
+                             len_trim(node%var_name) > 0
+        end if
+    end function declaration_is_collectable
+
+    subroutine collect_declaration_node(arena, node_index, node, context, &
+                                         error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(declaration_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        call set_empty(error_msg)
+        if (node%is_multi_declaration .and. allocated(node%var_names)) then
+            do i = 1, size(node%var_names)
+                call collect_one_declaration_entity(arena, node_index, node, &
+                    trim(node%var_names(i)), context, error_msg)
+                if (len_trim(error_msg) > 0) return
+            end do
+        else if (allocated(node%var_name)) then
+            call collect_one_declaration_entity(arena, node_index, node, &
+                trim(node%var_name), context, error_msg)
+        end if
+    end subroutine collect_declaration_node
+
+    subroutine collect_one_declaration_entity(arena, node_index, node, name, &
+                                               context, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(declaration_node), intent(in) :: node
+        character(len=*), intent(in) :: name
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(declaration_binding_t) :: binding
+        type(declaration_record_t) :: record
+        character(len=:), allocatable :: resolve_error
+
+        call set_empty(error_msg)
+        if (len_trim(name) == 0) return
+        call resolve_name_at_node(arena, node_index, name, binding, resolve_error)
+        if (len_trim(resolve_error) > 0) return
+        if (.not. binding%found) return
+        if (binding%scope_node_index <= 0 .or. &
+            (binding%binding_kind /= BINDING_DECLARATION .and. &
+             binding%binding_kind /= BINDING_NAMED_CONSTANT .and. &
+             binding%binding_kind /= BINDING_DUMMY_ARGUMENT .and. &
+             binding%binding_kind /= BINDING_FUNCTION_RESULT)) then
+            return
+        end if
+        call make_declaration_record(node, name, binding, context, record)
+        call store_declaration_record(context, record, error_msg)
+    end subroutine collect_one_declaration_entity
+
+    subroutine collect_parameter_declaration_node(arena, node_index, node, &
+                                                  context, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(parameter_declaration_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(declaration_binding_t) :: binding
+        type(declaration_record_t) :: record
+        character(len=:), allocatable :: resolve_error
+
+        call set_empty(error_msg)
+        if (.not. allocated(node%name)) return
+        if (len_trim(node%name) == 0) return
+        call resolve_name_at_node(arena, node_index, trim(node%name), binding, &
+                                  resolve_error)
+        if (len_trim(resolve_error) > 0) return
+        if (.not. binding%found) return
+        if (binding%scope_node_index <= 0 .or. &
+            (binding%binding_kind /= BINDING_DUMMY_ARGUMENT .and. &
+             binding%binding_kind /= BINDING_DECLARATION)) then
+            return
+        end if
+        call make_parameter_record(node, trim(node%name), binding, record)
+        call store_declaration_record(context, record, error_msg)
+    end subroutine collect_parameter_declaration_node
+
+    subroutine collect_function_result_declaration(arena, node_index, node, &
+                                                   context, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(function_def_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(declaration_binding_t), allocatable :: bindings(:)
+        type(declaration_binding_t) :: result_binding
+        type(declaration_record_t) :: record
+        character(len=:), allocatable :: resolve_error
+        integer :: i
+
+        call set_empty(error_msg)
+        call get_scope_bindings(arena, node_index, bindings, resolve_error)
+        if (len_trim(resolve_error) > 0) then
+            error_msg = resolve_error
+            return
+        end if
+        do i = 1, size(bindings)
+            if (bindings(i)%binding_kind /= BINDING_FUNCTION_RESULT) cycle
+            result_binding = bindings(i)
+            call make_function_result_record(arena, node, result_binding, &
+                                              context, record)
+            call store_declaration_record(context, record, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine collect_function_result_declaration
+
+    subroutine make_declaration_record(node, name, binding, context, record)
+        type(declaration_node), intent(in) :: node
+        character(len=*), intent(in) :: name
+        type(declaration_binding_t), intent(in) :: binding
+        type(lowering_context_t), intent(in) :: context
+        type(declaration_record_t), intent(out) :: record
+
+        record = declaration_record_t()
+        record%declaration_node_index = binding%declaration_node_index
+        record%declaration_entity_index = binding%declaration_entity_index
+        record%scope_node_index = binding%scope_node_index
+        record%name = trim(name)
+        if (allocated(node%type_name)) record%type_name = trim(node%type_name)
+        record%type_kind = node%resolved_type_kind
+        record%kind_value = node%resolved_kind_value
+        record%rank = node%resolved_rank
+        if (record%rank < 0 .and. allocated(node%dimension_indices)) then
+            record%rank = size(node%dimension_indices)
+        end if
+        record%is_array = node%is_array .or. record%rank > 0
+        record%is_parameter = node%is_parameter .and. &
+            binding%binding_kind == BINDING_NAMED_CONSTANT
+        record%value_kind = declaration_metadata_value_kind( &
+            record%type_kind, record%kind_value, record%type_name, context, &
+            node%line, node%column, node%resolved_derived_type_name)
+    end subroutine make_declaration_record
+
+    subroutine make_parameter_record(node, name, binding, record)
+        type(parameter_declaration_node), intent(in) :: node
+        character(len=*), intent(in) :: name
+        type(declaration_binding_t), intent(in) :: binding
+        type(declaration_record_t), intent(out) :: record
+
+        record = declaration_record_t()
+        record%declaration_node_index = binding%declaration_node_index
+        record%declaration_entity_index = binding%declaration_entity_index
+        record%scope_node_index = binding%scope_node_index
+        record%name = trim(name)
+        if (allocated(node%type_name)) record%type_name = trim(node%type_name)
+        record%type_kind = node%resolved_type_kind
+        record%kind_value = node%resolved_kind_value
+        record%rank = node%resolved_rank
+        if (record%rank < 0 .and. allocated(node%dimension_indices)) then
+            record%rank = size(node%dimension_indices)
+        end if
+        ! A parameter-list entry has no shape until its specification-part
+        ! declaration is visited; rank zero here means "unknown", not scalar.
+        if (.not. node%is_array .and. record%rank == 0) record%rank = -1
+        record%is_array = node%is_array .or. record%rank > 0
+        record%value_kind = declaration_metadata_value_kind( &
+            record%type_kind, record%kind_value, record%type_name)
+    end subroutine make_parameter_record
+
+    subroutine make_function_result_record(arena, node, binding, context, record)
+        type(ast_arena_t), intent(in) :: arena
+        type(function_def_node), intent(in) :: node
+        type(declaration_binding_t), intent(in) :: binding
+        type(lowering_context_t), intent(in) :: context
+        type(declaration_record_t), intent(out) :: record
+        integer :: value_kind, derived_index
+        integer :: i, j
+        character(len=:), allocatable :: kind_error
+        logical :: found
+
+        record = declaration_record_t()
+        record%declaration_node_index = binding%declaration_node_index
+        record%declaration_entity_index = binding%declaration_entity_index
+        record%scope_node_index = binding%scope_node_index
+        record%name = trim(binding%name)
+        if (allocated(node%return_type)) record%type_name = trim(node%return_type)
+        record%type_kind = node%resolved_type_kind
+        record%kind_value = node%resolved_kind_value
+        record%rank = 0
+        record%is_array = .false.
+
+        if (allocated(node%body_indices)) then
+            do i = 1, size(node%body_indices)
+                if (.not. node_exists(arena, node%body_indices(i))) cycle
+                select type (decl => arena%entries(node%body_indices(i))%node)
+                type is (declaration_node)
+                    found = .false.
+                    if (decl%is_multi_declaration .and. &
+                        allocated(decl%var_names)) then
+                        do j = 1, size(decl%var_names)
+                            if (same_name(decl%var_names(j), record%name)) then
+                                found = .true.
+                                exit
+                            end if
+                        end do
+                    else if (allocated(decl%var_name)) then
+                        found = same_name(decl%var_name, record%name)
+                    end if
+                    if (.not. found) cycle
+                    record%type_name = ''
+                    if (allocated(decl%type_name)) &
+                        record%type_name = trim(decl%type_name)
+                    record%type_kind = decl%resolved_type_kind
+                    record%kind_value = decl%resolved_kind_value
+                    record%rank = decl%resolved_rank
+                    if (record%rank < 0 .and. allocated(decl%dimension_indices)) &
+                        record%rank = size(decl%dimension_indices)
+                    record%is_array = decl%is_array .or. record%rank > 0
+                    exit
+                end select
+            end do
+        end if
+
+        value_kind = 0
+        derived_index = 0
+        call set_empty(kind_error)
+        call function_value_kind(node, context, value_kind, derived_index, &
+                                 kind_error, binding%scope_node_index)
+        if (value_kind > 0) record%value_kind = value_kind
+        if (record%type_kind == 0) then
+            record%type_kind = value_kind_type_kind(record%value_kind)
+        end if
+        if (record%value_kind == VALUE_ARRAY_RESULT .or. &
+            record%value_kind == VALUE_ALLOC_ARRAY_RESULT) record%is_array = .true.
+    end subroutine make_function_result_record
+
+    integer function declaration_metadata_value_kind(type_kind, kind_value, &
+        type_name, context, line, column, derived_name) result(value_kind)
+        integer, intent(in) :: type_kind
+        integer, intent(in) :: kind_value
+        character(len=*), intent(in) :: type_name
+        type(lowering_context_t), intent(in), optional :: context
+        integer, intent(in), optional :: line, column
+        character(len=*), intent(in), optional :: derived_name
+        character(len=:), allocatable :: kind_error
+        integer :: candidate, source_line, source_column
+
+        value_kind = 0
+        source_line = 1
+        source_column = 1
+        if (present(line)) source_line = line
+        if (present(column)) source_column = column
+        select case (type_kind)
+        case (TINT)
+            select case (kind_value)
+            case (1)
+                value_kind = VALUE_I8
+            case (2)
+                value_kind = VALUE_I16
+            case (8)
+                value_kind = VALUE_I64
+            case default
+                value_kind = VALUE_I32
+            end select
+        case (TREAL)
+            if (kind_value == 8) then
+                value_kind = VALUE_F64
+            else
+                value_kind = VALUE_F32
+            end if
+        case (TDOUBLE)
+            value_kind = VALUE_F64
+        case (TLOGICAL)
+            value_kind = VALUE_LOGICAL
+        case (TCHAR)
+            value_kind = VALUE_CHARACTER
+        case (TCOMPLEX)
+            if (kind_value == 8) then
+                value_kind = VALUE_C8
+            else
+                value_kind = VALUE_C4
+            end if
+        case (TDERIVED)
+            value_kind = VALUE_DERIVED
+        case default
+            if (present(derived_name)) then
+                if (len_trim(derived_name) > 0) then
+                    value_kind = VALUE_DERIVED
+                    return
+                end if
+            end if
+            if (len_trim(type_name) > 0) then
+                candidate = VALUE_I32
+                call set_empty(kind_error)
+                if (present(context)) then
+                    call type_name_value_kind(type_name, source_line, &
+                        source_column, candidate, kind_error, context)
+                else
+                    call type_name_value_kind(type_name, source_line, &
+                        source_column, candidate, kind_error)
+                end if
+                if (len_trim(kind_error) == 0) value_kind = candidate
+            end if
+        end select
+    end function declaration_metadata_value_kind
+
+    integer function value_kind_type_kind(value_kind) result(type_kind)
+        integer, intent(in) :: value_kind
+
+        select case (value_kind)
+        case (VALUE_F32, VALUE_F64)
+            type_kind = TREAL
+        case (VALUE_LOGICAL)
+            type_kind = TLOGICAL
+        case (VALUE_CHARACTER)
+            type_kind = TCHAR
+        case (VALUE_C4, VALUE_C8)
+            type_kind = TCOMPLEX
+        case (VALUE_DERIVED)
+            type_kind = TDERIVED
+        case default
+            type_kind = TINT
+        end select
+    end function value_kind_type_kind
+
+    subroutine store_declaration_record(context, record, error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        type(declaration_record_t), intent(in) :: record
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        call set_empty(error_msg)
+        if (record%declaration_node_index <= 0 .or. &
+            record%scope_node_index <= 0) return
+        do i = 1, context%declaration_record_count
+            if (.not. same_declaration_identity( &
+                context%declaration_records(i), record)) cycle
+            if (.not. same_declaration_metadata( &
+                context%declaration_records(i), record)) then
+                error_msg = 'conflicting declaration metadata for '// &
+                            trim(record%name)
+            else
+                call merge_declaration_metadata(context%declaration_records(i), &
+                                                record)
+            end if
+            return
+        end do
+        if (context%declaration_record_count >= &
+            size(context%declaration_records)) then
+            call grow_declaration_records(context)
+        end if
+        context%declaration_record_count = context%declaration_record_count + 1
+        context%declaration_records(context%declaration_record_count) = record
+    end subroutine store_declaration_record
+
+    subroutine grow_declaration_records(context)
+        type(lowering_context_t), intent(inout) :: context
+        type(declaration_record_t), allocatable :: tmp(:)
+        integer :: old_size, new_size
+
+        old_size = 0
+        if (allocated(context%declaration_records)) &
+            old_size = size(context%declaration_records)
+        new_size = max(64, 2 * old_size)
+        allocate(tmp(new_size))
+        if (context%declaration_record_count > 0) then
+            tmp(1:context%declaration_record_count) = &
+                context%declaration_records(1:context%declaration_record_count)
+        end if
+        call move_alloc(tmp, context%declaration_records)
+    end subroutine grow_declaration_records
+
+    logical function same_declaration_identity(lhs, rhs) result(same)
+        type(declaration_record_t), intent(in) :: lhs
+        type(declaration_record_t), intent(in) :: rhs
+
+        same = lhs%declaration_node_index == rhs%declaration_node_index .and. &
+               lhs%declaration_entity_index == rhs%declaration_entity_index .and. &
+               lhs%scope_node_index == rhs%scope_node_index
+    end function same_declaration_identity
+
+    logical function same_declaration_metadata(lhs, rhs) result(same)
+        type(declaration_record_t), intent(in) :: lhs
+        type(declaration_record_t), intent(in) :: rhs
+
+        same = .true.
+        if (lhs%type_kind > 0 .and. rhs%type_kind > 0) &
+            same = same .and. lhs%type_kind == rhs%type_kind
+        if (lhs%kind_value > 0 .and. rhs%kind_value > 0) &
+            same = same .and. lhs%kind_value == rhs%kind_value
+        if (lhs%value_kind > 0 .and. rhs%value_kind > 0) &
+            same = same .and. lhs%value_kind == rhs%value_kind
+        if (lhs%rank >= 0 .and. rhs%rank >= 0) then
+            same = same .and. lhs%rank == rhs%rank
+            same = same .and. (lhs%is_array .eqv. rhs%is_array)
+        end if
+        same = same .and. (lhs%is_parameter .eqv. rhs%is_parameter)
+    end function same_declaration_metadata
+
+    subroutine merge_declaration_metadata(destination, source)
+        type(declaration_record_t), intent(inout) :: destination
+        type(declaration_record_t), intent(in) :: source
+
+        if (destination%type_kind <= 0) destination%type_kind = source%type_kind
+        if (destination%kind_value <= 0) destination%kind_value = source%kind_value
+        if (destination%value_kind <= 0) destination%value_kind = source%value_kind
+        if (destination%rank < 0 .and. source%rank >= 0) then
+            destination%rank = source%rank
+            destination%is_array = source%is_array
+        end if
+        if (len_trim(destination%type_name) == 0) &
+            destination%type_name = source%type_name
+    end subroutine merge_declaration_metadata
+
+    integer function find_declaration_record(context, binding) result(index)
+        type(lowering_context_t), intent(in) :: context
+        type(declaration_binding_t), intent(in) :: binding
+        integer :: i
+
+        index = 0
+        if (.not. binding%found) return
+        do i = context%declaration_record_count, 1, -1
+            if (context%declaration_records(i)%declaration_node_index /= &
+                binding%declaration_node_index) cycle
+            if (context%declaration_records(i)%declaration_entity_index /= &
+                binding%declaration_entity_index) cycle
+            if (context%declaration_records(i)%scope_node_index /= &
+                binding%scope_node_index) cycle
+            index = i
+            return
+        end do
+    end function find_declaration_record
+
     subroutine lower_constant_declaration(node, context, value_kind, error_msg)
         type(declaration_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context

--- a/src/session_program_lowering_derived_type_ops.inc
+++ b/src/session_program_lowering_derived_type_ops.inc
@@ -415,6 +415,9 @@
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: name
         integer :: lower_bound, n_elems, slots, index
+        integer :: binding_index
+        type(declaration_binding_t) :: binding
+        character(len=:), allocatable :: binding_error
 
         if (node%is_multi_declaration) then
             error_msg = 'multi-variable derived array declarations are not supported'
@@ -425,6 +428,25 @@
             return
         end if
         name = node%var_name
+        binding_index = 0
+        if (context%current_declaration_index > 0) then
+            call resolve_name_at_node(context%arena, &
+                context%current_declaration_index, name, binding, binding_error)
+            if (len_trim(binding_error) == 0 .and. binding%found) then
+                binding_index = find_symbol_for_binding(context, binding)
+            end if
+        end if
+        if (binding_index > 0) then
+            if (context%symbols(binding_index)%is_array .and. &
+                context%symbols(binding_index)%is_derived .and. &
+                context%symbols(binding_index)%derived_type_index == &
+                derived_type_index) then
+                call set_empty(error_msg)
+                return
+            end if
+            error_msg = 'conflicting derived array declaration: '//trim(name)
+            return
+        end if
         if (find_symbol(context, name) > 0) then
             error_msg = 'duplicate derived array declaration: '//trim(name)
             return

--- a/src/session_program_lowering_derived_types.inc
+++ b/src/session_program_lowering_derived_types.inc
@@ -28,6 +28,10 @@
                     ! Best effort: ignore errors here; body lowering reports them.
                     call lower_constant_declaration(node, context, VALUE_I32, &
                                                     decl_err)
+                    if (len_trim(decl_err) == 0) then
+                        call register_declaration_bindings(context, node, &
+                            program%body_indices(i))
+                    end if
                 end select
             end do
         end select

--- a/src/session_program_lowering_functions.inc
+++ b/src/session_program_lowering_functions.inc
@@ -1390,6 +1390,23 @@
         end do
     end subroutine copy_module_exports
 
+    subroutine copy_declaration_registry(source, destination)
+        type(lowering_context_t), intent(in) :: source
+        type(lowering_context_t), intent(inout) :: destination
+
+        if (allocated(destination%declaration_records)) then
+            deallocate(destination%declaration_records)
+        end if
+        if (allocated(source%declaration_records)) then
+            allocate(destination%declaration_records( &
+                size(source%declaration_records)))
+            destination%declaration_records = source%declaration_records
+        end if
+        destination%declaration_record_count = source%declaration_record_count
+        destination%declaration_collection_complete = &
+            source%declaration_collection_complete
+    end subroutine copy_declaration_registry
+
     subroutine copy_host_global_symbols(source, destination)
         type(lowering_context_t), intent(in) :: source
         type(lowering_context_t), intent(inout) :: destination
@@ -1436,6 +1453,7 @@
         character(len=:), allocatable :: name, resolve_error, kind_error
         logical :: found
         integer :: i, value_kind, result_derived_index, procedure_index
+        integer :: declaration_index
 
         call set_empty(error_msg)
         do i = 1, arena%size
@@ -1452,6 +1470,14 @@
             if (binding_scope_is_module(arena, binding%scope_node_index)) cycle
             if (binding%binding_kind /= BINDING_DECLARATION .and. &
                 binding%binding_kind /= BINDING_FUNCTION_RESULT) cycle
+            declaration_index = find_declaration_record(context, binding)
+            if (declaration_index > 0 .and. &
+                context%declaration_records(declaration_index)%is_array) then
+                call register_host_array_global_symbol(context, binding, name, &
+                    context%declaration_records(declaration_index), error_msg)
+                if (len_trim(error_msg) > 0) return
+                cycle
+            end if
             if (find_symbol_for_binding(context, binding) > 0) cycle
             value_kind = 0
             call set_empty(kind_error)
@@ -1616,6 +1642,122 @@
             binding%declaration_node_index, binding%declaration_entity_index, &
             binding%scope_node_index, index)
     end subroutine register_host_global_symbol
+
+    subroutine register_host_array_global_symbol(context, binding, name, record, &
+                                                 error_msg)
+        ! A contained procedure can use a fixed-size host array before the host
+        ! procedure's body is lowered. Give that binding one static global, just
+        ! as module arrays receive, so the later host declaration reuses the
+        ! identity instead of allocating a second array.
+        use, intrinsic :: iso_c_binding, only: c_bool, c_char, c_double, c_float, &
+            c_int32_t, c_int64_t, c_loc, c_ptr, c_size_t
+        type(lowering_context_t), intent(inout) :: context
+        type(declaration_binding_t), intent(in) :: binding
+        character(len=*), intent(in) :: name
+        type(declaration_record_t), intent(in) :: record
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: global_name
+        character(kind=c_char), allocatable :: c_name(:)
+        integer(c_int32_t), target, allocatable :: array_i32(:)
+        real(c_float), target, allocatable :: array_f32(:)
+        real(c_double), target, allocatable :: array_f64(:)
+        type(c_ptr) :: elem_type, global_type, init_ptr
+        integer(c_size_t) :: init_size
+        integer(c_int32_t) :: global_id
+        integer :: array_lower, array_size, index
+        logical(c_bool) :: c_false_local
+
+        call set_empty(error_msg)
+        if (find_symbol_for_binding(context, binding) > 0) return
+        if (record%rank /= 1) return
+        if (.not. node_exists(context%arena, binding%declaration_node_index)) return
+        if (.not. host_array_scope_is_program(context%arena, &
+                                              binding%scope_node_index)) return
+        select type (decl => &
+                context%arena%entries(binding%declaration_node_index)%node)
+        type is (declaration_node)
+            if (decl%is_allocatable .or. decl%is_pointer .or. decl%is_target) return
+            call get_array_bounds(decl, context, array_lower, array_size, error_msg)
+        class default
+            return
+        end select
+        if (len_trim(error_msg) > 0) return
+        if (array_size <= 0) return
+
+        c_false_local = .false.
+        select case (record%value_kind)
+        case (VALUE_I32, VALUE_LOGICAL)
+            allocate (array_i32(array_size))
+            array_i32 = 0_c_int32_t
+            elem_type = lr_type_i32_s(context%session%handle)
+            init_ptr = c_loc(array_i32)
+            init_size = int(array_size, c_size_t) * 4_c_size_t
+        case (VALUE_F32)
+            allocate (array_f32(array_size))
+            array_f32 = 0.0_c_float
+            elem_type = lr_type_f32_s(context%session%handle)
+            init_ptr = c_loc(array_f32)
+            init_size = int(array_size, c_size_t) * 4_c_size_t
+        case (VALUE_F64)
+            allocate (array_f64(array_size))
+            array_f64 = 0.0_c_double
+            elem_type = lr_type_f64_s(context%session%handle)
+            init_ptr = c_loc(array_f64)
+            init_size = int(array_size, c_size_t) * 8_c_size_t
+        case default
+            return
+        end select
+        global_name = host_global_name(binding, name)
+        call to_c_chars(global_name, c_name)
+        global_type = lr_type_array_s(context%session%handle, elem_type, &
+                                      int(array_size, c_int64_t))
+        global_id = lr_session_global(context%session%handle, c_name, global_type, &
+                                      c_false_local, init_ptr, init_size)
+        if (global_id < 0_c_int32_t) then
+            error_msg = 'LIRIC could not create host-associated array: '//trim(name)
+            return
+        end if
+        global_id = lr_session_intern(context%session%handle, c_name)
+        if (global_id < 0_c_int32_t) then
+            error_msg = 'LIRIC could not intern host-associated array: '//trim(name)
+            return
+        end if
+
+        call grow_symbols(context)
+        index = context%symbol_count + 1
+        context%symbols(index) = symbol_t()
+        context%symbols(index)%name = trim(name)
+        context%symbols(index)%value_kind = record%value_kind
+        context%symbols(index)%has_address = .true.
+        context%symbols(index)%is_reference = .true.
+        context%symbols(index)%is_array = .true.
+        context%symbols(index)%array_rank = 1
+        context%symbols(index)%array_size = array_size
+        context%symbols(index)%array_lower_bound = array_lower
+        context%symbols(index)%array_dim_sizes(1) = array_size
+        context%symbols(index)%array_dim_lowers(1) = array_lower
+        context%symbols(index)%address%kind = LR_OP_KIND_GLOBAL
+        context%symbols(index)%address%payload = int(global_id, c_int64_t)
+        context%symbols(index)%address%typ = lr_type_ptr_s(context%session%handle)
+        context%symbols(index)%address%global_offset = 0_c_int64_t
+        context%symbols(index)%element_address = context%symbols(index)%address
+        context%symbol_count = index
+        call attach_symbol_binding(context, index, binding)
+        call set_empty(error_msg)
+    end subroutine register_host_array_global_symbol
+
+    logical function host_array_scope_is_program(arena, scope_node_index) &
+        result(is_program_scope)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: scope_node_index
+
+        is_program_scope = .false.
+        if (.not. node_exists(arena, scope_node_index)) return
+        select type (scope => arena%entries(scope_node_index)%node)
+        type is (program_node)
+            is_program_scope = .true.
+        end select
+    end function host_array_scope_is_program
 
     subroutine materialize_host_character_globals(context, error_msg)
         ! Host-associated character results and variables use a mutable global
@@ -2399,6 +2541,7 @@
         call copy_internal_function_names(parent_context, context)
         call copy_derived_type_table(parent_context, context)
         call copy_module_exports(parent_context, context)
+        call copy_declaration_registry(parent_context, context)
         call copy_host_global_symbols(parent_context, context)
         result_binding_index = 0
         if (function_node_index > 0) then
@@ -2545,7 +2688,14 @@
             if (len_trim(error_msg) > 0) return
             context%current_function_result_index = find_symbol(context, result_name)
         end if
-       if (value_kind == VALUE_DEFERRED_CHARACTER_RESULT .or. &
+        ! The result binding is synthetic in FortFront (its identity is the
+        ! function scope), so publish it before any specification or executable
+        ! expression can reference the result name (#457).
+        if (result_binding%found .and. context%current_function_result_index > 0) then
+            call attach_symbol_binding(context, context%current_function_result_index, &
+                                       result_binding)
+        end if
+        if (value_kind == VALUE_DEFERRED_CHARACTER_RESULT .or. &
                 value_kind == VALUE_DERIVED .or. &
                 value_kind == VALUE_ARRAY_RESULT .or. &
                 value_kind == VALUE_ALLOC_ARRAY_RESULT .or. &

--- a/src/session_program_lowering_functions_tail.inc
+++ b/src/session_program_lowering_functions_tail.inc
@@ -36,6 +36,7 @@
         call copy_internal_function_names(parent_context, context)
         call copy_derived_type_table(parent_context, context)
         call copy_module_exports(parent_context, context)
+        call copy_declaration_registry(parent_context, context)
         if (present(procedure_node_index)) then
             context%current_proc_node_index = procedure_node_index
         else

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -129,6 +129,15 @@
             call destroy(context%session)
             return
         end if
+        ! Resolve every scalar/array declaration by FortFront identity before
+        ! any procedure or main body emits executable code (#457). Storage is
+        ! still materialized in the active procedure; this pass only records
+        ! declaration metadata and rejects identity conflicts.
+        call collect_resolved_declarations(arena, root_index, context, error_msg)
+        if (len_trim(error_msg) > 0) then
+            call destroy(context%session)
+            return
+        end if
         ! Internal procedures are emitted before the main body, so ordinary
         ! local declarations have not populated the parent symbol table yet.
         ! Materialise storage for any declaration whose FortFront binding is

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -287,6 +287,24 @@ module session_program_lowering_types
         character(len=:), allocatable :: character_constant_text
     end type symbol_t
 
+    ! One resolved declaration record. The binding triple is the identity;
+    ! names and source spelling are metadata retained for diagnostics and
+    ! later declaration lowering. A record may exist before its procedure has
+    ! an active LIRIC function, so it deliberately carries no storage operand.
+    type, public :: declaration_record_t
+        integer :: declaration_node_index = 0
+        integer :: declaration_entity_index = 0
+        integer :: scope_node_index = 0
+        character(len=64) :: name = ''
+        character(len=64) :: type_name = ''
+        integer :: type_kind = 0
+        integer :: kind_value = 0
+        integer :: value_kind = VALUE_I32
+        integer :: rank = 0
+        logical :: is_array = .false.
+        logical :: is_parameter = .false.
+    end type declaration_record_t
+
     type, public :: array_section_info_t
         character(len=64) :: source_name = ''
         integer :: source_index = 0
@@ -450,16 +468,22 @@ module session_program_lowering_types
         type(symbol_t), allocatable :: symbols(:)
         integer :: symbol_count = 0
         ! Maps a FortFront (declaration, scope) binding identity onto a
-        ! slot in `symbols` (#327). Populated as declarations lower;
+        ! slot in `symbols` (#327). Populated as declarations materialize;
         ! consulted before any name comparison at a reference site.
         type(session_symbol_table_t) :: binding_table
+        ! Resolved declaration metadata collected before executable lowering
+        ! (#457). This registry has no LIRIC operands: those are materialized
+        ! only inside the active procedure, while every later path can still
+        ! consult one binding-keyed declaration record.
+        type(declaration_record_t), allocatable :: declaration_records(:)
+        integer :: declaration_record_count = 0
+        logical :: declaration_collection_complete = .false.
         ! Symbols at index <= block_scope_floor belong to an enclosing scope. A
         ! declaration inside a BLOCK whose name matches such a symbol creates a
         ! fresh shadowing slot instead of reusing the outer storage (#280).
         integer :: block_scope_floor = 0
         ! Number of explicit BLOCK/ASSOCIATE storage scopes currently active.
-        ! Ordinary declaration registration stays out of this issue's scope;
-        ! construct-local declarations are the identities that must be popped.
+        ! Construct-local declarations are the identities that must be popped.
         integer :: storage_scope_depth = 0
         ! Arena index of the declaration whose specification expressions
         ! are being lowered (#329), or 0 outside a declaration. A

--- a/test/test_session_declaration_collection_compiler.f90
+++ b/test/test_session_declaration_collection_compiler.f90
@@ -1,0 +1,98 @@
+program test_session_declaration_collection_compiler
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+    logical :: all_passed
+
+    print *, '=== direct session declaration collection compiler test ==='
+    all_passed = .true.
+    if (.not. test_host_array_binding_is_reused()) all_passed = .false.
+    if (.not. test_nested_declarations_are_reused()) all_passed = .false.
+    if (.not. test_missing_binding_is_diagnosed()) all_passed = .false.
+    if (.not. test_conflicting_declaration_is_diagnosed()) all_passed = .false.
+    if (.not. all_passed) stop 1
+    print *, 'PASS: resolved declarations are collected by binding identity'
+
+contains
+
+    logical function test_host_array_binding_is_reused()
+        ! The internal procedure is lowered before the host body. Its host array
+        ! must therefore use the declaration's one binding-backed global; the
+        ! pre-change lowerer materialized a scalar host seed and then rejected
+        ! the host declaration as a duplicate array.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer :: values(2)'//new_line('a')// &
+            '  values = [3, 4]'//new_line('a')// &
+            '  call bump()'//new_line('a')// &
+            '  if (values(1) /= 4 .or. values(2) /= 5) stop 71'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine bump()'//new_line('a')// &
+            '    values = values + 1'//new_line('a')// &
+            '  end subroutine bump'//new_line('a')// &
+            'end program main'
+
+        test_host_array_binding_is_reused = expect_exit_status( &
+            source, 0, '/tmp/ffc_session_host_array_collection_test')
+    end function test_host_array_binding_is_reused
+
+    logical function test_nested_declarations_are_reused()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer :: input'//new_line('a')// &
+            '  integer :: offset'//new_line('a')// &
+            '  input = 3'//new_line('a')// &
+            '  offset = 4'//new_line('a')// &
+            '  if (evaluate(input) /= 16) stop 91'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  integer function evaluate(argument) result(answer)'//new_line('a')// &
+            '    integer, intent(in) :: argument'//new_line('a')// &
+            '    integer :: answer'//new_line('a')// &
+            '    integer :: i'//new_line('a')// &
+            '    integer :: samples(2)'//new_line('a')// &
+            '    answer = offset + argument'//new_line('a')// &
+            '    block'//new_line('a')// &
+            '      integer :: offset'//new_line('a')// &
+            '      offset = 2'//new_line('a')// &
+            '      answer = answer + offset'//new_line('a')// &
+            '    end block'//new_line('a')// &
+            '    do i = 1, 2'//new_line('a')// &
+            '      samples(i) = i'//new_line('a')// &
+            '      answer = answer + samples(i)'//new_line('a')// &
+            '    end do'//new_line('a')// &
+            '    answer = answer + offset'//new_line('a')// &
+            '  end function evaluate'//new_line('a')// &
+            'end program main'
+
+        test_nested_declarations_are_reused = expect_exit_status( &
+            source, 0, '/tmp/ffc_session_declaration_collection_test')
+    end function test_nested_declarations_are_reused
+
+    logical function test_missing_binding_is_diagnosed()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer :: value'//new_line('a')// &
+            '  value = missing'//new_line('a')// &
+            'end program main'
+
+        test_missing_binding_is_diagnosed = expect_error_contains( &
+            source, 'integer identifier was not declared: missing', &
+            '/tmp/ffc_session_declaration_missing_binding_test')
+    end function test_missing_binding_is_diagnosed
+
+    logical function test_conflicting_declaration_is_diagnosed()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer :: value'//new_line('a')// &
+            '  real :: value'//new_line('a')// &
+            '  print *, value'//new_line('a')// &
+            'end program main'
+
+        test_conflicting_declaration_is_diagnosed = expect_error_contains( &
+            source, 'value', '/tmp/ffc_session_declaration_conflict_test')
+    end function test_conflicting_declaration_is_diagnosed
+
+end program test_session_declaration_collection_compiler


### PR DESCRIPTION
## Summary

- collect resolved scalar, array, dummy, named-constant, and function-result declarations once before executable lowering
- retain FortFront binding identity, owning scope, type/kind/rank metadata, and reuse records across contained-procedure contexts
- materialize fixed-size program host arrays through one binding-backed global so nested procedures do not create duplicate storage
- add independent end-to-end coverage for locals, host arrays, loop variables, results, interface-visible dummies, missing names, and conflicting declarations

The previous order-dependent path could seed a host array as a scalar while lowering a contained procedure, then reject the real host declaration as a duplicate array. The new collection pass makes FortFront's binding identity authoritative before procedure lowering and keeps storage materialization in the active procedure or host-global prepass.

## Validation

- `fo test test_session_declaration_collection_compiler`
- focused scope, block, array, multi-declaration, `.fmod`, and unsupported-diagnostic targets
- `fo fmt --check`
- `FO_TEST_TIMEOUT=600 FO_BUILD_TIMEOUT=120 LIBRARY_PATH=../liric/build fo`

Closes #457
