### PR TITLE
[reject-c-pointer-01] require SHAPE for array C_F_POINTER targets

### DIFF
--- a/src/session_program_lowering_c_ptr.inc
+++ b/src/session_program_lowering_c_ptr.inc
@@ -228,6 +228,12 @@
             error_msg = 'c_f_pointer target was not declared: '//trim(name)
             return
         end if
+        ! F2018 18.2.3.3: SHAPE is optional only when FPTR is scalar. An array
+        ! FPTR without SHAPE has no extents to take, so reject it here.
+        if (context%symbols(symbol_index)%is_array) then
+            error_msg = 'Expected SHAPE argument to C_F_POINTER with array FPTR'
+            return
+        end if
         ! Bind the Fortran pointer to the C address: the pointer adopts cp's
         ! address as its storage, so a later read of p dereferences that address
         ! (emit_*_load) and yields the value the C pointer refers to.

--- a/test/test_session_reject_c_pointer_01_compiler.f90
+++ b/test/test_session_reject_c_pointer_01_compiler.f90
@@ -1,0 +1,73 @@
+program test_session_reject_c_pointer_01_compiler
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== C_F_POINTER SHAPE requirement rejection test ==='
+
+    all_passed = .true.
+    if (.not. test_array_fptr_without_shape_rejected()) all_passed = .false.
+    if (.not. test_deferred_shape_fptr_without_shape_rejected()) &
+        all_passed = .false.
+    if (.not. test_scalar_fptr_without_shape_accepted()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: array C_F_POINTER targets require a SHAPE argument'
+
+contains
+
+    logical function test_array_fptr_without_shape_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  use, intrinsic :: iso_c_binding'//new_line('a')// &
+            '  integer, dimension(1:2), target :: my_array'//new_line('a')// &
+            '  integer, dimension(:), pointer :: my_array_ptr'//new_line('a')// &
+            '  type(c_ptr) :: cptr'//new_line('a')// &
+            '  my_array = 1'//new_line('a')// &
+            '  cptr = c_loc(my_array)'//new_line('a')// &
+            '  my_array_ptr => my_array'//new_line('a')// &
+            '  call c_f_pointer(cptr, my_array_ptr)'//new_line('a')// &
+            'end program main'
+
+        test_array_fptr_without_shape_rejected = expect_error_contains( &
+            source, 'Expected SHAPE argument to C_F_POINTER with array FPTR', &
+            '/tmp/ffc_session_reject_c_pointer_01_array')
+    end function test_array_fptr_without_shape_rejected
+
+    logical function test_deferred_shape_fptr_without_shape_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  use, intrinsic :: iso_c_binding'//new_line('a')// &
+            '  integer, dimension(3), target :: my_array'//new_line('a')// &
+            '  integer, pointer :: my_array_ptr(:)'//new_line('a')// &
+            '  type(c_ptr) :: cptr'//new_line('a')// &
+            '  my_array = 2'//new_line('a')// &
+            '  cptr = c_loc(my_array)'//new_line('a')// &
+            '  call c_f_pointer(cptr, my_array_ptr)'//new_line('a')// &
+            'end program main'
+
+        test_deferred_shape_fptr_without_shape_rejected = &
+            expect_error_contains(source, &
+            'Expected SHAPE argument to C_F_POINTER with array FPTR', &
+            '/tmp/ffc_session_reject_c_pointer_01_deferred')
+    end function test_deferred_shape_fptr_without_shape_rejected
+
+    logical function test_scalar_fptr_without_shape_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  use, intrinsic :: iso_c_binding'//new_line('a')// &
+            '  integer, target :: my_value'//new_line('a')// &
+            '  integer, pointer :: my_ptr'//new_line('a')// &
+            '  type(c_ptr) :: cptr'//new_line('a')// &
+            '  my_value = 7'//new_line('a')// &
+            '  cptr = c_loc(my_value)'//new_line('a')// &
+            '  call c_f_pointer(cptr, my_ptr)'//new_line('a')// &
+            '  stop my_ptr'//new_line('a')// &
+            'end program main'
+
+        test_scalar_fptr_without_shape_accepted = expect_exit_status( &
+            source, 7, '/tmp/ffc_session_c_pointer_01_scalar_ok')
+    end function test_scalar_fptr_without_shape_accepted
+
+end program test_session_reject_c_pointer_01_compiler


### PR DESCRIPTION
Closes #394

## Preserved compiler invariant

F2018 18.2.3.3: the SHAPE argument of C_F_POINTER is optional only when FPTR is scalar. An array FPTR has no extents without SHAPE, so `lower_c_f_pointer` now rejects the call with a source diagnostic instead of silently binding the pointer to the C address. The check runs on the resolved symbol's array attribute, not on filenames or message text.

## Red evidence (unmodified main)

```
test_session_reject_c_pointer_01_compiler  FAIL
 FAIL: unsupported source lowered without diagnostic   (array FPTR)
 FAIL: unsupported source lowered without diagnostic   (deferred-shape FPTR)
```

## Green evidence

```
fo test test_session_reject_c_pointer_01_compiler
  test_session_reject_c_pointer_01_compiler  PASS

scripts/conformance_gauntlet.sh --suite gfortran-dg --file c_f_pointer_shape_test.f90
  PASS=1  XFAIL=0  XPASS=0  FAIL=0  TOTAL=1
```

The corrected neighbour (scalar FPTR without SHAPE, dereferenced via `stop my_ptr`) still compiles and exits 7.

Full local `fo`: build OK, static OK, all tests green except `test_conformance_gauntlet_smoke` and `test_parity_dashboard`, which use fixed `/tmp` fixture roots and were being clobbered by other concurrent worktree runs on this machine; `test_parity_dashboard` additionally reports `stale snapshot FortFront revision`, reproduced with this branch's changes stashed, so it is pre-existing.