### PR TITLE
[reject-const-01] require valid constant initialization expressions (#387)

### DIFF
--- a/scripts/conformance_gauntlet.sh
+++ b/scripts/conformance_gauntlet.sh
@@ -197,9 +197,15 @@ dg_do_mode() {
     sed -n 's/.*dg-do[[:space:]]\+\([[:alnum:]_-]\+\).*/\1/p' "$1" | head -1
 }
 
+# A dg-error directive marked { xfail ... } records an error gfortran is not
+# expected to emit, so it does not make the file a negative test.
+dg_has_active_error() {
+    grep -E 'dg-error' "$1" | grep -qv 'xfail'
+}
+
 dg_test_kind() {
     local source="$1"
-    if grep -Eq 'dg-error' "$source"; then
+    if dg_has_active_error "$source"; then
         echo "negative"
         return
     fi
@@ -213,7 +219,7 @@ dg_test_kind() {
 
 dg_warning_only() {
     local source="$1"
-    grep -Eq 'dg-warning' "$source" && ! grep -Eq 'dg-error' "$source"
+    grep -Eq 'dg-warning' "$source" && ! dg_has_active_error "$source"
 }
 
 # Resolve ffc

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -11,7 +11,8 @@ module session_program_lowering
         block_data_node
     use ast_nodes_legacy, only: common_block_node, enum_node
     use ast_nodes_io, only: open_statement_node, close_statement_node, &
-        rewind_statement_node, io_implied_do_node, inquire_statement_node
+        rewind_statement_node, io_implied_do_node, inquire_statement_node, &
+        io_specifier_t
     use ast_nodes_misc, only: use_statement_node, interface_block_node, &
         module_procedure_node, &
         visibility_statement_node, data_statement_node, &
@@ -2586,4 +2587,6 @@ contains
     include 'session_program_lowering_select.inc'
     include 'session_program_lowering_diagnostics.inc'
     include 'session_program_lowering_reject_checks.inc'
+    include 'session_program_lowering_reject_const_init.inc'
+    include 'session_program_lowering_reject_const_overflow.inc'
 end module session_program_lowering

--- a/src/session_program_lowering_reject_const_init.inc
+++ b/src/session_program_lowering_reject_const_init.inc
@@ -1,0 +1,362 @@
+    ! Constant-expression validation (F2018 10.1.12).
+    !
+    ! A declaration initializer, and the ASYNCHRONOUS= specifier of a data
+    ! transfer statement, must be an initialization expression: every primary
+    ! must be a constant, a named constant, an inquiry whose result is fixed at
+    ! compile time, or an implied-do index of the same constructor. A reference
+    ! to a variable, to a user function, or to the shape of an assumed-shape or
+    ! deferred-shape array is not. A constant expression whose folded value
+    ! leaves the representable range of its type is invalid as well.
+    !
+    ! The check runs from validate_program, before any lowering, so it sees the
+    ! declaration list of every scope and never needs a lowering context.
+
+    subroutine check_constant_initialization_exprs(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (program_node)
+                if (allocated(nd%body_indices)) then
+                    call check_scope_const_inits(arena, nd%body_indices, error_msg)
+                end if
+            type is (module_node)
+                if (allocated(nd%declaration_indices)) then
+                    call check_scope_const_inits(arena, nd%declaration_indices, &
+                                                 error_msg)
+                end if
+            type is (function_def_node)
+                if (allocated(nd%body_indices)) then
+                    call check_scope_const_inits(arena, nd%body_indices, error_msg)
+                end if
+            type is (subroutine_def_node)
+                if (allocated(nd%body_indices)) then
+                    call check_scope_const_inits(arena, nd%body_indices, error_msg)
+                end if
+            end select
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine check_constant_initialization_exprs
+
+    subroutine check_scope_const_inits(arena, indices, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: reason
+        character(len=64) :: location
+        integer :: i
+
+        call set_empty(error_msg)
+        do i = 1, size(indices)
+            if (.not. node_exists(arena, indices(i))) cycle
+            select type (nd => arena%entries(indices(i))%node)
+            type is (declaration_node)
+                if (.not. nd%has_initializer) cycle
+                if (nd%initializer_index <= 0) cycle
+                call const_expr_reason(arena, indices, nd%initializer_index, &
+                                       '|', reason)
+                if (len_trim(reason) > 0) then
+                    write (location, '(" at line ",I0,", column ",I0)') &
+                        nd%line, nd%column
+                    error_msg = trim(reason)//trim(location)
+                    return
+                end if
+            type is (write_statement_node)
+                if (.not. allocated(nd%specifiers)) cycle
+                call check_async_specifiers(arena, indices, nd%specifiers, &
+                                            nd%line, nd%column, error_msg)
+            type is (read_statement_node)
+                if (.not. allocated(nd%specifiers)) cycle
+                call check_async_specifiers(arena, indices, nd%specifiers, &
+                                            nd%line, nd%column, error_msg)
+            end select
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine check_scope_const_inits
+
+    ! The ASYNCHRONOUS= specifier of READ/WRITE must be an initialization
+    ! expression (F2018 12.6.2.2); OPEN takes an ordinary scalar expression and
+    ! is therefore left alone.
+    subroutine check_async_specifiers(arena, indices, specifiers, line, col, &
+                                      error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        type(io_specifier_t), intent(in) :: specifiers(:)
+        integer, intent(in) :: line, col
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: reason
+        character(len=64) :: location
+        integer :: i
+
+        call set_empty(error_msg)
+        do i = 1, size(specifiers)
+            if (.not. allocated(specifiers(i)%name)) cycle
+            if (trim(lowercase_text(specifiers(i)%name)) /= 'asynchronous') cycle
+            call set_empty(reason)
+            if (specifiers(i)%value_node_index > 0) then
+                call const_expr_reason(arena, indices, &
+                                       specifiers(i)%value_node_index, '|', reason)
+            else if (allocated(specifiers(i)%value)) then
+                call bare_name_const_reason(arena, indices, specifiers(i)%value, &
+                                            reason)
+            end if
+            if (len_trim(reason) > 0) then
+                write (location, '(" at line ",I0,", column ",I0)') line, col
+                error_msg = trim(reason)//trim(location)
+                return
+            end if
+        end do
+    end subroutine check_async_specifiers
+
+    ! A specifier value kept as source text: only a bare name can name a
+    ! variable, so anything quoted or punctuated is left to the expression path.
+    subroutine bare_name_const_reason(arena, indices, text, reason)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable, intent(out) :: reason
+        character(len=:), allocatable :: name
+        integer :: i
+
+        call set_empty(reason)
+        name = trim(adjustl(text))
+        if (len(name) == 0) return
+        do i = 1, len(name)
+            if (scan(name(i:i), 'abcdefghijklmnopqrstuvwxyz'// &
+                     'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_') == 0) return
+        end do
+        if (scan(name(1:1), '0123456789_') /= 0) return
+        call identifier_const_reason(arena, indices, name, '|', reason)
+    end subroutine bare_name_const_reason
+
+    recursive subroutine const_expr_reason(arena, indices, idx, loop_names, reason)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        integer, intent(in) :: idx
+        character(len=*), intent(in) :: loop_names
+        character(len=:), allocatable, intent(out) :: reason
+        character(len=:), allocatable :: op, err, inner
+        integer :: i, li, ri, ln, cl
+
+        call set_empty(reason)
+        if (idx <= 0) return
+        if (.not. node_exists(arena, idx)) return
+        if (is_binary_op(arena, idx)) then
+            call get_binary_op_info(arena, idx, op, li, ri, ln, cl, err)
+            if (len_trim(err) > 0) return
+            call const_expr_reason(arena, indices, li, loop_names, reason)
+            if (len_trim(reason) > 0) return
+            call const_expr_reason(arena, indices, ri, loop_names, reason)
+            return
+        end if
+        select type (nd => arena%entries(idx)%node)
+        type is (identifier_node)
+            if (.not. allocated(nd%name)) return
+            call identifier_const_reason(arena, indices, nd%name, loop_names, &
+                                         reason)
+        type is (array_literal_node)
+            if (.not. allocated(nd%element_indices)) return
+            do i = 1, size(nd%element_indices)
+                call const_expr_reason(arena, indices, nd%element_indices(i), &
+                                       loop_names, reason)
+                if (len_trim(reason) > 0) return
+            end do
+        type is (do_loop_node)
+            ! An array-constructor implied-do; its index is constant inside.
+            inner = loop_names
+            if (allocated(nd%var_name)) then
+                inner = inner//trim(lowercase_text(nd%var_name))//'|'
+            end if
+            if (allocated(nd%body_indices)) then
+                do i = 1, size(nd%body_indices)
+                    call const_expr_reason(arena, indices, nd%body_indices(i), &
+                                           inner, reason)
+                    if (len_trim(reason) > 0) return
+                end do
+            end if
+            call const_expr_reason(arena, indices, nd%start_expr_index, &
+                                   loop_names, reason)
+            if (len_trim(reason) > 0) return
+            call const_expr_reason(arena, indices, nd%end_expr_index, &
+                                   loop_names, reason)
+            if (len_trim(reason) > 0) return
+            call const_expr_reason(arena, indices, nd%step_expr_index, &
+                                   loop_names, reason)
+        type is (io_implied_do_node)
+            inner = loop_names
+            if (allocated(nd%var_name)) then
+                inner = inner//trim(lowercase_text(nd%var_name))//'|'
+            end if
+            call const_expr_reason(arena, indices, nd%expr_index, inner, reason)
+            if (len_trim(reason) > 0) return
+            if (allocated(nd%object_indices)) then
+                do i = 1, size(nd%object_indices)
+                    call const_expr_reason(arena, indices, &
+                                           nd%object_indices(i), inner, reason)
+                    if (len_trim(reason) > 0) return
+                end do
+            end if
+            call const_expr_reason(arena, indices, nd%start_expr_index, &
+                                   loop_names, reason)
+            if (len_trim(reason) > 0) return
+            call const_expr_reason(arena, indices, nd%end_expr_index, &
+                                   loop_names, reason)
+            if (len_trim(reason) > 0) return
+            call const_expr_reason(arena, indices, nd%step_expr_index, &
+                                   loop_names, reason)
+        type is (call_or_subscript_node)
+            call call_const_reason(arena, indices, nd, loop_names, reason)
+        end select
+    end subroutine const_expr_reason
+
+    recursive subroutine call_const_reason(arena, indices, nd, loop_names, reason)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        type(call_or_subscript_node), intent(in) :: nd
+        character(len=*), intent(in) :: loop_names
+        character(len=:), allocatable, intent(out) :: reason
+        character(len=:), allocatable :: cname
+        integer :: i, first_arg
+
+        call set_empty(reason)
+        if (.not. allocated(nd%name)) return
+        cname = trim(lowercase_text(nd%name))
+        first_arg = 1
+        select case (cname)
+        case ('size', 'shape', 'lbound', 'ubound')
+            ! Array inquiries are constant only when the shape itself is.
+            if (allocated(nd%arg_indices)) then
+                if (size(nd%arg_indices) >= 1) then
+                    call shape_inquiry_reason(arena, indices, &
+                                              nd%arg_indices(1), reason)
+                    if (len_trim(reason) > 0) return
+                end if
+            end if
+            first_arg = 2
+        case ('kind', 'len', 'bit_size', 'huge', 'tiny', 'epsilon', 'digits', &
+              'radix', 'maxexponent', 'minexponent', 'precision', 'range', &
+              'storage_size', 'new_line', 'selected_int_kind', &
+              'selected_real_kind', 'selected_char_kind')
+            ! Type-parameter inquiries never read the argument's value.
+            return
+        case default
+            if (.not. nd%is_array_access) then
+                if (arena_has_function_def_named(arena, nd%name)) then
+                    reason = 'function reference '''//trim(nd%name)// &
+                             ''' is not a constant expression'
+                    return
+                end if
+            end if
+            call identifier_const_reason(arena, indices, nd%name, loop_names, &
+                                         reason)
+            if (len_trim(reason) > 0) return
+        end select
+        if (.not. allocated(nd%arg_indices)) return
+        do i = first_arg, size(nd%arg_indices)
+            call const_expr_reason(arena, indices, nd%arg_indices(i), &
+                                   loop_names, reason)
+            if (len_trim(reason) > 0) return
+        end do
+    end subroutine call_const_reason
+
+    ! A name is constant when it is an implied-do index of the enclosing
+    ! constructor, a named constant, or not declared in this scope at all (a
+    ! host- or use-associated name is left to the later lowering passes).
+    subroutine identifier_const_reason(arena, indices, name, loop_names, reason)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        character(len=*), intent(in) :: name
+        character(len=*), intent(in) :: loop_names
+        character(len=:), allocatable, intent(out) :: reason
+        character(len=:), allocatable :: lname
+        integer :: i
+
+        call set_empty(reason)
+        lname = trim(lowercase_text(name))
+        if (len(lname) == 0) return
+        if (index(loop_names, '|'//lname//'|') > 0) return
+        do i = 1, size(indices)
+            if (.not. node_exists(arena, indices(i))) cycle
+            select type (decl => arena%entries(indices(i))%node)
+            type is (declaration_node)
+                if (.not. declaration_declares_name(decl, lname)) cycle
+                if (decl%is_parameter) return
+                reason = 'variable '''//trim(name)// &
+                         ''' does not reduce to a constant expression'
+                return
+            end select
+        end do
+    end subroutine identifier_const_reason
+
+    subroutine shape_inquiry_reason(arena, indices, arg_index, reason)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        integer, intent(in) :: arg_index
+        character(len=:), allocatable, intent(out) :: reason
+        character(len=:), allocatable :: lname
+        integer :: i, d
+        logical :: assumed
+
+        call set_empty(reason)
+        if (arg_index <= 0) return
+        if (.not. node_exists(arena, arg_index)) return
+        select type (nd => arena%entries(arg_index)%node)
+        type is (identifier_node)
+            if (.not. allocated(nd%name)) return
+            lname = trim(lowercase_text(nd%name))
+        class default
+            return
+        end select
+        do i = 1, size(indices)
+            if (.not. node_exists(arena, indices(i))) cycle
+            select type (decl => arena%entries(indices(i))%node)
+            type is (declaration_node)
+                if (.not. declaration_declares_name(decl, lname)) cycle
+                if (.not. decl%is_array) return
+                if (decl%is_allocatable .or. decl%is_pointer) then
+                    reason = 'deferred-shape array '''//trim(lname)// &
+                             ''' has no constant shape in an '// &
+                             'initialization expression'
+                    return
+                end if
+                if (.not. allocated(decl%dimension_indices)) return
+                assumed = .false.
+                do d = 1, size(decl%dimension_indices)
+                    if (dim_is_assumed_shape(arena, decl%dimension_indices(d))) &
+                        assumed = .true.
+                end do
+                if (assumed) then
+                    reason = 'assumed-shape array '''//trim(lname)// &
+                             ''' has no constant shape in an '// &
+                             'initialization expression'
+                end if
+                return
+            end select
+        end do
+    end subroutine shape_inquiry_reason
+
+    logical function declaration_declares_name(decl, lname) result(declares)
+        type(declaration_node), intent(in) :: decl
+        character(len=*), intent(in) :: lname
+        integer :: k
+
+        declares = .false.
+        if (allocated(decl%var_name)) then
+            if (trim(lowercase_text(decl%var_name)) == lname) then
+                declares = .true.
+                return
+            end if
+        end if
+        if (.not. decl%is_multi_declaration) return
+        if (.not. allocated(decl%var_names)) return
+        do k = 1, size(decl%var_names)
+            if (trim(lowercase_text(decl%var_names(k))) == lname) then
+                declares = .true.
+                return
+            end if
+        end do
+    end function declaration_declares_name

--- a/src/session_program_lowering_reject_const_overflow.inc
+++ b/src/session_program_lowering_reject_const_overflow.inc
@@ -1,0 +1,331 @@
+    ! Arithmetic overflow in a constant expression (F2018 10.1.12).
+    !
+    ! A constant expression is evaluated by the compiler, so a folded value that
+    ! leaves the representable range of its type makes the program invalid
+    ! rather than merely wrapping at run time. Two contexts are folded here:
+    ! integer array bounds and declaration initializers, and a REAL() kind
+    ! conversion whose constant argument does not fit the requested kind.
+
+    subroutine check_constant_expression_overflow(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=64) :: location
+        integer :: n, d
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (declaration_node)
+                if (allocated(nd%dimension_indices)) then
+                    do d = 1, size(nd%dimension_indices)
+                        if (.not. expr_overflows_integer(arena, &
+                                nd%dimension_indices(d))) cycle
+                        write (location, '(" at line ",I0,", column ",I0)') &
+                            nd%line, nd%column
+                        error_msg = 'arithmetic overflow in constant '// &
+                                    'expression'//trim(location)
+                        return
+                    end do
+                end if
+                if (nd%has_initializer .and. nd%initializer_index > 0) then
+                    if (expr_overflows_integer(arena, nd%initializer_index)) then
+                        write (location, '(" at line ",I0,", column ",I0)') &
+                            nd%line, nd%column
+                        error_msg = 'arithmetic overflow in constant '// &
+                                    'expression'//trim(location)
+                        return
+                    end if
+                end if
+            type is (call_or_subscript_node)
+                if (.not. real_conversion_overflows(arena, nd)) cycle
+                write (location, '(" at line ",I0,", column ",I0)') &
+                    nd%line, nd%column
+                error_msg = 'arithmetic overflow in constant '// &
+                            'expression'//trim(location)
+                return
+            end select
+        end do
+    end subroutine check_constant_expression_overflow
+
+    logical function expr_overflows_integer(arena, idx) result(overflows)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        integer(c_int64_t) :: value
+        integer :: kind_bytes
+        logical :: ok
+
+        call const_int_fold(arena, idx, value, kind_bytes, ok, overflows)
+    end function expr_overflows_integer
+
+    ! Fold an integer constant expression built from literals, huge(), and the
+    ! +, -, * operators, tracking the kind so the result range is checked
+    ! against the type the expression actually has.
+    recursive subroutine const_int_fold(arena, idx, value, kind_bytes, ok, ovf)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        integer(c_int64_t), intent(out) :: value
+        integer, intent(out) :: kind_bytes
+        logical, intent(out) :: ok
+        logical, intent(out) :: ovf
+        character(len=:), allocatable :: op, err, lit_value, lit_type, cname
+        integer(c_int64_t) :: lv, rv
+        integer :: li, ri, ln, cl, lk, rk
+
+        value = 0_c_int64_t
+        kind_bytes = 4
+        ok = .false.
+        ovf = .false.
+        if (idx <= 0) return
+        if (.not. node_exists(arena, idx)) return
+        if (is_binary_op(arena, idx)) then
+            call get_binary_op_info(arena, idx, op, li, ri, ln, cl, err)
+            if (len_trim(err) > 0) return
+            call const_int_fold(arena, li, lv, lk, ok, ovf)
+            if (ovf) return
+            if (.not. ok) return
+            call const_int_fold(arena, ri, rv, rk, ok, ovf)
+            if (ovf) return
+            if (.not. ok) return
+            kind_bytes = max(lk, rk)
+            ok = .false.
+            select case (trim(op))
+            case ('+')
+                call i64_add_checked(lv, rv, value, ovf)
+                ok = .not. ovf
+            case ('-')
+                call i64_add_checked(lv, -rv, value, ovf)
+                ok = .not. ovf
+            case ('*')
+                call i64_mul_checked(lv, rv, value, ovf)
+                ok = .not. ovf
+            case default
+                return
+            end select
+            if (ovf) return
+            if (abs(value) > integer_kind_limit(kind_bytes)) then
+                ovf = .true.
+                ok = .false.
+            end if
+            return
+        end if
+        select type (nd => arena%entries(idx)%node)
+        type is (call_or_subscript_node)
+            if (.not. allocated(nd%name)) return
+            cname = trim(lowercase_text(nd%name))
+            if (cname /= 'huge') return
+            if (.not. allocated(nd%arg_indices)) return
+            if (size(nd%arg_indices) /= 1) return
+            call const_int_fold(arena, nd%arg_indices(1), lv, lk, ok, ovf)
+            ovf = .false.
+            if (.not. ok) return
+            kind_bytes = lk
+            value = integer_kind_limit(lk)
+            ok = .true.
+        class default
+            if (.not. is_literal(arena, idx)) return
+            call get_literal_info(arena, idx, lit_value, lit_type, err)
+            if (len_trim(err) > 0) return
+            if (allocated(lit_type)) then
+                if (len_trim(lit_type) > 0) then
+                    if (trim(lowercase_text(lit_type)) /= 'integer') return
+                end if
+            end if
+            call parse_integer_literal(lit_value, value, kind_bytes, ok)
+        end select
+    end subroutine const_int_fold
+
+    subroutine parse_integer_literal(text, value, kind_bytes, ok)
+        character(len=*), intent(in) :: text
+        integer(c_int64_t), intent(out) :: value
+        integer, intent(out) :: kind_bytes
+        logical, intent(out) :: ok
+        character(len=:), allocatable :: body, suffix
+        integer :: us, ios
+
+        value = 0_c_int64_t
+        kind_bytes = 4
+        ok = .false.
+        body = trim(adjustl(text))
+        if (len(body) == 0) return
+        us = index(body, '_')
+        if (us > 0) then
+            suffix = trim(body(us + 1:))
+            body = trim(body(:us - 1))
+            if (.not. is_integer_text(suffix)) return
+            read (suffix, *, iostat=ios) kind_bytes
+            if (ios /= 0) return
+        end if
+        if (.not. is_integer_text(body)) return
+        read (body, *, iostat=ios) value
+        if (ios /= 0) return
+        ok = .true.
+    end subroutine parse_integer_literal
+
+    integer(c_int64_t) function integer_kind_limit(kind_bytes) result(limit)
+        integer, intent(in) :: kind_bytes
+
+        select case (kind_bytes)
+        case (1)
+            limit = 127_c_int64_t
+        case (2)
+            limit = 32767_c_int64_t
+        case (8)
+            limit = huge(0_c_int64_t)
+        case default
+            limit = 2147483647_c_int64_t
+        end select
+    end function integer_kind_limit
+
+    subroutine i64_add_checked(a, b, r, ovf)
+        integer(c_int64_t), intent(in) :: a, b
+        integer(c_int64_t), intent(out) :: r
+        logical, intent(out) :: ovf
+
+        ovf = .false.
+        r = 0_c_int64_t
+        if (b > 0_c_int64_t) then
+            if (a > huge(0_c_int64_t) - b) then
+                ovf = .true.
+                return
+            end if
+        else if (b < 0_c_int64_t) then
+            if (a < -huge(0_c_int64_t) - b) then
+                ovf = .true.
+                return
+            end if
+        end if
+        r = a + b
+    end subroutine i64_add_checked
+
+    subroutine i64_mul_checked(a, b, r, ovf)
+        integer(c_int64_t), intent(in) :: a, b
+        integer(c_int64_t), intent(out) :: r
+        logical, intent(out) :: ovf
+
+        ovf = .false.
+        r = 0_c_int64_t
+        if (a /= 0_c_int64_t) then
+            if (abs(b) > huge(0_c_int64_t)/abs(a)) then
+                ovf = .true.
+                return
+            end if
+        end if
+        r = a*b
+    end subroutine i64_mul_checked
+
+    ! real(x, kind) with a constant x whose magnitude exceeds the target kind.
+    logical function real_conversion_overflows(arena, nd) result(overflows)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: nd
+        character(len=:), allocatable :: cname
+        real(c_double) :: value
+        integer(c_int64_t) :: kind_value
+        integer :: kind_bytes
+        logical :: ok, ovf
+
+        overflows = .false.
+        if (.not. allocated(nd%name)) return
+        cname = trim(lowercase_text(nd%name))
+        if (cname /= 'real') return
+        if (.not. allocated(nd%arg_indices)) return
+        if (size(nd%arg_indices) /= 2) return
+        call const_int_fold(arena, nd%arg_indices(2), kind_value, kind_bytes, &
+                            ok, ovf)
+        if (.not. ok) return
+        if (kind_value /= 4_c_int64_t) return
+        call const_real_fold(arena, nd%arg_indices(1), value, ok)
+        if (.not. ok) return
+        overflows = abs(value) > real(huge(0.0_c_float), c_double)
+    end function real_conversion_overflows
+
+    ! Fold a real constant expression built from real literals and huge().
+    recursive subroutine const_real_fold(arena, idx, value, ok)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        real(c_double), intent(out) :: value
+        logical, intent(out) :: ok
+        character(len=:), allocatable :: lit_value, lit_type, err, cname
+        integer :: kind_bytes
+
+        value = 0.0_c_double
+        ok = .false.
+        if (idx <= 0) return
+        if (.not. node_exists(arena, idx)) return
+        select type (nd => arena%entries(idx)%node)
+        type is (call_or_subscript_node)
+            if (.not. allocated(nd%name)) return
+            cname = trim(lowercase_text(nd%name))
+            if (cname /= 'huge') return
+            if (.not. allocated(nd%arg_indices)) return
+            if (size(nd%arg_indices) /= 1) return
+            call real_literal_kind(arena, nd%arg_indices(1), kind_bytes, ok)
+            if (.not. ok) return
+            if (kind_bytes == 8) then
+                value = huge(0.0_c_double)
+            else
+                value = real(huge(0.0_c_float), c_double)
+            end if
+        class default
+            if (.not. is_literal(arena, idx)) return
+            call get_literal_info(arena, idx, lit_value, lit_type, err)
+            if (len_trim(err) > 0) return
+            if (allocated(lit_type)) then
+                if (len_trim(lit_type) > 0) then
+                    if (trim(lowercase_text(lit_type)) /= 'real') return
+                end if
+            end if
+            call parse_real_literal(lit_value, value, kind_bytes, ok)
+        end select
+    end subroutine const_real_fold
+
+    subroutine real_literal_kind(arena, idx, kind_bytes, ok)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        integer, intent(out) :: kind_bytes
+        logical, intent(out) :: ok
+        character(len=:), allocatable :: lit_value, lit_type, err
+        real(c_double) :: value
+
+        kind_bytes = 4
+        ok = .false.
+        if (idx <= 0) return
+        if (.not. node_exists(arena, idx)) return
+        if (.not. is_literal(arena, idx)) return
+        call get_literal_info(arena, idx, lit_value, lit_type, err)
+        if (len_trim(err) > 0) return
+        if (allocated(lit_type)) then
+            if (len_trim(lit_type) > 0) then
+                if (trim(lowercase_text(lit_type)) /= 'real') return
+            end if
+        end if
+        call parse_real_literal(lit_value, value, kind_bytes, ok)
+    end subroutine real_literal_kind
+
+    subroutine parse_real_literal(text, value, kind_bytes, ok)
+        character(len=*), intent(in) :: text
+        real(c_double), intent(out) :: value
+        integer, intent(out) :: kind_bytes
+        logical, intent(out) :: ok
+        character(len=:), allocatable :: body, suffix
+        integer :: us, ios
+
+        value = 0.0_c_double
+        kind_bytes = 4
+        ok = .false.
+        body = trim(adjustl(text))
+        if (len(body) == 0) return
+        us = index(body, '_')
+        if (us > 0) then
+            suffix = trim(body(us + 1:))
+            body = trim(body(:us - 1))
+            if (.not. is_integer_text(suffix)) return
+            read (suffix, *, iostat=ios) kind_bytes
+            if (ios /= 0) return
+        else if (index(lowercase_text(body), 'd') > 0) then
+            kind_bytes = 8
+        end if
+        read (body, *, iostat=ios) value
+        if (ios /= 0) return
+        ok = .true.
+    end subroutine parse_real_literal

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -546,6 +546,10 @@
         if (len_trim(error_msg) > 0) return
         call check_format_specifications(arena, error_msg)
         if (len_trim(error_msg) > 0) return
+        call check_constant_initialization_exprs(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_constant_expression_overflow(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
         call set_empty(error_msg)
     end subroutine validate_program
     subroutine lower_program_return(arena, root_index, context, value, error_msg)

--- a/test/conformance/fail_owners_gfortran_dg.txt
+++ b/test/conformance/fail_owners_gfortran_dg.txt
@@ -90,7 +90,6 @@ eor_handling_2.f90 # owner=lazy-fortran/ffc#434; reason=owns fixed-width A input
 equiv_constraint_bind_c.f90 # owner=lazy-fortran/ffc#392; reason=enforce COMMON EQUIVALENCE SAVE and BLOCK DATA restrictions
 error_recovery_2.f90 # owner=lazy-fortran/fortfront#2898; reason=reject malformed iterators and delimiters
 error_recovery_3.f90 # owner=lazy-fortran/fortfront#2893; reason=require matching construct terminators
-error_recovery_4.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
 external_implicit_none_2.f90 # owner=lazy-fortran/fortfront#2892; reason=reject unresolved and use-before-definition symbols
 external_initializer.f90 # owner=lazy-fortran/fortfront#2895; reason=reject duplicate or incompatible declaration attributes
 f_c_string5.f90 # owner=lazy-fortran/ffc#453; reason=owns scalar conversion intrinsic dispatch; deferred character storage is dependency #349
@@ -129,9 +128,6 @@ impure_actual_1.f90 # owner=lazy-fortran/fortfront#2885; reason=enforce PURE ELE
 impure_assignment_1.f90 # owner=lazy-fortran/fortfront#2885; reason=enforce PURE ELEMENTAL and RECURSIVE restrictions
 impure_assignment_2.f90 # owner=lazy-fortran/fortfront#2885; reason=enforce PURE ELEMENTAL and RECURSIVE restrictions
 initialization_23.f90 # owner=lazy-fortran/ffc#388; reason=reject incompatible array constructor types
-initialization_25.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
-initialization_28.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
-initialization_7.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
 inline_sum_2.f90 # owner=lazy-fortran/ffc#359; reason=capture dummy-bound extents on entry
 interface_20.f90 # owner=lazy-fortran/fortfront#2882; reason=reject procedure-call signature mismatches
 interface_21.f90 # owner=lazy-fortran/fortfront#2882; reason=reject procedure-call signature mismatches
@@ -150,7 +146,6 @@ interface_derived_type_1.f90 # owner=lazy-fortran/fortfront#2892; reason=reject 
 interface_operator_1.f90 # owner=lazy-fortran/fortfront#2893; reason=require matching construct terminators
 interface_operator_2.f90 # owner=lazy-fortran/fortfront#2893; reason=require matching construct terminators
 interface_operator_3.f90 # owner=lazy-fortran/fortfront#2887; reason=validate USE exports renames and operator imports
-intrinsic_param_1.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
 invalid_name.f90 # owner=lazy-fortran/fortfront#2890; reason=reject invalid source and identifier characters
 invalid_procedure_name.f90 # owner=lazy-fortran/ffc#378; reason=reject malformed or ambiguous generic interfaces
 io_constraints_15.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
@@ -229,8 +224,6 @@ pr77391.f90 # owner=lazy-fortran/ffc#380; reason=reject invalid allocation and p
 pr77414.f90 # owner=lazy-fortran/fortfront#2888; reason=reject local and host-associated name collisions
 pr77583.f90 # owner=lazy-fortran/fortfront#2895; reason=reject duplicate or incompatible declaration attributes
 pr78719_2.f90 # owner=lazy-fortran/ffc#381; reason=enforce data and procedure pointer target contracts
-pr81027.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
-pr84734.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
 pr85798.f90 # owner=lazy-fortran/ffc#390; reason=enforce derived-type definition constraints
 pr87922.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
 pr88025.f90 # owner=lazy-fortran/ffc#384; reason=require valid character length expressions
@@ -245,7 +238,6 @@ pr91650_1.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list cons
 pr91660_1.f90 # owner=lazy-fortran/fortfront#2891; reason=reject malformed type and SELECT TYPE syntax
 pr91715.f90 # owner=lazy-fortran/fortfront#2891; reason=reject malformed type and SELECT TYPE syntax
 pr91959.f90 # owner=lazy-fortran/fortfront#2890; reason=reject invalid source and identifier characters
-pr91960_1.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
 pr93423.f90 # owner=lazy-fortran/fortfront#2900; reason=enforce submodule declaration consistency
 pr93601.f90 # owner=lazy-fortran/ffc#393; reason=reject BOZ literals outside permitted contexts
 pr93603.f90 # owner=lazy-fortran/ffc#393; reason=reject BOZ literals outside permitted contexts
@@ -324,7 +316,6 @@ volatile14.f90 # owner=lazy-fortran/fortfront#2883; reason=enforce explicit-inte
 whole_file_16.f90 # owner=lazy-fortran/fortfront#2883; reason=enforce explicit-interface declaration rules
 whole_file_24.f90 # owner=lazy-fortran/ffc#365; reason=owns allocatable derived components and function-result assignment
 whole_file_33.f90 # owner=lazy-fortran/ffc#334; reason=owns assumed-shape array dummy bounds and descriptor passing
-write_check4.f90 # owner=lazy-fortran/ffc#387; reason=require valid constant initialization expressions
 write_check5.f90 # owner=lazy-fortran/ffc#391; reason=reject malformed FORMAT descriptors
 write_invalid_format.f90 # owner=lazy-fortran/ffc#391; reason=reject malformed FORMAT descriptors
 zero_stride_1.f90 # owner=lazy-fortran/ffc#386; reason=reject invalid array indexing and shape expressions

--- a/test/conformance/skip_gfortran_dg.txt
+++ b/test/conformance/skip_gfortran_dg.txt
@@ -1139,6 +1139,7 @@ intrinsic_actual_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortra
 intrinsic_optional_char_arg_1.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
 intrinsic_pack_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
 intrinsic_pack_3.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics
+intrinsic_param_1.f90 # scope=compiler-flags; reason=dg-additional-options requests -std=f95, under which a transformational intrinsic is not a constant expression
 intrinsic_shadow_4.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
 intrinsic_size_3.f90 # scope=compiler-flags; reason=requires unmodeled gfortran.dg compiler-option semantics
 intrinsic_spread_2.f90 # scope=harness; reason=requires unmodeled DejaGNU directive semantics

--- a/test/test_session_reject_const_01_compiler.f90
+++ b/test/test_session_reject_const_01_compiler.f90
@@ -1,0 +1,183 @@
+program test_session_reject_const_01_compiler
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== constant initialization expression rejection test ==='
+
+    all_passed = .true.
+    if (.not. test_variable_in_initializer_rejected()) all_passed = .false.
+    if (.not. test_named_constant_inquiry_accepted()) all_passed = .false.
+    if (.not. test_assumed_shape_inquiry_rejected()) all_passed = .false.
+    if (.not. test_fixed_shape_inquiry_accepted()) all_passed = .false.
+    if (.not. test_implied_do_variable_rejected()) all_passed = .false.
+    if (.not. test_implied_do_index_accepted()) all_passed = .false.
+    if (.not. test_integer_bound_overflow_rejected()) all_passed = .false.
+    if (.not. test_in_range_bound_accepted()) all_passed = .false.
+    if (.not. test_real_conversion_overflow_rejected()) all_passed = .false.
+    if (.not. test_in_range_real_conversion_accepted()) all_passed = .false.
+    if (.not. test_variable_asynchronous_rejected()) all_passed = .false.
+    if (.not. test_constant_asynchronous_accepted()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: initialization expressions must reduce to constants'
+
+contains
+
+    ! Rule 1: an initializer may not read a variable.
+    logical function test_variable_in_initializer_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=2) :: xx = "aa"'//new_line('a')// &
+            '  integer :: iloc = index(xx, "bb")'//new_line('a')// &
+            '  print *, iloc'//new_line('a')// &
+            'end program main'
+
+        test_variable_in_initializer_rejected = expect_error_contains( &
+            source, 'does not reduce to a constant expression', &
+            '/tmp/ffc_reject_const_01_variable')
+    end function test_variable_in_initializer_rejected
+
+    logical function test_named_constant_inquiry_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=2), parameter :: xx = "aa"'//new_line('a')// &
+            '  integer, parameter :: n = len(xx)'//new_line('a')// &
+            '  stop n'//new_line('a')// &
+            'end program main'
+
+        test_named_constant_inquiry_accepted = expect_exit_status( &
+            source, 2, '/tmp/ffc_reject_const_01_named')
+    end function test_named_constant_inquiry_accepted
+
+    ! Rule 2: the shape of an assumed-shape dummy is not a constant.
+    logical function test_assumed_shape_inquiry_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: j(3)'//new_line('a')// &
+            '  j = 1'//new_line('a')// &
+            '  call doubling(j)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine doubling(n)'//new_line('a')// &
+            '    integer, intent(in) :: n(:)'//new_line('a')// &
+            '    integer :: m = size(n)'//new_line('a')// &
+            '    print *, m'//new_line('a')// &
+            '  end subroutine doubling'//new_line('a')// &
+            'end program main'
+
+        test_assumed_shape_inquiry_rejected = expect_error_contains( &
+            source, 'assumed-shape array', &
+            '/tmp/ffc_reject_const_01_assumed')
+    end function test_assumed_shape_inquiry_rejected
+
+    logical function test_fixed_shape_inquiry_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: fixed(4)'//new_line('a')// &
+            '  integer :: m = size(fixed)'//new_line('a')// &
+            '  fixed = 1'//new_line('a')// &
+            '  stop m'//new_line('a')// &
+            'end program main'
+
+        test_fixed_shape_inquiry_accepted = expect_exit_status( &
+            source, 4, '/tmp/ffc_reject_const_01_fixed')
+    end function test_fixed_shape_inquiry_accepted
+
+    ! Rule 3: an array-constructor implied-do may only use its own index.
+    logical function test_implied_do_variable_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: i, j'//new_line('a')// &
+            '  integer :: v(3) = [(j, i=1,3)]'//new_line('a')// &
+            '  print *, v'//new_line('a')// &
+            'end program main'
+
+        test_implied_do_variable_rejected = expect_error_contains( &
+            source, 'does not reduce to a constant expression', &
+            '/tmp/ffc_reject_const_01_impliedvar')
+    end function test_implied_do_variable_rejected
+
+    logical function test_implied_do_index_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  integer :: v(3) = [(i, i=1,3)]'//new_line('a')// &
+            '  stop v(3)'//new_line('a')// &
+            'end program main'
+
+        test_implied_do_index_accepted = expect_exit_status( &
+            source, 3, '/tmp/ffc_reject_const_01_impliedidx')
+    end function test_implied_do_index_accepted
+
+    ! Rule 4: a folded integer constant must stay inside its kind range.
+    logical function test_integer_bound_overflow_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: b(huge(1_8) + 1_8) = 0'//new_line('a')// &
+            '  print *, b(1)'//new_line('a')// &
+            'end program main'
+
+        test_integer_bound_overflow_rejected = expect_error_contains( &
+            source, 'arithmetic overflow in constant expression', &
+            '/tmp/ffc_reject_const_01_intovf')
+    end function test_integer_bound_overflow_rejected
+
+    logical function test_in_range_bound_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: b(huge(1_8) - huge(1_8) + 4) = 0'//new_line('a')// &
+            '  stop size(b)'//new_line('a')// &
+            'end program main'
+
+        test_in_range_bound_accepted = expect_exit_status( &
+            source, 4, '/tmp/ffc_reject_const_01_intok')
+    end function test_in_range_bound_accepted
+
+    ! Rule 5: a constant REAL() conversion must fit the requested kind.
+    logical function test_real_conversion_overflow_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  print *, real(huge(1.0_8), 4)'//new_line('a')// &
+            'end program main'
+
+        test_real_conversion_overflow_rejected = expect_error_contains( &
+            source, 'arithmetic overflow in constant expression', &
+            '/tmp/ffc_reject_const_01_realovf')
+    end function test_real_conversion_overflow_rejected
+
+    logical function test_in_range_real_conversion_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  print *, real(huge(1.0_4), 4)'//new_line('a')// &
+            'end program main'
+
+        test_in_range_real_conversion_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_reject_const_01_realok')
+    end function test_in_range_real_conversion_accepted
+
+    ! Rule 6: ASYNCHRONOUS= on a transfer statement is an init expression.
+    logical function test_variable_asynchronous_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(2) :: no'//new_line('a')// &
+            '  no = "no"'//new_line('a')// &
+            '  write(*,*,asynchronous=no) 7'//new_line('a')// &
+            'end program main'
+
+        test_variable_asynchronous_rejected = expect_error_contains( &
+            source, 'does not reduce to a constant expression', &
+            '/tmp/ffc_reject_const_01_async')
+    end function test_variable_asynchronous_rejected
+
+    logical function test_constant_asynchronous_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  write(*,*,asynchronous="no") 7'//new_line('a')// &
+            'end program main'
+
+        test_constant_asynchronous_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_reject_const_01_asyncok')
+    end function test_constant_asynchronous_accepted
+
+end program test_session_reject_const_01_compiler


### PR DESCRIPTION
Closes #387.

## Preserved compiler invariant

An initialization expression must reduce to a constant at compile time
(F2018 10.1.12). `validate_program` now enforces that before any lowering:

- A declaration initializer, and the `ASYNCHRONOUS=` specifier of a
  READ/WRITE, may not reference a variable, a user function, or the shape
  of an assumed-shape or deferred-shape array. An implied-do index of the
  same constructor and a type-parameter inquiry (`kind`, `len`, `huge`, …)
  stay constant.
- A folded integer array bound or initializer that leaves its kind range,
  and a constant `REAL(x, kind)` conversion whose value does not fit the
  requested kind, are rejected as arithmetic overflow.

Validation walks typed nodes and the declaration list of the enclosing
scope; nothing keys off filenames or gfortran message text. A name that is
not declared in the scope (host- or use-associated) is left to the later
passes, so the check only rejects what it can positively prove non-constant.

Harness: a `dg-error` directive marked `{ xfail ... }` records an error
gfortran is *not* expected to emit, so it no longer makes a file a negative
test (`initialization_25.f90`, whose only directive is xfail'd and whose
source line is commented out). `intrinsic_param_1.f90` needs
`-std=f95` — a transformational intrinsic *is* a valid constant expression
from F2003 on — so it joins the `compiler-flags` skip list rather than
being wrongly rejected under the default standard.

## Red evidence

Before the change, on the same tree with only the test present:

```
$ fo test test_session_reject_const_01_compiler
   FAIL: unsupported source lowered without diagnostic   (x6)
Summary: 0 passed, 1 failed, 0 skipped

$ scripts/conformance_gauntlet.sh --suite gfortran-dg --file error_recovery_4.f90 ... --file write_check4.f90
  FAIL: error_recovery_4.f90 (negative test accepted)
  ... 9 files
  PASS=0  XFAIL=0  XPASS=0  FAIL=9  NOREF=0  SKIP=0  TOTAL=9
```

## Green evidence

```
$ fo test test_session_reject_const_01_compiler
test_session_reject_const_01_compiler      PASS
Summary: 1 passed, 0 failed, 0 skipped

$ scripts/conformance_gauntlet.sh --suite gfortran-dg --file error_recovery_4.f90 ... --file write_check4.f90
  PASS=8  XFAIL=0  XPASS=0  FAIL=0  NOREF=0  SKIP=1  TOTAL=9

$ fo
Build: OK   Static: OK   Tests: 263/264
```

The one remaining red test is `test_parity_dashboard`: editing any
conformance manifest stales `test/conformance/parity_dashboard.tsv`'s
recorded manifest digest. Regenerating that snapshot needs full
`--require-provenance` runs of all four suites on an idle machine, and
docs/CONFORMANCE.md requires such a PR to be merged with a merge commit
rather than squashed — so it is left to the periodic parity refresh, as in
the recent manifest-touching PRs.