### PR TITLE
[reject-alloc-02] require valid ALLOCATE status specifiers (#382)

### DIFF
--- a/src/session_program_lowering_allocatable.inc
+++ b/src/session_program_lowering_allocatable.inc
@@ -1,3 +1,82 @@
+    subroutine validate_allocate_status_specifiers(arena, node, context, error_msg)
+        ! #382: an ALLOCATE stat= specifier must name a scalar INTEGER
+        ! variable and errmsg= must name a scalar default CHARACTER variable.
+        ! Only resolved plain identifiers carry enough information here; other
+        ! forms (array elements, components) stay with the existing handling.
+        type(ast_arena_t), intent(in) :: arena
+        type(allocate_statement_node), intent(in) :: node
+        type(lowering_context_t), intent(in) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: sym
+        logical :: is_scalar
+
+        call set_empty(error_msg)
+
+        call resolve_status_specifier_symbol(arena, node%stat_var_index, &
+                                             context, sym, is_scalar)
+        if (sym > 0) then
+            if (.not. is_scalar) then
+                call allocate_status_error(node, 'stat', &
+                    'a scalar INTEGER variable', error_msg)
+                return
+            end if
+            if (context%symbols(sym)%value_kind /= VALUE_I32 .and. &
+                context%symbols(sym)%value_kind /= VALUE_I64) then
+                call allocate_status_error(node, 'stat', &
+                    'a scalar INTEGER variable', error_msg)
+                return
+            end if
+        end if
+
+        call resolve_status_specifier_symbol(arena, node%errmsg_var_index, &
+                                             context, sym, is_scalar)
+        if (sym > 0) then
+            if (.not. is_scalar) then
+                call allocate_status_error(node, 'errmsg', &
+                    'a scalar default CHARACTER variable', error_msg)
+                return
+            end if
+            if (context%symbols(sym)%value_kind /= VALUE_CHARACTER) then
+                call allocate_status_error(node, 'errmsg', &
+                    'a scalar default CHARACTER variable', error_msg)
+                return
+            end if
+        end if
+    end subroutine validate_allocate_status_specifiers
+
+    subroutine resolve_status_specifier_symbol(arena, node_index, context, &
+                                               symbol_index, is_scalar)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(out) :: symbol_index
+        logical, intent(out) :: is_scalar
+        character(len=:), allocatable :: name, local_error
+
+        symbol_index = 0
+        is_scalar = .true.
+        if (node_index <= 0) return
+        if (.not. is_identifier(arena, node_index)) return
+        call get_identifier_name(arena, node_index, name, local_error)
+        if (len_trim(local_error) > 0) return
+        symbol_index = find_symbol_compat(context, name)
+        if (symbol_index <= 0) return
+        if (context%symbols(symbol_index)%is_array) is_scalar = .false.
+        if (context%symbols(symbol_index)%array_rank > 0) is_scalar = .false.
+    end subroutine resolve_status_specifier_symbol
+
+    subroutine allocate_status_error(node, specifier, requirement, error_msg)
+        type(allocate_statement_node), intent(in) :: node
+        character(len=*), intent(in) :: specifier
+        character(len=*), intent(in) :: requirement
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=64) :: location
+
+        write (location, '(" at line ",I0,", column ",I0)') node%line, node%column
+        error_msg = 'ALLOCATE '//specifier//'= must be '//requirement// &
+                    trim(location)
+    end subroutine allocate_status_error
+
     subroutine lower_allocatable_declaration(node, context, error_msg, &
                                              value_kind_override)
         ! integer/real/logical/character, allocatable :: a(:) or a(:,:)

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -826,6 +826,11 @@
         type is (allocate_statement_node)
             ! allocate(<type> :: x) on a class(*) allocatable populates the
             ! polymorphic descriptor; everything else uses the array path.
+            ! #382: invalid stat=/errmsg= status specifiers are rejected
+            ! before any allocation is lowered.
+            call validate_allocate_status_specifiers(arena, node, context, &
+                                                     error_msg)
+            if (len_trim(error_msg) > 0) return
             if (allocate_targets_class_star(arena, node, context)) then
                 call lower_class_star_allocate(arena, node, context, error_msg)
             else

