### PR TITLE
[assumed-size-spec-01] resolve leading-dimension dummies (#356)

### DIFF
--- a/src/session_program_lowering_arrays.inc
+++ b/src/session_program_lowering_arrays.inc
@@ -1446,15 +1446,46 @@
         ! The actual must not reference the dummy being resolved - directly
         ! (a) or inside a subexpression (a/b). current_proc_name never advances
         ! to the caller, so folding such an actual re-enters this routine on the
-        ! same name forever (sin_02 stack overflow). Bail as non-constant.
+        ! same name forever (sin_02 stack overflow). The one safe case is an
+        ! actual that is exactly the dummy's own spelling (LAPACK style:
+        ! `call copy(a, lda, ...)` against `A(LDA, *)`): resolve it in the
+        ! caller's scope only, which terminates because it never re-enters here.
         if (expr_refs_name(arena, actual_index, name)) then
-            error_msg = 'compile-time integer parameter was not declared: '// &
-                        trim(name)
+            call fold_caller_scope_i32_name(arena, context, actual_index, name, &
+                                            constant_value, error_msg)
             return
         end if
         call eval_i32_constant(arena, actual_index, context, constant_value, &
                                error_msg)
     end subroutine fold_i32_constant_from_call_site
+
+    subroutine fold_caller_scope_i32_name(arena, context, actual_index, name, &
+                                          constant_value, error_msg)
+        ! Fold an actual argument that is the bare identifier `name`, resolved
+        ! in the scope of the call site rather than the callee. The callee's
+        ! dummy of the same spelling is deliberately not consulted, so this
+        ! never recurses back into the call-site fold.
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: actual_index
+        character(len=*), intent(in) :: name
+        integer(c_int64_t), intent(out) :: constant_value
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: actual_name, name_err
+        type(declaration_binding_t) :: binding
+
+        constant_value = 0_c_int64_t
+        error_msg = 'compile-time integer parameter was not declared: '//trim(name)
+        if (.not. is_identifier(arena, actual_index)) return
+        call get_identifier_name(arena, actual_index, actual_name, name_err)
+        if (len_trim(name_err) > 0) return
+        if (.not. same_name(actual_name, name)) return
+        call resolve_name_at_node(arena, actual_index, actual_name, binding, &
+                                  name_err)
+        if (len_trim(name_err) > 0) return
+        if (.not. binding%found) return
+        call fold_i32_binding(arena, context, binding, constant_value, error_msg)
+    end subroutine fold_caller_scope_i32_name
 
     ! Constant-fold selected_int_kind / selected_real_kind so they may appear
     ! in a compile-time integer parameter initializer (kind selection).

--- a/test/conformance/fail_owners_lfortran.txt
+++ b/test/conformance/fail_owners_lfortran.txt
@@ -8,6 +8,5 @@ implicit_interface_38b.f90 # owner=lazy-fortran/ffc#353; reason=register positio
 implicit_typing_07.f90 # owner=lazy-fortran/ffc#355; reason=collect old-style PARAMETER bindings
 include_03.f90 # owner=lazy-fortran/ffc#354; reason=expand Fortran INCLUDE lines
 interface_29.f90 # owner=lazy-fortran/ffc#357; reason=preserve bodies after interface blocks
-lapack_05.f90 # owner=lazy-fortran/ffc#356; reason=resolve leading-dimension dummies
 modules_58_module.f90 # owner=lazy-fortran/ffc#358; reason=lower multi-object ALLOCATE
 pointer_13.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities

--- a/test/test_session_assumed_size_array_compiler.f90
+++ b/test/test_session_assumed_size_array_compiler.f90
@@ -9,6 +9,7 @@ program test_session_assumed_size_array
     all_passed = .true.
     if (.not. test_rank1_bare_star()) all_passed = .false.
     if (.not. test_rank2_last_dim_star()) all_passed = .false.
