### PR TITLE
[procptr-shape-01] pass shaped arrays through procedure pointers (#362)

### DIFF
--- a/src/session_program_lowering_arrays.inc
+++ b/src/session_program_lowering_arrays.inc
@@ -787,7 +787,7 @@
         if (is_subroutine_call_statement(arena, node_index)) then
             call get_subroutine_call_name(arena, node_index, call_name, err)
             if (len_trim(err) > 0) return
-            if (.not. same_name(call_name, proc_name)) return
+            if (.not. call_name_reaches_proc(arena, call_name, proc_name)) return
             call get_subroutine_call_arg_indices(arena, node_index, arg_indices, &
                                                  err)
             if (len_trim(err) > 0) return
@@ -797,11 +797,55 @@
         select type (cnode => arena%entries(node_index)%node)
         type is (call_or_subscript_node)
             if (.not. allocated(cnode%name)) return
-            if (.not. same_name(cnode%name, proc_name)) return
+            if (.not. call_name_reaches_proc(arena, cnode%name, proc_name)) return
             if (allocated(cnode%arg_indices)) arg_indices = cnode%arg_indices
             matches = .true.
         end select
     end function call_targets_proc
+
+    logical function call_name_reaches_proc(arena, call_name, proc_name) &
+            result(reaches)
+        ! True when a call written as call_name reaches proc_name: either it
+        ! names proc_name directly, or call_name is a procedure pointer that the
+        ! program associates with proc_name (#362). An indirect call through such
+        ! a pointer supplies its actuals to proc_name's dummies exactly like a
+        ! direct call, so assumed-shape extent resolution must see it.
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: call_name
+        character(len=*), intent(in) :: proc_name
+
+        reaches = .true.
+        if (same_name(call_name, proc_name)) return
+        reaches = proc_pointer_binds_target(arena, call_name, proc_name)
+    end function call_name_reaches_proc
+
+    logical function proc_pointer_binds_target(arena, ptr_name, proc_name) &
+            result(binds)
+        ! True when the arena holds a pointer assignment `ptr_name => proc_name`.
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: ptr_name
+        character(len=*), intent(in) :: proc_name
+        integer :: n
+        character(len=:), allocatable :: lhs_name, rhs_name, err
+
+        binds = .false.
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (pnode => arena%entries(n)%node)
+            type is (pointer_assignment_node)
+                if (.not. is_identifier(arena, pnode%pointer_index)) cycle
+                if (.not. is_identifier(arena, pnode%target_index)) cycle
+                call get_identifier_name(arena, pnode%pointer_index, lhs_name, err)
+                if (len_trim(err) > 0) cycle
+                if (.not. same_name(lhs_name, ptr_name)) cycle
+                call get_identifier_name(arena, pnode%target_index, rhs_name, err)
+                if (len_trim(err) > 0) cycle
+                if (.not. same_name(rhs_name, proc_name)) cycle
+                binds = .true.
+                return
+            end select
+        end do
+    end function proc_pointer_binds_target
 
     subroutine array_decl_extents(context, var_name, dim_count, extents, ok)
         ! Find var_name's array declaration anywhere in the arena and compute its

--- a/src/session_program_lowering_pointer.inc
+++ b/src/session_program_lowering_pointer.inc
@@ -736,6 +736,38 @@
         ok = idx > 0 .and. context%symbols(idx)%is_proc_pointer
     end function is_proc_pointer_call
 
+    subroutine resolve_proc_pointer_callee_name(arena, ptr_name, callee_name)
+        ! Name to validate an indirect call against (#362). A procedure pointer
+        ! associated with a procedure defined or interfaced in this unit keeps
+        ! that procedure's interface: the call must use the same descriptor
+        ! passing and rank checks as a direct call, so argument lowering is
+        ! driven by the target's name. Without a resolvable target the pointer's
+        ! own name is kept, which carries no dummy information.
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: ptr_name
+        character(len=:), allocatable, intent(out) :: callee_name
+        integer :: n
+        character(len=:), allocatable :: lhs_name, rhs_name, err
+
+        callee_name = trim(ptr_name)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (pnode => arena%entries(n)%node)
+            type is (pointer_assignment_node)
+                if (.not. is_identifier(arena, pnode%pointer_index)) cycle
+                if (.not. is_identifier(arena, pnode%target_index)) cycle
+                call get_identifier_name(arena, pnode%pointer_index, lhs_name, err)
+                if (len_trim(err) > 0) cycle
+                if (.not. same_name(lhs_name, ptr_name)) cycle
+                call get_identifier_name(arena, pnode%target_index, rhs_name, err)
+                if (len_trim(err) > 0) cycle
+                if (arena_proc_param_count(arena, rhs_name) < 0) cycle
+                callee_name = trim(rhs_name)
+                return
+            end select
+        end do
+    end subroutine resolve_proc_pointer_callee_name
+
     subroutine lower_i32_proc_ptr_call(arena, node, context, value, error_msg)
         ! Indirect integer function call through a procedure pointer.
         type(ast_arena_t), intent(in) :: arena
@@ -747,13 +779,15 @@
         type(lr_operand_desc_t), allocatable :: args(:)
         integer, allocatable :: copyback_indices(:)
         integer :: idx
+        character(len=:), allocatable :: callee_name
 
         idx = find_symbol_compat(context, node%name)
+        call resolve_proc_pointer_callee_name(arena, node%name, callee_name)
         if (.not. emit_ptr_load(context%session, context%symbols(idx)%address, &
                                 callee_ptr, error_msg)) return
         if (allocated(node%arg_indices)) then
             call prepare_reference_args(arena, node%arg_indices, context, &
-                                        VALUE_I32, node%name, args, &
+                                        VALUE_I32, callee_name, args, &
                                         copyback_indices, error_msg)
             if (len_trim(error_msg) > 0) return
         else
@@ -777,17 +811,20 @@
         type(lr_operand_desc_t), allocatable :: args(:)
         integer, allocatable :: copyback_indices(:)
         integer :: idx
+        character(len=:), allocatable :: callee_name
 
         call get_subroutine_call_name(arena, node_index, name, error_msg)
         if (len_trim(error_msg) > 0) return
         idx = find_symbol_compat(context, name)
+        call resolve_proc_pointer_callee_name(arena, name, callee_name)
         if (.not. emit_ptr_load(context%session, context%symbols(idx)%address, &
                                 callee_ptr, error_msg)) return
         call get_subroutine_call_arg_indices(arena, node_index, arg_indices, &
                                              error_msg)
         if (len_trim(error_msg) > 0) return
         call prepare_reference_args(arena, arg_indices, context, VALUE_I32, &
-                                    name, args, copyback_indices, error_msg)
+                                    callee_name, args, copyback_indices, &
+                                    error_msg)
         if (len_trim(error_msg) > 0) return
         if (.not. emit_void_indirect_call(context%session, callee_ptr, args, &
                                           error_msg)) return

--- a/test/test_session_pointer_proc_compiler.f90
+++ b/test/test_session_pointer_proc_compiler.f90
@@ -55,5 +55,72 @@ program test_session_pointer_proc
         'end program main', 10, &
         '/tmp/ffc_proc_ptr_sub_test')) stop 1
 
