### PR TITLE
[associate-kind-01] preserve kind constants in ASSOCIATE (#363)

### DIFF
--- a/src/session_program_lowering_arrays.inc
+++ b/src/session_program_lowering_arrays.inc
@@ -122,6 +122,7 @@
             return
         end if
         if (iso_c_binding_kind_value(id_name, kind_value)) has_var = .false.
+        if (iso_fortran_env_kind_value(id_name, kind_value)) has_var = .false.
     end function bound_identifier_references_variable
 
     logical function declaration_bound_is_variable_driven(node, context) &
@@ -1302,6 +1303,10 @@
                     end if
                 end if
                 if (iso_c_binding_kind_value(id_name, constant_value)) then
+                    call set_empty(error_msg)
+                    return
+                end if
+                if (iso_fortran_env_kind_value(id_name, constant_value)) then
                     call set_empty(error_msg)
                     return
                 end if

--- a/src/session_program_lowering_const_fold.inc
+++ b/src/session_program_lowering_const_fold.inc
@@ -24,6 +24,35 @@
         end select
     end function iso_c_binding_kind_value
 
+    ! ISO_FORTRAN_ENV integer-kind named constants used as compile-time integer
+    ! values (e.g. "associate (k => int32)" or "integer, parameter :: ik =
+    ! int64"), matching the kind numbers gfortran reports at runtime. Only the
+    ! kind-parameter constants are folded here; the storage-size and unit
+    ! constants keep their own lowering paths.
+    logical function iso_fortran_env_kind_value(name, value) result(found)
+        character(len=*), intent(in) :: name
+        integer(c_int64_t), intent(out) :: value
+        character(len=:), allocatable :: lo
+
+        lo = lowercase_text(trim(name))
+        found = .true.
+        select case (lo)
+        case ('int8')
+            value = 1_c_int64_t
+        case ('int16')
+            value = 2_c_int64_t
+        case ('int32', 'real32')
+            value = 4_c_int64_t
+        case ('int64', 'real64')
+            value = 8_c_int64_t
+        case ('real128')
+            value = 16_c_int64_t
+        case default
+            found = .false.
+            value = 0_c_int64_t
+        end select
+    end function iso_fortran_env_kind_value
+
     ! Determine the kind number of an integer literal's optional kind suffix
     ! (12_8, 12_int64, 12_c_long); a bare literal is default kind 4.
     subroutine integer_literal_kind_number(text, k, error_msg)

--- a/src/session_program_lowering_integer.inc
+++ b/src/session_program_lowering_integer.inc
@@ -96,6 +96,18 @@
                   call set_empty(error_msg)
                   return
               end if
+              ! An intrinsic-module kind constant (iso_fortran_env int32,
+              ! iso_c_binding c_int) has no lowering symbol either; it is a
+              ! compile-time integer whose value is its kind number.
+              const_found = iso_fortran_env_kind_value(id_name, const_value)
+              if (.not. const_found) then
+                  const_found = iso_c_binding_kind_value(id_name, const_value)
+              end if
+              if (const_found) then
+                  value = i32_immediate(context%session, const_value)
+                  call set_empty(error_msg)
+                  return
+              end if
               error_msg = 'integer identifier was not declared: '//trim(id_name)
               return
           end if

--- a/test/test_session_associate_compiler.f90
+++ b/test/test_session_associate_compiler.f90
@@ -13,6 +13,8 @@ program test_session_associate
     if (.not. test_associate_scope_drops_binding()) all_passed = .false.
     if (.not. test_associate_print_value()) all_passed = .false.
     if (.not. test_associate_real_expr_alias()) all_passed = .false.
+    if (.not. test_associate_kind_constant_selector()) all_passed = .false.
+    if (.not. test_associate_kind_constant_expression()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: associate constructs lower through direct LIRIC'
@@ -121,5 +123,42 @@ contains
             source, '   7.00000000    '//new_line('a'), &
             '/tmp/ffc_session_associate_real_expr')
     end function test_associate_real_expr_alias
+
+    logical function test_associate_kind_constant_selector()
+        ! An ISO_FORTRAN_ENV kind constant is a named integer constant: the
+        ! associate name must carry its value (4 for int32), not the default
+        ! zero of an unresolved identifier. Matches gfortran.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'use, intrinsic :: iso_fortran_env, only: int32'// &
+            new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'associate (k => int32)'//new_line('a')// &
+            '    print *, k'//new_line('a')// &
+            'end associate'//new_line('a')// &
+            'end program main'
+
+        test_associate_kind_constant_selector = expect_output( &
+            source, '           4'//new_line('a'), &
+            '/tmp/ffc_session_associate_kind_const')
+    end function test_associate_kind_constant_selector
+
+    logical function test_associate_kind_constant_expression()
+        ! The bound constant stays usable in further integer expressions and
+        ! keeps its own kind number (int64 is 8).
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'use, intrinsic :: iso_fortran_env, only: int8, int64'// &
+            new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'associate (k => int64, m => int8)'//new_line('a')// &
+            '    stop k + m'//new_line('a')// &
+            'end associate'//new_line('a')// &
+            'end program main'
+
+        test_associate_kind_constant_expression = expect_exit_status( &
+            source, 9, &
+            '/tmp/ffc_session_associate_kind_expr')
+    end function test_associate_kind_constant_expression
 
 end program test_session_associate


### PR DESCRIPTION
Closes #363.

## Preserved compiler invariant

A named constant keeps its value and kind when it is associated. An
ASSOCIATE selector naming an intrinsic-module kind constant
(`associate (k => int32)`) has no lowering symbol, so the integer
expression path previously either rejected it as undeclared or let
implicit typing swallow it and emit a silent zero.

`iso_fortran_env_kind_value` folds `int8/int16/int32/int64` and
`real32/real64/real128` to their kind numbers, and is wired into:

- the runtime integer expression path (`lower_i32_expression`),
- the compile-time integer folder (`eval_i32_constant`),
- the array-bound variability probe (`bound_identifier_references_variable`).

The lookups are split into separate `if` tests rather than chained with
`.or.`, since Fortran does not short-circuit and the second call would
clobber the folded value.

## Red evidence

`fo test test_session_associate_compiler` with the new cases on
unmodified `src/`:

```
 FAIL: integer identifier was not declared: int32
 FAIL: integer identifier was not declared: int64
Summary: 0 passed, 1 failed, 0 skipped
```

Directly: `print *, int32, real64` compiled to `0   0.00000000`
(gfortran: `4  8`).

## Green evidence

```
test_session_associate_compiler            PASS       0.44s
Summary: 1 passed, 0 failed, 0 skipped
```

`print *, int32, real64` now emits `           4           8`, matching
gfortran. Full `fo` pipeline: Build OK, Static OK, whole suite green
except `test_parity_dashboard`, which fails on this machine before this
change too (`ERROR: stale snapshot FortFront revision` — the recorded
parity snapshot predates the local FortFront checkout).

## Notes

`associate_79.f90` is not promoted: that fixture needs a
complex-returning contained function (`complex(wp) function myfunc`),
which the direct LIRIC session does not lower yet. It stays owned by a
follow-up.