+    if (.not. test_leading_dimension_dummy()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: assumed-size dummies lower through direct LIRIC'
@@ -66,5 +67,44 @@ contains
         test_rank2_last_dim_star = expect_output(source, expected, &
             '/tmp/ffc_session_assumed_size_r2')
     end function test_rank2_last_dim_star
+
+    logical function test_leading_dimension_dummy()
+        ! LAPACK-style external subroutine: the leading dimensions of a(lda, *)
+        ! and b(ldb, *) are dummy arguments whose actuals are named constants
+        ! spelled exactly like the dummies. Both leading dimensions must
+        ! resolve so the column stride addresses the caller's storage.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'integer, parameter :: lda = 4, ldb = 5, n = 3'//new_line('a')// &
+            'real :: a(lda, n), b(ldb, n)'//new_line('a')// &
+            'integer :: i, j'//new_line('a')// &
+            'do j = 1, n'//new_line('a')// &
+            'do i = 1, lda'//new_line('a')// &
+            'a(i, j) = real(i + (j - 1)*lda)'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'b = -1.0'//new_line('a')// &
+            'call copy_matrix(lda, n, a, lda, b, ldb)'//new_line('a')// &
+            'print *, b(1, 1), b(4, 3), b(5, 1)'//new_line('a')// &
+            'end program main'//new_line('a')// &
+            'subroutine copy_matrix(m, n, a, lda, b, ldb)'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'integer, intent(in) :: m, n, lda, ldb'//new_line('a')// &
+            'real, intent(in) :: a(lda, *)'//new_line('a')// &
+            'real, intent(inout) :: b(ldb, *)'//new_line('a')// &
+            'integer :: i, j'//new_line('a')// &
+            'do j = 1, n'//new_line('a')// &
+            'do i = 1, m'//new_line('a')// &
+            'b(i, j) = a(i, j)'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'end subroutine'
+        character(len=*), parameter :: expected = &
+            '   1.00000000       12.0000000      -1.00000000    '//new_line('a')
+
+        test_leading_dimension_dummy = expect_output(source, expected, &
+            '/tmp/ffc_session_assumed_size_lda')
+    end function test_leading_dimension_dummy
 
 end program test_session_assumed_size_array


### PR DESCRIPTION
Closes #356.

## Problem

An assumed-size dummy `A(LDA, *)` folds its leading dimension from the single
call site's actual argument. The recursion guard in
`fold_i32_constant_from_call_site` bailed out whenever the actual referenced the
dummy's own spelling, which is exactly the LAPACK convention
(`call copy_matrix(m, n, a, lda, b, ldb)` against `real :: A(LDA, *)`). Lowering
rejected the whole unit with `compile-time integer parameter was not declared: lda`.

## Change

`src/session_program_lowering_arrays.inc`: when the actual is exactly the bare
identifier that spells the dummy, resolve it in the **caller's** scope via
`resolve_name_at_node` on the actual's own AST node. That terminates by
construction — it never re-enters the call-site fold, so the sin_02 stack
overflow the guard was added for stays fixed. Actuals that reference the dummy
inside a larger expression (`factorial(n - 1)`) are still rejected as
non-constant.

## Preserved invariant

The trailing `*` still carries no extent, `*` before the final dimension is
still rejected, and no final extent is inferred. Only the leading, explicit
specification expressions are resolved, and they drive the element-address
strides.

## Red evidence (unmodified main)

    test_session_assumed_size_array_compiler   FAIL
     FAIL: compile-time integer parameter was not declared: lda

    scripts/conformance_gauntlet.sh --suite lfortran --file lapack_05.f90
      FAIL: lapack_05.f90 (ffc failed)

## Green evidence

    test_session_assumed_size_array_compiler   PASS
    PASS=1 XFAIL=0 XPASS=0 FAIL=0   (lapack_05.f90)

New case `test_leading_dimension_dummy` copies a 4x3 matrix through
`a(lda, *)` / `b(ldb, *)` with distinct leading dimensions (4 vs 5) in an
external subroutine; the expected stdout was taken from gfortran.

`lapack_05.f90` is dropped from `test/conformance/fail_owners_lfortran.txt`
(it now PASSes, so it is not an xfail either).

Full local `fo` pipeline: Static OK, Build OK, tests green except
`test_conformance_gauntlet_smoke` (FLAKY under load, passes on rerun) and
`test_parity_dashboard`, which fails identically on unmodified `origin/main`
in this environment (snapshot revision ancestry).