### PR TITLE
Distinguish valid and ambiguous USE renames (#371)

### DIFF
--- a/src/session_program_lowering_derived_module_ops.inc
+++ b/src/session_program_lowering_derived_module_ops.inc
@@ -520,9 +520,10 @@
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
         integer(c_int64_t) :: constant_value
-        integer :: index, io_stat
+        integer :: index, io_stat, existing_idx
         character(len=:), allocatable :: local_name
         logical :: imported
+        logical :: rebind, skip
 
         call set_empty(error_msg)
         if (.not. allocated(param%name)) return
@@ -539,9 +540,13 @@
                         trim(param%name)
             return
         end if
-        if (find_symbol_compat(context, trim(local_name)) > 0) return
-        call grow_symbols(context)
-        index = context%symbol_count + 1
+        call check_use_rename_collision(context, trim(local_name), &
+                                        trim(use_node%module_name), &
+                                        trim(param%name), existing_idx, &
+                                        rebind, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call use_import_symbol_slot(context, existing_idx, rebind, index, skip)
+        if (skip) return
         context%symbols(index)%name = trim(local_name)
         context%symbols(index)%value_kind = VALUE_I32
         context%symbols(index)%value = i32_immediate(context%session, &
@@ -549,7 +554,9 @@
         context%symbols(index)%is_parameter = .true.
         context%symbols(index)%has_i32_constant = .true.
         context%symbols(index)%i32_constant = constant_value
-        context%symbol_count = index
+        call record_use_rename_source(context, index, &
+                                      trim(use_node%module_name), &
+                                      trim(param%name))
     end subroutine import_fmod_parameter
 
     subroutine import_fmod_variable(use_node, var, context, error_msg)
@@ -567,8 +574,9 @@
         character(len=:), allocatable :: local_name
         character(kind=c_char), allocatable :: c_name(:)
         integer(c_int32_t) :: global_id
-        integer :: sym_idx, value_kind
+        integer :: sym_idx, value_kind, existing_idx
         logical :: imported
+        logical :: rebind, skip
 
         call set_empty(error_msg)
         if (.not. allocated(var%name)) return
@@ -578,7 +586,14 @@
         if (.not. imported) return
         value_kind = value_kind_of_token(trim(var%kind))
         if (value_kind == 0) return
-        if (find_symbol_compat(context, trim(local_name)) > 0) return
+        call check_use_rename_collision(context, trim(local_name), &
+                                        trim(use_node%module_name), &
+                                        trim(var%name), existing_idx, rebind, &
+                                        error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (existing_idx > 0) then
+            if (.not. rebind) return
+        end if
         if (allocated(var%c_name) .and. len_trim(var%c_name) > 0) then
             mangled = trim(var%c_name)
         else
@@ -591,8 +606,8 @@
             error_msg = 'module variable global not found: '//trim(mangled)
             return
         end if
-        call grow_symbols(context)
-        sym_idx = context%symbol_count + 1
+        call use_import_symbol_slot(context, existing_idx, rebind, sym_idx, skip)
+        if (skip) return
         context%symbols(sym_idx)%name = trim(local_name)
         context%symbols(sym_idx)%value_kind = value_kind
         context%symbols(sym_idx)%has_address = .true.
@@ -601,8 +616,91 @@
         context%symbols(sym_idx)%address%payload = int(global_id, c_int64_t)
         context%symbols(sym_idx)%address%typ = lr_type_ptr_s(context%session%handle)
         context%symbols(sym_idx)%address%global_offset = 0_c_int64_t
-        context%symbol_count = sym_idx
+        call record_use_rename_source(context, sym_idx, &
+                                      trim(use_node%module_name), &
+                                      trim(var%name))
     end subroutine import_fmod_variable
+
+    subroutine check_use_rename_collision(context, local_name, module_name, &
+                                          remote_name, existing_idx, rebind, &
+                                          error_msg)
+        ! Classify a USE import of module_name::remote_name under local_name
+        ! against the symbols already registered in this unit.
+        !   existing_idx == 0                 the local name is free.
+        !   existing_idx > 0, rebind = .true. the local name is held by a
+        !       symbol with no recorded import origin; it adopts this remote
+        !       binding and the caller rebinds that slot in place.
+        !   existing_idx > 0, rebind = .false. the very same remote binding is
+        !       already imported under this local name; the repeat is valid
+        !       (F2018 19.5.2) and the caller skips it.
+        ! A different remote binding under an already-bound local name is
+        ! ambiguous and rejected.
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: local_name
+        character(len=*), intent(in) :: module_name
+        character(len=*), intent(in) :: remote_name
+        integer, intent(out) :: existing_idx
+        logical, intent(out) :: rebind
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        rebind = .false.
+        call set_empty(error_msg)
+        existing_idx = find_symbol_compat(context, local_name)
+        if (existing_idx <= 0) return
+        if (.not. allocated(context%symbols(existing_idx)%use_rename_module)) then
+            rebind = .true.
+            return
+        end if
+        if (.not. allocated(context%symbols(existing_idx)%use_rename_remote)) &
+            return
+        if (same_name(context%symbols(existing_idx)%use_rename_module, &
+                      module_name)) then
+            if (same_name(context%symbols(existing_idx)%use_rename_remote, &
+                          remote_name)) return
+        end if
+        error_msg = 'ambiguous use rename local name: '//trim(local_name)
+    end subroutine check_use_rename_collision
+
+    subroutine use_import_symbol_slot(context, existing_idx, rebind, sym_idx, &
+                                      skip)
+        ! Pick the symbol table slot a USE import writes into: the adopted
+        ! existing slot, or a fresh one. skip = .true. when the same binding is
+        ! already imported and nothing must be written.
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: existing_idx
+        logical, intent(in) :: rebind
+        integer, intent(out) :: sym_idx
+        logical, intent(out) :: skip
+
+        skip = .false.
+        sym_idx = 0
+        if (existing_idx > 0) then
+            if (.not. rebind) then
+                skip = .true.
+                return
+            end if
+            sym_idx = existing_idx
+            context%symbols(sym_idx) = symbol_t()
+            return
+        end if
+        call grow_symbols(context)
+        sym_idx = context%symbol_count + 1
+        context%symbol_count = sym_idx
+    end subroutine use_import_symbol_slot
+
+    subroutine record_use_rename_source(context, sym_idx, module_name, &
+                                        remote_name)
+        ! Remember the remote binding a renamed local symbol came from so a
+        ! later import of the same binding is recognised as a repeat.
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: sym_idx
+        character(len=*), intent(in) :: module_name
+        character(len=*), intent(in) :: remote_name
+
+        if (sym_idx <= 0) return
+        context%symbols(sym_idx)%use_rename_module = trim(module_name)
+        context%symbols(sym_idx)%use_rename_remote = trim(remote_name)
+    end subroutine record_use_rename_source
 
     subroutine import_use_renames(arena, export_idx, use_node, context, error_msg)
         ! use m, only: local => remote binds module symbol `remote` under the
@@ -622,6 +720,9 @@
         integer :: line
         integer :: column
         integer :: symbol_idx
+        integer :: existing_idx
+        logical :: rebind
+        logical :: skip
         character(len=:), allocatable :: decl_name
         character(len=:), allocatable :: decl_type_name
 
@@ -670,13 +771,18 @@
                 call eval_i32_constant(context%arena, init_index, context, &
                                        constant_value, error_msg)
                 if (len_trim(error_msg) > 0) return
-                if (find_symbol_compat(context, trim(use_node%rename_list(i)%s)) > 0) then
-                    error_msg = 'duplicate use rename local name: '// &
-                                trim(use_node%rename_list(i)%s)
-                    return
+                call check_use_rename_collision(context, &
+                    trim(use_node%rename_list(i)%s), &
+                    trim(context%module_exports(export_idx)%module_name), &
+                    trim(use_node%rename_list(i + 1)%s), existing_idx, &
+                    rebind, error_msg)
+                if (len_trim(error_msg) > 0) return
+                call use_import_symbol_slot(context, existing_idx, rebind, &
+                                            symbol_idx, skip)
+                if (skip) then
+                    found = .true.
+                    exit
                 end if
-                call grow_symbols(context)
-                symbol_idx = context%symbol_count + 1
                 context%symbols(symbol_idx)%name = trim(use_node%rename_list(i)%s)
                 context%symbols(symbol_idx)%value_kind = VALUE_I32
                 context%symbols(symbol_idx)%value = i32_immediate(context%session, &
@@ -684,7 +790,9 @@
                 context%symbols(symbol_idx)%is_parameter = .true.
                 context%symbols(symbol_idx)%has_i32_constant = .true.
                 context%symbols(symbol_idx)%i32_constant = constant_value
-                context%symbol_count = symbol_idx
+                call record_use_rename_source(context, symbol_idx, &
+                    trim(context%module_exports(export_idx)%module_name), &
+                    trim(use_node%rename_list(i + 1)%s))
                 found = .true.
                 exit
             end do
@@ -723,7 +831,8 @@
         type(lowering_context_t), intent(inout) :: context
         logical, intent(out) :: found
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: i, var_idx, value_kind, status, sym_idx
+        integer :: i, var_idx, value_kind, status, sym_idx, existing_idx
+        logical :: rebind, skip
         integer(c_int32_t) :: global_id
         character(len=:), allocatable :: var_name, mangled, name_err
         character(kind=c_char), allocatable :: c_name(:)
@@ -742,9 +851,15 @@
                 call set_empty(error_msg)
                 return
             end if
-            if (find_symbol_compat(context, local_name) > 0) then
-                error_msg = 'duplicate use rename local name: '//local_name
-                return
+            call check_use_rename_collision(context, local_name, &
+                trim(context%module_exports(export_idx)%module_name), &
+                remote_name, existing_idx, rebind, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (existing_idx > 0) then
+                if (.not. rebind) then
+                    found = .true.
+                    return
+                end if
             end if
             mangled = module_procedure_mangled( &
                 trim(context%module_exports(export_idx)%module_name), &
@@ -762,8 +877,12 @@
                 found = .true.
                 return
             end if
-            call grow_symbols(context)
-            sym_idx = context%symbol_count + 1
+            call use_import_symbol_slot(context, existing_idx, rebind, &
+                                        sym_idx, skip)
+            if (skip) then
+                found = .true.
+                return
+            end if
             context%symbols(sym_idx)%name = local_name
             context%symbols(sym_idx)%value_kind = value_kind
             context%symbols(sym_idx)%has_address = .true.
@@ -773,7 +892,9 @@
             context%symbols(sym_idx)%address%typ = &
                 lr_type_ptr_s(context%session%handle)
             context%symbols(sym_idx)%address%global_offset = 0_c_int64_t
-            context%symbol_count = sym_idx
+            call record_use_rename_source(context, sym_idx, &
+                trim(context%module_exports(export_idx)%module_name), &
+                remote_name)
             found = .true.
             return
         end do
@@ -1067,6 +1188,13 @@
                 return
             end if
         end do
+        ! A generic interface declared by the module is an export too: it is
+        ! registered under its generic name when the module is lowered in this
+        ! unit, so ONLY may name it (#371).
+        if (find_generic(context, name) > 0) then
+            module_exports_name = .true.
+            return
+        end if
         ! Module procedures are not recorded in module_exports_t (only data
         ! symbols are), so resolve a procedure name against the module body
         ! itself (#263). A USE-only of a contained function or subroutine is a

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -303,6 +303,13 @@ module session_program_lowering_types
         ! kept so a later constant's initializer can fold a reference to
         ! this one (z_pad = x_pad // y_pad) at compile time.
         character(len=:), allocatable :: character_constant_text
+        ! Remote binding this symbol was imported from by a USE rename
+        ! (module name plus the name used inside that module). Repeating the
+        ! same remote binding under the same local name is valid; a second,
+        ! different remote binding under that local name is ambiguous
+        ! (F2018 19.5.2).
+        character(len=:), allocatable :: use_rename_module
+        character(len=:), allocatable :: use_rename_remote
     end type symbol_t
 
     ! One resolved declaration record. The binding triple is the identity;

--- a/test/conformance/fail_owners_gfortran_dg.txt
+++ b/test/conformance/fail_owners_gfortran_dg.txt
@@ -134,7 +134,6 @@ initialization_25.f90 # owner=lazy-fortran/ffc#387; reason=require valid constan
 initialization_28.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
 initialization_7.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
 inline_sum_2.f90 # owner=lazy-fortran/ffc#359; reason=capture dummy-bound extents on entry
-interface_17.f90 # owner=lazy-fortran/ffc#371; reason=distinguish valid and ambiguous USE renames
 interface_20.f90 # owner=lazy-fortran/fortfront#2882; reason=reject procedure-call signature mismatches
 interface_21.f90 # owner=lazy-fortran/fortfront#2882; reason=reject procedure-call signature mismatches
 interface_23.f90 # owner=lazy-fortran/fortfront#2883; reason=enforce explicit-interface declaration rules
@@ -310,7 +309,6 @@ unexpected_interface.f90 # owner=lazy-fortran/fortfront#2896; reason=reject cons
 unf_io_convert_2.f90 # scope=vendor; reason=GNU CONVERT unformatted I/O extension
 unlimited_polymorphic_14.f90 # owner=lazy-fortran/ffc#419; reason=owns scalar SELECT TYPE guard dispatch and CLASS DEFAULT
 unsigned_37.f90 # owner=lazy-fortran/fortfront#2894; reason=reject malformed or disallowed literal forms
-use_11.f90 # owner=lazy-fortran/ffc#371; reason=distinguish valid and ambiguous USE renames
 use_15.f90 # owner=lazy-fortran/fortfront#2887; reason=validate USE exports renames and operator imports
 use_16.f90 # owner=lazy-fortran/fortfront#2887; reason=validate USE exports renames and operator imports
 use_19.f90 # owner=lazy-fortran/fortfront#2887; reason=validate USE exports renames and operator imports
@@ -318,7 +316,6 @@ use_31.f90 # owner=lazy-fortran/fortfront#2893; reason=require matching construc
 use_9.f90 # owner=lazy-fortran/fortfront#2887; reason=validate USE exports renames and operator imports
 use_iso_c_binding.f90 # owner=lazy-fortran/fortfront#2887; reason=validate USE exports renames and operator imports
 use_rename_11.f90 # owner=lazy-fortran/fortfront#2887; reason=validate USE exports renames and operator imports
-use_rename_4.f90 # owner=lazy-fortran/ffc#371; reason=distinguish valid and ambiguous USE renames
 use_rename_5.f90 # owner=lazy-fortran/fortfront#2887; reason=validate USE exports renames and operator imports
 used_types_23.f90 # owner=lazy-fortran/fortfront#2892; reason=reject unresolved and use-before-definition symbols
 used_types_25.f90 # owner=lazy-fortran/fortfront#2888; reason=reject local and host-associated name collisions

--- a/test/test_session_read_fmod_compiler.f90
+++ b/test/test_session_read_fmod_compiler.f90
@@ -17,6 +17,12 @@ program test_session_read_fmod_compiler
     if (.not. test_use_module_fmod_rejects_unknown_only()) all_passed = .false.
     if (.not. test_use_module_fmod_not_found_errors()) all_passed = .false.
     if (.not. test_use_module_variable_from_fmod()) all_passed = .false.
+    if (.not. test_use_repeated_rename_is_valid()) all_passed = .false.
+    if (.not. test_use_repeated_rename_one_statement()) all_passed = .false.
+    if (.not. test_use_two_locals_one_remote()) all_passed = .false.
+    if (.not. test_use_conflicting_rename_rejected()) all_passed = .false.
+    if (.not. test_same_file_repeated_rename_is_valid()) all_passed = .false.
+    if (.not. test_same_file_conflicting_rename_rejected()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: module .fmod read-on-USE'
@@ -247,6 +253,202 @@ contains
         end if
         ok = .true.
     end function test_use_module_variable_from_fmod
+
+    subroutine write_rename_matrix_fmod(dir, error_msg)
+        ! A module exporting two distinct integer constants, so a rename
+        ! matrix can bind one local name to the same remote entity twice
+        ! (valid) or to two different remote entities (ambiguous).
+        character(len=*), intent(in) :: dir
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(module_info_t) :: info
+
+        call execute_command_line('mkdir -p '//dir)
+        info%name = 'm'
+        allocate (info%parameters(2))
+        info%parameters(1)%name = 'alpha'
+        info%parameters(1)%kind = 'integer'
+        info%parameters(1)%value = '13'
+        info%parameters(2)%name = 'beta'
+        info%parameters(2)%kind = 'integer'
+        info%parameters(2)%value = '21'
+        allocate (info%derived_types(0))
+        call write_fmod(dir//'/m.fmod', info, error_msg)
+    end subroutine write_rename_matrix_fmod
+
+    logical function run_rename_case(tag, source, expected_exit) result(ok)
+        ! Compile and run a rename matrix program, checking its exit status.
+        character(len=*), intent(in) :: tag
+        character(len=*), intent(in) :: source
+        integer, intent(in) :: expected_exit
+        character(len=*), parameter :: dir = '/tmp/ffc_read_fmod_matrix_dir'
+        character(len=*), parameter :: exe = '/tmp/ffc_read_fmod_matrix'
+        character(len=:), allocatable :: error_msg
+        integer :: exit_stat, cmd_stat
+
+        ok = .false.
+        call write_rename_matrix_fmod(dir, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: write_fmod: ', trim(error_msg)
+            return
+        end if
+        call compile_with_include(source, exe, dir, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: '//tag//' rejected: ', trim(error_msg)
+            call execute_command_line('rm -f '//dir//'/m.fmod')
+            return
+        end if
+        call execute_command_line(exe, exitstat=exit_stat, cmdstat=cmd_stat)
+        call execute_command_line('rm -f '//exe//' '//dir//'/m.fmod')
+        if (cmd_stat /= 0) then
+            print *, 'FAIL: '//tag//' binary did not run'
+            return
+        end if
+        if (exit_stat /= expected_exit) then
+            print *, 'FAIL: '//tag//' expected exit ', expected_exit, &
+                ' got ', exit_stat
+            return
+        end if
+        ok = .true.
+    end function run_rename_case
+
+    logical function test_use_repeated_rename_is_valid() result(ok)
+        ! Importing the same remote binding under the same local name from two
+        ! USE statements is not ambiguous (F2018 19.5.2).
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  use m, only: alias => alpha'//new_line('a')// &
+            '  use m, only: alias => alpha'//new_line('a')// &
+            '  stop alias'//new_line('a')// &
+            'end program main'
+
+        ok = run_rename_case('repeated rename', source, 13)
+    end function test_use_repeated_rename_is_valid
+
+    logical function test_use_repeated_rename_one_statement() result(ok)
+        ! The same repetition within a single ONLY list is equally valid.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  use m, only: alias => alpha, alias => alpha'//new_line('a')// &
+            '  stop alias'//new_line('a')// &
+            'end program main'
+
+        ok = run_rename_case('repeated rename in one statement', source, 13)
+    end function test_use_repeated_rename_one_statement
+
+    logical function test_use_two_locals_one_remote() result(ok)
+        ! One remote binding may reach two distinct local names.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  use m, only: first => alpha'//new_line('a')// &
+            '  use m, only: second => alpha'//new_line('a')// &
+            '  stop first + second'//new_line('a')// &
+            'end program main'
+
+        ok = run_rename_case('two locals one remote', source, 26)
+    end function test_use_two_locals_one_remote
+
+    logical function test_use_conflicting_rename_rejected() result(ok)
+        ! Two distinct remote bindings under one local name stay ambiguous.
+        character(len=*), parameter :: dir = '/tmp/ffc_read_fmod_matrix_dir'
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  use m, only: alias => alpha'//new_line('a')// &
+            '  use m, only: alias => beta'//new_line('a')// &
+            '  stop alias'//new_line('a')// &
+            'end program main'
+        character(len=:), allocatable :: error_msg
+
+        ok = .false.
+        call write_rename_matrix_fmod(dir, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: write_fmod: ', trim(error_msg)
+            return
+        end if
+        call compile_with_include(source, '/tmp/ffc_read_fmod_ambiguous', dir, &
+            error_msg)
+        call execute_command_line('rm -f /tmp/ffc_read_fmod_ambiguous '// &
+            dir//'/m.fmod')
+        if (len_trim(error_msg) == 0) then
+            print *, 'FAIL: conflicting USE rename was accepted'
+            return
+        end if
+        if (index(error_msg, 'ambiguous') == 0) then
+            print *, 'FAIL: wrong conflicting-rename diagnostic: ', &
+                trim(error_msg)
+            return
+        end if
+        ok = .true.
+    end function test_use_conflicting_rename_rejected
+
+    function same_file_rename_source(first, second) result(source)
+        ! A module and a using program in one file, so the renames resolve
+        ! against in-arena module exports rather than a .fmod.
+        character(len=*), intent(in) :: first
+        character(len=*), intent(in) :: second
+        character(len=:), allocatable :: source
+
+        source = 'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer, parameter :: alpha = 13'//new_line('a')// &
+            '  integer, parameter :: beta = 21'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m, only: '//first//new_line('a')// &
+            '  use m, only: '//second//new_line('a')// &
+            '  stop alias'//new_line('a')// &
+            'end program main'
+    end function same_file_rename_source
+
+    logical function test_same_file_repeated_rename_is_valid() result(ok)
+        ! Repeating one remote binding under one local name must not be
+        ! reported as a duplicate when the module is in the same file.
+        character(len=*), parameter :: exe = '/tmp/ffc_same_file_rename'
+        character(len=:), allocatable :: error_msg
+        integer :: exit_stat, cmd_stat
+
+        ok = .false.
+        call compile_with_include( &
+            same_file_rename_source('alias => alpha', 'alias => alpha'), &
+            exe, '/tmp/ffc_read_fmod_empty', error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: same-file repeated rename rejected: ', &
+                trim(error_msg)
+            return
+        end if
+        call execute_command_line(exe, exitstat=exit_stat, cmdstat=cmd_stat)
+        call execute_command_line('rm -f '//exe)
+        if (cmd_stat /= 0) then
+            print *, 'FAIL: same-file repeated rename binary did not run'
+            return
+        end if
+        if (exit_stat /= 13) then
+            print *, 'FAIL: same-file repeated rename exit ', exit_stat
+            return
+        end if
+        ok = .true.
+    end function test_same_file_repeated_rename_is_valid
+
+    logical function test_same_file_conflicting_rename_rejected() result(ok)
+        ! Distinct remote bindings under one local name stay ambiguous.
+        character(len=:), allocatable :: error_msg
+
+        ok = .false.
+        call compile_with_include( &
+            same_file_rename_source('alias => alpha', 'alias => beta'), &
+            '/tmp/ffc_same_file_ambiguous', '/tmp/ffc_read_fmod_empty', &
+            error_msg)
+        call execute_command_line('rm -f /tmp/ffc_same_file_ambiguous')
+        if (len_trim(error_msg) == 0) then
+            print *, 'FAIL: same-file conflicting rename was accepted'
+            return
+        end if
+        if (index(error_msg, 'ambiguous') == 0) then
+            print *, 'FAIL: wrong same-file conflicting diagnostic: ', &
+                trim(error_msg)
+            return
+        end if
+        ok = .true.
+    end function test_same_file_conflicting_rename_rejected
 
     subroutine compile_with_include(source, exe_path, include_dir, error_msg)
         character(len=*), intent(in) :: source


### PR DESCRIPTION
Closes #371.

## Preserved compiler invariant

One local name may denote exactly one remote binding. Importing the *same*
remote binding again under that name — repeated USE statements, a repeat inside
one ONLY list, or `only: i, j => i` — is valid (F2018 19.5.2) and is now a
no-op. Two *different* remote bindings under one local name are still rejected,
now with `ambiguous use rename local name: <name>`.

## Change

- `symbol_t` records the remote binding (`use_rename_module` /
  `use_rename_remote`) a symbol was imported from.
- `check_use_rename_collision` classifies a collision by binding identity
  instead of local text; a local name already present without a recorded origin
  adopts the binding and is rebound in place, so `j` in `only: i, j => i` binds
  the same module global as `i`.
- ONLY may name a generic interface: it is an export of the module like any
  procedure (`interface_17.f90`).
- Promotes gfortran-dg `interface_17.f90`, `use_11.f90`, `use_rename_4.f90` out
  of `fail_owners_gfortran_dg.txt`.

## Red evidence (before)

`fo test test_session_read_fmod_compiler`:

```
FAIL: conflicting USE rename was accepted
FAIL: same-file repeated rename rejected: duplicate use rename local name: alias
FAIL: wrong same-file conflicting diagnostic: duplicate use rename local name: alias
Summary: 0 passed, 1 failed
```

Gauntlet: `PASS=0 FAIL=3` for the three promoted files.

## Green evidence (after)

```
test_session_read_fmod_compiler   PASS
scripts/conformance_gauntlet.sh --suite gfortran-dg --file interface_17.f90 \
    --file use_11.f90 --file use_rename_4.f90
  PASS=3  XFAIL=0  XPASS=0  FAIL=0
```

Full local `fo` pipeline: Build OK, tests green except `test_parity_dashboard`,
which fails identically on unmodified `main` (stale parity snapshot, needs the
documented four-suite regeneration).