### PR TITLE
[pointer-scalar-01] lower scalar data-pointer association

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -517,11 +517,13 @@ contains
                 node_index)
             if (len_trim(error_msg) > 0) return
             if (value_kind /= VALUE_I32 .and. value_kind /= VALUE_F32 .and. &
-                value_kind /= VALUE_F64 .and. value_kind /= VALUE_LOGICAL) then
+                value_kind /= VALUE_F64 .and. value_kind /= VALUE_LOGICAL .and. &
+                value_kind /= VALUE_CHARACTER) then
                 call unsupported_feature_error('pointer/target declaration', &
                     node%line, node%column, &
-                    'direct LIRIC session supports scalar integer, real, and '// &
-                    'logical pointer/target only (#245 slice B3a)', error_msg)
+                    'direct LIRIC session supports scalar integer, real, logical, '// &
+                    'and fixed-length character pointer/target only (#452)', &
+                    error_msg)
                 return
             end if
             call lower_scalar_pointer_target(node, context, value_kind, error_msg)
@@ -834,6 +836,7 @@ contains
         character(len=64) :: string_name
         logical :: fold_ok
         integer :: symbol_index
+        type(lr_operand_desc_t) :: value
 
         call set_empty(error_msg)
         symbol_index = find_symbol_compat(context, name)
@@ -858,9 +861,22 @@ contains
             context, 'char.', context%string_literal_count)
         call materialize_liric_string(context%session, trim(string_name), &
             literal_text, &
-            context%symbols(symbol_index)%value, &
+            value, &
             error_msg)
         if (len_trim(error_msg) > 0) return
+        if ((context%symbols(symbol_index)%is_target .or. &
+            context%symbols(symbol_index)%is_pointer) .and. &
+            context%symbols(symbol_index)%has_address) then
+            if (.not. emit_memcpy(context%session, &
+                context%symbols(symbol_index)%address, value, &
+                i64_immediate(context%session, int( &
+                context%symbols(symbol_index)%character_length + 1, &
+                c_int64_t)), error_msg)) return
+            context%symbols(symbol_index)%value = &
+                context%symbols(symbol_index)%address
+        else
+            context%symbols(symbol_index)%value = value
+        end if
         context%symbols(symbol_index)%has_character_value = .true.
     end subroutine lower_character_initializer
 

--- a/src/session_program_lowering_character.inc
+++ b/src/session_program_lowering_character.inc
@@ -385,6 +385,7 @@
         character(len=:), allocatable :: bin_op
         integer :: bin_left, bin_right, bin_line, bin_col
         character(len=:), allocatable :: lit_value, lit_type
+        type(lr_operand_desc_t) :: literal_ptr
 
         if (.not. node_exists(arena, node%value_index)) then
             error_msg = 'character assignment value does not reference an AST node'
@@ -526,9 +527,26 @@
             context, 'char.', context%string_literal_count)
         call materialize_liric_string(context%session, trim(string_name), &
                                       literal_text, &
-                                      context%symbols(symbol_index)%value, &
+                                      literal_ptr, &
                                       error_msg)
         if (len_trim(error_msg) > 0) return
+
+        ! A scalar character target/pointer owns a stable mutable buffer. Keep
+        ! the symbol's data pointer bound to that buffer instead of rebinding it
+        ! to an immutable literal/global on every assignment.
+        if ((context%symbols(symbol_index)%is_target .or. &
+             context%symbols(symbol_index)%is_pointer) .and. &
+            context%symbols(symbol_index)%has_address) then
+            if (.not. emit_memcpy(context%session, &
+                context%symbols(symbol_index)%address, literal_ptr, &
+                i64_immediate(context%session, int( &
+                    context%symbols(symbol_index)%character_length + 1, &
+                    c_int64_t)), error_msg)) return
+            context%symbols(symbol_index)%value = &
+                context%symbols(symbol_index)%address
+        else
+            context%symbols(symbol_index)%value = literal_ptr
+        end if
 
         context%symbols(symbol_index)%has_character_value = .true.
         call set_empty(error_msg)
