### PR TITLE
[equivalence-param-01] fold named constants in EQUIVALENCE subscripts

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -233,7 +233,7 @@ module session_program_lowering
         MAX_GENERIC_SPECIFICS, &
         MODVAR_OK, MODVAR_UNSUPPORTED, &
         common_slot_t, COMMON_MAX_SLOTS, &
-        EQUIV_MAX_MEMBERS, &
+        EQUIV_MAX_MEMBERS, equiv_member_t, &
         ARRAY_MAX_RANK, &
         namelist_group_t, &
         statement_function_t, &

--- a/src/session_program_lowering_equivalence.inc
+++ b/src/session_program_lowering_equivalence.inc
@@ -3,16 +3,22 @@
     ! COMMON. The members of one EQUIVALENCE group name the same storage, so a
     ! write through one member is observable, bit-for-bit, through another.
     !
-    ! Model: emit one zero-initialised global per group, sized to the largest
+    ! Model: emit one zero-initialised global per group, sized to hold every
     ! member, and bind every member as an addressed reference into it. Each
     ! member keeps its own value_kind, so a load/store uses that member's type at
     ! the shared address - reading an integer back as a real reinterprets the
     ! bits exactly as gfortran does.
     !
-    ! Scope: scalar integer(4)/integer(8)/real(4)/real(8)/logical members of a
-    ! single (a, b, ...) group. Arrays, character, and offset associations
-    ! (substrings, array elements) leave the symbols plain locals and surface the
-    ! usual diagnostics rather than miscompiling.
+    ! An array-element designator ("a(3)", "a(np)") associates that element with
+    ! the group's association point, so the member's own storage starts that many
+    ! bytes earlier in the group global (#370). The subscript is a constant
+    ! expression: a named constant resolves through its FortFront binding before
+    ! the byte offset is computed, and a nonconstant subscript is diagnosed.
+    !
+    ! Scope: integer(4)/integer(8)/real(4)/real(8)/logical members of a single
+    ! (a, b, ...) group, scalars or 1D arrays. Character members and substring
+    ! designators leave the symbols plain locals and surface the usual
+    ! diagnostics rather than miscompiling.
 
     logical function is_equivalence_text(text)
         ! An EQUIVALENCE statement begins with the keyword after blanks.
@@ -32,8 +38,7 @@
         type(ast_arena_t), intent(in) :: arena
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
-        character(len=:), allocatable :: names(:)
-        integer :: kinds(EQUIV_MAX_MEMBERS)
+        type(equiv_member_t) :: members(EQUIV_MAX_MEMBERS)
         integer :: member_count, group_index, n, byte_size
         character(len=:), allocatable :: gname
         character(kind=c_char), allocatable :: c_name(:)
@@ -51,12 +56,12 @@
             type is (comment_node)
                 if (.not. is_equivalence_text(node%text)) cycle
                 group_index = group_index + 1
-                call collect_equivalence_members(arena, node%text, names, kinds, &
-                                                  member_count, error_msg)
+                call collect_equivalence_members(arena, context, n, node%text, &
+                                                 members, member_count, &
+                                                 byte_size, error_msg)
                 if (len_trim(error_msg) > 0) return
                 if (member_count == 0) cycle
-                byte_size = equivalence_group_size(kinds, member_count)
-                allocate(zero_bytes(byte_size))
+                allocate (zero_bytes(byte_size))
                 zero_bytes = char(0)
                 gname = equivalence_global_name(group_index)
                 call to_c_chars(gname, c_name)
@@ -67,9 +72,10 @@
                                               gtype, c_false_local, &
                                               c_loc(zero_bytes), &
                                               int(byte_size, c_size_t))
-                deallocate(zero_bytes)
+                deallocate (zero_bytes)
                 if (global_id < 0_c_int32_t) then
-                    error_msg = 'LIRIC could not create EQUIVALENCE global: '//gname
+                    error_msg = 'LIRIC could not create EQUIVALENCE global: '// &
+                                gname
                     return
                 end if
             end select