--- a/test/conformance/fail_owners_gfortran_dg.txt
+++ b/test/conformance/fail_owners_gfortran_dg.txt
@@ -4,7 +4,6 @@ EXformat_2.f90 # owner=lazy-fortran/ffc#366; reason=implement internal E and X f
 allocatable_dummy_2.f90 # owner=lazy-fortran/ffc#380; reason=reject invalid allocation and pointer definition targets
 allocate_alloc_opt_2.f90 # owner=lazy-fortran/ffc#380; reason=reject invalid allocation and pointer definition targets
 allocate_class_2.f90 # owner=lazy-fortran/ffc#380; reason=reject invalid allocation and pointer definition targets
-allocate_stat_2.f90 # owner=lazy-fortran/ffc#382; reason=require valid ALLOCATE status specifiers
 argument_checking_25.f90 # owner=lazy-fortran/ffc#380; reason=reject invalid allocation and pointer definition targets
 array_constructor_2.f90 # owner=lazy-fortran/ffc#388; reason=reject incompatible array constructor types
 array_constructor_39.f90 # owner=lazy-fortran/ffc#459; reason=owns typed constructors and implied-DO elements

--- a/test/test_session_reject_alloc_02_compiler.f90
+++ b/test/test_session_reject_alloc_02_compiler.f90
@@ -1,0 +1,114 @@
+program test_session_reject_alloc_02_compiler
+    ! #382: an ALLOCATE stat= specifier must name a scalar INTEGER variable
+    ! and an errmsg= specifier must name a scalar default CHARACTER variable.
+    ! Array or wrong-typed status targets are rejected with a source
+    ! diagnostic; the corrected scalar neighbours still compile and run.
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    character(len=*), parameter :: STAT_FRAGMENT = &
+        'ALLOCATE stat= must be a scalar INTEGER variable'
+    character(len=*), parameter :: ERRMSG_FRAGMENT = &
+        'ALLOCATE errmsg= must be a scalar default CHARACTER variable'
+    logical :: all_passed
+
+    print *, '=== ALLOCATE status specifier rejection test ==='
+
+    all_passed = .true.
+    if (.not. test_array_stat_rejected()) all_passed = .false.
+    if (.not. test_character_stat_rejected()) all_passed = .false.
+    if (.not. test_array_errmsg_rejected()) all_passed = .false.
+    if (.not. test_integer_errmsg_rejected()) all_passed = .false.
+    if (.not. test_scalar_stat_accepted()) all_passed = .false.
+    if (.not. test_scalar_stat_and_errmsg_accepted()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: invalid ALLOCATE status specifiers are rejected'
+
+contains
+
+    logical function test_array_stat_rejected()
+        ! gfortran.dg/allocate_stat_2.f90: stat = ier with integer ier(4).
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, dimension(4) :: ier = 0'//new_line('a')// &
+            '  integer, dimension(:), allocatable :: a'//new_line('a')// &
+            '  allocate (a(16), stat = ier)'//new_line('a')// &
+            'end program main'
+
+        test_array_stat_rejected = expect_error_contains( &
+            source, STAT_FRAGMENT, '/tmp/ffc_session_reject_alloc02_stat_array')
+    end function test_array_stat_rejected
+
+    logical function test_character_stat_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=30) :: ier'//new_line('a')// &
+            '  integer, dimension(:), allocatable :: a'//new_line('a')// &
+            '  allocate (a(16), stat = ier)'//new_line('a')// &
+            'end program main'
+
+        test_character_stat_rejected = expect_error_contains( &
+            source, STAT_FRAGMENT, '/tmp/ffc_session_reject_alloc02_stat_char')
+    end function test_character_stat_rejected
+
+    logical function test_array_errmsg_rejected()
+        ! gfortran.dg/allocate_stat_2.f90: errmsg = er with er(2) character.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: ier'//new_line('a')// &
+            '  character(len=30), dimension(2) :: er'//new_line('a')// &
+            '  integer, dimension(:), allocatable :: a'//new_line('a')// &
+            '  allocate (a(14), stat=ier, errmsg=er)'//new_line('a')// &
+            'end program main'
+
+        test_array_errmsg_rejected = expect_error_contains( &
+            source, ERRMSG_FRAGMENT, &
+            '/tmp/ffc_session_reject_alloc02_errmsg_array')
+    end function test_array_errmsg_rejected
+
+    logical function test_integer_errmsg_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: ier'//new_line('a')// &
+            '  integer :: er'//new_line('a')// &
+            '  integer, dimension(:), allocatable :: a'//new_line('a')// &
+            '  allocate (a(14), stat=ier, errmsg=er)'//new_line('a')// &
+            'end program main'
+
+        test_integer_errmsg_rejected = expect_error_contains( &
+            source, ERRMSG_FRAGMENT, &
+            '/tmp/ffc_session_reject_alloc02_errmsg_int')
+    end function test_integer_errmsg_rejected
+
+    logical function test_scalar_stat_accepted()
+        ! Corrected neighbour: a scalar INTEGER stat= is set to 0 on success.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: ier = 7'//new_line('a')// &
+            '  integer, dimension(:), allocatable :: a'//new_line('a')// &
+            '  allocate (a(16), stat = ier)'//new_line('a')// &
+            '  stop ier + 3'//new_line('a')// &
+            'end program main'
+
+        test_scalar_stat_accepted = expect_exit_status( &
+            source, 3, '/tmp/ffc_session_alloc02_stat_ok')
+    end function test_scalar_stat_accepted
+
+    logical function test_scalar_stat_and_errmsg_accepted()
+        ! Corrected neighbour: scalar INTEGER stat= plus scalar default
+        ! CHARACTER errmsg=.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: ier = 7'//new_line('a')// &
+            '  character(len=30) :: er'//new_line('a')// &
+            '  integer, dimension(:), allocatable :: a'//new_line('a')// &
+            '  allocate (a(14), stat=ier, errmsg=er)'//new_line('a')// &
+            '  stop ier + 5'//new_line('a')// &
+            'end program main'
+
+        test_scalar_stat_and_errmsg_accepted = expect_exit_status( &
+            source, 5, '/tmp/ffc_session_alloc02_stat_errmsg_ok')
+    end function test_scalar_stat_and_errmsg_accepted
+
+end program test_session_reject_alloc_02_compiler