+    ! #362: an assumed-shape dummy reached through a procedure pointer uses the
+    ! same descriptor-passing ABI as a direct call.
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'implicit none'//new_line('a')// &
+        'procedure(), pointer :: fp'//new_line('a')// &
+        'integer :: v(4)'//new_line('a')// &
+        'v = [1, 2, 3, 4]'//new_line('a')// &
+        'fp => total'//new_line('a')// &
+        'stop fp(v)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        'integer function total(a)'//new_line('a')// &
+        'integer, intent(in) :: a(:)'//new_line('a')// &
+        'integer :: i'//new_line('a')// &
+        'total = 0'//new_line('a')// &
+        'do i = 1, size(a)'//new_line('a')// &
+        'total = total + a(i)'//new_line('a')// &
+        'end do'//new_line('a')// &
+        'end function total'//new_line('a')// &
+        'end program main', 10, &
+        '/tmp/ffc_proc_ptr_assumed_shape_test')) stop 1
+
+    ! #362: a shaped actual through a procedure pointer also reaches an
+    ! assumed-shape subroutine dummy, which writes back into the caller.
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'implicit none'//new_line('a')// &
+        'procedure(), pointer :: sp'//new_line('a')// &
+        'integer :: v(3)'//new_line('a')// &
+        'v = [1, 2, 3]'//new_line('a')// &
+        'sp => bump'//new_line('a')// &
+        'call sp(v)'//new_line('a')// &
+        'stop v(1) + v(2) + v(3)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        'subroutine bump(a)'//new_line('a')// &
+        'integer, intent(inout) :: a(:)'//new_line('a')// &
+        'integer :: i'//new_line('a')// &
+        'do i = 1, size(a)'//new_line('a')// &
+        'a(i) = a(i) + 10'//new_line('a')// &
+        'end do'//new_line('a')// &
+        'end subroutine bump'//new_line('a')// &
+        'end program main', 36, &
+        '/tmp/ffc_proc_ptr_assumed_shape_sub_test')) stop 1
+
+    ! #362 negative: a scalar actual passed through the pointer to an
+    ! assumed-shape dummy is rejected with the same source diagnostic a direct
+    ! call to the same procedure produces (no extent-bearing whole-array
+    ! actual), instead of silently lowering a rank-mismatched call.
+    if (.not. expect_error_contains( &
+        'program main'//new_line('a')// &
+        'implicit none'//new_line('a')// &
+        'procedure(), pointer :: fp'//new_line('a')// &
+        'fp => total'//new_line('a')// &
+        'stop fp(3)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        'integer function total(a)'//new_line('a')// &
+        'integer, intent(in) :: a(:)'//new_line('a')// &
+        'integer :: i'//new_line('a')// &
+        'total = 0'//new_line('a')// &
+        'do i = 1, size(a)'//new_line('a')// &
+        'total = total + a(i)'//new_line('a')// &
+        'end do'//new_line('a')// &
+        'end function total'//new_line('a')// &
+        'end program main', &
+        'assumed-shape dummy extent must come from a whole-array actual', &
+        '/tmp/ffc_proc_ptr_rank_mismatch_test')) stop 1
+
     print *, 'PASS: procedure pointer to function and subroutine'
 end program test_session_pointer_proc


