### PR TITLE
[include-01] expand Fortran INCLUDE lines (#354)

### DIFF
--- a/app/ffc.f90
+++ b/app/ffc.f90
@@ -3,11 +3,13 @@ program ffc_main
     use ffc_module_artefact, only: FFC_FMOD_VERSION
     use fortfront_compiler, only: compiler_frontend_options_t, &
         compiler_frontend_result_t, &
-        compile_frontend_from_file, INPUT_MODE_LAZY, &
+        compile_frontend_from_file, compile_frontend_from_string, &
+        INPUT_MODE_LAZY, &
         INPUT_MODE_STANDARD
     use session_program_lowering, only: lower_program_to_liric_exe, &
         lower_program_to_liric_object
     use ffc_cli_options, only: cli_options_t, parse_arguments, CLI_PATH_LEN
+    use ffc_include_expansion, only: expand_source_includes
     implicit none
 
     type(compiler_frontend_options_t) :: frontend_options
@@ -19,6 +21,8 @@ program ffc_main
     character(len=:), allocatable :: primary_diag
     character(len=CLI_PATH_LEN) :: output_file
     character(len=CLI_PATH_LEN), allocatable :: search_paths(:)
+    character(len=:), allocatable :: program_source
+    character(len=:), allocatable :: include_error
     integer :: nargs, i
 
     nargs = command_argument_count()
@@ -53,6 +57,14 @@ program ffc_main
     do i = 1, size(opts%link_inputs)
         call append_path(search_paths, dirname(trim(opts%link_inputs(i))))
     end do
+
+    ! INCLUDE lines are expanded textually before the frontend sees the source,
+    ! so included declarations take part in semantic analysis in place. When the
+    ! input file itself cannot be read, program_source stays unallocated and the
+    ! frontend's own file diagnostic is used instead.
+    call expand_source_includes(trim(opts%input_file), opts%include_paths, &
+        program_source, include_error)
+    if (len_trim(include_error) > 0) call report_failure(include_error)
 
     ! A .lf file is lazy Fortran by definition: compile it under lazy inference,
     ! which standardizes the AST so inferred declarations (including function
@@ -92,8 +104,13 @@ contains
         frontend_options%input_mode = input_mode
         frontend_options%standardize = standardize
 
-        call compile_frontend_from_file(trim(opts%input_file), frontend_result, &
-            frontend_options)
+        if (allocated(program_source)) then
+            call compile_frontend_from_string(program_source, frontend_result, &
+                frontend_options)
+        else
+            call compile_frontend_from_file(trim(opts%input_file), &
+                frontend_result, frontend_options)
+        end if
         if (.not. frontend_result%success()) then
             diag_msg = trim(frontend_result%diagnostic_text)
             return

--- a/scripts/conformance_gauntlet.sh
+++ b/scripts/conformance_gauntlet.sh
@@ -544,13 +544,23 @@ while IFS= read -r full_path <&3; do
     # through to its normal failure handling below.
     ffc_extra=()
     ref_extra=()
+
+    # LFortran's integration tests keep INCLUDE material in a directory named
+    # after the test (CMake INCLUDE_PATH <stem>). Both compilers get that
+    # directory on their include search path so the reference and ffc see the
+    # same source.
+    stem_include_dir="${full_path%.*}"
+    if [ -d "$stem_include_dir" ]; then
+        ffc_extra=(-I "$stem_include_dir")
+        ref_extra=(-I "$stem_include_dir")
+    fi
     if [ -s "$MODULE_INDEX" ]; then
         prereq_list="$TMPDIR_WORK/prereq_${TOTAL_COUNT}.txt"
         resolve_prerequisites "$full_path" "$SUITE_ROOT" "$MODULE_INDEX" "$prereq_list"
         if [ -s "$prereq_list" ]; then
             inc_dir="$TMPDIR_WORK/inc_${TOTAL_COUNT}"
             mkdir -p "$inc_dir"
-            ffc_extra=(-I "$inc_dir")
+            ffc_extra+=(-I "$inc_dir")
             # The gfortran reference ALWAYS receives the full prerequisite source
             # list so its binary links: whether ffc can compile a prerequisite is
             # an ffc concern, not the reference's. ffc objects are only added when
@@ -587,6 +597,23 @@ while IFS= read -r full_path <&3; do
                 "$note" "$warning_expectation"
             continue
         else
+            # A file the gfortran reference rejects too (e.g. a corpus source
+            # that INCLUDEs a file absent from the corpus) has no oracle: both
+            # compilers agree it is not compilable, which is the same NO-REF
+            # disposition step 6 records when only gfortran rejects.
+            if ! is_lazy_suite && \
+                ! compile_with_gfortran "$full_path" "$ref_exe" \
+                    "${ref_extra[@]}"; then
+                ref_exit=1
+                NOREF_COUNT=$((NOREF_COUNT + 1))
+                IS_NOREF_RECORD=1
+                status="PASS"
+                note="gfortran rejects too; no reference (NO-REF)"
+                PASS_COUNT=$((PASS_COUNT + 1))
+                write_result_record "$rel_path" "$status" "$ffc_exit" \
+                    "$ref_exit" "$note" "$warning_expectation"
+                continue
+            fi
             status="FAIL"
             note="ffc compilation failed"
             FAIL_COUNT=$((FAIL_COUNT + 1))

--- a/src/ffc_include_expansion.f90
+++ b/src/ffc_include_expansion.f90
@@ -1,0 +1,260 @@
+module ffc_include_expansion
+    ! Textual expansion of Fortran INCLUDE lines (F2018 clause 6.4.2).
+    !
+    ! The include line is replaced by the content of the referenced file before
+    ! the frontend parses the program, so declarations pulled in by an include
+    ! participate in semantic analysis exactly as if they had been written in
+    ! place. The including file's own directory is searched first, then the
+    ! user's -I directories. Include cycles and missing files are reported with
+    ! the include site so the diagnostic still points at real source.
+    implicit none
+    private
+
+    public :: expand_source_includes
+
+    integer, parameter :: PATH_LEN = 512
+    integer, parameter :: MAX_INCLUDE_DEPTH = 64
+
+contains
+
+    ! Reads path and returns its source with every INCLUDE line expanded.
+    ! source stays unallocated when path itself cannot be read; that case is
+    ! left to the frontend so its file diagnostic is preserved.
+    subroutine expand_source_includes(path, include_paths, source, error_msg)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: include_paths(:)
+        character(len=:), allocatable, intent(out) :: source
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=PATH_LEN) :: stack(MAX_INCLUDE_DEPTH)
+
+        error_msg = ''
+        call expand_file(path, dirname(path), include_paths, stack, 0, source, &
+                         error_msg)
+        if (len_trim(error_msg) > 0) then
+            if (allocated(source)) deallocate (source)
+        end if
+    end subroutine expand_source_includes
+
+    recursive subroutine expand_file(path, root_dir, include_paths, stack, &
+                                     depth, source, error_msg)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: root_dir
+        character(len=*), intent(in) :: include_paths(:)
+        character(len=PATH_LEN), intent(inout) :: stack(:)
+        integer, intent(in) :: depth
+        character(len=:), allocatable, intent(out) :: source
+        character(len=:), allocatable, intent(inout) :: error_msg
+        character(len=:), allocatable :: text
+        character(len=:), allocatable :: line
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: resolved
+        character(len=:), allocatable :: nested
+        integer :: pos, nl, line_no, i
+
+        call read_whole_file(path, text)
+        if (.not. allocated(text)) return
+        if (depth >= MAX_INCLUDE_DEPTH) then
+            error_msg = 'include nesting too deep at '//trim(path)
+            return
+        end if
+        stack(depth + 1) = path
+
+        source = ''
+        pos = 1
+        line_no = 0
+        do while (pos <= len(text))
+            nl = index(text(pos:), new_line('a'))
+            if (nl == 0) then
+                line = text(pos:)
+                pos = len(text) + 1
+            else
+                line = text(pos:pos + nl - 2)
+                pos = pos + nl
+            end if
+            line_no = line_no + 1
+
+            if (.not. include_name(line, name)) then
+                source = source//line//new_line('a')
+                cycle
+            end if
+
+            call resolve_include(name, dirname(path), root_dir, &
+                                 include_paths, resolved)
+            if (.not. allocated(resolved)) then
+                error_msg = "include file not found: '"//name// &
+                            "' (included at "//trim(path)//':'// &
+                            int_text(line_no)//')'
+                return
+            end if
+            do i = 1, depth + 1
+                if (trim(stack(i)) == resolved) then
+                    error_msg = "include cycle: '"//resolved// &
+                                "' (included at "//trim(path)//':'// &
+                                int_text(line_no)//')'
+                    return
+                end if
+            end do
+
+            call expand_file(resolved, root_dir, include_paths, stack, &
+                             depth + 1, nested, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (.not. allocated(nested)) then
+                error_msg = "cannot read include file: '"//resolved// &
+                            "' (included at "//trim(path)//':'// &
+                            int_text(line_no)//')'
+                return
+            end if
+            source = source//nested
+        end do
+    end subroutine expand_file
+
+    ! True when line is an INCLUDE line; then name holds the quoted file name.
+    logical function include_name(line, name) result(is_include)
+        character(len=*), intent(in) :: line
+        character(len=:), allocatable, intent(out) :: name
+        character(len=:), allocatable :: rest
+        character(len=1) :: quote
+        integer :: closing
+
+        is_include = .false.
+        if (allocated(name)) deallocate (name)
+        rest = adjustl(strip_bom(line))
+        if (len_trim(rest) < 10) return
+        if (lowercase(rest(1:7)) /= 'include') return
+        rest = adjustl(rest(8:))
+        if (len_trim(rest) < 3) return
+        quote = rest(1:1)
+        if (quote /= '''' .and. quote /= '"') return
+        closing = index(rest(2:), quote)
+        if (closing <= 1) return
+        name = rest(2:closing)
+        if (len_trim(name) == 0) return
+        ! Only blanks or a trailing comment may follow the file name.
+        rest = adjustl(rest(closing + 2:))
+        if (len_trim(rest) > 0) then
+            if (rest(1:1) /= '!') return
+        end if
+        is_include = .true.
+    end function include_name
+
+    ! Searches the including file's directory first, then the compiled file's
+    ! own directory, then the -I paths.
+    subroutine resolve_include(name, source_dir, root_dir, include_paths, &
+                               resolved)
+        character(len=*), intent(in) :: name
+        character(len=*), intent(in) :: source_dir
+        character(len=*), intent(in) :: root_dir
+        character(len=*), intent(in) :: include_paths(:)
+        character(len=:), allocatable, intent(out) :: resolved
+        character(len=:), allocatable :: candidate
+        logical :: found
+        integer :: i
+
+        if (allocated(resolved)) deallocate (resolved)
+        if (name(1:1) == '/') then
+            inquire (file=name, exist=found)
+            if (found) resolved = name
+            return
+        end if
+
+        candidate = source_dir//'/'//name
+        inquire (file=candidate, exist=found)
+        if (found) then
+            resolved = candidate
+            return
+        end if
+
+        candidate = root_dir//'/'//name
+        inquire (file=candidate, exist=found)
+        if (found) then
+            resolved = candidate
+            return
+        end if
+
+        do i = 1, size(include_paths)
+            if (len_trim(include_paths(i)) == 0) cycle
+            candidate = trim(include_paths(i))//'/'//name
+            inquire (file=candidate, exist=found)
+            if (found) then
+                resolved = candidate
+                return
+            end if
+        end do
+    end subroutine resolve_include
+
+    subroutine read_whole_file(path, text)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: text
+        integer :: unit, io_stat, bytes
+
+        open (newunit=unit, file=path, status='old', action='read', &
+              access='stream', form='unformatted', iostat=io_stat)
+        if (io_stat /= 0) return
+        inquire (unit=unit, size=bytes)
+        if (bytes <= 0) then
+            allocate (character(len=0) :: text)
+            close (unit)
+            return
+        end if
+        allocate (character(len=bytes) :: text)
+        read (unit, iostat=io_stat) text
+        close (unit)
+        if (io_stat /= 0) deallocate (text)
+    end subroutine read_whole_file
+
+    ! Drops a UTF-8 byte order mark and a trailing carriage return.
+    function strip_bom(line) result(clean)
+        character(len=*), intent(in) :: line
+        character(len=:), allocatable :: clean
+        integer :: n
+
+        clean = line
+        n = len(clean)
+        if (n >= 3) then
+            if (clean(1:3) == achar(239)//achar(187)//achar(191)) then
+                clean = clean(4:)
+                n = len(clean)
+            end if
+        end if
+        if (n >= 1) then
+            if (clean(n:n) == achar(13)) clean = clean(:n - 1)
+        end if
+    end function strip_bom
+
+    function lowercase(text) result(lowered)
+        character(len=*), intent(in) :: text
+        character(len=len(text)) :: lowered
+        integer :: i, code
+
+        lowered = text
+        do i = 1, len(lowered)
+            code = iachar(lowered(i:i))
+            if (code >= iachar('A') .and. code <= iachar('Z')) then
+                lowered(i:i) = achar(code + 32)
+            end if
+        end do
+    end function lowercase
+
+    function dirname(path) result(dir)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable :: dir
+        integer :: slash
+
+        slash = index(trim(path), '/', back=.true.)
+        if (slash > 0) then
+            dir = path(1:slash - 1)
+        else
+            dir = '.'
+        end if
+    end function dirname
+
+    function int_text(value) result(text)
+        integer, intent(in) :: value
+        character(len=:), allocatable :: text
+        character(len=32) :: buffer
+
+        write (buffer, '(I0)') value
+        text = trim(buffer)
+    end function int_text
+
+end module ffc_include_expansion

--- a/test/conformance/fail_owners_gfortran_dg.txt
+++ b/test/conformance/fail_owners_gfortran_dg.txt
@@ -28,7 +28,6 @@ block_proc_ptr_1.f90 # owner=lazy-fortran/ffc#362; reason=pass shaped arrays thr
 blockdata_1.f90 # owner=lazy-fortran/ffc#463; reason=lower structured DATA initialization
 blockdata_8.f90 # owner=lazy-fortran/fortfront#2896; reason=reject constructs in forbidden program sections
 bom_error.f90 # owner=lazy-fortran/fortfront#2890; reason=reject invalid source and identifier characters
-bom_include.f90 # owner=lazy-fortran/ffc#354; reason=owns source-relative INCLUDE expansion and retained ingestion diagnostics
 bound_resolve_after_error_1.f90 # owner=lazy-fortran/ffc#380; reason=reject invalid allocation and pointer definition targets
 bounds_check_3.f90 # owner=lazy-fortran/ffc#337; reason=owns triplet section bounds, stride sign, omitted bounds, and zero extents
 c_f_pointer_shape_test.f90 # owner=lazy-fortran/ffc#394; reason=require SHAPE for array C_F_POINTER targets
@@ -134,7 +133,7 @@ initialization_23.f90 # owner=lazy-fortran/ffc#388; reason=reject incompatible a
 initialization_25.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
 initialization_28.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
 initialization_7.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
-inline_sum_2.f90 # owner=lazy-fortran/ffc#354; reason=owns source-relative INCLUDE expansion
+inline_sum_2.f90 # owner=lazy-fortran/ffc#359; reason=capture dummy-bound extents on entry
 interface_17.f90 # owner=lazy-fortran/ffc#371; reason=distinguish valid and ambiguous USE renames
 interface_20.f90 # owner=lazy-fortran/fortfront#2882; reason=reject procedure-call signature mismatches
 interface_21.f90 # owner=lazy-fortran/fortfront#2882; reason=reject procedure-call signature mismatches

--- a/test/conformance/fail_owners_lfortran.txt
+++ b/test/conformance/fail_owners_lfortran.txt
@@ -6,7 +6,6 @@ arrays_07_size.f90 # owner=lazy-fortran/ffc#359; reason=capture dummy-bound exte
 common_18.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
 implicit_interface_38b.f90 # owner=lazy-fortran/ffc#353; reason=register positional alternate-return slots
 implicit_typing_07.f90 # owner=lazy-fortran/ffc#355; reason=collect old-style PARAMETER bindings
-include_03.f90 # owner=lazy-fortran/ffc#354; reason=expand Fortran INCLUDE lines
 interface_29.f90 # owner=lazy-fortran/ffc#357; reason=preserve bodies after interface blocks
 modules_58_module.f90 # owner=lazy-fortran/ffc#358; reason=lower multi-object ALLOCATE
 pointer_13.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities

--- a/test/conformance/xfail_lfortran.txt
+++ b/test/conformance/xfail_lfortran.txt
@@ -1639,9 +1639,7 @@ implied_do_loops8.f90 # owner=lazy-fortran/ffc#450; reason=lower descriptor-back
 implied_do_loops9.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
 implied_do_loops_print.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
 implied_do_loops_strings.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
-include_01.f90 # owner=lazy-fortran/ffc#354; reason=expand Fortran INCLUDE lines
 include_02.f90 # owner=lazy-fortran/ffc#354; reason=expand Fortran INCLUDE lines
-include_04.f90 # owner=lazy-fortran/ffc#354; reason=expand Fortran INCLUDE lines
 infer_walrus_shadow_01.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
 infer_walrus_shadow_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
 infer_walrus_struct_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once

--- a/test/test_session_include_compiler.f90
+++ b/test/test_session_include_compiler.f90
@@ -1,0 +1,229 @@
+program test_session_include_compiler
+    ! Behavioural coverage for Fortran INCLUDE line expansion (F2018 6.4.2).
+    ! Every case drives the ffc CLI on real files on disk and checks observable
+    ! program output or the emitted diagnostic.
+    implicit none
+
+    character(len=*), parameter :: WORK = '/tmp/ffc_include_test'
+    logical :: ok
+
+    print *, '=== direct session include compiler test ==='
+
+    ok = .true.
+    if (.not. check_source_relative()) ok = .false.
+    if (.not. check_include_path_flag()) ok = .false.
+    if (.not. check_nested_include()) ok = .false.
+    if (.not. check_missing_include()) ok = .false.
+    if (.not. check_include_cycle()) ok = .false.
+    if (.not. ok) stop 1
+
+    print *, 'PASS: include lines expand and report missing files and cycles'
+
+contains
+
+    logical function check_source_relative() result(ok)
+        character(len=:), allocatable :: output
+
+        ok = .false.
+        call reset_work()
+        call write_file(WORK//'/value.inc', 'integer, parameter :: v = 42')
+        call write_file(WORK//'/main.f90', &
+                        'program main'//new_line('a')// &
+                        'implicit none'//new_line('a')// &
+                        "include 'value.inc'"//new_line('a')// &
+                        "print '(I0)', v"//new_line('a')// &
+                        'end program main')
+        if (.not. compile_ok(WORK//'/main.f90', '')) return
+        call run_exe(output)
+        if (first_line(output) /= '42') then
+            print *, 'FAIL: source-relative include output was ', &
+                first_line(output)
+            return
+        end if
+        ok = .true.
+    end function check_source_relative
+
+    logical function check_include_path_flag() result(ok)
+        character(len=:), allocatable :: output
+
+        ok = .false.
+        call reset_work()
+        call execute_command_line('mkdir -p '//WORK//'/inc')
+        call write_file(WORK//'/inc/value.inc', 'integer, parameter :: v = 42')
+        call write_file(WORK//'/main.f90', &
+                        'program main'//new_line('a')// &
+                        'implicit none'//new_line('a')// &
+                        "include 'value.inc'"//new_line('a')// &
+                        "print '(I0)', v"//new_line('a')// &
+                        'end program main')
+        if (.not. compile_ok(WORK//'/main.f90', '-I '//WORK//'/inc')) return
+        call run_exe(output)
+        if (first_line(output) /= '42') then
+            print *, 'FAIL: -I include output was ', first_line(output)
+            return
+        end if
+        ok = .true.
+    end function check_include_path_flag
+
+    logical function check_nested_include() result(ok)
+        character(len=:), allocatable :: output
+
+        ok = .false.
+        call reset_work()
+        call write_file(WORK//'/inner.inc', 'integer, parameter :: v = 42')
+        call write_file(WORK//'/outer.inc', &
+                        "include 'inner.inc'"//new_line('a')// &
+                        'integer, parameter :: w = v')
+        call write_file(WORK//'/main.f90', &
+                        'program main'//new_line('a')// &
+                        'implicit none'//new_line('a')// &
+                        "include 'outer.inc'"//new_line('a')// &
+                        "print '(I0)', w"//new_line('a')// &
+                        'end program main')
+        if (.not. compile_ok(WORK//'/main.f90', '')) return
+        call run_exe(output)
+        if (first_line(output) /= '42') then
+            print *, 'FAIL: nested include output was ', first_line(output)
+            return
+        end if
+        ok = .true.
+    end function check_nested_include
+
+    logical function check_missing_include() result(ok)
+        ok = .false.
+        call reset_work()
+        call write_file(WORK//'/main.f90', &
+                        'program main'//new_line('a')// &
+                        'implicit none'//new_line('a')// &
+                        "include 'absent.inc'"//new_line('a')// &
+                        'end program main')
+        ok = compile_fails_with(WORK//'/main.f90', '', &
+                                'include file not found')
+    end function check_missing_include
+
+    logical function check_include_cycle() result(ok)
+        ok = .false.
+        call reset_work()
+        call write_file(WORK//'/loop.inc', "include 'loop.inc'")
+        call write_file(WORK//'/main.f90', &
+                        'program main'//new_line('a')// &
+                        'implicit none'//new_line('a')// &
+                        "include 'loop.inc'"//new_line('a')// &
+                        'end program main')
+        ok = compile_fails_with(WORK//'/main.f90', '', 'include cycle')
+    end function check_include_cycle
+
+    logical function compile_ok(source_path, extra_args) result(ok)
+        character(len=*), intent(in) :: source_path
+        character(len=*), intent(in) :: extra_args
+        character(len=:), allocatable :: stderr_text
+        integer :: exit_stat
+
+        call run_ffc(source_path, extra_args, exit_stat, stderr_text)
+        ok = exit_stat == 0
+        if (.not. ok) then
+            print *, 'FAIL: ffc rejected ', source_path
+            print *, '  stderr: ', trim(stderr_text)
+        end if
+    end function compile_ok
+
+    logical function compile_fails_with(source_path, extra_args, fragment) &
+        result(ok)
+        character(len=*), intent(in) :: source_path
+        character(len=*), intent(in) :: extra_args
+        character(len=*), intent(in) :: fragment
+        character(len=:), allocatable :: stderr_text
+        integer :: exit_stat
+
+        ok = .false.
+        call run_ffc(source_path, extra_args, exit_stat, stderr_text)
+        if (exit_stat == 0) then
+            print *, 'FAIL: expected failure for ', source_path
+            return
+        end if
+        if (index(stderr_text, fragment) == 0) then
+            print *, 'FAIL: diagnostic missing "'//fragment//'"'
+            print *, '  stderr: ', trim(stderr_text)
+            return
+        end if
+        ok = .true.
+    end function compile_fails_with
+
+    subroutine run_ffc(source_path, extra_args, exit_stat, stderr_text)
+        character(len=*), intent(in) :: source_path
+        character(len=*), intent(in) :: extra_args
+        integer, intent(out) :: exit_stat
+        character(len=:), allocatable, intent(out) :: stderr_text
+        character(len=:), allocatable :: command
+        integer :: cmd_stat
+
+        command = "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc "// &
+                  '2>/dev/null | head -n 1); test -n "$exe" && "$exe" '// &
+                  trim(extra_args)//' '//source_path//' -o '//WORK// &
+                  '/prog > '//WORK//'/stdout 2> '//WORK//"/stderr'"
+        exit_stat = -1
+        call execute_command_line(command, exitstat=exit_stat, cmdstat=cmd_stat)
+        stderr_text = read_text(WORK//'/stderr')
+    end subroutine run_ffc
+
+    subroutine run_exe(output)
+        character(len=:), allocatable, intent(out) :: output
+        integer :: exit_stat, cmd_stat
+
+        call execute_command_line(WORK//'/prog > '//WORK//'/run.out', &
+                                  exitstat=exit_stat, cmdstat=cmd_stat)
+        output = read_text(WORK//'/run.out')
+        if (exit_stat /= 0) print *, 'FAIL: program exited with ', exit_stat
+    end subroutine run_exe
+
+    subroutine reset_work()
+        call execute_command_line('rm -rf '//WORK//' && mkdir -p '//WORK)
+    end subroutine reset_work
+
+    subroutine write_file(path, contents)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: contents
+        integer :: unit, io_stat
+
+        open (newunit=unit, file=path, status='replace', action='write', &
+              iostat=io_stat)
+        if (io_stat /= 0) then
+            print *, 'FAIL: cannot write ', path
+            return
+        end if
+        write (unit, '(A)') contents
+        close (unit)
+    end subroutine write_file
+
+    function first_line(text) result(line)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: line
+        integer :: nl
+
+        nl = index(text, new_line('a'))
+        if (nl > 0) then
+            line = trim(text(:nl - 1))
+        else
+            line = trim(text)
+        end if
+    end function first_line
+
+    function read_text(path) result(text)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable :: text
+        character(len=1024) :: line
+        integer :: unit, io_stat
+
+        text = ''
+        open (newunit=unit, file=path, status='old', action='read', &
+              iostat=io_stat)
+        if (io_stat /= 0) return
+        do
+            read (unit, '(A)', iostat=io_stat) line
+            if (io_stat /= 0) exit
+            text = text//trim(line)//new_line('a')
+        end do
+        close (unit)
+    end function read_text
+
+end program test_session_include_compiler

--- a/test/test_session_unsupported_diagnostics.f90
+++ b/test/test_session_unsupported_diagnostics.f90
@@ -653,6 +653,8 @@ contains
     end function test_cli_return_statement_diagnostic
 
     logical function test_cli_include_statement_diagnostic()
+        ! The CLI expands INCLUDE lines, so an unresolvable include name is
+        ! now reported as a missing include file at its include site.
         character(len=*), parameter :: source = &
             'program main'//new_line('a')// &
             '  include "missing.inc"'//new_line('a')// &
@@ -660,7 +662,7 @@ contains
 
         test_cli_include_statement_diagnostic = expect_cli_error_contains( &
             source, &
-            'unsupported include statement', &
+            'include file not found', &
             '/tmp/ffc_cli_include_test')
     end function test_cli_include_statement_diagnostic
 


### PR DESCRIPTION
Closes #354.

## What changed

- NEW `src/ffc_include_expansion.f90`: textual INCLUDE expansion (F2018 6.4.2) before the frontend parses the source, so included declarations take part in semantic analysis in place. Search order: the including file's directory, the compiled file's own directory, then `-I` paths. Missing files and include cycles are reported with the include site; nesting depth is bounded.
- `app/ffc.f90`: expands includes for the input file and compiles from the expanded source; if the input file itself cannot be read, the frontend's own file diagnostic is preserved.
- `scripts/conformance_gauntlet.sh`: passes an LFortran-style per-test include directory (`<stem>/`) to both ffc and the gfortran reference, and classifies a file the reference also rejects as NO-REF instead of FAIL (symmetric with the existing "gfortran rejects, ffc runs" NO-REF rule).
- Manifests: `include_03.f90` promoted out of `fail_owners_lfortran`, `bom_include.f90` out of `fail_owners_gfortran_dg`, `include_01.f90`/`include_04.f90` out of `xfail_lfortran`. `inline_sum_2.f90` re-owned to #359 (its include now expands; it fails later on assumed-shape dummy extents).

## Preserved invariant

Source diagnostics stay source-located: an unresolvable include is reported as `include file not found: '<name>' (included at <file>:<line>)` at the include site, and a cycle as `include cycle: ...`. The direct-session lowerer still declines a residual `include_statement` node for string-API callers.

## Red evidence (unmodified main)

```
$ ffc /tmp/redchk/main.f90 -o prog     # main.f90 has: include 'value.inc'
/tmp/redchk/main.f90:3:1: error: unsupported include statement: direct LIRIC session does not expand source include files
exit=1
$ fo test test_session_include_compiler
Summary: 0 passed, 1 failed
```

## Green evidence

```
$ fo test test_session_include_compiler          -> PASS
$ scripts/conformance_gauntlet.sh --suite lfortran --file include_03.f90  -> PASS=1 FAIL=0
$ scripts/conformance_gauntlet.sh --suite gfortran-dg --file bom_include.f90 -> PASS
$ fo                                             -> all tests green except test_parity_dashboard
```

`test_parity_dashboard` fails identically on the unmodified base commit (verified in a clean worktree at fbcc8dd): the synthetic dashboard-generation expectations are already broken on main, unrelated to this change.