@@ -896,7 +914,18 @@
         if (.not. emit_memcpy(context%session, offset, null_ptr, &
             i64_immediate(context%session, 1_c_int64_t), error_msg)) return
 
-        context%symbols(dest_symbol_index)%value = buf
+        if ((context%symbols(dest_symbol_index)%is_target .or. &
+             context%symbols(dest_symbol_index)%is_pointer) .and. &
+            context%symbols(dest_symbol_index)%has_address) then
+            if (.not. emit_memcpy(context%session, &
+                context%symbols(dest_symbol_index)%address, buf, &
+                i64_immediate(context%session, int(dest_len + 1, c_int64_t)), &
+                error_msg)) return
+            context%symbols(dest_symbol_index)%value = &
+                context%symbols(dest_symbol_index)%address
+        else
+            context%symbols(dest_symbol_index)%value = buf
+        end if
         context%symbols(dest_symbol_index)%has_character_value = .true.
         call set_empty(error_msg)
     end subroutine lower_fixed_char_expr_assignment

--- a/src/session_program_lowering_derived_type_ops.inc
+++ b/src/session_program_lowering_derived_type_ops.inc
@@ -278,6 +278,35 @@
                 return
             end if
         end if
+        if (node%is_pointer .or. node%is_target) then
+            if (node%is_array) then
+                call unsupported_feature_error( &
+                    'derived pointer/target array declaration', node%line, &
+                    node%column, 'direct LIRIC session supports scalar plain '// &
+                    'derived pointer/target declarations only (#452)', error_msg)
+                return
+            end if
+            if (node%is_allocatable) then
+                call unsupported_feature_error( &
+                    'allocatable derived pointer/target declaration', node%line, &
+                    node%column, 'direct LIRIC session does not combine '// &
+                    'ALLOCATABLE with scalar derived pointer/target lowering', &
+                    error_msg)
+                return
+            end if
+            if (.not. allocated(node%var_name)) then
+                error_msg = 'derived pointer/target declaration did not expose a name'
+                return
+            end if
+            call define_derived_symbol(context, node, node%var_name, &
+                                       derived_type_index, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (node%is_target .and. node%has_initializer) then
+                call lower_derived_scalar_initializer(node, context, &
+                    derived_type_index, error_msg)
+            end if
+            return
+        end if
         if (node%has_initializer .and. node%is_array) then
             call unsupported_feature_error('derived type array initializer', &
                                            node%line, node%column, &
@@ -495,6 +524,11 @@
             ! caller-supplied hidden argument.
             if (context%symbols(index)%is_derived .and. &
                 context%symbols(index)%derived_type_index == derived_type_index) then
+                if (node%is_target) context%symbols(index)%is_target = .true.
+                if (node%is_pointer) then
+                    context%symbols(index)%is_pointer = .true.
+                    context%symbols(index)%is_associated = .false.
+                end if
                 call set_empty(error_msg)
                 return
             end if
@@ -525,11 +559,32 @@
         context%symbols(index)%derived_type_index = derived_type_index
         context%symbols(index)%array_size = slot_count
 
+        if (node%is_pointer) then
+            context%symbols(index)%is_pointer = .true.
+            context%symbols(index)%is_associated = .false.
+        end if
+        if (node%is_target) context%symbols(index)%is_target = .true.
+
+        ! A plain scalar derived pointer has no instance storage until `p => t`.
+        ! Keep the type/layout metadata so component references can use the
+        ! target's adopted element-address array after association.
+        if (node%is_pointer .and. .not. node%is_target) then
+            context%symbol_count = index
+            call set_empty(error_msg)
+            return
+        end if
+
         if (.not. emit_i32_array_alloca(context%session,  &
             slot_count, context%symbols(index)%element_address, &
             error_msg)) then
             error_msg = 'derived_alloca['//trim(name)//']: '//error_msg
             return
+        end if
+
+        if (node%is_target) then
+            context%symbols(index)%address = context%symbols(index)%element_address
+            context%symbols(index)%has_address = .true.
+            context%symbols(index)%is_reference = .true.
         end if
 
         call init_derived_component_defaults(context, index, derived_type_index, &

--- a/src/session_program_lowering_pointer.inc
+++ b/src/session_program_lowering_pointer.inc
@@ -6,17 +6,34 @@
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: value_kind
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: i
+        integer :: i, character_length
+
+        character_length = 0
+        if (value_kind == VALUE_CHARACTER) then
+            if (.not. allocated(node%type_name)) then
+                error_msg = 'character pointer/target declaration has no type'
+                return
+            end if
+            call parse_character_length(node%type_name, character_length, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (character_length <= 0) then
+                call unsupported_feature_error('character pointer/target declaration', &
+                    node%line, node%column, &
+                    'direct LIRIC session supports fixed-length character '// &
+                    'pointer/target declarations only (#452)', error_msg)
+                return
+            end if
+        end if
 
         if (node%is_multi_declaration .and. allocated(node%var_names)) then
             do i = 1, size(node%var_names)
                 call define_scalar_pointer_target_symbol(context, node, &
-                                              node%var_names(i), value_kind, error_msg)
+                    node%var_names(i), value_kind, character_length, error_msg)
                 if (len_trim(error_msg) > 0) return
             end do
         else if (allocated(node%var_name)) then
             call define_scalar_pointer_target_symbol(context, node, node%var_name, &
-                                                     value_kind, error_msg)
+                value_kind, character_length, error_msg)
         else
             error_msg = 'pointer/target declaration did not expose a variable name'
         end if
@@ -183,11 +200,12 @@
     end subroutine define_pointer_array_stub
 
     subroutine define_scalar_pointer_target_symbol(context, node, name, value_kind, &
-                                                   error_msg)
+                                                   character_length, error_msg)
         type(lowering_context_t), intent(inout) :: context
         type(declaration_node), intent(in) :: node
         character(len=*), intent(in) :: name
         integer, intent(in) :: value_kind
+        integer, intent(in) :: character_length
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: symbol_index
 
@@ -204,7 +222,11 @@
             call set_empty(error_msg)
             return
         end if
-        call define_symbol(context, name, value_kind, error_msg)
+        if (value_kind == VALUE_CHARACTER) then
+            call define_character_symbol(context, name, character_length, error_msg)
+        else
+            call define_symbol(context, name, value_kind, error_msg)
+        end if
         if (len_trim(error_msg) > 0) return
         symbol_index = find_symbol_compat(context, name)
         if (symbol_index <= 0) then
@@ -219,8 +241,13 @@
             context%symbols(symbol_index)%has_address = .true.
             context%symbols(symbol_index)%is_reference = .true.
             if (node%has_initializer .and. node%initializer_index > 0) then
-                call lower_scalar_initializer(context, name, value_kind, &
-                                              node%initializer_index, error_msg)
+                if (value_kind == VALUE_CHARACTER) then
+                    call lower_character_initializer(context, name, &
+                        node%initializer_index, error_msg)
+                else
+                    call lower_scalar_initializer(context, name, value_kind, &
+                        node%initializer_index, error_msg)
+                end if
                 if (len_trim(error_msg) > 0) return
             end if
         else
@@ -261,6 +288,29 @@
             if (.not. emit_liric_f64_store(context%session, &
                 context%symbols(symbol_index)%value, &
                 context%symbols(symbol_index)%address, error_msg)) return
+        case (VALUE_CHARACTER)
+            if (context%symbols(symbol_index)%character_length <= 0) then
+                error_msg = 'character target has no fixed storage length'
+                return
+            end if
+            if (.not. emit_alloca_bytes(context%session, &
+                i64_immediate(context%session, int( &
+                    context%symbols(symbol_index)%character_length + 1, &
+                    c_int64_t)), context%symbols(symbol_index)%address, &
+                error_msg)) return
+            call fill_spaces(context, context%symbols(symbol_index)%address, &
+                i32_immediate(context%session, int( &
+                    context%symbols(symbol_index)%character_length, c_int64_t)), &
+                error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (.not. emit_liric_store_char_byte(context%session, &
+                context%symbols(symbol_index)%address, &
+                i32_immediate(context%session, int( &
+                    context%symbols(symbol_index)%character_length, c_int64_t)), &
+                i32_immediate(context%session, 0_c_int64_t), error_msg)) return
+            context%symbols(symbol_index)%value = &
+                context%symbols(symbol_index)%address
+            context%symbols(symbol_index)%has_character_value = .true.
         case default
             error_msg = 'unsupported target scalar kind for direct LIRIC session'
             return
@@ -337,7 +387,38 @@
             call alias_pointer_array(context, ptr_index, target_index, error_msg)
             return
         end if
+        if (context%symbols(ptr_index)%value_kind /= &
+            context%symbols(target_index)%value_kind) then
+            error_msg = 'pointer and target scalar kinds do not match'
+            return
+        end if
+        if (context%symbols(ptr_index)%is_derived .neqv. &
+            context%symbols(target_index)%is_derived) then
+            error_msg = 'pointer and target scalar kinds do not match'
+            return
+        end if
+        if (context%symbols(ptr_index)%is_derived .and. &
+            context%symbols(ptr_index)%derived_type_index /= &
+            context%symbols(target_index)%derived_type_index) then
+            error_msg = 'pointer and target derived types do not match'
+            return
+        end if
+        if (context%symbols(ptr_index)%value_kind == VALUE_CHARACTER .and. &
+            context%symbols(ptr_index)%character_length /= &
+            context%symbols(target_index)%character_length) then
+            error_msg = 'pointer and target character lengths do not match'
+            return
+        end if
         context%symbols(ptr_index)%address = context%symbols(target_index)%address
+        if (context%symbols(ptr_index)%is_derived) then
+            context%symbols(ptr_index)%element_address = &
+                context%symbols(target_index)%element_address
+            context%symbols(ptr_index)%array_size = &
+                context%symbols(target_index)%array_size
+        else if (context%symbols(ptr_index)%value_kind == VALUE_CHARACTER) then
+            context%symbols(ptr_index)%value = &
+                context%symbols(target_index)%value
+        end if
         context%symbols(ptr_index)%has_address = .true.
         context%symbols(ptr_index)%is_reference = .true.
         context%symbols(ptr_index)%is_associated = .true.

--- a/test/test_session_scalar_pointer_compiler.f90
+++ b/test/test_session_scalar_pointer_compiler.f90
@@ -1,0 +1,104 @@
+program test_session_scalar_pointer_compiler
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    print *, '=== direct session scalar data-pointer compiler test ==='
+
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'integer, target :: i'//new_line('a')// &
+        'integer, pointer :: ip'//new_line('a')// &
+        'real, target :: r'//new_line('a')// &
+        'real, pointer :: rp'//new_line('a')// &
+        'logical, target :: flag'//new_line('a')// &
+        'logical, pointer :: fp'//new_line('a')// &
+        'i = 4'//new_line('a')// &
+        'r = 5.5'//new_line('a')// &
+        'flag = .true.'//new_line('a')// &
+        'ip => i'//new_line('a')// &
+        'rp => r'//new_line('a')// &
+        'fp => flag'//new_line('a')// &
+        'ip = 8'//new_line('a')// &
+        'r = 6.5'//new_line('a')// &
+        'if (.not. fp) stop 1'//new_line('a')// &
+        'if (.not. associated(ip, i)) stop 2'//new_line('a')// &
+        'if (.not. associated(rp, r)) stop 3'//new_line('a')// &
+        'if (.not. associated(fp, flag)) stop 4'//new_line('a')// &
+        'nullify(ip, rp, fp)'//new_line('a')// &
+        'if (associated(ip) .or. associated(rp) .or. associated(fp)) stop 5'// &
+        new_line('a')// &
+        'if (.not. flag) stop 6'//new_line('a')// &
+        'stop i + int(r) + 1'//new_line('a')// &
+        'end program main', 15, &
+        '/tmp/ffc_session_scalar_pointer_numeric')) stop 1
+
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'integer, target :: value'//new_line('a')// &
+        'value = 3'//new_line('a')// &
+        'call bump(value)'//new_line('a')// &
+        'stop value'//new_line('a')// &
+        'contains'//new_line('a')// &
+        'subroutine bump(target_value)'//new_line('a')// &
+        'integer, target, intent(inout) :: target_value'//new_line('a')// &
+        'integer, pointer :: p'//new_line('a')// &
+        'p => target_value'//new_line('a')// &
+        'p = 9'//new_line('a')// &
+        'end subroutine bump'//new_line('a')// &
+        'end program main', 9, &
+        '/tmp/ffc_session_scalar_pointer_dummy')) stop 2
+
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'character(len=3), target :: text'//new_line('a')// &
+        'character(len=3), pointer :: ptext'//new_line('a')// &
+        "text = 'abc'"//new_line('a')// &
+        'ptext => text'//new_line('a')// &
+        "ptext = 'xy'"//new_line('a')// &
+        "if (text /= 'xy ') stop 1"//new_line('a')// &
+        'if (.not. associated(ptext, text)) stop 2'//new_line('a')// &
+        'nullify(ptext)'//new_line('a')// &
+        'if (associated(ptext)) stop 3'//new_line('a')// &
+        'stop len_trim(text)'//new_line('a')// &
+        'end program main', 2, &
+        '/tmp/ffc_session_scalar_pointer_character')) stop 3
+
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'type :: pair_t'//new_line('a')// &
+        '  integer :: left'//new_line('a')// &
+        '  integer :: right'//new_line('a')// &
+        'end type pair_t'//new_line('a')// &
+        'type(pair_t), target :: value'//new_line('a')// &
+        'type(pair_t), pointer :: pvalue'//new_line('a')// &
+        'type(pair_t) :: copy'//new_line('a')// &
+        'value = pair_t(2, 4)'//new_line('a')// &
+        'pvalue => value'//new_line('a')// &
+        'pvalue%left = 7'//new_line('a')// &
+        'pvalue%right = 3'//new_line('a')// &
+        'if (.not. associated(pvalue, value)) stop 1'//new_line('a')// &
+        'copy = pvalue'//new_line('a')// &
+        'nullify(pvalue)'//new_line('a')// &
+        'if (associated(pvalue)) stop 2'//new_line('a')// &
+        'stop copy%left + copy%right'//new_line('a')// &
+        'end program main', 10, &
+        '/tmp/ffc_session_scalar_pointer_derived')) stop 4
+
+    if (.not. expect_error_contains( &
+        'program main'//new_line('a')// &
+        'integer :: value'//new_line('a')// &
+        'integer, pointer :: p'//new_line('a')// &
+        'p => value'//new_line('a')// &
+        'end program main', 'right of => is not a target or pointer', &
+        '/tmp/ffc_session_scalar_pointer_non_target')) stop 5
+
+    if (.not. expect_error_contains( &
+        'program main'//new_line('a')// &
+        'integer, target :: value'//new_line('a')// &
+        'real, pointer :: p'//new_line('a')// &
+        'p => value'//new_line('a')// &
+        'end program main', 'pointer and target scalar kinds do not match', &
+        '/tmp/ffc_session_scalar_pointer_incompatible')) stop 6
+
+    print *, 'PASS: scalar data-pointer storage, aliasing, queries, and diagnostics'
+end program test_session_scalar_pointer_compiler


### PR DESCRIPTION
Closes #452.

## Summary
- lower scalar integer, real, logical, fixed-length character, and plain derived TARGET/POINTER declarations
- preserve target storage identity through `=>`, `NULLIFY`, `ASSOCIATED`, and supported scalar TARGET dummies
- reject scalar pointer associations with incompatible kinds/types
- add independent behavioral coverage for aliasing, mutation, character buffers, derived values, dummy targets, and diagnostics

## Validation
- `FO_TEST_TIMEOUT=600 FO_BUILD_TIMEOUT=240 LIBRARY_PATH=../liric/build fo`
- static: 319/319
- build: 372/372
- tests: 255/255
- lint: pass