@@ -83,9 +89,8 @@
         type(ast_arena_t), intent(in) :: arena
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
-        character(len=:), allocatable :: names(:)
-        integer :: kinds(EQUIV_MAX_MEMBERS)
-        integer :: member_count, group_index, n, i, sym
+        type(equiv_member_t) :: members(EQUIV_MAX_MEMBERS)
+        integer :: member_count, group_index, n, i, sym, byte_size
 
         call set_empty(error_msg)
         group_index = 0
@@ -95,13 +100,14 @@
             type is (comment_node)
                 if (.not. is_equivalence_text(node%text)) cycle
                 group_index = group_index + 1
-                call collect_equivalence_members(arena, node%text, names, kinds, &
-                                                  member_count, error_msg)
+                call collect_equivalence_members(arena, context, n, node%text, &
+                                                 members, member_count, &
+                                                 byte_size, error_msg)
                 if (len_trim(error_msg) > 0) return
                 do i = 1, member_count
-                    sym = find_symbol_compat(context, trim(names(i)))
+                    sym = find_symbol_compat(context, trim(members(i)%var_name))
                     if (sym <= 0) cycle
-                    call rebind_equivalence_symbol(group_index, kinds(i), sym, &
+                    call rebind_equivalence_symbol(group_index, members(i), sym, &
                                                    context, error_msg)
                     if (len_trim(error_msg) > 0) return
                 end do
@@ -109,38 +115,202 @@
         end do
     end subroutine bind_equivalence_symbols
 
-    subroutine collect_equivalence_members(arena, text, names, kinds, &
-                                           member_count, error_msg)
-        ! Parse "equivalence (a, b, ...)" into member names and their kinds,
-        ! taken from each member's scalar program declaration.
+    subroutine collect_equivalence_members(arena, context, node_index, text, &
+                                           members, member_count, byte_size, &
+                                           error_msg)
+        ! Parse "equivalence (a, b(np), ...)" into members with their kinds,
+        ! shapes and designated-element offsets, then lay the group out.
         type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: node_index
         character(len=*), intent(in) :: text
-        character(len=:), allocatable, intent(out) :: names(:)
-        integer, intent(out) :: kinds(:)
+        type(equiv_member_t), intent(out) :: members(:)
         integer, intent(out) :: member_count
+        integer, intent(out) :: byte_size
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: group
+        character(len=:), allocatable :: items(:)
         integer :: i
 
         call set_empty(error_msg)
         member_count = 0
+        byte_size = 0
         call parse_equivalence_group(text, group, error_msg)
         if (len_trim(error_msg) > 0) return
-        call split_csv(group, names, member_count)
+        call split_equivalence_designators(group, items, member_count)
         if (member_count < 2) then
             error_msg = 'EQUIVALENCE group needs at least two members: '//text
             return
         end if
-        if (member_count > size(kinds)) then
+        if (member_count > size(members)) then
             error_msg = 'too many EQUIVALENCE members for direct lowering'
             return
         end if
         do i = 1, member_count
-            call program_declaration_kind(arena, trim(names(i)), kinds(i), &
-                                         error_msg)
+            call parse_equivalence_member(arena, context, node_index, &
+                                          trim(items(i)), members(i), error_msg)
             if (len_trim(error_msg) > 0) return
         end do
+        call layout_equivalence_group(members, member_count, byte_size)
     end subroutine collect_equivalence_members
+
+    subroutine parse_equivalence_member(arena, context, node_index, item, &
+                                        member, error_msg)
+        ! One designator: a bare name, or "name(subscript)" with a constant
+        ! subscript. The declaration supplies the kind and shape.
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: item
+        type(equiv_member_t), intent(out) :: member
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: base_name, sub_text
+        integer :: open_paren, close_paren, subscript
+
+        call set_empty(error_msg)
+        open_paren = index(item, '(')
+        close_paren = index(item, ')', back=.true.)
+        if (open_paren == 0) then
+            base_name = trim(item)
+            sub_text = ''
+        else
+            if (close_paren <= open_paren) then
+                error_msg = 'malformed EQUIVALENCE designator: '//trim(item)
+                return
+            end if
+            base_name = trim(adjustl(item(1:open_paren - 1)))
+            sub_text = trim(adjustl(item(open_paren + 1:close_paren - 1)))
+        end if
+        member%var_name = base_name
+        call program_declaration_kind_full(arena, base_name, member%value_kind, &
+                                           member%is_array, member%array_size, &
+                                           error_msg)
+        if (len_trim(error_msg) > 0) return
+        member%byte_offset = 0
+        if (len(sub_text) == 0) return
+        if (.not. member%is_array) then
+            error_msg = 'EQUIVALENCE subscript on a non-array member: '//trim(item)
+            return
+        end if
+        call fold_equivalence_subscript(arena, context, node_index, sub_text, &
+                                        subscript, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (subscript < 1 .or. subscript > member%array_size) then
+            error_msg = 'EQUIVALENCE subscript is out of bounds: '//trim(item)
+            return
+        end if
+        member%byte_offset = (subscript - 1)* &
+                             equivalence_kind_size(member%value_kind)
+    end subroutine parse_equivalence_member
+
+    subroutine fold_equivalence_subscript(arena, context, node_index, sub_text, &
+                                          subscript, error_msg)
+        ! An EQUIVALENCE subscript is a constant expression (F2018 8.10.3): an
+        ! integer literal, or a named constant that resolves through the
+        ! EQUIVALENCE statement's own binding scope before the byte offset is
+        ! computed. Anything else is not constant and is diagnosed.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: sub_text
+        integer, intent(out) :: subscript
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer(c_int64_t) :: value
+        integer :: ios
+        logical :: found
+
+        call set_empty(error_msg)
+        subscript = 0
+        read (sub_text, *, iostat=ios) subscript
+        if (ios == 0) return
+        call fold_named_constant_at_node(context, node_index, sub_text, value, &
+                                         found, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. found) then
+            call fold_equivalence_parameter_decl(arena, context, sub_text, &
+                                                 value, found)
+        end if
+        if (.not. found) then
+            error_msg = 'EQUIVALENCE subscript is not a constant expression: '// &
+                        trim(sub_text)
+            return
+        end if
+        subscript = int(value)
+    end subroutine fold_equivalence_subscript
+
+    subroutine fold_equivalence_parameter_decl(arena, context, name, value, found)
+        ! Fallback for a named constant FortFront cannot bind at the comment
+        ! node that carries the EQUIVALENCE statement: fold the initialiser of
+        ! the PARAMETER declaration that spells this name.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        character(len=*), intent(in) :: name
+        integer(c_int64_t), intent(out) :: value
+        logical, intent(out) :: found
+        character(len=:), allocatable :: fold_error
+        integer :: n
+
+        value = 0_c_int64_t
+        found = .false.
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (decl => arena%entries(n)%node)
+            type is (declaration_node)
+                if (.not. decl%is_parameter) cycle
+                if (.not. decl%has_initializer) cycle
+                if (decl%initializer_index <= 0) cycle
+                if (.not. declaration_names_var(decl, name)) cycle
+                call eval_i32_constant(arena, decl%initializer_index, context, &
+                                       value, fold_error)
+                if (len_trim(fold_error) > 0) return
+                found = .true.
+                return
+            end select
+        end do
+    end subroutine fold_equivalence_parameter_decl
+
+    subroutine split_equivalence_designators(text, items, count)
+        ! Split the group list on commas that are not inside a subscript.
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable, intent(out) :: items(:)
+        integer, intent(out) :: count
+        integer :: i, start, depth, max_len, n
+        character(len=:), allocatable :: piece
+
+        count = 0
+        n = count_commas(text) + 1
+        max_len = max(len(text), 1)
+        allocate (character(len=max_len) :: items(n))
+        items = ''
+        start = 1
+        depth = 0
+        do i = 1, len(text) + 1
+            if (i > len(text)) then
+                piece = trim(adjustl(text(start:)))
+            else if (text(i:i) == '(') then
+                depth = depth + 1
+                cycle
+            else if (text(i:i) == ')') then
+                depth = depth - 1
+                cycle
+            else if (text(i:i) == ',' .and. depth == 0) then
+                if (i > start) then
+                    piece = trim(adjustl(text(start:i - 1)))
+                else
+                    piece = ''
+                end if
+                start = i + 1
+            else
+                cycle
+            end if
+            if (len(piece) > 0) then
+                count = count + 1
+                items(count) = piece
+            end if
+        end do
+    end subroutine split_equivalence_designators
 
     subroutine parse_equivalence_group(text, group, error_msg)
         ! "equivalence (a, b)" -> group="a, b". Only a single parenthesised group
@@ -163,18 +333,36 @@
         group = rest(open_paren + 1:close_paren - 1)
     end subroutine parse_equivalence_group
 
-    integer function equivalence_group_size(kinds, member_count) result(byte_size)
-        ! The group occupies storage as large as its largest member.
-        integer, intent(in) :: kinds(:)
+    subroutine layout_equivalence_group(members, member_count, byte_size)
+        ! Every member's designated element sits on the group's association
+        ! point, so a member whose designator names element k starts that many
+        ! bytes before it. The group spans from the earliest start to the last
+        ! byte any member occupies.
+        type(equiv_member_t), intent(inout) :: members(:)
         integer, intent(in) :: member_count
-        integer :: i, sz
+        integer, intent(out) :: byte_size
+        integer :: i, anchor, span
+
+        anchor = 0
+        do i = 1, member_count
+            if (members(i)%byte_offset > anchor) anchor = members(i)%byte_offset
+        end do
         byte_size = 0
         do i = 1, member_count
-            sz = equivalence_kind_size(kinds(i))
-            if (sz > byte_size) byte_size = sz
+            members(i)%start_offset = anchor - members(i)%byte_offset
+            span = members(i)%start_offset + equivalence_member_size(members(i))
+            if (span > byte_size) byte_size = span
         end do
         if (byte_size <= 0) byte_size = 4
-    end function equivalence_group_size
+    end subroutine layout_equivalence_group
+
+    integer function equivalence_member_size(member) result(sz)
+        ! Storage the member itself occupies, in bytes.
+        type(equiv_member_t), intent(in) :: member
+
+        sz = equivalence_kind_size(member%value_kind)
+        if (member%is_array) sz = sz*max(member%array_size, 1)
+    end function equivalence_member_size
 
     integer function equivalence_kind_size(value_kind) result(sz)
         integer, intent(in) :: value_kind
@@ -186,10 +374,12 @@
         end select
     end function equivalence_kind_size
 
-    subroutine rebind_equivalence_symbol(group_index, value_kind, sym, context, &
+    subroutine rebind_equivalence_symbol(group_index, member, sym, context, &
                                          error_msg)
         use, intrinsic :: iso_c_binding, only: c_char, c_int32_t, c_int64_t
-        integer, intent(in) :: group_index, value_kind, sym
+        integer, intent(in) :: group_index
+        type(equiv_member_t), intent(in) :: member
+        integer, intent(in) :: sym
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: gname
@@ -203,13 +393,24 @@
             error_msg = 'EQUIVALENCE global not found: '//gname
             return
         end if
-        context%symbols(sym)%value_kind = value_kind
+        context%symbols(sym)%value_kind = member%value_kind
         context%symbols(sym)%has_address = .true.
         context%symbols(sym)%is_reference = .true.
         context%symbols(sym)%address%kind = LR_OP_KIND_GLOBAL
         context%symbols(sym)%address%payload = int(global_id, c_int64_t)
         context%symbols(sym)%address%typ = lr_type_ptr_s(context%session%handle)
-        context%symbols(sym)%address%global_offset = 0_c_int64_t
+        context%symbols(sym)%address%global_offset = &
+            int(member%start_offset, c_int64_t)
+        if (member%is_array) then
+            context%symbols(sym)%is_array = .true.
+            context%symbols(sym)%array_rank = 1
+            context%symbols(sym)%array_size = member%array_size
+            context%symbols(sym)%array_dim_sizes(1) = member%array_size
+            context%symbols(sym)%array_dim_lowers(1) = 1
+            ! Element GEP addresses off element_address, the same field a local
+            ! array's alloca fills (session_program_lowering_array_elements.inc).
+            context%symbols(sym)%element_address = context%symbols(sym)%address
+        end if
         call set_empty(error_msg)
     end subroutine rebind_equivalence_symbol
 

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -188,6 +188,20 @@ module session_program_lowering_types
         character(len=:), allocatable :: array_init_values(:)
     end type common_slot_t
 
+    ! One member of an EQUIVALENCE group (#370). `byte_offset` is the storage
+    ! offset of the designated element inside the member itself (nonzero only
+    ! for an array-element designator); `start_offset` is where the member's
+    ! own storage begins inside the group global, once every member's
+    ! designated element has been aligned on the shared association point.
+    type, public :: equiv_member_t
+        character(len=:), allocatable :: var_name
+        integer :: value_kind = VALUE_I32
+        logical :: is_array = .false.
+        integer :: array_size = 0
+        integer :: byte_offset = 0
+        integer :: start_offset = 0
+    end type equiv_member_t
+
     type, public :: symbol_t
         ! `name` is display data (diagnostics, mangling), not identity.
         ! Identity is the FortFront binding below, when this symbol came

--- a/test/test_session_equivalence_compiler.f90
+++ b/test/test_session_equivalence_compiler.f90
@@ -1,7 +1,7 @@
 program test_session_equivalence_compiler
     ! #280 (issue_1745): EQUIVALENCE overlays the storage of its members. A write
     ! through one member is observable bit-for-bit through another.
-    use ffc_test_support, only: expect_output
+    use ffc_test_support, only: expect_output, expect_error_contains
     implicit none
     logical :: all_passed
 
@@ -10,6 +10,9 @@ program test_session_equivalence_compiler
 
     if (.not. test_int_real_overlay()) all_passed = .false.
     if (.not. test_real_write_seen_as_int()) all_passed = .false.
+    if (.not. test_module_named_constant_subscript()) all_passed = .false.
+    if (.not. test_local_named_constant_subscript()) all_passed = .false.
+    if (.not. test_nonconstant_subscript_rejected()) all_passed = .false.
 
     if (all_passed) then
         print *, 'PASS: EQUIVALENCE overlays storage through direct LIRIC session'
@@ -54,5 +57,69 @@ contains
         test_real_write_seen_as_int = expect_output( &
             source, '  1065353216'//new_line('a'), '/tmp/ffc_equiv_ri_test')
     end function test_real_write_seen_as_int
+
+    logical function test_module_named_constant_subscript()
+        ! #370: an EQUIVALENCE array-element subscript is a constant
+        ! expression. A USE-associated named constant must fold before the
+        ! byte offset is computed, so r overlays a(3), not a(1).
+        character(len=*), parameter :: source = &
+            'module cst'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer, parameter :: np = 3'//new_line('a')// &
+            'end module cst'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use cst, only: np'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer :: a(5)'//new_line('a')// &
+            '  real :: r'//new_line('a')// &
+            '  equivalence (a(np), r)'//new_line('a')// &
+            '  a(1) = 0'//new_line('a')// &
+            '  a(3) = 0'//new_line('a')// &
+            '  r = 1.0'//new_line('a')// &
+            '  print *, a(1)'//new_line('a')// &
+            '  print *, a(3)'//new_line('a')// &
+            'end program main'
+        ! 1.0 as IEEE-754 single precision is 0x3F800000 = 1065353216, and it
+        ! lands on element 3 only when np folds to 3.
+        test_module_named_constant_subscript = expect_output( &
+            source, '           0'//new_line('a')// &
+            '  1065353216'//new_line('a'), '/tmp/ffc_equiv_modparam_test')
+    end function test_module_named_constant_subscript
+
+    logical function test_local_named_constant_subscript()
+        ! The same fold for a named constant declared in the program itself.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer, parameter :: np = 2'//new_line('a')// &
+            '  integer :: a(4)'//new_line('a')// &
+            '  real :: r'//new_line('a')// &
+            '  equivalence (a(np), r)'//new_line('a')// &
+            '  a(2) = 0'//new_line('a')// &
+            '  r = 1.0'//new_line('a')// &
+            '  print *, a(2)'//new_line('a')// &
+            'end program main'
+        test_local_named_constant_subscript = expect_output( &
+            source, '  1065353216'//new_line('a'), &
+            '/tmp/ffc_equiv_localparam_test')
+    end function test_local_named_constant_subscript
+
+    logical function test_nonconstant_subscript_rejected()
+        ! A nonconstant subscript is not a constant expression: diagnose it
+        ! rather than picking an arbitrary offset.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer :: n'//new_line('a')// &
+            '  integer :: a(4)'//new_line('a')// &
+            '  real :: r'//new_line('a')// &
+            '  equivalence (a(n), r)'//new_line('a')// &
+            '  n = 1'//new_line('a')// &
+            '  r = 1.0'//new_line('a')// &
+            '  print *, a(1)'//new_line('a')// &
+            'end program main'
+        test_nonconstant_subscript_rejected = expect_error_contains( &
+            source, 'EQUIVALENCE subscript', '/tmp/ffc_equiv_nonconst_test')
+    end function test_nonconstant_subscript_rejected
 
 end program test_session_equivalence_compiler


### PR DESCRIPTION
Closes #370.

## Preserved compiler invariant

An EQUIVALENCE array-element designator subscript is a constant expression
(F2018 8.10.3). It is now resolved before the byte offset is computed:
an integer literal, or a named constant folded through the FortFront
binding at the EQUIVALENCE statement (with a PARAMETER-declaration
fallback for names FortFront cannot bind at the comment node that carries
the statement). A nonconstant subscript is diagnosed rather than silently
associating element 1.

Group layout now puts every member's designated element on the shared
association point: a member designated by element k starts k-1 elements
earlier inside the group global, and array members bind with their shape
and element address so element GEPs address the shared storage.

## Red evidence

`fo test test_session_equivalence_compiler` on unmodified main, with the
three new cases:

```
 FAIL: COMMON variable not declared: a(np)
 FAIL: COMMON variable not declared: a(np)
 FAIL: diagnostic did not contain "EQUIVALENCE subscript"
   actual: COMMON variable not declared: a(n)
Summary: 0 passed, 1 failed, 0 skipped
```

## Green evidence

```
fo test test_session_equivalence_compiler
test_session_equivalence_compiler          PASS       0.06s
Summary: 1 passed, 0 failed, 0 skipped
```

Full `fo` pipeline: Static OK, Build OK, all tests pass except
`test_parity_dashboard`, which fails identically on unmodified
origin/main in the same worktree (verified by stashing the change) —
a snapshot-revision/environment failure, not this diff.

## Not promoted: module_equivalence_6.f90

`test/conformance/fail_owners_gfortran_dg.txt` lists this case under
#370, but its failure is unrelated to EQUIVALENCE subscripts. Reduced:

```fortran
MODULE A
  INTEGER :: X
  INTEGER :: Y
END MODULE A
MODULE B
  USE A
END MODULE B
PROGRAM p
  INTEGER :: ii
  ii = Y          ! error: integer identifier was not declared: Y
END PROGRAM p
```

Reading a chained-USE re-exported module variable on the right-hand side
fails with no EQUIVALENCE anywhere; the same program with a direct
`USE A` compiles. That is a separate module re-export defect and is left
for its own issue.