### PR TITLE
[reject-boz-01] reject BOZ literals outside permitted contexts

### DIFF
--- a/src/session_program_lowering_literal_utils.inc
+++ b/src/session_program_lowering_literal_utils.inc
@@ -282,6 +282,21 @@
         end if
     end function is_boz_literal_text
 
+    logical function node_is_boz_literal(arena, node_index) result(is_boz)
+        !! True when the arena node is a literal whose spelling is a
+        !! BOZ-literal-constant. Non-literal nodes and missing nodes are not.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: value, literal_type, err
+
+        is_boz = .false.
+        if (node_index <= 0) return
+        if (.not. node_exists(arena, node_index)) return
+        call get_literal_info(arena, node_index, value, literal_type, err)
+        if (len_trim(err) > 0) return
+        is_boz = is_boz_literal_text(value)
+    end function node_is_boz_literal
+
     logical function is_boz_designator(c)
         character(len=1), intent(in) :: c
 

--- a/src/session_program_lowering_reject_checks.inc
+++ b/src/session_program_lowering_reject_checks.inc
@@ -468,6 +468,145 @@
         end do
     end subroutine check_boz_ctor_elements
 
+    ! A BOZ-literal-constant has no type of its own (F2018 7.7.1): it is a
+    ! bit pattern that borrows the type of the context it appears in. The only
+    ! contexts that supply one are a DATA-statement value, an argument of
+    ! INT/REAL/DBLE/CMPLX, and - by the gfortran extension already lowered
+    ! here - the right side of an intrinsic assignment to an integer or real
+    ! variable. Everything else has no type to lend it: an unlimited
+    ! polymorphic or otherwise non-numeric assignment target, an ASSOCIATE
+    ! selector, or a structure-constructor component.
+    subroutine check_boz_literal_contexts(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n, i
+        character(len=:), allocatable :: callee
+        character(len=64) :: location
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (associate_node)
+                if (.not. allocated(nd%associations)) cycle
+                do i = 1, size(nd%associations)
+                    if (.not. node_is_boz_literal(arena, &
+                                                  nd%associations(i)%expr_index)) cycle
+                    write (location, '(" at line ",I0,", column ",I0)') &
+                        get_node_line(arena, nd%associations(i)%expr_index), &
+                        get_node_column(arena, nd%associations(i)%expr_index)
+                    error_msg = 'associate selector'//trim(location)// &
+                                ' cannot be a BOZ literal constant'
+                    return
+                end do
+            type is (call_or_subscript_node)
+                if (.not. allocated(nd%arg_indices)) cycle
+                call set_empty(callee)
+                if (allocated(nd%name)) callee = trim(nd%name)
+                if (boz_argument_intrinsic(callee)) cycle
+                do i = 1, size(nd%arg_indices)
+                    if (.not. node_is_boz_literal(arena, nd%arg_indices(i))) cycle
+                    write (location, '(" at line ",I0,", column ",I0)') &
+                        get_node_line(arena, nd%arg_indices(i)), &
+                        get_node_column(arena, nd%arg_indices(i))
+                    error_msg = 'BOZ literal constant'//trim(location)// &
+                                ' cannot appear as an argument to '''// &
+                                callee//''''
+                    return
+                end do
+            type is (assignment_node)
+                if (.not. node_is_boz_literal(arena, nd%value_index)) cycle
+                if (boz_assignment_target_typed(arena, nd%target_index)) cycle
+                write (location, '(" at line ",I0,", column ",I0)') &
+                    get_node_line(arena, nd%value_index), &
+                    get_node_column(arena, nd%value_index)
+                error_msg = 'BOZ literal constant'//trim(location)// &
+                            ' cannot be assigned to a non-numeric variable'
+                return
+            end select
+        end do
+    end subroutine check_boz_literal_contexts
+
+    ! The intrinsics whose defining interface accepts a typeless BOZ actual
+    ! argument and gives it a type (F2018 16.9): the conversion family, plus
+    ! the legacy FLOAT/DFLOAT/DCMPLX spellings gfortran maps onto it.
+    logical function boz_argument_intrinsic(name) result(ok)
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: low
+
+        low = trim(lowercase_text(name))
+        ok = low == 'int' .or. low == 'real' .or. low == 'dble' .or. &
+             low == 'cmplx' .or. low == 'dcmplx' .or. low == 'float' .or. &
+             low == 'dfloat'
+    end function boz_argument_intrinsic
+
+    ! True when the assignment target can lend a BOZ right-hand side a type:
+    ! an integer or real variable. A target with no visible declaration is
+    ! left alone - lazy-fortran infers its type from the assignment itself.
+    logical function boz_assignment_target_typed(arena, target_index) result(ok)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: target_index
+        character(len=:), allocatable :: name, err, type_name
+
+        ok = .true.
+        if (target_index <= 0) return
+        if (.not. node_exists(arena, target_index)) return
+        if (.not. is_identifier(arena, target_index)) return
+        call get_identifier_name(arena, target_index, name, err)
+        if (len_trim(err) > 0) return
+        call declared_type_name_of(arena, name, type_name)
+        if (.not. allocated(type_name)) return
+        if (len_trim(type_name) == 0) return
+        ok = boz_compatible_type(type_name)
+    end function boz_assignment_target_typed
+
+    logical function boz_compatible_type(type_name) result(ok)
+        character(len=*), intent(in) :: type_name
+        character(len=:), allocatable :: low
+
+        low = trim(lowercase_text(type_name))
+        ok = .false.
+        if (len(low) >= 7) then
+            if (low(1:7) == 'integer') ok = .true.
+        end if
+        if (len(low) >= 4) then
+            if (low(1:4) == 'real') ok = .true.
+        end if
+        if (len(low) >= 6) then
+            if (low(1:6) == 'double') ok = .true.
+        end if
+    end function boz_compatible_type
+
+    ! Declared type spelling of a named entity, searched across every
+    ! declaration in the arena. Empty when the name has no declaration.
+    subroutine declared_type_name_of(arena, name, type_name)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable, intent(out) :: type_name
+        integer :: n, i
+
+        call set_empty(type_name)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (decl => arena%entries(n)%node)
+            type is (declaration_node)
+                if (.not. allocated(decl%type_name)) cycle
+                if (allocated(decl%var_name)) then
+                    if (same_name(decl%var_name, name)) then
+                        type_name = trim(decl%type_name)
+                        return
+                    end if
+                end if
+                if (.not. allocated(decl%var_names)) cycle
+                do i = 1, size(decl%var_names)
+                    if (.not. same_name(decl%var_names(i), name)) cycle
+                    type_name = trim(decl%type_name)
+                    return
+                end do
+            end select
+        end do
+    end subroutine declared_type_name_of
+
     ! An assumed-size specifier (*) is only well-formed as the extent of the
     ! LAST array dimension; a bare asterisk anywhere earlier is not a valid
     ! array-spec (gfortran: "Bad specification for assumed size array" for a

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -516,6 +516,8 @@
         if (len_trim(error_msg) > 0) return
         call check_boz_in_array_constructors(arena, error_msg)
         if (len_trim(error_msg) > 0) return
+        call check_boz_literal_contexts(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
         call check_assumed_size_dimension_order(arena, error_msg)
         if (len_trim(error_msg) > 0) return
         call check_intrinsic_external_conflict(arena, error_msg)

--- a/test/test_session_reject_boz_01_compiler.f90
+++ b/test/test_session_reject_boz_01_compiler.f90
@@ -1,0 +1,115 @@
+program test_session_reject_boz_01_compiler
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== BOZ literal context rejection compiler test ==='
+
+    all_passed = .true.
+    if (.not. test_boz_to_class_star_rejected()) all_passed = .false.
+    if (.not. test_boz_associate_selector_rejected()) all_passed = .false.
+    if (.not. test_boz_structure_constructor_rejected()) all_passed = .false.
+    if (.not. test_boz_integer_assignment_accepted()) all_passed = .false.
+    if (.not. test_associate_integer_selector_accepted()) all_passed = .false.
+    if (.not. test_data_integer_component_accepted()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: BOZ literals rejected outside permitted contexts'
+
+contains
+
+    logical function test_boz_to_class_star_rejected()
+        !! gfortran.dg/pr93601.f90: a BOZ literal may only be assigned to an
+        !! integer or real variable; an unlimited polymorphic target has no
+        !! such type to take the bit pattern.
+        character(len=*), parameter :: source = &
+            'program p'//new_line('a')// &
+            '   class(*), allocatable :: z'//new_line('a')// &
+            "   z = z'1'"//new_line('a')// &
+            'end'
+
+        test_boz_to_class_star_rejected = expect_error_contains( &
+            source, 'BOZ literal constant', &
+            '/tmp/ffc_session_boz01_class_reject')
+    end function test_boz_to_class_star_rejected
+
+    logical function test_boz_associate_selector_rejected()
+        !! gfortran.dg/pr93603.f90: an associate selector cannot be a BOZ
+        !! literal constant - it has no type to associate with.
+        character(len=*), parameter :: source = &
+            'program p'//new_line('a')// &
+            "  associate (y => z'1')"//new_line('a')// &
+            '  end associate'//new_line('a')// &
+            'end'
+
+        test_boz_associate_selector_rejected = expect_error_contains( &
+            source, 'BOZ literal constant', &
+            '/tmp/ffc_session_boz01_assoc_reject')
+    end function test_boz_associate_selector_rejected
+
+    logical function test_boz_structure_constructor_rejected()
+        !! gfortran.dg/pr93604.f90: a BOZ literal is not a valid structure
+        !! constructor component value, not even in a DATA statement.
+        character(len=*), parameter :: source = &
+            'program p'//new_line('a')// &
+            '   type t'//new_line('a')// &
+            '      integer :: a'//new_line('a')// &
+            '   end type'//new_line('a')// &
+            '   type(t) :: x'//new_line('a')// &
+            "   data x /t(z'1')/"//new_line('a')// &
+            'end'
+
+        test_boz_structure_constructor_rejected = expect_error_contains( &
+            source, 'BOZ literal constant', &
+            '/tmp/ffc_session_boz01_ctor_reject')
+    end function test_boz_structure_constructor_rejected
+
+    logical function test_boz_integer_assignment_accepted()
+        !! Corrected neighbour of pr93601: an integer target still accepts a
+        !! BOZ literal.
+        character(len=*), parameter :: source = &
+            'program p'//new_line('a')// &
+            '   integer :: z'//new_line('a')// &
+            "   z = z'1'"//new_line('a')// &
+            '   print *, z'//new_line('a')// &
+            '   stop 0'//new_line('a')// &
+            'end'
+
+        test_boz_integer_assignment_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_session_boz01_class_accept')
+    end function test_boz_integer_assignment_accepted
+
+    logical function test_associate_integer_selector_accepted()
+        !! Corrected neighbour of pr93603: a typed selector associates fine.
+        character(len=*), parameter :: source = &
+            'program p'//new_line('a')// &
+            "  associate (y => int(z'1'))"//new_line('a')// &
+            '    print *, y'//new_line('a')// &
+            '  end associate'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end'
+
+        test_associate_integer_selector_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_session_boz01_assoc_accept')
+    end function test_associate_integer_selector_accepted
+
+    logical function test_data_integer_component_accepted()
+        !! Corrected neighbour of pr93604: an ordinary integer constant in the
+        !! structure constructor keeps the DATA statement valid.
+        character(len=*), parameter :: source = &
+            'program p'//new_line('a')// &
+            '   type t'//new_line('a')// &
+            '      integer :: a'//new_line('a')// &
+            '   end type'//new_line('a')// &
+            '   type(t) :: x'//new_line('a')// &
+            '   data x /t(1)/'//new_line('a')// &
+            '   print *, x%a'//new_line('a')// &
+            '   stop 0'//new_line('a')// &
+            'end'
+
+        test_data_integer_component_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_session_boz01_ctor_accept')
+    end function test_data_integer_component_accepted
+
+end program test_session_reject_boz_01_compiler


### PR DESCRIPTION
Closes #393.

## Preserved compiler invariant

A BOZ-literal-constant is typeless (F2018 7.7.1); it only borrows the type of the context it appears in. ffc silently lowered three contexts that supply no type:

- assignment to a non-numeric variable (gfortran.dg `pr93601.f90`, `class(*)` target)
- an ASSOCIATE selector (`pr93603.f90`)
- a structure-constructor component, including inside DATA (`pr93604.f90`)

`check_boz_literal_contexts` validates typed nodes, not text: the associate selector expression, call/constructor argument lists (only the conversion intrinsics INT/REAL/DBLE/CMPLX and the legacy FLOAT/DFLOAT/DCMPLX spellings give a BOZ argument a type), and assignment targets whose declared type is neither integer nor real. A target with no visible declaration is left alone so lazy-fortran inference is unaffected; `i = z'ff'`, `int(z'ff')`, and DATA with numeric components still compile and run.

## Red evidence (unmodified main)

```
scripts/conformance_gauntlet.sh --suite gfortran-dg --file pr93601.f90 --file pr93603.f90 --file pr93604.f90
  FAIL: pr93601.f90 (negative test accepted)
  FAIL: pr93603.f90 (negative test accepted)
  FAIL: pr93604.f90 (negative test accepted)
  PASS=0 FAIL=3

fo test test_session_reject_boz_01_compiler
  FAIL: unsupported source lowered without diagnostic   (x3; the three corrected neighbours already passed)
```

## Green evidence

```
fo test test_session_reject_boz_01_compiler            PASS
scripts/conformance_gauntlet.sh ... pr93601/3/4        PASS=3 FAIL=0
fo                                                     Build OK; suite green except test_parity_dashboard,
                                                       which fails identically on the unmodified tree
                                                       (stale snapshot FortFront revision, pre-existing)
```