### PR DESCRIPTION
Closes #362.

## What changed
- `src/session_program_lowering_pointer.inc`: `resolve_proc_pointer_callee_name` resolves `fp => proc` at each indirect call site, so `prepare_reference_args` lowers the actuals against the target's interface instead of the pointer's (interface-less) name.
- `src/session_program_lowering_arrays.inc`: `call_name_reaches_proc` lets assumed-shape extent resolution see calls written through a procedure pointer bound to the callee.
- `test/test_session_pointer_proc_compiler.f90`: rank-1 assumed-shape function dummy and `intent(inout)` subroutine dummy called through a pointer, plus a negative fixture.

## Preserved compiler invariant
An indirect call through a procedure pointer with a resolvable target uses exactly the same descriptor-passing ABI, extent resolution, and rank/type validation as a direct call to that procedure. A pointer with no resolvable target keeps its previous behaviour. The negative fixture asserts the indirect call emits the same source diagnostic a direct call with the same rank-mismatched actual emits (no silent lowering).

## Evidence
Red (before, on main): `stop fp(v)` with `integer, intent(in) :: a(:)` failed to compile — `error: unsupported assumed-shape array: assumed-shape dummy extent must come from a whole-array actual of compile-time size`; after the callee-side fix alone it failed with `error: unsupported array argument: whole-array procedure arguments are not supported`.

Green: same program now compiles and `STOP 10` (1+2+3+4); `fo test test_session_pointer_proc_compiler` passes (all five cases).

Full `fo` pipeline: only `test_parity_dashboard` fails, and it fails identically on unmodified `origin/main` in a clean worktree (stale snapshot revision/digest, environment-dependent). No other test regressed.