### PR TITLE
[scope-06] fence legacy text symbol lookup

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -48,6 +48,7 @@ module session_program_lowering
         resolve_identifier_binding, BINDING_DECLARATION, &
         BINDING_DUMMY_ARGUMENT, BINDING_FUNCTION_RESULT, &
         BINDING_NAMED_CONSTANT, ASSOCIATION_DIRECT, ASSOCIATION_HOST, &
+        ASSOCIATION_USE, &
         BINDING_ASSOCIATE_NAME
     use liric_session_bindings, only: destroy, begin_i32_main, &
         liric_session_t, &
@@ -397,7 +398,7 @@ contains
         if (len_trim(name) == 0) return
         ! The declaration has just run, so the newest same-named slot is the
         ! one it produced. This is the last place text is used as a key.
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) return
         call resolve_name_at_node(context%arena, node_index, name, binding, &
             resolve_error)
@@ -773,7 +774,7 @@ contains
         integer :: symbol_index
 
         call set_empty(error_msg)
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) return
         select case (value_kind)
         case (VALUE_F32)
@@ -835,7 +836,7 @@ contains
         integer :: symbol_index
 
         call set_empty(error_msg)
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) return
         if (context%symbols(symbol_index)%is_runtime_fixed_character) then
             call lower_runtime_fixed_char_assignment(context%arena, init_index, &
@@ -892,7 +893,7 @@ contains
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: index
 
-        index = find_symbol(context, name)
+        index = find_symbol_compat(context, name)
         if (index <= 0) then
             call define_local_class_star_symbol(context, name, error_msg)
             return
@@ -921,7 +922,7 @@ contains
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: index
 
-        if (find_symbol(context, name) > 0) then
+        if (find_symbol_compat(context, name) > 0) then
             error_msg = 'duplicate class(*) declaration: '//trim(name)
             return
         end if
@@ -970,7 +971,7 @@ contains
         else
             value_kind = VALUE_I32
         end if
-        symbol_index = find_symbol(context, node%name)
+        symbol_index = find_symbol_compat(context, node%name)
         if (symbol_index <= 0) then
             error_msg = 'parameter declaration did not match a dummy argument: '// &
                 trim(node%name)
@@ -1032,7 +1033,7 @@ contains
             if (len_trim(binding_error) == 0 .and. binding%found) &
                 has_current_binding = .true.
         end if
-        text_index = find_symbol(context, name)
+        text_index = find_symbol_compat(context, name)
         existing_index = text_index
         if (has_current_binding) then
             binding_index = find_symbol_for_binding(context, binding)
@@ -1346,7 +1347,7 @@ contains
                 return
             end if
             if (allocated(target%name) .and. allocated(target%arg_indices)) then
-                symbol_index = find_symbol(context, target%name)
+                symbol_index = find_symbol_compat(context, target%name)
                 if (symbol_index > 0) then
                     if (context%symbols(symbol_index)%is_allocatable) then
                         call lower_array_element_assignment(arena, node, target, &
@@ -1369,7 +1370,7 @@ contains
         end select
         call identifier_name(arena, node%target_index, name, error_msg)
         if (len_trim(error_msg) > 0) return
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) then
             error_msg = 'assignment target was not declared: '//trim(name)
             return
@@ -1941,7 +1942,7 @@ contains
         end if
         call get_identifier_name(arena, arg_indices(1), var_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        symbol_index = find_symbol(context, var_name)
+        symbol_index = find_symbol_compat(context, var_name)
         if (symbol_index <= 0) then
             error_msg = trim(name)//' argument is not declared: '//trim(var_name)
             return
@@ -2345,7 +2346,13 @@ contains
             context%function_node_indices(1:size(tmp_indices)) = tmp_indices
     end subroutine grow_function_names
 
-    integer function find_symbol(context, name) result(index)
+    integer function find_symbol_compat(context, name) result(index)
+        !! Compatibility lookup for symbols synthesized without a FortFront
+        !! declaration (for example inferred locals, DO variables, and ABI
+        !! temporaries). Reference sites with an AST node must use
+        !! resolve_symbol_at_node so declaration identity is consulted first.
+        !! Keep this adapter private while the remaining synthetic-symbol
+        !! paths migrate away from textual lookup (#332).
         type(lowering_context_t), intent(in) :: context
         character(len=*), intent(in) :: name
         integer :: i
@@ -2362,15 +2369,15 @@ contains
                 return
             end if
         end do
-    end function find_symbol
+    end function find_symbol_compat
 
     integer function find_symbol_same_scope(context, name) result(index)
-        ! Like find_symbol, but ignores symbols belonging to an enclosing scope
-        ! (index <= block_scope_floor). A declaration that re-uses a name from an
-        ! outer BLOCK scope is a legal shadow, not a duplicate (#280).
+        ! Like find_symbol_compat, but ignores symbols belonging to an enclosing
+        ! scope (index <= block_scope_floor). A declaration that re-uses a name
+        ! from an outer BLOCK scope is a legal shadow, not a duplicate (#280).
         type(lowering_context_t), intent(in) :: context
         character(len=*), intent(in) :: name
-        index = find_symbol(context, name)
+        index = find_symbol_compat(context, name)
         if (index > 0 .and. index <= context%block_scope_floor) index = 0
     end function find_symbol_same_scope
 
@@ -2380,12 +2387,13 @@ contains
         !!
         !! FortFront owns name resolution: it maps the reference to a
         !! declaration binding, and the binding table maps that identity to a
-        !! symbol slot. Only when the reference has no FortFront binding, or
-        !! the bound declaration has no lowering symbol yet, does this fall
-        !! back to the historical text lookup — that fallback still carries
-        !! the symbols ffc synthesises without a declaration (inferred
-        !! lazy-Fortran locals, DO variables, ABI temporaries), which the
-        !! remaining scope issues will migrate.
+        !! symbol slot. Local bindings must resolve to an exact symbol identity.
+        !! Host- and USE-associated symbols may additionally use the private
+        !! compatibility adapter because module and .fmod import paths can
+        !! materialize legacy storage without carrying the local binding table
+        !! entry. The same exception covers inferred lazy-Fortran symbols that
+        !! have no collected declaration record. Collected direct/local
+        !! bindings never fall through to a flat name scan (#332).
         type(lowering_context_t), intent(in) :: context
         integer, intent(in) :: node_index
         character(len=*), intent(in) :: name
@@ -2395,21 +2403,23 @@ contains
 
         index = 0
         if (node_index <= 0) then
-            index = find_symbol(context, name)
+            index = find_symbol_compat(context, name)
             return
         end if
         call resolve_name_at_node(context%arena, node_index, name, binding, &
             resolve_error)
         if (len_trim(resolve_error) == 0 .and. binding%found) then
-            bound = context%binding_table%find_binding( &
-                binding%declaration_node_index, &
-                binding%declaration_entity_index, binding%scope_node_index)
+            bound = find_symbol_for_binding(context, binding)
             if (symbol_slot_holds_binding(context, bound, binding)) then
                 index = bound
                 return
             end if
+            if (binding%association /= ASSOCIATION_HOST .and. &
+                binding%association /= ASSOCIATION_USE .and. &
+                find_declaration_record(context, binding) > 0) return
         end if
-        index = find_symbol(context, name)
+        if (len_trim(resolve_error) > 0) return
+        index = find_symbol_compat(context, name)
     end function resolve_symbol_at_node
 
     integer function find_symbol_for_binding(context, binding) result(index)

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -2399,7 +2399,7 @@ contains
         character(len=*), intent(in) :: name
         type(declaration_binding_t) :: binding
         character(len=:), allocatable :: resolve_error
-        integer :: bound
+        integer :: bound, compat
 
         index = 0
         if (node_index <= 0) then
@@ -2412,6 +2412,12 @@ contains
             bound = find_symbol_for_binding(context, binding)
             if (symbol_slot_holds_binding(context, bound, binding)) then
                 index = bound
+                return
+            end if
+            compat = find_symbol_compat(context, name)
+            if (compat > 0 .and. context%symbols(compat)%&
+                is_statement_function_argument) then
+                index = compat
                 return
             end if
             if (binding%association /= ASSOCIATION_HOST .and. &

--- a/src/session_program_lowering_allocatable.inc
+++ b/src/session_program_lowering_allocatable.inc
@@ -65,7 +65,7 @@
                                          value_kind, error_msg)
                 if (len_trim(error_msg) > 0) return
                 if (value_kind == VALUE_CHARACTER) then
-                    symbol_index = find_symbol(context, node%var_names(i))
+                    symbol_index = find_symbol_compat(context, node%var_names(i))
                     if (symbol_index > 0) &
                         context%symbols(symbol_index)%character_length = &
                             character_length
@@ -75,7 +75,7 @@
             call declare_allocatable(context, node%var_name, rank, value_kind, &
                                      error_msg)
             if (len_trim(error_msg) == 0 .and. value_kind == VALUE_CHARACTER) then
-                symbol_index = find_symbol(context, node%var_name)
+                symbol_index = find_symbol_compat(context, node%var_name)
                 if (symbol_index > 0) &
                     context%symbols(symbol_index)%character_length = &
                         character_length
@@ -151,7 +151,7 @@
              size(node%shape_indices) == 0)) then
             call get_identifier_name(arena, node%var_indices(1), name, error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, name)
+            symbol_index = find_symbol_compat(context, name)
             if (symbol_index > 0) then
                 if (context%symbols(symbol_index)%is_allocatable .and. &
                     context%symbols(symbol_index)%array_rank == 0) then
@@ -168,7 +168,7 @@
             return
         end if
 
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) then
             call unsupported_feature_error('allocate statement', node%line, &
                 node%column, 'allocate target is not declared: '//trim(name), &
@@ -272,7 +272,7 @@
         if (is_identifier(arena, vi)) then
             call get_identifier_name(arena, vi, name, error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, name)
+            symbol_index = find_symbol_compat(context, name)
             if (symbol_index <= 0) return
             if (context%symbols(symbol_index)%is_allocatable .and. &
                 context%symbols(symbol_index)%array_rank == 0) then
@@ -288,7 +288,7 @@
             call set_empty(error_msg)
             return
         end if
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) return
         if (.not. context%symbols(symbol_index)%is_allocatable) return
 
@@ -369,7 +369,7 @@
             call set_empty(error_msg)
             return
         end if
-        sym = find_symbol(context, name)
+        sym = find_symbol_compat(context, name)
         if (sym <= 0) return
         if (context%symbols(sym)%value_kind /= VALUE_I32) return
         call assign_i32_to_symbol(context, sym, &
@@ -399,7 +399,7 @@
         call get_identifier_name(arena, node%var_indices(1), name, error_msg)
         if (len_trim(error_msg) > 0) return
 
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) then
             call unsupported_feature_error('allocate statement', node%line, &
                 node%column, 'allocate target is not declared: '//trim(name), &
@@ -584,7 +584,7 @@
                     return
                 end if
                 inner_name = trim(adjustl(expr(open_paren + 1:close_paren - 1)))
-                symbol_index = find_symbol(context, inner_name)
+                symbol_index = find_symbol_compat(context, inner_name)
                 if (symbol_index <= 0 .or. &
                     context%symbols(max(symbol_index, 1))%value_kind /= &
                     VALUE_CHARACTER) then
@@ -602,7 +602,7 @@
         if (verify(trim(expr), &
             'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_') &
             == 0) then
-            symbol_index = find_symbol(context, trim(expr))
+            symbol_index = find_symbol_compat(context, trim(expr))
             if (symbol_index <= 0) then
                 error_msg = 'length variable is not declared: '//trim(expr)
                 return
@@ -654,7 +654,7 @@
         end if
         call get_identifier_name(arena, node%var_indices(1), target_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        target_sym = find_symbol(context, target_name)
+        target_sym = find_symbol_compat(context, target_name)
         if (target_sym > 0) then
             if (context%symbols(target_sym)%is_allocatable .and. &
                 context%symbols(target_sym)%array_rank == 0) then
@@ -670,8 +670,8 @@
         call get_identifier_name(arena, source_expr, source_name, error_msg)
         if (len_trim(error_msg) > 0) return
 
-        target_sym = find_symbol(context, target_name)
-        source_sym = find_symbol(context, source_name)
+        target_sym = find_symbol_compat(context, target_name)
+        source_sym = find_symbol_compat(context, source_name)
         if (target_sym <= 0 .or. source_sym <= 0) then
             error_msg = 'mold/source allocate references an undeclared variable'
             return
@@ -1079,7 +1079,7 @@
         if (.not. is_identifier(arena, node_index)) return
         call get_identifier_name(arena, node_index, name, err)
         if (len_trim(err) > 0) return
-        sym = find_symbol(context, name)
+        sym = find_symbol_compat(context, name)
         if (sym <= 0) return
         scalar = .not. context%symbols(sym)%is_array .and. &
                  .not. context%symbols(sym)%is_allocatable .and. &
@@ -1203,7 +1203,7 @@
             return
         end if
 
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) then
             call unsupported_feature_error('deallocate statement', node%line, &
                 node%column, 'deallocate target is not declared: '//trim(name), &
@@ -1294,8 +1294,8 @@
         if (len_trim(error_msg) > 0) return
         call get_identifier_name(arena, arg_indices(2), to_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        from_sym = find_symbol(context, from_name)
-        to_sym   = find_symbol(context, to_name)
+        from_sym = find_symbol_compat(context, from_name)
+        to_sym   = find_symbol_compat(context, to_name)
         if (from_sym <= 0 .or. .not. context%symbols(from_sym)%is_allocatable) then
             error_msg = 'move_alloc: from argument is not an allocatable: '// &
                         trim(from_name)
@@ -1359,7 +1359,7 @@
         if (is_contained_function_reference(node, context)) return
         nargs = size(node%arg_indices)
         if (nargs < 1 .or. nargs > 2) return
-        symbol_index = find_symbol(context, node%name)
+        symbol_index = find_symbol_compat(context, node%name)
         if (symbol_index <= 0) return
         if (.not. context%symbols(symbol_index)%is_allocatable) return
         rank = context%symbols(symbol_index)%array_rank
@@ -1384,7 +1384,7 @@
         if (is_contained_function_reference(node, context)) return
         nargs = size(node%arg_indices)
         if (nargs < 1 .or. nargs > 2) return
-        symbol_index = find_symbol(context, node%name)
+        symbol_index = find_symbol_compat(context, node%name)
         if (symbol_index <= 0) return
         if (.not. context%symbols(symbol_index)%is_array) return
         if (context%symbols(symbol_index)%is_allocatable) return
@@ -1571,7 +1571,7 @@
             error_msg = 'character allocatable assignment target has no name'
             return
         end if
-        symbol_index = find_symbol(context, target%name)
+        symbol_index = find_symbol_compat(context, target%name)
         if (symbol_index <= 0) then
             error_msg = 'character allocatable array was not declared: '// &
                         trim(target%name)
@@ -1613,7 +1613,7 @@
             error_msg = 'character allocatable print target has no name'
             return
         end if
-        symbol_index = find_symbol(context, node%name)
+        symbol_index = find_symbol_compat(context, node%name)
         if (symbol_index <= 0) then
             error_msg = 'character allocatable array was not declared: '// &
                         trim(node%name)
@@ -1703,7 +1703,7 @@
         type(lr_operand_desc_t) :: descriptor, zero
         integer :: index, k
 
-        index = find_symbol(context, name)
+        index = find_symbol_compat(context, name)
         if (index > 0) then
             ! The allocatable array function result was pre-registered onto the
             ! caller's descriptor (param 0). Its body declaration re-states the
@@ -1793,7 +1793,7 @@
         call identifier_name(arena, arg_indices(1), name, error_msg)
         if (len_trim(error_msg) > 0) return
 
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) then
             error_msg = 'allocated argument was not declared: '//trim(name)
             return

--- a/src/session_program_lowering_array_elements.inc
+++ b/src/session_program_lowering_array_elements.inc
@@ -33,7 +33,7 @@
 
         call identifier_name(arena, slice_node%array_index, source_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        source_index = find_symbol(context, source_name)
+        source_index = find_symbol_compat(context, source_name)
         if (source_index <= 0) then
             error_msg = 'array section base was not declared: '//trim(source_name)
             return
@@ -491,7 +491,7 @@
             call set_empty(error_msg)
             return
         end if
-        sym = find_symbol(context, name)
+        sym = find_symbol_compat(context, name)
         if (sym <= 0) return
         if (.not. context%symbols(sym)%is_array .and. &
             .not. context%symbols(sym)%is_allocatable) return
@@ -631,7 +631,7 @@
         if (is_identifier(arena, expr_index)) then
             call get_identifier_name(arena, expr_index, id_name, err)
             if (len_trim(err) > 0) return
-            i = find_symbol(context, id_name)
+            i = find_symbol_compat(context, id_name)
             if (i > 0) then
                 if (is_elementwise_array_operand(context, i)) sym = i
             end if
@@ -847,7 +847,7 @@
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index <= 0) then
                 error_msg = 'whole-array expression identifier was not declared: '// &
                             trim(id_name)
@@ -1661,7 +1661,7 @@
 
         vk = VALUE_I32
         if (allocated(target%name)) then
-            sym_idx = find_symbol(context, target%name)
+            sym_idx = find_symbol_compat(context, target%name)
             if (sym_idx > 0) vk = context%symbols(sym_idx)%value_kind
         end if
 
@@ -1781,7 +1781,7 @@
             return
         end if
 
-        symbol_index = find_symbol(context, node%name)
+        symbol_index = find_symbol_compat(context, node%name)
         if (symbol_index <= 0) then
             error_msg = 'array identifier was not declared: '//trim(node%name)
             return
@@ -2023,7 +2023,7 @@
         integer :: symbol_index
 
         if (allocated(node%name)) then
-            symbol_index = find_symbol(context, node%name)
+            symbol_index = find_symbol_compat(context, node%name)
             if (symbol_index > 0) then
                 if (context%symbols(symbol_index)%is_allocatable) then
                     call lower_allocatable_element_address(arena, node, &
@@ -2057,7 +2057,7 @@
             error_msg = 'real array access requires an array name'
             return
         end if
-        symbol_index = find_symbol(context, node%name)
+        symbol_index = find_symbol_compat(context, node%name)
         if (symbol_index <= 0) then
             error_msg = 'real array identifier was not declared: '//trim(node%name)
             return
@@ -2150,7 +2150,7 @@
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index > 0) then
                 if (context%symbols(symbol_index)%is_array .or. &
                     context%symbols(symbol_index)%value_kind /= VALUE_I32) then
@@ -2376,7 +2376,7 @@
         if (.not. is_identifier(arena, idx)) return
         call get_identifier_name(arena, idx, name, name_err)
         if (len_trim(name_err) > 0) return
-        s = find_symbol(context, name)
+        s = find_symbol_compat(context, name)
         if (s <= 0) return
         if (.not. context%symbols(s)%is_array) return
         if (context%symbols(s)%is_allocatable) return

--- a/src/session_program_lowering_arrays.inc
+++ b/src/session_program_lowering_arrays.inc
@@ -116,7 +116,7 @@
         end if
         call get_identifier_name(arena, idx, id_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        symbol_index = find_symbol(context, id_name)
+        symbol_index = find_symbol_compat(context, id_name)
         if (symbol_index > 0) then
             if (context%symbols(symbol_index)%has_i32_constant) has_var = .false.
             return
@@ -154,11 +154,11 @@
         if (.not. declaration_bound_is_variable_driven(node, context)) return
         if (node%is_multi_declaration .and. allocated(node%var_names)) then
             do k = 1, size(node%var_names)
-                if (find_symbol(context, node%var_names(k)) > 0) return
+                if (find_symbol_compat(context, node%var_names(k)) > 0) return
             end do
             is_local = .true.
         else if (allocated(node%var_name)) then
-            is_local = find_symbol(context, node%var_name) <= 0
+            is_local = find_symbol_compat(context, node%var_name) <= 0
         end if
     end function declaration_is_runtime_local_array
 
@@ -175,7 +175,7 @@
         is_rebind = .false.
         if (.not. declaration_is_runtime_rank1(node, context)) return
         if (allocated(node%var_name)) then
-            index = find_symbol(context, node%var_name)
+            index = find_symbol_compat(context, node%var_name)
             if (index > 0) then
                 if (context%symbols(index)%is_array_result) is_rebind = .true.
             end if
@@ -183,7 +183,7 @@
         end if
         if (node%is_multi_declaration .and. allocated(node%var_names)) then
             do k = 1, size(node%var_names)
-                index = find_symbol(context, node%var_names(k))
+                index = find_symbol_compat(context, node%var_names(k))
                 if (index > 0) then
                     if (context%symbols(index)%is_array_result) is_rebind = .true.
                 end if
@@ -436,7 +436,7 @@
                 'contained procedure', error_msg)
             return
         end if
-        index = find_symbol(context, name)
+        index = find_symbol_compat(context, name)
         ! Guard the symbol-table access on its own line: .or. does not
         ! short-circuit, so index <= 0 must gate the array read separately.
         if (index <= 0) then
@@ -563,7 +563,7 @@
             ! runtime extent arguments already loaded for this dummy (one per
             ! dimension, rank-1 or rank-2) by bind_hidden_extent_params before
             ! this declaration ran.
-            index = find_symbol(context, name)
+            index = find_symbol_compat(context, name)
             if (dim_count >= 1 .and. dim_count <= 2 .and. index > 0) then
                 if (all(context%symbols(index)%has_runtime_dim_size(1:dim_count))) &
                         then
@@ -1284,7 +1284,7 @@
             call fold_scoped_i32_name(arena, context, node_index, id_name, &
                                       constant_value, scoped_found, error_msg)
             if (len_trim(error_msg) == 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index > 0) then
                 if (context%symbols(symbol_index)%has_i32_constant .and. &
                     context%symbols(symbol_index)%is_transient_i32_constant) then
@@ -1636,7 +1636,7 @@
         if (is_identifier(arena, arg_index)) then
             call get_identifier_name(arena, arg_index, id_name, error_msg)
             if (len_trim(error_msg) > 0) return
-            sym = find_symbol(context, id_name)
+            sym = find_symbol_compat(context, id_name)
             if (sym <= 0) then
                 error_msg = 'kind argument was not declared: '//trim(id_name)
                 return
@@ -1714,7 +1714,7 @@
         end if
         call get_identifier_name(arena, node%arg_indices(1), id_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, id_name)
+        sym = find_symbol_compat(context, id_name)
         if (sym > 0) then
             if (.not. context%symbols(sym)%is_array) sym = 0
         end if
@@ -1841,7 +1841,7 @@
         end if
         call get_identifier_name(arena, node%arg_indices(1), id_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, id_name)
+        sym = find_symbol_compat(context, id_name)
         if (sym <= 0) then
             error_msg = 'len argument was not declared: '//trim(id_name)
             return
@@ -1905,7 +1905,7 @@
         if (binding_index > 0) then
             index = binding_index
         else
-            index = find_symbol(context, name)
+            index = find_symbol_compat(context, name)
         end if
         is_dummy = .false.
         if (index > 0) then
@@ -2436,7 +2436,7 @@
             ! needs no explicit declaration. When it is not an existing symbol,
             ! bind a temporary i32 slot for the loop and drop it afterwards.
             created_temp = .false.
-            vsym = find_symbol(context, dnode%var_name)
+            vsym = find_symbol_compat(context, dnode%var_name)
             if (vsym <= 0) then
                 call grow_symbols(context)
                 vsym = context%symbol_count + 1
@@ -2843,7 +2843,7 @@
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, name, err)
             if (len_trim(err) > 0) return
-            sym = find_symbol(context, name)
+            sym = find_symbol_compat(context, name)
             if (sym > 0) scalar = .not. is_elementwise_array_operand(context, sym)
         end if
     end function is_scalar_broadcast_rhs
@@ -2871,7 +2871,7 @@
             call get_identifier_name(arena, rhs%arg_indices(1), source_name, &
                                      error_msg)
             if (len_trim(error_msg) > 0) return
-            source_index = find_symbol(context, source_name)
+            source_index = find_symbol_compat(context, source_name)
             if (source_index <= 0) then
                 error_msg = 'shape argument was not declared: '//trim(source_name)
                 return
@@ -2931,7 +2931,7 @@
         call get_identifier_name(arena, node%arg_indices(1), source_name, &
                                  error_msg)
         if (len_trim(error_msg) > 0) return
-        source_index = find_symbol(context, source_name)
+        source_index = find_symbol_compat(context, source_name)
         if (source_index <= 0) then
             error_msg = 'shape argument was not declared: '//trim(source_name)
             return
@@ -2987,7 +2987,7 @@
         end block
         call get_identifier_name(arena, node%arg_indices(1), array_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        source_index = find_symbol(context, array_name)
+        source_index = find_symbol_compat(context, array_name)
         if (source_index <= 0) then
             error_msg = 'size argument was not declared: '//trim(array_name)
             return
@@ -3133,7 +3133,7 @@
 
         call get_identifier_name(arena, node%arg_indices(1), array_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        source_index = find_symbol(context, array_name)
+        source_index = find_symbol_compat(context, array_name)
         if (source_index <= 0) then
             error_msg = trim(reduction_name)//' argument was not declared: '// &
                         trim(array_name)
@@ -3583,7 +3583,7 @@
         call get_identifier_name(arena, node%arg_indices(arg_pos), arg_name, error_msg)
         if (len_trim(error_msg) > 0) return
 
-        symbol_index = find_symbol(context, arg_name)
+        symbol_index = find_symbol_compat(context, arg_name)
         if (symbol_index <= 0) then
             error_msg = trim(intrinsic_name)//' '//trim(arg_role)// &
                         ' was not declared: '//trim(arg_name)
@@ -4092,7 +4092,7 @@
         if (is_identifier(arena, mask_index)) then
             call get_identifier_name(arena, mask_index, name, err)
             if (len_trim(err) > 0) return
-            sym = find_symbol(context, name)
+            sym = find_symbol_compat(context, name)
             if (sym <= 0) return
             if (context%symbols(sym)%is_array) extent = &
                 context%symbols(sym)%array_size
@@ -4124,7 +4124,7 @@
         end if
         call get_identifier_name(arena, mask_index, name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, name)
+        sym = find_symbol_compat(context, name)
         if (sym <= 0) then
             error_msg = 'pack/unpack mask was not declared: '//trim(name)
             return
@@ -4222,7 +4222,7 @@
             end if
             call get_identifier_name(arena, rhs%arg_indices(1), name, error_msg)
             if (len_trim(error_msg) > 0) return
-            source_index = find_symbol(context, name)
+            source_index = find_symbol_compat(context, name)
             if (source_index <= 0) then
                 error_msg = 'pack array was not declared: '//trim(name)
                 return
@@ -4404,7 +4404,7 @@
             end if
             call get_identifier_name(arena, rhs%arg_indices(1), name, error_msg)
             if (len_trim(error_msg) > 0) return
-            vector_index = find_symbol(context, name)
+            vector_index = find_symbol_compat(context, name)
             if (vector_index <= 0 .or. .not. &
                 context%symbols(max(vector_index, 1))%is_array) then
                 error_msg = 'unpack vector must be a declared array: '//trim(name)
@@ -4421,7 +4421,7 @@
             if (is_identifier(arena, rhs%arg_indices(3))) then
                 call get_identifier_name(arena, rhs%arg_indices(3), name, &
                                          name_err)
-                if (len_trim(name_err) == 0) field_sym = find_symbol(context, name)
+                if (len_trim(name_err) == 0) field_sym = find_symbol_compat(context, name)
             end if
             if (field_sym > 0) then
                 field_is_scalar = .not. context%symbols(field_sym)%is_array
@@ -4456,7 +4456,7 @@
         call get_identifier_name(arena, node%arg_indices(arg_pos), arg_name, &
                                  error_msg)
         if (len_trim(error_msg) > 0) return
-        symbol_index = find_symbol(context, arg_name)
+        symbol_index = find_symbol_compat(context, arg_name)
         if (symbol_index <= 0) then
             error_msg = trim(intrinsic_name)//' mask was not declared: '// &
                         trim(arg_name)
@@ -4730,7 +4730,7 @@
                                 call get_identifier_name(arena, sn%arg_indices(1), &
                                                          arg_name, error_msg)
                                 if (len_trim(error_msg) > 0) return
-                                shape_sym = find_symbol(context, arg_name)
+                                shape_sym = find_symbol_compat(context, arg_name)
                                 if (shape_sym > 0) then
                                     if (context%symbols(shape_sym)%is_array) return
                                 end if
@@ -4898,7 +4898,7 @@
         end if
         call get_identifier_name(arena, source_index, arg_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        source_sym = find_symbol(context, arg_name)
+        source_sym = find_symbol_compat(context, arg_name)
         if (source_sym <= 0) then
             error_msg = 'reshape source array was not declared: '//trim(arg_name)
             return

--- a/src/session_program_lowering_assumed_shape_extent.inc
+++ b/src/session_program_lowering_assumed_shape_extent.inc
@@ -252,7 +252,7 @@
             if (rank < 1) cycle
             call parameter_name(arena, param_indices(i), name, error_msg)
             if (len_trim(error_msg) > 0) return
-            sym_index = find_symbol(context, name)
+            sym_index = find_symbol_compat(context, name)
             if (sym_index <= 0) then
                 error_msg = 'assumed-shape dummy was not registered: '// &
                             trim(name)
@@ -287,7 +287,7 @@
 
         call get_identifier_name(arena, node_index, id_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        symbol_index = find_symbol(context, id_name)
+        symbol_index = find_symbol_compat(context, id_name)
         if (symbol_index <= 0) then
             error_msg = 'allocatable array argument was not declared: '// &
                         trim(id_name)
@@ -324,7 +324,7 @@
         end if
         call get_identifier_name(arena, node_index, id_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        symbol_index = find_symbol(context, id_name)
+        symbol_index = find_symbol_compat(context, id_name)
         if (symbol_index <= 0) then
             error_msg = 'array argument was not declared: '//trim(id_name)
             return

--- a/src/session_program_lowering_c_ptr.inc
+++ b/src/session_program_lowering_c_ptr.inc
@@ -15,7 +15,7 @@
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: index
 
-        if (find_symbol(context, name) > 0) then
+        if (find_symbol_compat(context, name) > 0) then
             error_msg = 'duplicate c_ptr declaration: '//trim(name)
             return
         end if
@@ -100,7 +100,7 @@
                 call set_empty(error_msg)
                 return
             end if
-            symbol_index = find_symbol(context, name)
+            symbol_index = find_symbol_compat(context, name)
             if (symbol_index <= 0) then
                 error_msg = 'c_ptr identifier was not declared: '//trim(name)
                 return
@@ -150,7 +150,7 @@
         end if
         call get_identifier_name(arena, arg_indices(1), name, error_msg)
         if (len_trim(error_msg) > 0) return
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) then
             error_msg = 'c_loc argument was not declared: '//trim(name)
             return
@@ -223,7 +223,7 @@
         end if
         call get_identifier_name(arena, arg_indices(2), name, error_msg)
         if (len_trim(error_msg) > 0) return
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) then
             error_msg = 'c_f_pointer target was not declared: '//trim(name)
             return

--- a/src/session_program_lowering_char_arrays.inc
+++ b/src/session_program_lowering_char_arrays.inc
@@ -191,7 +191,7 @@
 
         is_dummy = .false.
         if (.not. allocated(node%var_name)) return
-        index = find_symbol(context, node%var_name)
+        index = find_symbol_compat(context, node%var_name)
         if (index <= 0) return
         if (context%symbols(index)%is_parameter) is_dummy = .true.
     end function character_array_is_dummy
@@ -210,7 +210,7 @@
         integer :: index
         integer :: dim_count
 
-        if (find_symbol(context, name) > 0) then
+        if (find_symbol_compat(context, name) > 0) then
             error_msg = 'duplicate array declaration: '//trim(name)
             return
         end if
@@ -369,7 +369,7 @@
             error_msg = 'character array access requires an array name'
             return
         end if
-        symbol_index = find_symbol(context, node%name)
+        symbol_index = find_symbol_compat(context, node%name)
         if (symbol_index <= 0) then
             error_msg = 'character array was not declared: '//trim(node%name)
             return
@@ -595,7 +595,7 @@
                 call declare_allocatable(context, node%var_names(i), 1, &
                                          VALUE_CHARACTER, error_msg)
                 if (len_trim(error_msg) > 0) return
-                symbol_index = find_symbol(context, node%var_names(i))
+                symbol_index = find_symbol_compat(context, node%var_names(i))
                 if (symbol_index > 0) &
                     context%symbols(symbol_index)%character_length = 0
             end do
@@ -603,7 +603,7 @@
             call declare_allocatable(context, node%var_name, 1, VALUE_CHARACTER, &
                                      error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, node%var_name)
+            symbol_index = find_symbol_compat(context, node%var_name)
             if (symbol_index > 0) &
                 context%symbols(symbol_index)%character_length = 0
         else
@@ -651,7 +651,7 @@
         if (.not. allocated(target%arg_indices)) return
         if (size(target%arg_indices) /= 1) return
 
-        symbol_index = find_symbol(context, target%name)
+        symbol_index = find_symbol_compat(context, target%name)
         if (symbol_index <= 0) return
         if (.not. context%symbols(symbol_index)%is_allocatable) return
         if (context%symbols(symbol_index)%value_kind /= VALUE_CHARACTER) return

--- a/src/session_program_lowering_character.inc
+++ b/src/session_program_lowering_character.inc
@@ -7,7 +7,7 @@
         integer :: existing_index
         integer :: source_index
 
-        existing_index = find_symbol(context, name)
+        existing_index = find_symbol_compat(context, name)
         if (existing_index > 0) then
             if (context%in_internal_function .and. &
                 existing_index == context%current_function_result_index) then
@@ -90,7 +90,7 @@
 
         call define_deferred_character_symbol(context, name, error_msg)
         if (len_trim(error_msg) > 0) return
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) then
             error_msg = &
                 'internal error defining runtime-length character local: '// &
@@ -152,7 +152,7 @@
             'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_') &
             /= 0) return
 
-        source_index = find_symbol(context, inner)
+        source_index = find_symbol_compat(context, inner)
         if (source_index <= 0) return
         if (context%symbols(source_index)%value_kind /= VALUE_CHARACTER) &
             source_index = 0
@@ -243,7 +243,7 @@
 
         ! No FortFront binding: a symbol ffc synthesised without a declaration
         ! of its own still resolves by name, as it did before #329.
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) return
         if (.not. context%symbols(symbol_index)%has_i32_constant) return
         if (context%symbols(symbol_index)%i32_constant <= 0) return
@@ -275,7 +275,7 @@
         if (verify(expr, &
             'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_') &
             == 0) then
-            symbol_index = find_symbol(context, expr)
+            symbol_index = find_symbol_compat(context, expr)
             if (symbol_index <= 0) return
             runtime_character_length = &
                 .not. context%symbols(symbol_index)%has_i32_constant
@@ -339,7 +339,7 @@
         if (len(token) == 0) return
         if (verify(token(1:1), &
             'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_') /= 0) return
-        symbol_index = find_symbol(context, token)
+        symbol_index = find_symbol_compat(context, token)
         if (symbol_index <= 0) return
         token_is_runtime_symbol = &
             .not. context%symbols(symbol_index)%has_i32_constant
@@ -353,7 +353,7 @@
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: index
 
-        if (find_symbol(context, name) > 0) then
+        if (find_symbol_compat(context, name) > 0) then
             error_msg = 'duplicate character declaration: '//trim(name)
             return
         end if
@@ -553,7 +553,7 @@
 
         call get_identifier_name(arena, value_index, src_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        src_index = find_symbol(context, src_name)
+        src_index = find_symbol_compat(context, src_name)
         if (src_index <= 0 .or. &
             context%symbols(max(src_index, 1))%value_kind /= VALUE_CHARACTER) then
             call unsupported_feature_error('character assignment', 0, 0, &
@@ -689,7 +689,7 @@
         type(lr_operand_desc_t) :: data_addr
         type(lr_operand_desc_t) :: len_addr
 
-        if (find_symbol(context, name) > 0) then
+        if (find_symbol_compat(context, name) > 0) then
             error_msg = 'duplicate character declaration: '//trim(name)
             return
         end if
@@ -795,7 +795,7 @@
             call get_identifier_name(arena, node%arg_indices(1), id_name, &
                                      error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
         else
             call unsupported_feature_error('len/len_trim argument', node%line, &
                 node%column, 'direct LIRIC session only supports len/len_trim '// &
@@ -1131,7 +1131,7 @@
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index <= 0 .or. &
                 context%symbols(max(symbol_index, 1))%value_kind /= &
                 VALUE_CHARACTER) then
@@ -1181,7 +1181,7 @@
         integer :: symbol_index
 
         symbol_index = 0
-        if (allocated(node%name)) symbol_index = find_symbol(context, node%name)
+        if (allocated(node%name)) symbol_index = find_symbol_compat(context, node%name)
         if (symbol_index > 0) then
             if (context%symbols(symbol_index)%is_allocatable) then
                 ! An allocatable character array addresses its element pointer
@@ -1301,7 +1301,7 @@
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, id_err)
             if (len_trim(id_err) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index > 0) &
                 is_char = context%symbols(symbol_index)%value_kind == &
                           VALUE_CHARACTER

--- a/src/session_program_lowering_cmp_typecheck.inc
+++ b/src/session_program_lowering_cmp_typecheck.inc
@@ -82,7 +82,7 @@
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, id_err)
             if (len_trim(id_err) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index <= 0) return
             cls = comparison_value_kind_class( &
                   context%symbols(symbol_index)%value_kind)

--- a/src/session_program_lowering_common.inc
+++ b/src/session_program_lowering_common.inc
@@ -1225,7 +1225,7 @@
                                    node, slots, slot_count, error_msg)
         if (len_trim(error_msg) > 0) return
         do i = 1, slot_count
-            sym = find_symbol(context, slots(i)%var_name)
+            sym = find_symbol_compat(context, slots(i)%var_name)
             if (sym <= 0) then
                 call declare_pending_common_symbol(context, slots(i)%var_name, &
                                                    sym)

--- a/src/session_program_lowering_complex.inc
+++ b/src/session_program_lowering_complex.inc
@@ -89,7 +89,7 @@
             ! A complex array element reference (a(i)): recognized by the
             ! declared array symbol's element kind, same as the identifier case.
             if (.not. allocated(node%name)) return
-            sym = find_symbol(context, node%name)
+            sym = find_symbol_compat(context, node%name)
             if (sym <= 0) return
             if (.not. context%symbols(sym)%is_array) return
             is_c = context%symbols(sym)%value_kind == want_kind
@@ -97,7 +97,7 @@
             if (.not. is_identifier(arena, node_index)) return
             call get_identifier_name(arena, node_index, name, err)
             if (len_trim(err) > 0) return
-            sym = find_symbol(context, name)
+            sym = find_symbol_compat(context, name)
             if (sym <= 0) return
             is_c = context%symbols(sym)%value_kind == want_kind
         end select
@@ -280,7 +280,7 @@
                                           error_msg)
         type is (call_or_subscript_node)
             sym = 0
-            if (allocated(rhs%name)) sym = find_symbol(context, rhs%name)
+            if (allocated(rhs%name)) sym = find_symbol_compat(context, rhs%name)
             if (sym > 0) then
                 if (context%symbols(sym)%is_array .and. &
                     context%symbols(sym)%value_kind == VALUE_C4) then
@@ -298,7 +298,7 @@
             if (is_identifier(arena, rhs_index)) then
                 call get_identifier_name(arena, rhs_index, name, error_msg)
                 if (len_trim(error_msg) > 0) return
-                sym = find_symbol(context, name)
+                sym = find_symbol_compat(context, name)
             end if
             if (sym > 0 .and. context%symbols(sym)%value_kind == VALUE_C4) then
                 call load_complex_identifier(arena, rhs_index, context, VALUE_C4, &
@@ -393,7 +393,7 @@
                                           error_msg)
         type is (call_or_subscript_node)
             sym = 0
-            if (allocated(rhs%name)) sym = find_symbol(context, rhs%name)
+            if (allocated(rhs%name)) sym = find_symbol_compat(context, rhs%name)
             if (sym > 0) then
                 if (context%symbols(sym)%is_array .and. &
                     context%symbols(sym)%value_kind == VALUE_C8) then
@@ -411,7 +411,7 @@
             if (is_identifier(arena, rhs_index)) then
                 call get_identifier_name(arena, rhs_index, name, error_msg)
                 if (len_trim(error_msg) > 0) return
-                sym = find_symbol(context, name)
+                sym = find_symbol_compat(context, name)
             end if
             if (sym > 0 .and. context%symbols(sym)%value_kind == VALUE_C8) then
                 call load_complex_identifier(arena, rhs_index, context, VALUE_C8, &
@@ -613,7 +613,7 @@
         end if
         call get_identifier_name(arena, rhs_index, src_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        src_idx = find_symbol(context, src_name)
+        src_idx = find_symbol_compat(context, src_name)
         if (src_idx <= 0) then
             error_msg = tag//' rhs not declared: '//trim(src_name)
             return
@@ -760,7 +760,7 @@
         if (is_identifier(arena, node%arg_indices(1))) then
             call get_identifier_name(arena, node%arg_indices(1), arg_name, err)
             if (len_trim(err) > 0) return
-            sym = find_symbol(context, arg_name)
+            sym = find_symbol_compat(context, arg_name)
             if (sym <= 0) return
             if (context%symbols(sym)%is_array) return
             matches = context%symbols(sym)%value_kind == want_kind
@@ -786,7 +786,7 @@
             if (arg%base_expr_index > 0) return
             if (.not. allocated(arg%name)) return
             if (.not. allocated(arg%arg_indices)) return
-            sym = find_symbol(context, arg%name)
+            sym = find_symbol_compat(context, arg%name)
             if (sym <= 0) return
             if (.not. context%symbols(sym)%is_array) return
             matches = context%symbols(sym)%value_kind == want_kind
@@ -817,7 +817,7 @@
         end if
         call get_identifier_name(arena, node%arg_indices(1), arg_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, arg_name)
+        sym = find_symbol_compat(context, arg_name)
         if (want_imag) then
             slot = context%symbols(sym)%element_address
         else
@@ -905,7 +905,7 @@
                 call set_empty(error_msg)
                 return
             end if
-            sym = find_symbol(context, base_name)
+            sym = find_symbol_compat(context, base_name)
             if (sym <= 0) return
             vk = context%symbols(sym)%value_kind
             if (vk /= VALUE_C4 .and. vk /= VALUE_C8) return
@@ -926,7 +926,7 @@
         type is (call_or_subscript_node)
             if (base%base_expr_index > 0) return
             if (.not. allocated(base%name)) return
-            sym = find_symbol(context, base%name)
+            sym = find_symbol_compat(context, base%name)
             if (sym <= 0) return
             vk = context%symbols(sym)%value_kind
             if (vk /= VALUE_C4 .and. vk /= VALUE_C8) return

--- a/src/session_program_lowering_complex_arrays.inc
+++ b/src/session_program_lowering_complex_arrays.inc
@@ -23,7 +23,7 @@
             error_msg = 'complex array access requires an array name'
             return
         end if
-        symbol_index = find_symbol(context, node%name)
+        symbol_index = find_symbol_compat(context, node%name)
         if (symbol_index <= 0) then
             error_msg = 'complex array identifier was not declared: '// &
                         trim(node%name)
@@ -199,7 +199,7 @@
         if (.not. is_identifier(arena, node_index)) return
         call get_identifier_name(arena, node_index, nm, err)
         if (len_trim(err) > 0) return
-        sym = find_symbol(context, nm)
+        sym = find_symbol_compat(context, nm)
         if (sym <= 0) return
         if (.not. context%symbols(sym)%is_array) then
             sym = 0

--- a/src/session_program_lowering_const_fold.inc
+++ b/src/session_program_lowering_const_fold.inc
@@ -139,7 +139,7 @@
         if (is_identifier(arena, arg_index)) then
             call get_identifier_name(arena, arg_index, id_name, error_msg)
             if (len_trim(error_msg) > 0) return
-            sym = find_symbol(context, id_name)
+            sym = find_symbol_compat(context, id_name)
             if (sym <= 0) then
                 error_msg = 'huge argument was not declared: '//trim(id_name)
                 return
@@ -274,7 +274,7 @@
         else if (is_identifier(arena, arg_index)) then
             call get_identifier_name(arena, arg_index, id_name, error_msg)
             if (len_trim(error_msg) > 0) return
-            sym = find_symbol(context, id_name)
+            sym = find_symbol_compat(context, id_name)
             if (sym <= 0) then
                 error_msg = 'range argument was not declared: '//trim(id_name)
                 return
@@ -535,7 +535,7 @@
         else if (is_identifier(arena, arg_index)) then
             call get_identifier_name(arena, arg_index, id_name, error_msg)
             if (len_trim(error_msg) > 0) return
-            sym = find_symbol(context, id_name)
+            sym = find_symbol_compat(context, id_name)
             if (sym <= 0) then
                 error_msg = 'digits argument was not declared: '//trim(id_name)
                 return

--- a/src/session_program_lowering_data.inc
+++ b/src/session_program_lowering_data.inc
@@ -122,7 +122,7 @@
         end if
         call identifier_name(arena, obj_index, name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, name)
+        sym = find_symbol_compat(context, name)
         if (sym <= 0) then
             error_msg = 'data statement target was not declared: '//trim(name)
             return
@@ -220,7 +220,7 @@
         ! its variable, so resolve the control inside the loop, not before it.
         select type (idn => arena%entries(obj_index)%node)
         type is (io_implied_do_node)
-            var_sym = find_symbol(context, idn%var_name)
+            var_sym = find_symbol_compat(context, idn%var_name)
         class default
             error_msg = 'data implied-do node expected'
             return
@@ -287,7 +287,7 @@
 
         select type (tgt => arena%entries(obj_index)%node)
         type is (call_or_subscript_node)
-            sym = find_symbol(context, tgt%name)
+            sym = find_symbol_compat(context, tgt%name)
             if (sym <= 0) then
                 error_msg = 'data statement target was not declared: '//tgt%name
                 return
@@ -371,7 +371,7 @@
                 error_msg = 'data implied-do has no control variable'
                 return
             end if
-            var_sym = find_symbol(context, idn%var_name)
+            var_sym = find_symbol_compat(context, idn%var_name)
             if (var_sym <= 0) then
                 error_msg = 'data implied-do control variable not declared: '// &
                             idn%var_name

--- a/src/session_program_lowering_declarations.inc
+++ b/src/session_program_lowering_declarations.inc
@@ -52,6 +52,10 @@
 
         is_collectable = .false.
         if (node_index <= 0) return
+        ! FortFront-inserted declarations are legacy inferred symbols. They
+        ! intentionally stay on the compatibility path until their lowering
+        ! storage is migrated to binding identity (#332).
+        if (node%is_inferred) return
         ! DIMENSION contributes shape to a later typed declaration, and EXTERNAL
         ! contributes a procedure name. Neither introduces scalar/array storage.
         if (declaration_is_bare_dimension(node)) return
@@ -540,7 +544,7 @@
         end if
 
         name = node%var_name
-        index = find_symbol(context, name)
+        index = find_symbol_compat(context, name)
         if (index > 0) then
             ! Already collected by the parameter pre-pass (used for derived-type
             ! array component bounds). Re-declaring the same integer parameter is
@@ -584,7 +588,7 @@
         integer :: index
 
         name = node%var_name
-        if (find_symbol(context, name) > 0) then
+        if (find_symbol_compat(context, name) > 0) then
             error_msg = 'duplicate parameter declaration: '//trim(name)
             return
         end if
@@ -597,7 +601,7 @@
 
         call define_symbol(context, name, value_kind, error_msg)
         if (len_trim(error_msg) > 0) return
-        index = find_symbol(context, name)
+        index = find_symbol_compat(context, name)
         if (index <= 0) then
             error_msg = 'parameter declaration did not register a symbol: '// &
                         trim(name)
@@ -678,7 +682,7 @@
 
         call define_character_symbol(context, name, len(literal_text), error_msg)
         if (len_trim(error_msg) > 0) return
-        index = find_symbol(context, name)
+        index = find_symbol_compat(context, name)
         if (index <= 0) then
             error_msg = 'character parameter did not register a symbol: '// &
                         trim(name)
@@ -735,7 +739,7 @@
             call get_identifier_name(context%arena, node_index, id_name, &
                                      id_err)
             if (len_trim(id_err) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index <= 0) return
             if (.not. &
                 allocated(context%symbols(symbol_index)%character_constant_text)) &
@@ -972,7 +976,7 @@
             end if
             if (found) return
         end if
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) return
         if (.not. context%symbols(symbol_index)%is_parameter) return
         if (.not. context%symbols(symbol_index)%has_i32_constant) return

--- a/src/session_program_lowering_deferred_char.inc
+++ b/src/session_program_lowering_deferred_char.inc
@@ -33,7 +33,7 @@ integer function resolve_concat_operand(arena, node_index, context, &
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, name, error_msg)
             if (len_trim(error_msg) > 0) return
-            idx = find_symbol(context, trim(name))
+            idx = find_symbol_compat(context, trim(name))
             if (idx > 0) then
                 symbol_index = idx
                 out_name = trim(name)
@@ -402,7 +402,7 @@ integer function resolve_concat_operand(arena, node_index, context, &
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, lit_value, error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, lit_value)
+            symbol_index = find_symbol_compat(context, lit_value)
             if (symbol_index <= 0 .or. &
                 context%symbols(symbol_index)%value_kind /= VALUE_CHARACTER) then
                 error_msg = 'character argument is not declared: '//trim(lit_value)
@@ -461,7 +461,7 @@ integer function resolve_concat_operand(arena, node_index, context, &
             else if (is_identifier(arena, arg_indices(i))) then
                 call get_identifier_name(arena, arg_indices(i), id_name, error_msg)
                 if (len_trim(error_msg) > 0) return
-                symbol_index = find_symbol(context, id_name)
+                symbol_index = find_symbol_compat(context, id_name)
                 if (symbol_index > 0 .and. &
                     context%symbols(symbol_index)%value_kind == VALUE_CHARACTER) then
                     call prepare_deferred_char_actual(arena, arg_indices(i), &
@@ -753,7 +753,7 @@ integer function resolve_concat_operand(arena, node_index, context, &
         else if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, err)
             if (len_trim(err) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index <= 0) return
             if (context%symbols(symbol_index)%value_kind == VALUE_CHARACTER &
                 .and. .not. context%symbols(symbol_index)%is_deferred_character) &

--- a/src/session_program_lowering_derived_ctor.inc
+++ b/src/session_program_lowering_derived_ctor.inc
@@ -41,7 +41,7 @@
         if (is_identifier(arena, node%value_index)) then
             call get_identifier_name(arena, node%value_index, id_name, id_err)
             if (len_trim(id_err) > 0) return
-            src_index = find_symbol(context, id_name)
+            src_index = find_symbol_compat(context, id_name)
             if (src_index <= 0) return
             if (.not. context%symbols(src_index)%is_derived) return
             if (context%symbols(src_index)%is_array) return

--- a/src/session_program_lowering_derived_module_ops.inc
+++ b/src/session_program_lowering_derived_module_ops.inc
@@ -539,7 +539,7 @@
                         trim(param%name)
             return
         end if
-        if (find_symbol(context, trim(local_name)) > 0) return
+        if (find_symbol_compat(context, trim(local_name)) > 0) return
         call grow_symbols(context)
         index = context%symbol_count + 1
         context%symbols(index)%name = trim(local_name)
@@ -578,7 +578,7 @@
         if (.not. imported) return
         value_kind = value_kind_of_token(trim(var%kind))
         if (value_kind == 0) return
-        if (find_symbol(context, trim(local_name)) > 0) return
+        if (find_symbol_compat(context, trim(local_name)) > 0) return
         if (allocated(var%c_name) .and. len_trim(var%c_name) > 0) then
             mangled = trim(var%c_name)
         else
@@ -670,7 +670,7 @@
                 call eval_i32_constant(context%arena, init_index, context, &
                                        constant_value, error_msg)
                 if (len_trim(error_msg) > 0) return
-                if (find_symbol(context, trim(use_node%rename_list(i)%s)) > 0) then
+                if (find_symbol_compat(context, trim(use_node%rename_list(i)%s)) > 0) then
                     error_msg = 'duplicate use rename local name: '// &
                                 trim(use_node%rename_list(i)%s)
                     return
@@ -742,7 +742,7 @@
                 call set_empty(error_msg)
                 return
             end if
-            if (find_symbol(context, local_name) > 0) then
+            if (find_symbol_compat(context, local_name) > 0) then
                 error_msg = 'duplicate use rename local name: '//local_name
                 return
             end if
@@ -821,7 +821,7 @@
                 'scalar parameters', error_msg)
             return
         end if
-        if (find_symbol(context, local_name) > 0) then
+        if (find_symbol_compat(context, local_name) > 0) then
             error_msg = 'duplicate use rename local name: '//trim(local_name)
             return
         end if
@@ -1192,7 +1192,7 @@
             call get_declaration_var_name(arena, param_idx, decl_name, error_msg)
             if (len_trim(error_msg) > 0) return
             if (.not. use_only_wants(use_node, trim(decl_name))) cycle
-            if (find_symbol(context, decl_name) > 0) cycle
+            if (find_symbol_compat(context, decl_name) > 0) cycle
             call get_declaration_type_name(arena, param_idx, decl_type_name, &
                                            error_msg)
             if (len_trim(error_msg) > 0) return

--- a/src/session_program_lowering_derived_type_ops.inc
+++ b/src/session_program_lowering_derived_type_ops.inc
@@ -356,7 +356,7 @@
                 'value expression', error_msg)
             return
         end if
-        symbol_index = find_symbol(context, node%var_name)
+        symbol_index = find_symbol_compat(context, node%var_name)
         if (symbol_index <= 0) then
             error_msg = 'derived initializer target not defined: '//trim(node%var_name)
             return
@@ -447,7 +447,7 @@
             error_msg = 'conflicting derived array declaration: '//trim(name)
             return
         end if
-        if (find_symbol(context, name) > 0) then
+        if (find_symbol_compat(context, name) > 0) then
             error_msg = 'duplicate derived array declaration: '//trim(name)
             return
         end if
@@ -488,7 +488,7 @@
         integer :: slot_count
         integer :: index
 
-        index = find_symbol(context, name)
+        index = find_symbol_compat(context, name)
         if (index > 0) then
             ! Re-declaring the pre-bound function result variable (result(p)
             ! with type(t) :: p inside the body) is a no-op; its storage is the
@@ -713,7 +713,7 @@
 
         call component_base_name(arena, base_index, base_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        symbol_index = find_symbol(context, base_name)
+        symbol_index = find_symbol_compat(context, base_name)
         if (symbol_index <= 0) then
             error_msg = 'component base was not declared: '//trim(base_name)
             return
@@ -870,7 +870,7 @@
         if (.not. is_identifier(arena, base_var_index)) return
         call get_identifier_name(arena, base_var_index, var_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        symbol_index = find_symbol(context, var_name)
+        symbol_index = find_symbol_compat(context, var_name)
         if (symbol_index <= 0) return
         if (.not. context%symbols(symbol_index)%is_derived) return
         type_index = context%symbols(symbol_index)%derived_type_index
@@ -1002,7 +1002,7 @@
         pct = index(name, '%')
         var_name = trim(name(1:pct - 1))
         method_name = trim(name(pct + 1:))
-        symbol_index = find_symbol(context, var_name)
+        symbol_index = find_symbol_compat(context, var_name)
         if (symbol_index <= 0) then
             error_msg = 'type-bound call base was not declared: '//var_name
             return
@@ -1350,7 +1350,7 @@
         if (is_identifier(arena, value_index)) then
             call get_identifier_name(arena, value_index, name, error_msg)
             if (len_trim(error_msg) > 0) return
-            sym = find_symbol(context, name)
+            sym = find_symbol_compat(context, name)
             if (sym <= 0) then
                 error_msg = 'array component assignment rhs was not declared: '// &
                             trim(name)
@@ -1639,7 +1639,7 @@
         end if
         call get_identifier_name(arena, value_index, name, error_msg)
         if (len_trim(error_msg) > 0) return
-        src_sym = find_symbol(context, name)
+        src_sym = find_symbol_compat(context, name)
         if (src_sym <= 0) then
             error_msg = 'allocatable array component assignment rhs was not '// &
                         'declared: '//trim(name)
@@ -1982,7 +1982,7 @@
         if (is_identifier(arena, base_index)) then
             call get_identifier_name(arena, base_index, id_name, error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index <= 0) then
                 error_msg = 'component base was not declared: '//trim(id_name)
                 return
@@ -2008,7 +2008,7 @@
                 error_msg = 'only one-dimensional derived arrays are supported'
                 return
             end if
-            symbol_index = find_symbol(context, base%name)
+            symbol_index = find_symbol_compat(context, base%name)
             if (symbol_index <= 0) then
                 error_msg = 'component base was not declared: '//trim(base%name)
                 return
@@ -2227,7 +2227,7 @@
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index <= 0) then
                 error_msg = 'component base was not declared: '//trim(id_name)
                 return
@@ -2261,7 +2261,7 @@
                 error_msg = 'only one-dimensional derived arrays are supported'
                 return
             end if
-            symbol_index = find_symbol(context, base%name)
+            symbol_index = find_symbol_compat(context, base%name)
             if (symbol_index <= 0) then
                 error_msg = 'component base was not declared: '//trim(base%name)
                 return
@@ -2628,7 +2628,7 @@
         if (is_identifier(arena, base_index)) then
             call get_identifier_name(arena, base_index, id_name, err)
             if (len_trim(err) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
         else
             select type (base => arena%entries(base_index)%node)
             type is (call_or_subscript_node)
@@ -2640,7 +2640,7 @@
                                                            context)
                     return
                 end if
-                if (allocated(base%name)) symbol_index = find_symbol(context, base%name)
+                if (allocated(base%name)) symbol_index = find_symbol_compat(context, base%name)
             type is (component_access_node)
                 outer_type = component_base_type_index(arena, &
                                                        base%base_expr_index, context)

--- a/src/session_program_lowering_enum.inc
+++ b/src/session_program_lowering_enum.inc
@@ -58,7 +58,7 @@
         integer :: index
 
         call set_empty(error_msg)
-        if (find_symbol(context, name) > 0) then
+        if (find_symbol_compat(context, name) > 0) then
             error_msg = 'duplicate enumerator declaration: '//trim(name)
             return
         end if

--- a/src/session_program_lowering_equivalence.inc
+++ b/src/session_program_lowering_equivalence.inc
@@ -99,7 +99,7 @@
                                                   member_count, error_msg)
                 if (len_trim(error_msg) > 0) return
                 do i = 1, member_count
-                    sym = find_symbol(context, trim(names(i)))
+                    sym = find_symbol_compat(context, trim(names(i)))
                     if (sym <= 0) cycle
                     call rebind_equivalence_symbol(group_index, kinds(i), sym, &
                                                    context, error_msg)

--- a/src/session_program_lowering_expr_lowering.inc
+++ b/src/session_program_lowering_expr_lowering.inc
@@ -40,7 +40,7 @@
             return
         end select
 
-        symbol_index = find_symbol(context, arg_name)
+        symbol_index = find_symbol_compat(context, arg_name)
         if (symbol_index <= 0) then
             error_msg = 'present argument is not a dummy: '//trim(arg_name)
             return
@@ -649,7 +649,7 @@
                 if (.not. is_contained_function_reference(node, context) .and. &
                     (node%is_array_access .or. &
                      is_declared_array_element_ref(node, context))) then
-                    symbol_index = find_symbol(context, node%name)
+                    symbol_index = find_symbol_compat(context, node%name)
                     if (symbol_index > 0) then
                         is_f32 = context%symbols(symbol_index)%value_kind == VALUE_F32
                     end if
@@ -1100,7 +1100,7 @@
                 if (.not. is_contained_function_reference(node, context) .and. &
                     (node%is_array_access .or. &
                      is_declared_array_element_ref(node, context))) then
-                    symbol_index = find_symbol(context, node%name)
+                    symbol_index = find_symbol_compat(context, node%name)
                     if (symbol_index > 0) then
                         is_f64 = context%symbols(symbol_index)%value_kind == VALUE_F64
                     end if
@@ -1347,7 +1347,7 @@
             error_msg = 'integer(8) array access requires an array name'
             return
         end if
-        symbol_index = find_symbol(context, node%name)
+        symbol_index = find_symbol_compat(context, node%name)
         if (symbol_index <= 0) then
             error_msg = 'integer(8) array identifier was not declared: '// &
                         trim(node%name)
@@ -1516,7 +1516,7 @@
             error_msg = 'integer(1) array access requires an array name'
             return
         end if
-        symbol_index = find_symbol(context, node%name)
+        symbol_index = find_symbol_compat(context, node%name)
         if (symbol_index <= 0) then
             error_msg = 'integer(1) array identifier was not declared: '// &
                         trim(node%name)
@@ -1649,7 +1649,7 @@
             error_msg = 'integer(2) array access requires an array name'
             return
         end if
-        symbol_index = find_symbol(context, node%name)
+        symbol_index = find_symbol_compat(context, node%name)
         if (symbol_index <= 0) then
             error_msg = 'integer(2) array identifier was not declared: '// &
                         trim(node%name)

--- a/src/session_program_lowering_forall.inc
+++ b/src/session_program_lowering_forall.inc
@@ -35,7 +35,7 @@
 
         ! Ensure every index has an i32 loop symbol before lowering any bounds.
         do k = 1, node%num_indices
-            sym = find_symbol(context, trim(node%index_names(k)))
+            sym = find_symbol_compat(context, trim(node%index_names(k)))
             if (sym <= 0) then
                 call define_i32_symbol(context, trim(node%index_names(k)), &
                                        error_msg)

--- a/src/session_program_lowering_functions.inc
+++ b/src/session_program_lowering_functions.inc
@@ -1424,7 +1424,7 @@
                     source%symbols(i)%binding_entity_index
                 binding%scope_node_index = source%symbols(i)%binding_scope_index
                 if (find_symbol_for_binding(destination, binding) > 0) cycle
-            else if (find_symbol(destination, trim(source%symbols(i)%name)) > 0) then
+            else if (find_symbol_compat(destination, trim(source%symbols(i)%name)) > 0) then
                 cycle
             end if
             call grow_symbols(destination)
@@ -2686,7 +2686,7 @@
         else
             call define_symbol(context, result_name, value_kind, error_msg)
             if (len_trim(error_msg) > 0) return
-            context%current_function_result_index = find_symbol(context, result_name)
+            context%current_function_result_index = find_symbol_compat(context, result_name)
         end if
         ! The result binding is synthetic in FortFront (its identity is the
         ! function scope), so publish it before any specification or executable

--- a/src/session_program_lowering_functions_tail.inc
+++ b/src/session_program_lowering_functions_tail.inc
@@ -1206,7 +1206,7 @@
         if (has_binding) then
             index = find_symbol_for_binding(context, binding)
         else
-            index = find_symbol(context, name)
+            index = find_symbol_compat(context, name)
         end if
         if (index > 0 .and. .not. has_binding) then
             error_msg = 'duplicate function parameter: '//trim(name)

--- a/src/session_program_lowering_inferred.inc
+++ b/src/session_program_lowering_inferred.inc
@@ -34,7 +34,7 @@
             ! Skip if already explicitly declared
             if (name_is_explicitly_declared(context, id_name)) cycle
             ! Skip if already registered (from a prior inferred seed)
-            sym_idx = find_symbol(context, id_name)
+            sym_idx = find_symbol_compat(context, id_name)
             if (sym_idx > 0) cycle
             ! Try to register from inferred type
             call try_seed_inferred_symbol(arena, i, id_name, context, error_msg)

--- a/src/session_program_lowering_inquire.inc
+++ b/src/session_program_lowering_inquire.inc
@@ -147,7 +147,7 @@
         integer :: sym
 
         call set_empty(error_msg)
-        sym = find_symbol(context, var_name)
+        sym = find_symbol_compat(context, var_name)
         if (sym <= 0) then
             error_msg = 'inquire '//trim(kind_label)//'= target was not '// &
                         'declared: '//trim(var_name)
@@ -194,7 +194,7 @@
         path_ptr = printf_format_ptr(context%session, path_id)
 
         if (len_trim(exist_var) > 0) then
-            sym = find_symbol(context, exist_var)
+            sym = find_symbol_compat(context, exist_var)
             if (sym <= 0) then
                 error_msg = 'inquire exist= target was not declared: '// &
                             trim(exist_var)
@@ -279,9 +279,9 @@
         read (unit_str, *, iostat=ios) unit_number
         if (ios == 0) then
             write (pseudo_name, '(A,I0)') '.unit.', unit_number
-            sym = find_symbol(context, trim(pseudo_name))
+            sym = find_symbol_compat(context, trim(pseudo_name))
         else
-            sym = find_symbol(context, trim(unit_str))
+            sym = find_symbol_compat(context, trim(unit_str))
         end if
         if (sym > 0) is_opened = context%symbols(sym)%is_file_unit
 

--- a/src/session_program_lowering_integer.inc
+++ b/src/session_program_lowering_integer.inc
@@ -429,7 +429,7 @@
       ! An integer(8)/(1)/(2) array element must load through its own width;
       ! reject here instead of silently misreading through an i32-width GEP.
       if (allocated(node%name)) then
-          symbol_index = find_symbol(context, node%name)
+          symbol_index = find_symbol_compat(context, node%name)
           if (symbol_index > 0) then
               if (context%symbols(symbol_index)%value_kind == VALUE_I64 .or. &
                   context%symbols(symbol_index)%value_kind == VALUE_I8 .or. &

--- a/src/session_program_lowering_internal_read.inc
+++ b/src/session_program_lowering_internal_read.inc
@@ -8,7 +8,7 @@
         is_internal_read = .false.
         if (.not. allocated(node%unit_spec)) return
         if (trim(node%unit_spec) == '*') return
-        symbol_index = find_symbol(context, trim(node%unit_spec))
+        symbol_index = find_symbol_compat(context, trim(node%unit_spec))
         if (symbol_index <= 0) return
         is_internal_read = &
             context%symbols(symbol_index)%value_kind == VALUE_CHARACTER
@@ -43,7 +43,7 @@
             return
         end if
 
-        buf_index = find_symbol(context, trim(node%unit_spec))
+        buf_index = find_symbol_compat(context, trim(node%unit_spec))
         if (.not. context%symbols(buf_index)%has_character_value) then
             call unsupported_feature_error('internal read', node%line, &
                 node%column, 'internal read source must be assigned first', &
@@ -53,7 +53,7 @@
 
         call identifier_name(arena, node%var_indices(1), target_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        target_index = find_symbol(context, target_name)
+        target_index = find_symbol_compat(context, target_name)
         if (target_index <= 0) then
             error_msg = 'internal read target was not declared: '//trim(target_name)
             return

--- a/src/session_program_lowering_internal_write.inc
+++ b/src/session_program_lowering_internal_write.inc
@@ -8,7 +8,7 @@
         is_internal_write = .false.
         if (.not. allocated(node%unit_spec)) return
         if (trim(node%unit_spec) == '*') return
-        symbol_index = find_symbol(context, trim(node%unit_spec))
+        symbol_index = find_symbol_compat(context, trim(node%unit_spec))
         if (symbol_index <= 0) return
         is_internal_write = &
             context%symbols(symbol_index)%value_kind == VALUE_CHARACTER .and. &
@@ -98,7 +98,7 @@
             return
         end if
 
-        symbol_index = find_symbol(context, trim(node%unit_spec))
+        symbol_index = find_symbol_compat(context, trim(node%unit_spec))
         if (context%symbols(symbol_index)%is_deferred_character) then
             call unsupported_feature_error('internal write', node%line, &
                 node%column, 'internal write target must be a fixed-length '// &

--- a/src/session_program_lowering_internal_write_compound.inc
+++ b/src/session_program_lowering_internal_write_compound.inc
@@ -21,7 +21,7 @@
         end if
         item_total = size(node%arg_indices)
 
-        symbol_index = find_symbol(context, trim(node%unit_spec))
+        symbol_index = find_symbol_compat(context, trim(node%unit_spec))
         if (context%symbols(symbol_index)%is_deferred_character) then
             call unsupported_feature_error('internal write', node%line, &
                 node%column, 'internal write target must be a fixed-length '// &

--- a/src/session_program_lowering_intrinsics.inc
+++ b/src/session_program_lowering_intrinsics.inc
@@ -1414,12 +1414,12 @@
             return
         end if
 
-        a_index = find_symbol(context, a_name)
+        a_index = find_symbol_compat(context, a_name)
         if (a_index <= 0) then
             error_msg = 'dot_product first argument was not declared: '//trim(a_name)
             return
         end if
-        b_index = find_symbol(context, b_name)
+        b_index = find_symbol_compat(context, b_name)
         if (b_index <= 0) then
             error_msg = 'dot_product second argument was not declared: '//trim(b_name)
             return
@@ -1493,12 +1493,12 @@
             error_msg = 'dot_product requires exactly two array arguments'
             return
         end if
-        a_index = find_symbol(context, a_name)
+        a_index = find_symbol_compat(context, a_name)
         if (a_index <= 0) then
             error_msg = 'dot_product first argument not declared: '//trim(a_name)
             return
         end if
-        b_index = find_symbol(context, b_name)
+        b_index = find_symbol_compat(context, b_name)
         if (b_index <= 0) then
             error_msg = 'dot_product second argument not declared: '//trim(b_name)
             return
@@ -1560,12 +1560,12 @@
             error_msg = 'dot_product requires exactly two array arguments'
             return
         end if
-        a_index = find_symbol(context, a_name)
+        a_index = find_symbol_compat(context, a_name)
         if (a_index <= 0) then
             error_msg = 'dot_product first argument not declared: '//trim(a_name)
             return
         end if
-        b_index = find_symbol(context, b_name)
+        b_index = find_symbol_compat(context, b_name)
         if (b_index <= 0) then
             error_msg = 'dot_product second argument not declared: '//trim(b_name)
             return
@@ -1696,7 +1696,7 @@
             return
         end if
 
-        symbol_index = find_symbol(context, var_name)
+        symbol_index = find_symbol_compat(context, var_name)
         if (symbol_index <= 0) then
             error_msg = 'get_command_argument value variable is not declared: '// &
                         trim(var_name)

--- a/src/session_program_lowering_intrinsics_extra.inc
+++ b/src/session_program_lowering_intrinsics_extra.inc
@@ -15,7 +15,7 @@
         end if
         call get_identifier_name(arena, node%arg_indices(1), array_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, array_name)
+        sym = find_symbol_compat(context, array_name)
         if (sym <= 0) then
             error_msg = 'lbound: array not declared: '//trim(array_name)
             return
@@ -58,7 +58,7 @@
         end if
         call get_identifier_name(arena, node%arg_indices(1), array_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, array_name)
+        sym = find_symbol_compat(context, array_name)
         if (sym <= 0) then
             error_msg = 'ubound: array not declared: '//trim(array_name)
             return
@@ -141,7 +141,7 @@
         if (is_identifier(arena, left_idx)) then
             call get_identifier_name(arena, left_idx, name, name_err)
             if (len_trim(name_err) == 0) then
-                sym = find_symbol(context, name)
+                sym = find_symbol_compat(context, name)
                 if (sym > 0) then
                     if (context%symbols(sym)%is_array) then
                         mask_sym = sym
@@ -155,7 +155,7 @@
         if (is_identifier(arena, right_idx)) then
             call get_identifier_name(arena, right_idx, name, name_err)
             if (len_trim(name_err) == 0) then
-                sym = find_symbol(context, name)
+                sym = find_symbol_compat(context, name)
                 if (sym > 0) then
                     if (context%symbols(sym)%is_array) then
                         mask_sym = sym
@@ -325,7 +325,7 @@
 
         call get_identifier_name(arena, node%arg_indices(1), mask_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, mask_name)
+        sym = find_symbol_compat(context, mask_name)
         if (sym <= 0) then
             error_msg = 'count: array not declared: '//trim(mask_name)
             return
@@ -397,7 +397,7 @@
 
         call get_identifier_name(arena, node%arg_indices(1), mask_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, mask_name)
+        sym = find_symbol_compat(context, mask_name)
         if (sym <= 0) then
             error_msg = 'any: array not declared: '//trim(mask_name)
             return
@@ -472,7 +472,7 @@
 
         call get_identifier_name(arena, node%arg_indices(1), mask_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, mask_name)
+        sym = find_symbol_compat(context, mask_name)
         if (sym <= 0) then
             error_msg = 'all: array not declared: '//trim(mask_name)
             return
@@ -636,7 +636,7 @@
         if (.not. is_identifier(arena, idx)) return
         call get_identifier_name(arena, idx, name, err)
         if (len_trim(err) > 0) return
-        sym = find_symbol(context, name)
+        sym = find_symbol_compat(context, name)
         if (sym <= 0) return
         if (.not. is_elementwise_array_operand(context, sym)) sym = 0
     end function whole_array_symbol
@@ -697,7 +697,7 @@
         end if
         call get_identifier_name(arena, node%arg_indices(1), array_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, array_name)
+        sym = find_symbol_compat(context, array_name)
         if (sym <= 0) then
             error_msg = trim(which)//': array not declared: '//trim(array_name)
             return
@@ -716,7 +716,7 @@
             if (is_identifier(arena, value_node)) then
                 call get_identifier_name(arena, value_node, name, error_msg)
                 if (len_trim(error_msg) > 0) return
-                i = find_symbol(context, name)
+                i = find_symbol_compat(context, name)
                 if (i > 0) then
                     if (context%symbols(i)%is_array) then
                         mask_sym = i

--- a/src/session_program_lowering_io_typecheck.inc
+++ b/src/session_program_lowering_io_typecheck.inc
@@ -165,7 +165,7 @@
             if (c == '_') cycle
             return
         end do
-        sym = find_symbol(context, t)
+        sym = find_symbol_compat(context, t)
         if (sym <= 0) return
         select case (context%symbols(sym)%value_kind)
         case (VALUE_I32, VALUE_I64, VALUE_I8, VALUE_I16, VALUE_F32, VALUE_F64, &

--- a/src/session_program_lowering_literal_utils.inc
+++ b/src/session_program_lowering_literal_utils.inc
@@ -95,7 +95,7 @@
             type is (array_slice_node)
                 call get_identifier_name(arena, arg%array_index, arg_name, err)
                 if (len_trim(err) > 0) return
-                sym = find_symbol(context, arg_name)
+                sym = find_symbol_compat(context, arg_name)
                 if (sym <= 0) return
                 ok = context%symbols(sym)%is_array .and. &
                      context%symbols(sym)%value_kind == vk
@@ -119,7 +119,7 @@
         end if
         call get_identifier_name(arena, node%arg_indices(1), arg_name, err)
         if (len_trim(err) > 0) return
-        sym = find_symbol(context, arg_name)
+        sym = find_symbol_compat(context, arg_name)
         if (sym <= 0) return
         ! A 1-D allocatable reduces over its element kind just like a fixed
         ! array, so the result print kind follows the allocatable element kind.
@@ -175,7 +175,7 @@
         if (is_identifier(arena, arg_idx)) then
             call get_identifier_name(arena, arg_idx, id_name, err)
             if (len_trim(err) > 0) return
-            sym = find_symbol(context, id_name)
+            sym = find_symbol_compat(context, id_name)
             if (sym <= 0) return
             select case (context%symbols(sym)%value_kind)
             case (VALUE_F32)
@@ -205,8 +205,8 @@
         if (len_trim(err) > 0) return
         call get_identifier_name(arena, node%arg_indices(2), b_name, err)
         if (len_trim(err) > 0) return
-        a_sym = find_symbol(context, a_name)
-        b_sym = find_symbol(context, b_name)
+        a_sym = find_symbol_compat(context, a_name)
+        b_sym = find_symbol_compat(context, b_name)
         if (a_sym <= 0 .or. b_sym <= 0) return
         ok = context%symbols(a_sym)%is_array .and. &
              context%symbols(a_sym)%array_rank == 1 .and. &
@@ -469,7 +469,7 @@
                 return
             end if
         end if
-        sym = find_symbol(context, suffix)
+        sym = find_symbol_compat(context, suffix)
         if (sym > 0) then
             if (context%symbols(sym)%has_i32_constant) then
                 is_f64 = context%symbols(sym)%i32_constant == 8_c_int64_t

--- a/src/session_program_lowering_logical_reduction.inc
+++ b/src/session_program_lowering_logical_reduction.inc
@@ -277,7 +277,7 @@
         if (is_identifier(arena, idx)) then
             call get_identifier_name(arena, idx, name, name_err)
             if (len_trim(name_err) == 0) then
-                s = find_symbol(context, name)
+                s = find_symbol_compat(context, name)
                 if (s > 0) then
                     if (context%symbols(s)%is_array .or. &
                         (context%symbols(s)%is_allocatable .and. &
@@ -599,7 +599,7 @@
         if (is_identifier(arena, idx)) then
             call get_identifier_name(arena, idx, name, name_err)
             if (len_trim(name_err) == 0) then
-                s = find_symbol(context, name)
+                s = find_symbol_compat(context, name)
                 if (s > 0) then
                     if (context%symbols(s)%is_array) then
                         sym = s

--- a/src/session_program_lowering_loops.inc
+++ b/src/session_program_lowering_loops.inc
@@ -77,7 +77,7 @@
         logical :: step_is_runtime
 
         value = i32_immediate(context%session, 0_c_int64_t)
-        loop_symbol_index = find_symbol(context, var_name)
+        loop_symbol_index = find_symbol_compat(context, var_name)
         if (loop_symbol_index <= 0) then
             error_msg = 'DO loop variable was not declared: '//trim(var_name)
             return

--- a/src/session_program_lowering_module_vars.inc
+++ b/src/session_program_lowering_module_vars.inc
@@ -805,7 +805,7 @@
         integer :: sym_idx
 
         call set_empty(error_msg)
-        if (find_symbol(context, var_name) > 0) return
+        if (find_symbol_compat(context, var_name) > 0) return
         mangled = module_procedure_mangled(module_name, trim(var_name))
         call to_c_chars(mangled, c_name)
         global_id = lr_session_intern(context%session%handle, c_name)
@@ -939,7 +939,7 @@
                 if (.not. node_exists(arena, param_idx)) cycle
                 select type (node => arena%entries(param_idx)%node)
                 type is (declaration_node)
-                    if (find_symbol(context, node%var_name) > 0) cycle
+                    if (find_symbol_compat(context, node%var_name) > 0) cycle
                     if (node%is_array .or. node%is_multi_declaration) cycle
                     call declaration_value_kind(node, value_kind, kind_err, &
                                                 context)

--- a/src/session_program_lowering_namelist.inc
+++ b/src/session_program_lowering_namelist.inc
@@ -118,7 +118,7 @@
         integer :: sym, vk
 
         call set_empty(error_msg)
-        sym = find_symbol(context, name)
+        sym = find_symbol_compat(context, name)
         if (sym <= 0) then
             call unsupported_feature_error('namelist member', line, col, &
                 'namelist member not declared: '//name, error_msg)

--- a/src/session_program_lowering_open_close.inc
+++ b/src/session_program_lowering_open_close.inc
@@ -178,7 +178,7 @@
             unit_number = int(context%next_file_unit)
             context%next_file_unit = context%next_file_unit + 1_c_int32_t
             uval_op = i32_immediate(context%session, int(unit_number, c_int64_t))
-            sym = find_symbol(context, trim(nuvar))
+            sym = find_symbol_compat(context, trim(nuvar))
             if (sym > 0) then
                 if (.not. context%symbols(sym)%has_address) then
                     if (.not. emit_i32_alloca(context%session, &
@@ -207,7 +207,7 @@
                 call track_literal_unit(context, unit_number, file_handle, &
                                          error_msg)
             else
-                sym = find_symbol(context, trim(ustr))
+                sym = find_symbol_compat(context, trim(ustr))
                 if (sym <= 0) then
                     error_msg = 'open unit= variable not declared: '//trim(ustr)
                     return
@@ -326,11 +326,11 @@
         integer :: sym
 
         write (pseudo_name, '(A,I0)') '.unit.', unit_number
-        sym = find_symbol(context, trim(pseudo_name))
+        sym = find_symbol_compat(context, trim(pseudo_name))
         if (sym <= 0) then
             call define_symbol(context, trim(pseudo_name), VALUE_C_PTR, error_msg)
             if (len_trim(error_msg) > 0) return
-            sym = find_symbol(context, trim(pseudo_name))
+            sym = find_symbol_compat(context, trim(pseudo_name))
         end if
         if (.not. context%symbols(sym)%is_file_unit) then
             if (.not. emit_ptr_alloca(context%session, ptr_slot, error_msg)) return
@@ -354,11 +354,11 @@
 
         call set_empty(error_msg)
         write (pseudo_name, '(A,I0)') '.unit.', unit_number
-        sym = find_symbol(context, trim(pseudo_name))
+        sym = find_symbol_compat(context, trim(pseudo_name))
         if (sym <= 0) then
             call define_symbol(context, trim(pseudo_name), VALUE_C_PTR, error_msg)
             if (len_trim(error_msg) > 0) return
-            sym = find_symbol(context, trim(pseudo_name))
+            sym = find_symbol_compat(context, trim(pseudo_name))
         end if
         context%symbols(sym)%file_ptr_address = slot
         context%symbols(sym)%is_file_unit = .true.
@@ -441,10 +441,10 @@
         read (plain, *, iostat=ios) unit_number
         if (ios == 0) then
             write (pseudo_name, '(A,I0)') '.unit.', unit_number
-            sym = find_symbol(context, trim(pseudo_name))
+            sym = find_symbol_compat(context, trim(pseudo_name))
         else
             unit_number = -1
-            sym = find_symbol(context, trim(plain))
+            sym = find_symbol_compat(context, trim(plain))
             if (sym > 0) then
                 if (context%symbols(sym)%has_unit_const) &
                     unit_number = context%symbols(sym)%unit_const
@@ -518,7 +518,7 @@
                                  error_msg)) return
         call alias_unit_to_slot(context, unit_number, ptr_slot, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, file_unit_pseudo_name(unit_number))
+        sym = find_symbol_compat(context, file_unit_pseudo_name(unit_number))
     end subroutine connect_implicit_unit
 
     ! --- file-unit WRITE -----------------------------------------------------
@@ -537,7 +537,7 @@
             is_file_unit_write = .true.
             return
         end if
-        sym = find_symbol(context, trim(node%unit_spec))
+        sym = find_symbol_compat(context, trim(node%unit_spec))
         if (sym <= 0) return
         is_file_unit_write = context%symbols(sym)%is_file_unit .or. &
                              context%symbols(sym)%has_unit_const
@@ -597,7 +597,7 @@
         if (.not. allocated(node%io_control_list)) return
         call io_control_value(node%io_control_list, 'iostat', var_name)
         if (len_trim(var_name) == 0) return
-        sym = find_symbol(context, var_name)
+        sym = find_symbol_compat(context, var_name)
         if (sym <= 0) then
             error_msg = 'iostat target was not declared: '//trim(var_name)
             return

--- a/src/session_program_lowering_pointer.inc
+++ b/src/session_program_lowering_pointer.inc
@@ -127,7 +127,7 @@
         call define_declared_array_symbol(context, node, name, array_lower_bound, &
                                           array_size, value_kind, error_msg)
         if (len_trim(error_msg) > 0) return
-        index = find_symbol(context, name)
+        index = find_symbol_compat(context, name)
         if (index <= 0) then
             error_msg = 'target array declaration lost its symbol: '//trim(name)
             return
@@ -158,7 +158,7 @@
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: index
 
-        index = find_symbol(context, name)
+        index = find_symbol_compat(context, name)
         if (index > 0) then
             ! Re-declaration (e.g. dummy refresh): just record the attributes.
             context%symbols(index)%is_pointer = .true.
@@ -191,7 +191,7 @@
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: symbol_index
 
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index > 0) then
             ! A dummy argument already has its own pass-by-reference storage, so a
             ! `target` attribute on it needs no new slot; just record the flag.
@@ -206,7 +206,7 @@
         end if
         call define_symbol(context, name, value_kind, error_msg)
         if (len_trim(error_msg) > 0) return
-        symbol_index = find_symbol(context, name)
+        symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) then
             error_msg = 'pointer/target declaration lost its symbol: '//trim(name)
             return
@@ -280,7 +280,7 @@
 
         call get_identifier_name(arena, node%pointer_index, ptr_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        ptr_index = find_symbol(context, ptr_name)
+        ptr_index = find_symbol_compat(context, ptr_name)
         if (ptr_index > 0 .and. context%symbols(ptr_index)%is_proc_pointer) then
             call lower_proc_pointer_assignment(arena, node, context, error_msg)
             return
@@ -300,7 +300,7 @@
         end if
         call get_identifier_name(arena, node%target_index, target_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        target_index = find_symbol(context, target_name)
+        target_index = find_symbol_compat(context, target_name)
         if (target_index <= 0) then
             error_msg = 'pointer assignment source was not declared: '// &
                         trim(target_name)
@@ -405,7 +405,7 @@
         do i = 1, size(node%pointer_indices)
             call get_identifier_name(arena, node%pointer_indices(i), name, error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, name)
+            symbol_index = find_symbol_compat(context, name)
             if (symbol_index <= 0) then
                 error_msg = 'nullify argument was not declared: '//trim(name)
                 return
@@ -449,7 +449,7 @@
         end if
         call get_identifier_name(arena, arg_indices(1), ptr_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        ptr_idx = find_symbol(context, ptr_name)
+        ptr_idx = find_symbol_compat(context, ptr_name)
         if (ptr_idx <= 0) then
             error_msg = 'associated argument was not declared: '//trim(ptr_name)
             return
@@ -475,7 +475,7 @@
         end if
         call get_identifier_name(arena, arg_indices(2), target_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        tgt_idx = find_symbol(context, target_name)
+        tgt_idx = find_symbol_compat(context, target_name)
         if (tgt_idx <= 0) then
             error_msg = 'associated second argument was not declared: '// &
                         trim(target_name)
@@ -526,7 +526,7 @@
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: idx
 
-        idx = find_symbol(context, name)
+        idx = find_symbol_compat(context, name)
         if (idx > 0) then
             ! Already declared (e.g. a dummy re-declaration); benign.
             call set_empty(error_msg)
@@ -562,7 +562,7 @@
 
         call get_identifier_name(arena, node%pointer_index, ptr_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        ptr_idx = find_symbol(context, ptr_name)
+        ptr_idx = find_symbol_compat(context, ptr_name)
         if (ptr_idx <= 0) then
             error_msg = 'procedure pointer was not declared: '//trim(ptr_name)
             return
@@ -584,7 +584,7 @@
             return
         end if
         ! Check whether target is another procedure pointer being copied.
-        target_idx = find_symbol(context, target_name)
+        target_idx = find_symbol_compat(context, target_name)
         if (target_idx > 0 .and. context%symbols(target_idx)%is_proc_pointer) then
             ! Copy the callee ptr from the source slot into the destination slot.
             if (.not. emit_ptr_load(context%session, &
@@ -621,7 +621,7 @@
         character(len=*), intent(in) :: name
         integer :: idx
 
-        idx = find_symbol(context, name)
+        idx = find_symbol_compat(context, name)
         ok = idx > 0 .and. context%symbols(idx)%is_proc_pointer
     end function is_proc_pointer_call
 
@@ -637,7 +637,7 @@
         integer, allocatable :: copyback_indices(:)
         integer :: idx
 
-        idx = find_symbol(context, node%name)
+        idx = find_symbol_compat(context, node%name)
         if (.not. emit_ptr_load(context%session, context%symbols(idx)%address, &
                                 callee_ptr, error_msg)) return
         if (allocated(node%arg_indices)) then
@@ -669,7 +669,7 @@
 
         call get_subroutine_call_name(arena, node_index, name, error_msg)
         if (len_trim(error_msg) > 0) return
-        idx = find_symbol(context, name)
+        idx = find_symbol_compat(context, name)
         if (.not. emit_ptr_load(context%session, context%symbols(idx)%address, &
                                 callee_ptr, error_msg)) return
         call get_subroutine_call_arg_indices(arena, node_index, arg_indices, &

--- a/src/session_program_lowering_polymorphic.inc
+++ b/src/session_program_lowering_polymorphic.inc
@@ -183,7 +183,7 @@
         ! Bind the associate name to the selector's derived storage. For
         ! `select type (v)` the names coincide and the symbol is already bound.
         if (trim(assoc_name) /= trim(sel_name)) then
-            idx = find_symbol(context, assoc_name)
+            idx = find_symbol_compat(context, assoc_name)
             if (idx <= 0) then
                 call grow_symbols(context)
                 idx = context%symbol_count + 1

--- a/src/session_program_lowering_print_expr.inc
+++ b/src/session_program_lowering_print_expr.inc
@@ -133,7 +133,7 @@
         else if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index > 0) then
                 if (context%symbols(symbol_index)%value_kind == VALUE_F32) then
                     call lower_f32_expression(arena, node_index, context, &
@@ -448,7 +448,7 @@
         else if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index > 0) then
                 if (context%symbols(symbol_index)%value_kind == VALUE_F32) then
                     call lower_f32_expression(arena, node_index, context, &
@@ -710,7 +710,7 @@
 
         value_kind = VALUE_I32
         if (.not. allocated(node%name)) return
-        symbol_index = find_symbol(context, node%name)
+        symbol_index = find_symbol_compat(context, node%name)
         if (symbol_index <= 0) return
         if (.not. context%symbols(symbol_index)%is_array .and. &
             .not. context%symbols(symbol_index)%is_allocatable) return

--- a/src/session_program_lowering_print_ops.inc
+++ b/src/session_program_lowering_print_ops.inc
@@ -957,7 +957,7 @@
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, lit_value, error_msg)
             if (len_trim(error_msg) > 0) return
-            symbol_index = find_symbol(context, lit_value)
+            symbol_index = find_symbol_compat(context, lit_value)
             if (symbol_index > 0) then
                 if (context%symbols(symbol_index)%value_kind == VALUE_CHARACTER &
                     .and. context%symbols(symbol_index)%has_character_value) then
@@ -997,7 +997,7 @@
         end if
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, id_err)
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index > 0) &
                 is_char = context%symbols(symbol_index)%value_kind == VALUE_CHARACTER
             return

--- a/src/session_program_lowering_read_ops.inc
+++ b/src/session_program_lowering_read_ops.inc
@@ -19,7 +19,7 @@
             is_file_unit_read = .true.
             return
         end if
-        sym = find_symbol(context, trim(node%unit_spec))
+        sym = find_symbol_compat(context, trim(node%unit_spec))
         if (sym > 0) is_file_unit_read = context%symbols(sym)%is_file_unit .or. &
                                          context%symbols(sym)%has_unit_const
     end function is_file_unit_read
@@ -208,7 +208,7 @@
         if (.not. allocated(node%io_control_list)) return
         call io_control_value(node%io_control_list, 'iostat', var_name)
         if (len_trim(var_name) == 0) return
-        sym = find_symbol(context, var_name)
+        sym = find_symbol_compat(context, var_name)
         if (sym <= 0) then
             error_msg = 'iostat target was not declared: '//trim(var_name)
             return
@@ -332,7 +332,7 @@
         call set_empty(error_msg)
         call identifier_name(arena, node_index, var_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, var_name)
+        sym = find_symbol_compat(context, var_name)
         if (sym <= 0) then
             error_msg = 'read target was not declared: '//trim(var_name)
             return

--- a/src/session_program_lowering_reduction_expr.inc
+++ b/src/session_program_lowering_reduction_expr.inc
@@ -38,7 +38,7 @@
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, id_err)
             if (len_trim(id_err) > 0) return
-            sym = find_symbol(context, id_name)
+            sym = find_symbol_compat(context, id_name)
             if (sym <= 0) return
             if (.not. is_elementwise_array_operand(context, sym)) return
             if (context%symbols(sym)%value_kind /= vk) return
@@ -108,7 +108,7 @@
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, error_msg)
             if (len_trim(error_msg) > 0) return
-            sym = find_symbol(context, id_name)
+            sym = find_symbol_compat(context, id_name)
             if (sym <= 0) then
                 error_msg = 'reduction expression identifier was not declared: '// &
                             trim(id_name)

--- a/src/session_program_lowering_runtime_alloc.inc
+++ b/src/session_program_lowering_runtime_alloc.inc
@@ -642,7 +642,7 @@
         if (is_identifier(arena, node%value_index)) then
             call get_identifier_name(arena, node%value_index, src_name, id_err)
             if (len_trim(id_err) == 0) then
-                src_sym = find_symbol(context, src_name)
+                src_sym = find_symbol_compat(context, src_name)
                 if (src_sym > 0) then
                     if (context%symbols(src_sym)%is_array .and. &
                         .not. context%symbols(src_sym)%is_allocatable .and. &

--- a/src/session_program_lowering_save.inc
+++ b/src/session_program_lowering_save.inc
@@ -188,7 +188,7 @@
         ! existing (enclosing-scope) slot onto this saved global rather than
         ! rejecting it as a duplicate. A genuine same-scope duplicate already
         ! addresses this saved global, so this rebind is idempotent.
-        existing_idx = find_symbol(context, name)
+        existing_idx = find_symbol_compat(context, name)
         if (existing_idx > 0) then
             sym_idx = existing_idx
         else

--- a/src/session_program_lowering_scalar_allocatable.inc
+++ b/src/session_program_lowering_scalar_allocatable.inc
@@ -41,7 +41,7 @@
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: index
 
-        index = find_symbol(context, name)
+        index = find_symbol_compat(context, name)
         if (index > 0) then
             if (context%symbols(index)%is_parameter .and. &
                 .not. context%symbols(index)%is_array .and. &
@@ -128,7 +128,7 @@
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: index
 
-        index = find_symbol(context, name)
+        index = find_symbol_compat(context, name)
         if (index > 0) then
             ! A pre-bound allocatable derived result (class(t)/type(t) function
             ! result, or a re-declaration of an already-defined instance): its

--- a/src/session_program_lowering_select.inc
+++ b/src/session_program_lowering_select.inc
@@ -352,7 +352,7 @@
         end if
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, id_err)
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index > 0) is_character_selector = &
                 context%symbols(symbol_index)%value_kind == VALUE_CHARACTER
         end if
@@ -819,7 +819,7 @@
         call select_type_selector(arena, selector_idx, sel_name, &
                                   assoc_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sel_index = find_symbol(context, sel_name)
+        sel_index = find_symbol_compat(context, sel_name)
         if (sel_index <= 0) then
             error_msg = 'select type selector was not declared: '//trim(sel_name)
             return
@@ -1081,7 +1081,7 @@
             if (.not. emit_i32_load(context%session, data_ptr, typed_value, &
                                     error_msg)) return
         end if
-        idx = find_symbol(context, assoc_name)
+        idx = find_symbol_compat(context, assoc_name)
         if (idx <= 0) then
             call grow_symbols(context)
             idx = context%symbol_count + 1
@@ -1155,7 +1155,7 @@
         end if
         call get_identifier_name(arena, node%selector_index, sel_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sel_index = find_symbol(context, sel_name)
+        sel_index = find_symbol_compat(context, sel_name)
         if (sel_index <= 0) then
             call unsupported_feature_error('select rank statement', node%line, &
                 node%column, 'select rank selector was not declared: '// &
@@ -1259,7 +1259,7 @@
         if (.not. is_identifier(arena, node%var_indices(1))) return
         call get_identifier_name(arena, node%var_indices(1), name, err)
         if (len_trim(err) > 0) return
-        idx = find_symbol(context, name)
+        idx = find_symbol_compat(context, name)
         if (idx <= 0) return
         allocate_targets_class_star = &
             context%symbols(idx)%value_kind == VALUE_CLASS_STAR
@@ -1280,7 +1280,7 @@
         call set_empty(error_msg)
         call get_identifier_name(arena, node%var_indices(1), name, error_msg)
         if (len_trim(error_msg) > 0) return
-        idx = find_symbol(context, name)
+        idx = find_symbol_compat(context, name)
         if (idx <= 0) then
             error_msg = 'allocate target is not declared: '//trim(name)
             return

--- a/src/session_program_lowering_statement_function.inc
+++ b/src/session_program_lowering_statement_function.inc
@@ -338,6 +338,7 @@
         ! A by-value binding: the identifier resolves to the operand directly,
         ! never to storage, so reference/address paths stay disabled.
         sym%is_parameter = .true.
+        sym%is_statement_function_argument = .true.
         sym%has_address = .false.
         sym%is_reference = .false.
     end subroutine set_bound_arg_symbol

--- a/src/session_program_lowering_statement_function.inc
+++ b/src/session_program_lowering_statement_function.inc
@@ -299,7 +299,7 @@
         ! dummy (f(a, a+1)) whose binding must not shadow the caller's variable.
         do k = 1, n
             dummy_name = trim(context%statement_functions(sf)%arg_names(k))
-            slot = find_symbol(context, dummy_name)
+            slot = find_symbol_compat(context, dummy_name)
             dummy_kinds(k) = VALUE_I32
             if (slot > 0) dummy_kinds(k) = context%symbols(slot)%value_kind
             call lower_scalar_expression_kind(arena, arg_indices(k), &
@@ -308,7 +308,7 @@
         end do
         do k = 1, n
             dummy_name = trim(context%statement_functions(sf)%arg_names(k))
-            slot = find_symbol(context, dummy_name)
+            slot = find_symbol_compat(context, dummy_name)
             if (slot > 0) then
                 had_symbol(k) = .true.
                 saved_slots(k) = slot

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -174,6 +174,11 @@
             call destroy(context%session)
             return
         end if
+        call assert_declaration_collection_complete(context, error_msg)
+        if (len_trim(error_msg) > 0) then
+            call destroy(context%session)
+            return
+        end if
         call lower_internal_functions(arena, root_index, context, error_msg)
         if (len_trim(error_msg) > 0) then
             call destroy(context%session)
@@ -274,6 +279,21 @@
         call destroy(context%session)
         call set_empty(error_msg)
     end subroutine lower_program_to_liric_path
+
+    subroutine assert_declaration_collection_complete(context, error_msg)
+        !! Executable lowering may only begin after all declaration bindings
+        !! have been collected. Keep this guard at the transition from global
+        !! setup to procedure/body emission so new lowering paths cannot bypass
+        !! the scoped declaration model (#332).
+        type(lowering_context_t), intent(in) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (.not. context%declaration_collection_complete) then
+            error_msg = 'executable lowering started before declaration collection completed'
+            return
+        end if
+        call set_empty(error_msg)
+    end subroutine assert_declaration_collection_complete
 
     function unit_prefix_from_path(path) result(prefix)
         ! A short, bounded, collision-resistant token for a module object's

--- a/src/session_program_lowering_transfer.inc
+++ b/src/session_program_lowering_transfer.inc
@@ -77,7 +77,7 @@
         if (is_identifier(arena, node_index)) then
             call get_identifier_name(arena, node_index, id_name, id_err)
             if (len_trim(id_err) > 0) return
-            symbol_index = find_symbol(context, id_name)
+            symbol_index = find_symbol_compat(context, id_name)
             if (symbol_index > 0) then
                 if (.not. context%symbols(symbol_index)%is_array) &
                     kind = context%symbols(symbol_index)%value_kind
@@ -113,7 +113,7 @@
             if (node%is_array_access .or. &
                 is_declared_array_element_ref(node, context) .or. &
                 is_allocatable_element_ref(node, context)) then
-                symbol_index = find_symbol(context, node%name)
+                symbol_index = find_symbol_compat(context, node%name)
                 if (symbol_index > 0) &
                     kind = context%symbols(symbol_index)%value_kind
             end if

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -207,6 +207,10 @@ module session_program_lowering_types
         type(lr_operand_desc_t) :: value
         type(lr_operand_desc_t) :: address
         logical :: is_parameter = .false.
+        ! Temporary by-value override used while inlining a statement function;
+        ! it is resolved by its synthetic name until the body expression is
+        ! restored (#332).
+        logical :: is_statement_function_argument = .false.
         logical :: is_reference = .false.
         logical :: has_address = .false.
         ! Bound to a COMMON slot global (session_program_lowering_common.inc):

--- a/src/session_program_lowering_where.inc
+++ b/src/session_program_lowering_where.inc
@@ -303,7 +303,7 @@
             end if
             call get_identifier_name(arena, stmt%target_index, name, error_msg)
             if (len_trim(error_msg) > 0) return
-            target_symbol = find_symbol(context, name)
+            target_symbol = find_symbol_compat(context, name)
             if (target_symbol <= 0) then
                 error_msg = 'WHERE assignment target was not declared: '//trim(name)
                 return
@@ -418,7 +418,7 @@
         if (.not. is_identifier(arena, node_index)) return
         call get_identifier_name(arena, node_index, name, err)
         if (len_trim(err) > 0) return
-        sym = find_symbol(context, name)
+        sym = find_symbol_compat(context, name)
         if (sym <= 0) then
             sym = 0
             return

--- a/src/session_program_lowering_write_ops.inc
+++ b/src/session_program_lowering_write_ops.inc
@@ -100,7 +100,7 @@
         call set_empty(error_msg)
         call identifier_name(arena, node_index, var_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        sym = find_symbol(context, var_name)
+        sym = find_symbol_compat(context, var_name)
         if (sym <= 0) then
             error_msg = 'read target was not declared: '//trim(var_name)
             return


### PR DESCRIPTION
Closes #332

## Summary

- rename the private flat symbol helper to `find_symbol_compat` and fence legacy synthetic, host-associated, and `.fmod` import paths
- make AST-node resolution identity-first through `find_symbol_for_binding`; collected direct/local bindings do not fall back to text lookup
- assert declaration collection is complete before procedure/body emission
- keep FortFront-inserted inferred declarations on the explicit compatibility path

## Verification

- `fo test test_session_block_shadow_compiler test_session_dummy_array_bound_call_site_compiler test_session_read_fmod_compiler test_session_scope_resolution_compiler test_session_declaration_collection_compiler`
- `fo`
- `fo fmt --check`
- `git diff --check`
- no exact `find_symbol(` calls remain under `src/session_program_lowering*.f90` or `src/session_program_lowering*.inc`