### PR TITLE
[reject-data-01] enforce DATA object and initializer restrictions (#383)

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -197,6 +197,7 @@ module session_program_lowering
         integer_opcode, parse_i32_literal
     use ffc_strings, only: set_empty
     use ast_arena_source_text, only: get_source_text
+    use ast_base, only: LITERAL_STRING
     use ffc_fortfront_queries, only: node_exists, get_node_type_at, &
         get_type_for_node, mono_type_t, &
         TINT, TREAL, TCHAR, TLOGICAL, TARRAY, TCOMPLEX, TDOUBLE, TDERIVED, &

--- a/src/session_program_lowering_data.inc
+++ b/src/session_program_lowering_data.inc
@@ -504,3 +504,312 @@
         if (len_trim(error_msg) > 0) return
         value = int(v64)
     end subroutine data_fold_const_int
+
+    ! DATA statement object and initializer restrictions (#383).
+    !
+    ! A data-stmt-object must be a variable that is definable at
+    ! initialization time: not a named constant, not a pointer, and not an
+    ! entity that already carries a declaration initializer. A data-stmt-value
+    ! must be a constant expression, so every name it references has to be a
+    ! named constant, and its type must agree with the object's type class.
+    ! Each of these is checked before lowering, where the typed declarations
+    ! are the earliest layer that carries the attributes.
+    subroutine check_data_statement_restrictions(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (data_statement_node)
+                call check_one_data_statement(arena, nd, error_msg)
+            end select
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine check_data_statement_restrictions
+
+    subroutine check_one_data_statement(arena, node, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(data_statement_node), intent(in) :: node
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: bound, obj_class
+        integer :: i
+
+        call set_empty(error_msg)
+        if (.not. allocated(node%object_indices)) return
+        bound = '|'
+        do i = 1, size(node%object_indices)
+            call collect_implied_do_names(arena, node%object_indices(i), bound)
+        end do
+        if (allocated(node%value_indices)) then
+            do i = 1, size(node%value_indices)
+                call collect_implied_do_names(arena, node%value_indices(i), bound)
+            end do
+        end if
+        obj_class = ''
+        do i = 1, size(node%object_indices)
+            call check_data_object_node(arena, node%object_indices(i), &
+                                        obj_class, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+        if (.not. allocated(node%value_indices)) return
+        do i = 1, size(node%value_indices)
+            call check_data_value_node(arena, node%value_indices(i), obj_class, &
+                                       bound, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine check_one_data_statement
+
+    recursive subroutine collect_implied_do_names(arena, idx, bound)
+        !! Append every implied-do control variable name reachable from idx to
+        !! the '|'-delimited membership string. Those names are bound by the
+        !! DATA statement itself, so they are not required to be constants.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        character(len=:), allocatable, intent(inout) :: bound
+        integer :: j
+
+        if (.not. node_exists(arena, idx)) return
+        select type (nd => arena%entries(idx)%node)
+        type is (io_implied_do_node)
+            if (allocated(nd%var_name)) then
+                bound = bound//trim(lowercase_text(nd%var_name))//'|'
+            end if
+            if (.not. allocated(nd%object_indices)) return
+            do j = 1, size(nd%object_indices)
+                call collect_implied_do_names(arena, nd%object_indices(j), bound)
+            end do
+        end select
+    end subroutine collect_implied_do_names
+
+    recursive subroutine check_data_object_node(arena, idx, obj_class, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        character(len=:), allocatable, intent(inout) :: obj_class
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: name
+        integer :: j, decl
+
+        call set_empty(error_msg)
+        if (.not. node_exists(arena, idx)) return
+        select type (nd => arena%entries(idx)%node)
+        type is (io_implied_do_node)
+            if (.not. allocated(nd%object_indices)) return
+            do j = 1, size(nd%object_indices)
+                call check_data_object_node(arena, nd%object_indices(j), &
+                                            obj_class, error_msg)
+                if (len_trim(error_msg) > 0) return
+            end do
+            return
+        end select
+        call data_base_name(arena, idx, name)
+        if (len_trim(name) == 0) return
+        decl = declaration_index_for_name(arena, name)
+        if (decl <= 0) return
+        obj_class = data_type_class_of_declaration(arena, decl)
+        call check_data_object_attributes(arena, decl, name, idx, error_msg)
+    end subroutine check_data_object_node
+
+    subroutine check_data_object_attributes(arena, decl, name, idx, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: decl, idx
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=64) :: location
+
+        call set_empty(error_msg)
+        write (location, '(" at line ",I0,", column ",I0)') &
+            get_node_line(arena, idx), get_node_column(arena, idx)
+        select type (dn => arena%entries(decl)%node)
+        type is (declaration_node)
+            if (dn%is_parameter) then
+                error_msg = 'named constant '''//trim(name)//''' shall not '// &
+                    'appear in a DATA statement'//trim(location)
+            else if (dn%is_pointer) then
+                error_msg = 'data-stmt-object '''//trim(name)//''' has the '// &
+                    'POINTER attribute'//trim(location)
+            else if (dn%has_initializer) then
+                error_msg = 'symbol '''//trim(name)//''' already is '// &
+                    'initialized in its declaration'//trim(location)
+            end if
+        end select
+    end subroutine check_data_object_attributes
+
+    recursive subroutine check_data_value_node(arena, idx, obj_class, bound, &
+                                               error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        character(len=*), intent(in) :: obj_class, bound
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: name, val_class
+        character(len=64) :: location
+        integer :: j, decl
+
+        call set_empty(error_msg)
+        if (.not. node_exists(arena, idx)) return
+        call check_data_value_children(arena, idx, obj_class, bound, error_msg)
+        if (len_trim(error_msg) > 0) return
+        val_class = data_value_type_class(arena, idx)
+        write (location, '(" at line ",I0,", column ",I0)') &
+            get_node_line(arena, idx), get_node_column(arena, idx)
+        if (len(obj_class) > 0 .and. len(val_class) > 0) then
+            if (obj_class /= val_class) then
+                error_msg = 'incompatible types in DATA statement: '// &
+                    obj_class//' object with '//val_class//' value'// &
+                    trim(location)
+                return
+            end if
+        end if
+        call data_base_name(arena, idx, name)
+        if (len_trim(name) == 0) return
+        if (index(bound, '|'//trim(lowercase_text(name))//'|') > 0) return
+        decl = declaration_index_for_name(arena, name)
+        if (decl <= 0) return
+        j = decl
+        select type (dn => arena%entries(j)%node)
+        type is (declaration_node)
+            if (.not. dn%is_parameter) then
+                error_msg = 'symbol '''//trim(name)//''' must be a '// &
+                    'PARAMETER in DATA statement'//trim(location)
+            end if
+        end select
+    end subroutine check_data_value_node
+
+    recursive subroutine check_data_value_children(arena, idx, obj_class, bound, &
+                                                   error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        character(len=*), intent(in) :: obj_class, bound
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: op, err
+        integer :: j, li, ri, ln, cl
+
+        call set_empty(error_msg)
+        if (is_binary_op(arena, idx)) then
+            call get_binary_op_info(arena, idx, op, li, ri, ln, cl, err)
+            if (len_trim(err) > 0) return
+            call check_data_value_node(arena, li, '', bound, error_msg)
+            if (len_trim(error_msg) > 0) return
+            call check_data_value_node(arena, ri, obj_class, bound, error_msg)
+            return
+        end if
+        select type (nd => arena%entries(idx)%node)
+        type is (call_or_subscript_node)
+            if (.not. allocated(nd%arg_indices)) return
+            do j = 1, size(nd%arg_indices)
+                call check_data_value_node(arena, nd%arg_indices(j), '', bound, &
+                                           error_msg)
+                if (len_trim(error_msg) > 0) return
+            end do
+        type is (io_implied_do_node)
+            if (.not. allocated(nd%object_indices)) return
+            do j = 1, size(nd%object_indices)
+                call check_data_value_node(arena, nd%object_indices(j), &
+                                           obj_class, bound, error_msg)
+                if (len_trim(error_msg) > 0) return
+            end do
+        end select
+    end subroutine check_data_value_children
+
+    subroutine data_base_name(arena, idx, name)
+        !! The name a DATA object or value expression is rooted at: the
+        !! identifier itself, or the array name of an element reference.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        character(len=:), allocatable, intent(out) :: name
+
+        name = ''
+        if (.not. node_exists(arena, idx)) return
+        select type (nd => arena%entries(idx)%node)
+        type is (identifier_node)
+            if (allocated(nd%name)) name = trim(nd%name)
+        type is (call_or_subscript_node)
+            if (allocated(nd%name)) name = trim(nd%name)
+        end select
+    end subroutine data_base_name
+
+    integer function declaration_index_for_name(arena, name) result(idx)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer :: n, k
+
+        idx = 0
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (declaration_node)
+                if (allocated(nd%var_name)) then
+                    if (same_name(nd%var_name, name)) then
+                        idx = n
+                        return
+                    end if
+                end if
+                if (.not. allocated(nd%var_names)) cycle
+                do k = 1, size(nd%var_names)
+                    if (same_name(trim(nd%var_names(k)), name)) then
+                        idx = n
+                        return
+                    end if
+                end do
+            end select
+        end do
+    end function declaration_index_for_name
+
+    function data_type_class_of_declaration(arena, decl) result(cls)
+        !! 'character' or 'numeric' for a declaration, '' when unknown.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: decl
+        character(len=:), allocatable :: cls
+
+        cls = ''
+        if (.not. node_exists(arena, decl)) return
+        select type (dn => arena%entries(decl)%node)
+        type is (declaration_node)
+            if (.not. allocated(dn%type_name)) return
+            cls = data_type_class_of_name(dn%type_name)
+        end select
+    end function data_type_class_of_declaration
+
+    function data_type_class_of_name(type_name) result(cls)
+        character(len=*), intent(in) :: type_name
+        character(len=:), allocatable :: cls, low
+
+        cls = ''
+        low = trim(lowercase_text(type_name))
+        if (len(low) >= 9) then
+            if (low(1:9) == 'character') then
+                cls = 'character'
+                return
+            end if
+        end if
+        select case (low)
+        case ('integer', 'real', 'logical', 'complex', 'double precision')
+            cls = 'numeric'
+        end select
+    end function data_type_class_of_name
+
+    function data_value_type_class(arena, idx) result(cls)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        character(len=:), allocatable :: cls, name
+        integer :: decl
+
+        cls = ''
+        if (.not. node_exists(arena, idx)) return
+        select type (nd => arena%entries(idx)%node)
+        type is (literal_node)
+            if (nd%literal_kind == LITERAL_STRING) then
+                cls = 'character'
+            else
+                cls = 'numeric'
+            end if
+            return
+        end select
+        call data_base_name(arena, idx, name)
+        if (len_trim(name) == 0) return
+        decl = declaration_index_for_name(arena, name)
+        if (decl <= 0) return
+        cls = data_type_class_of_declaration(arena, decl)
+    end function data_value_type_class

--- a/src/session_program_lowering_reject_checks.inc
+++ b/src/session_program_lowering_reject_checks.inc
@@ -1379,3 +1379,143 @@
             end select
         end do
     end function name_in_equivalence
+
+    ! DATA forms the parser cannot represent (#383). Two invalid families
+    ! never reach the typed AST: a DATA statement whose initializer is not a
+    ! constant expression (data a(1:2) / myint(b), .../, or a truncated value
+    ! list) and old-style slashed initialization in a declaration
+    ! (integer z /10/), which conflicts with the DATA attribute rules. Both
+    ! would otherwise be silently dropped and the objects left uninitialised,
+    ! so they are rejected from the source text, the only layer that still
+    ! holds them.
+    subroutine check_data_source_forms(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: source, line
+        integer :: pos, next_nl, line_no, data_lines, first_data_line
+        character(len=64) :: location
+        logical :: found
+
+        call set_empty(error_msg)
+        call get_source_text(arena, source, found)
+        if (.not. found) return
+        pos = 1
+        line_no = 0
+        data_lines = 0
+        first_data_line = 0
+        do while (pos <= len(source))
+            next_nl = index(source(pos:), new_line('a'))
+            if (next_nl == 0) then
+                line = source(pos:)
+                pos = len(source) + 1
+            else
+                line = source(pos:pos + next_nl - 2)
+                pos = pos + next_nl
+            end if
+            line_no = line_no + 1
+            line = strip_source_comment(line)
+            if (is_old_style_init_line(line)) then
+                write (location, '(" at line ",I0)') line_no
+                error_msg = 'old-style slashed initialization in a '// &
+                    'declaration is not accepted; the DATA attribute '// &
+                    'conflicts here'//trim(location)
+                return
+            end if
+            if (is_data_statement_line(line)) then
+                data_lines = data_lines + 1
+                if (first_data_line == 0) first_data_line = line_no
+            end if
+        end do
+        if (data_lines <= count_data_statement_nodes(arena)) return
+        write (location, '(" at line ",I0)') first_data_line
+        error_msg = 'invalid initializer in DATA statement'//trim(location)
+    end subroutine check_data_source_forms
+
+    integer function count_data_statement_nodes(arena) result(total)
+        type(ast_arena_t), intent(in) :: arena
+        integer :: n
+
+        total = 0
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (data_statement_node)
+                total = total + 1
+            end select
+        end do
+    end function count_data_statement_nodes
+
+    function strip_source_comment(line) result(code)
+        character(len=*), intent(in) :: line
+        character(len=:), allocatable :: code
+        integer :: i
+        logical :: in_single, in_double
+
+        in_single = .false.
+        in_double = .false.
+        code = line
+        do i = 1, len(line)
+            if (line(i:i) == '''' .and. .not. in_double) then
+                in_single = .not. in_single
+            else if (line(i:i) == '"' .and. .not. in_single) then
+                in_double = .not. in_double
+            else if (line(i:i) == '!') then
+                if (.not. in_single .and. .not. in_double) then
+                    if (i == 1) then
+                        code = ''
+                    else
+                        code = line(:i - 1)
+                    end if
+                    return
+                end if
+            end if
+        end do
+    end function strip_source_comment
+
+    logical function is_data_statement_line(line) result(is_data)
+        character(len=*), intent(in) :: line
+        character(len=:), allocatable :: low
+
+        is_data = .false.
+        low = trim(adjustl(lowercase_text(line)))
+        if (len(low) < 6) return
+        if (low(1:5) /= 'data ') return
+        if (index(low, '/') == 0) return
+        is_data = .true.
+    end function is_data_statement_line
+
+    logical function is_old_style_init_line(line) result(is_old)
+        character(len=*), intent(in) :: line
+        character(len=:), allocatable :: low
+        integer :: slash
+
+        is_old = .false.
+        low = trim(adjustl(lowercase_text(line)))
+        if (len_trim(low) == 0) return
+        if (index(low, '::') > 0) return
+        slash = index(low, '/')
+        if (slash == 0) return
+        if (.not. starts_with_type_keyword(low)) return
+        is_old = .true.
+    end function is_old_style_init_line
+
+    logical function starts_with_type_keyword(low) result(is_type)
+        character(len=*), intent(in) :: low
+        character(len=16), parameter :: keywords(6) = &
+            [character(len=16) :: 'integer', 'real', 'logical', 'complex', &
+             'character', 'double precision']
+        integer :: k, klen
+
+        is_type = .false.
+        do k = 1, size(keywords)
+            klen = len_trim(keywords(k))
+            if (len(low) <= klen) cycle
+            if (low(1:klen) /= trim(keywords(k))) cycle
+            if (low(klen + 1:klen + 1) == ' ' .or. &
+                low(klen + 1:klen + 1) == '(' .or. &
+                low(klen + 1:klen + 1) == '*') then
+                is_type = .true.
+                return
+            end if
+        end do
+    end function starts_with_type_keyword

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -536,6 +536,10 @@
         if (len_trim(error_msg) > 0) return
         call check_automatic_storage_association(arena, error_msg)
         if (len_trim(error_msg) > 0) return
+        call check_data_statement_restrictions(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_data_source_forms(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
         call set_empty(error_msg)
     end subroutine validate_program
     subroutine lower_program_return(arena, root_index, context, value, error_msg)

--- a/test/test_session_reject_data_01_compiler.f90
+++ b/test/test_session_reject_data_01_compiler.f90
@@ -1,0 +1,182 @@
+program test_session_reject_data_01_compiler
+    ! DATA object and initializer restrictions (#383). A data-stmt-object must
+    ! be a definable variable that is not a named constant, not a pointer and
+    ! not already initialized in its declaration; a data-stmt-value must be a
+    ! constant expression of the object's type class. Each invalid form is
+    ! rejected with its own diagnostic while the corrected neighbour compiles
+    ! and runs.
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== DATA object/initializer restriction compiler test ==='
+
+    all_passed = .true.
+    if (.not. test_parameter_object_rejected()) all_passed = .false.
+    if (.not. test_pointer_object_rejected()) all_passed = .false.
+    if (.not. test_initialized_object_rejected()) all_passed = .false.
+    if (.not. test_variable_value_rejected()) all_passed = .false.
+    if (.not. test_type_mismatch_rejected()) all_passed = .false.
+    if (.not. test_nonconstant_initializer_rejected()) all_passed = .false.
+    if (.not. test_variable_subscript_value_rejected()) all_passed = .false.
+    if (.not. test_old_style_init_rejected()) all_passed = .false.
+    if (.not. test_valid_data_statement_accepted()) all_passed = .false.
+    if (.not. test_valid_section_data_accepted()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: invalid DATA objects and initializers rejected, ' // &
+        'valid DATA statements still lowered'
+
+contains
+
+    logical function test_parameter_object_rejected()
+        ! A named constant has no storage to initialize (gfortran: "shall not
+        ! appear in a DATA statement").
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, parameter :: a(2) = 1'//new_line('a')// &
+            '  data a(2) /a(1)/'//new_line('a')// &
+            '  print *, a'//new_line('a')// &
+            'end program main'
+
+        test_parameter_object_rejected = expect_error_contains( &
+            source, 'shall not appear in a DATA statement', &
+            '/tmp/ffc_data01_param_object')
+    end function test_parameter_object_rejected
+
+    logical function test_pointer_object_rejected()
+        ! A pointer data-stmt-object initializes the target, not the pointer.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, pointer :: x'//new_line('a')// &
+            '  data x /2/'//new_line('a')// &
+            '  print *, 1'//new_line('a')// &
+            'end program main'
+
+        test_pointer_object_rejected = expect_error_contains( &
+            source, 'POINTER attribute', '/tmp/ffc_data01_pointer_object')
+    end function test_pointer_object_rejected
+
+    logical function test_initialized_object_rejected()
+        ! An entity initialized in its declaration cannot be initialized again.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  real :: x(2) = 1.0'//new_line('a')// &
+            '  data x /1.0, 2.0/'//new_line('a')// &
+            '  print *, x'//new_line('a')// &
+            'end program main'
+
+        test_initialized_object_rejected = expect_error_contains( &
+            source, 'already is initialized', '/tmp/ffc_data01_initialized')
+    end function test_initialized_object_rejected
+
+    logical function test_variable_value_rejected()
+        ! A data-stmt-value must be constant, so a plain variable is invalid.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: i = 0'//new_line('a')// &
+            '  integer :: z(2)'//new_line('a')// &
+            '  data z /2*i/'//new_line('a')// &
+            '  print *, z'//new_line('a')// &
+            'end program main'
+
+        test_variable_value_rejected = expect_error_contains( &
+            source, 'must be a PARAMETER in DATA statement', &
+            '/tmp/ffc_data01_variable_value')
+    end function test_variable_value_rejected
+
+    logical function test_type_mismatch_rejected()
+        ! A character constant cannot initialize an integer object.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=3), parameter :: mychar(3) = ' // &
+            '[ "abc", "def", "ghi" ]'//new_line('a')// &
+            '  integer :: c(2)'//new_line('a')// &
+            '  data c / mychar(1), mychar(3) /'//new_line('a')// &
+            '  print *, c'//new_line('a')// &
+            'end program main'
+
+        test_type_mismatch_rejected = expect_error_contains( &
+            source, 'incompatible types in DATA statement', &
+            '/tmp/ffc_data01_type_mismatch')
+    end function test_type_mismatch_rejected
+
+    logical function test_nonconstant_initializer_rejected()
+        ! A parameter array indexed by an array element is not a constant
+        ! expression; the parser cannot build the statement at all, so the
+        ! source form itself is rejected instead of being dropped silently and
+        ! leaving the object uninitialised.
+        character(len=*), parameter :: source = &
+            'integer, parameter, dimension(4) :: myint = [4,3,2,1]'// &
+            new_line('a')// &
+            'integer :: a(5)'//new_line('a')// &
+            'data a(1:2) / myint(a(1)), myint(2) /'//new_line('a')// &
+            'end'
+
+        test_nonconstant_initializer_rejected = expect_error_contains( &
+            source, 'invalid initializer in DATA statement', &
+            '/tmp/ffc_data01_invalid_initializer')
+    end function test_nonconstant_initializer_rejected
+
+    logical function test_variable_subscript_value_rejected()
+        ! A parameter array indexed by a variable is not a constant expression.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, parameter :: myint(4) = [4, 3, 2, 1]'//new_line('a')// &
+            '  integer :: a(5), b'//new_line('a')// &
+            '  data a(1:2) / myint(b), myint(2) /'//new_line('a')// &
+            '  print *, a(1)'//new_line('a')// &
+            'end program main'
+
+        test_variable_subscript_value_rejected = expect_error_contains( &
+            source, 'must be a PARAMETER in DATA statement', &
+            '/tmp/ffc_data01_variable_subscript')
+    end function test_variable_subscript_value_rejected
+
+    logical function test_old_style_init_rejected()
+        ! Old-style slashed initialization gives the entity the DATA attribute.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer z /10/'//new_line('a')// &
+            '  print *, z'//new_line('a')// &
+            'end program main'
+
+        test_old_style_init_rejected = expect_error_contains( &
+            source, 'old-style slashed initialization', &
+            '/tmp/ffc_data01_old_style')
+    end function test_old_style_init_rejected
+
+    logical function test_valid_data_statement_accepted()
+        ! Corrected neighbour: definable objects, constant values of the
+        ! object's type class.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, parameter :: k = 7'//new_line('a')// &
+            '  integer :: z(2)'//new_line('a')// &
+            '  data z /2*k/'//new_line('a')// &
+            '  if (z(1) + z(2) /= 14) stop 1'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_valid_data_statement_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_data01_valid_data')
+    end function test_valid_data_statement_accepted
+
+    logical function test_valid_section_data_accepted()
+        ! Corrected neighbour of the invalid-initializer case: parameter
+        ! array elements with constant subscripts as the values.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, parameter :: myint(4) = [4, 3, 2, 1]'//new_line('a')// &
+            '  integer :: a(2)'//new_line('a')// &
+            '  data a / myint(1), myint(2) /'//new_line('a')// &
+            '  if (a(1) + a(2) /= 7) stop 1'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_valid_section_data_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_data01_valid_section')
+    end function test_valid_section_data_accepted
+
+end program test_session_reject_data_01_compiler


### PR DESCRIPTION
Closes #383.

## Preserved compiler invariant

A DATA statement may only initialize definable variables with constant values.
Before this change ffc accepted every invalid form in the issue's fixture set:
it either lowered it or, when FortFront could not build the statement, dropped
it silently and left the objects uninitialised.

Rules added:

Typed AST (`src/session_program_lowering_data.inc`, run from `validate_program`):
- data-stmt-object that is a named constant -> "shall not appear in a DATA statement"
- data-stmt-object with the POINTER attribute
- data-stmt-object already initialized in its declaration
- data-stmt-value naming a non-PARAMETER symbol (implied-do control variables excepted)
- data-stmt-value whose type class disagrees with the object's

Source form (`src/session_program_lowering_reject_checks.inc`), for the two
families the parser cannot represent and would otherwise drop:
- a DATA statement with a non-constant initializer
- old-style slashed declaration initialization (`integer z /10/`)

Valid DATA statements, including implied-do objects/values and repeat counts,
still lower and run unchanged; the new test asserts two corrected neighbours.

## Red evidence (unmodified main)

`fo test test_session_reject_data_01_compiler` failed with
`FAIL: unsupported source lowered without diagnostic` for each invalid form,
and all 12 gfortran.dg fixtures compiled with exit status 0.

## Green evidence

- `fo test test_session_reject_data_01_compiler` -> 1 passed
- `scripts/conformance_gauntlet.sh --suite gfortran-dg` over the 12 named files:
  `PASS=12 XFAIL=0 XPASS=0 FAIL=0 TOTAL=12`
- full `fo`: Build OK, Static OK, tests green except two pre-existing failures
  unrelated to this change: `test_parity_dashboard` (fails identically on
  unmodified main - snapshot pins an older FortFront revision than the local
  checkout) and `test_conformance_gauntlet_smoke`, which times out only under
  parallel load and passes on its own (108s).