### PR DESCRIPTION
Closes #382.

## Invariant preserved
An ALLOCATE stat= specifier must name a scalar INTEGER variable; errmsg= must name a scalar default CHARACTER variable (F2003 C623/C624). Both are now validated against the resolved symbol (rank and value kind, not filename or message text) before any allocation is lowered, so an invalid status target is a source diagnostic instead of being silently dropped.

## Red evidence
Before the fix, `fo test test_session_reject_alloc_02_compiler`:
```
 === ALLOCATE status specifier rejection test ===
 FAIL: unsupported source lowered without diagnostic  (x4)
Summary: 0 passed, 1 failed
```
`scripts/conformance_gauntlet.sh --suite gfortran-dg --file allocate_stat_2.f90` -> `FAIL: allocate_stat_2.f90 (negative test accepted)`.

## Green evidence
`fo test test_session_reject_alloc_02_compiler` -> 1 passed (4 rejections plus 2 corrected scalar-neighbour programs that compile and exit with the expected status).
`scripts/conformance_gauntlet.sh --suite gfortran-dg --file allocate_stat_2.f90 --ffc build/fo/bin/ffc` -> PASS=1 FAIL=0; the file is removed from `fail_owners_gfortran_dg.txt`.
Full `fo` pipeline: build OK, whole suite green except `test_parity_dashboard`, which fails identically on unmodified origin/main (`stale snapshot FortFront revision`) — pre-existing snapshot drift, not caused by this change.