### PR TITLE
Reject unsupported real and complex kinds instead of narrowing (#413)

### DIFF
--- a/src/session_program_lowering_declarations.inc
+++ b/src/session_program_lowering_declarations.inc
@@ -796,12 +796,19 @@
                                             value_kind, error_msg, context, &
                                             reference_index)
         case ('real')
+            call check_float_kind_supported('real', kind_spec, line, column, &
+                                            error_msg, context, reference_index)
+            if (len_trim(error_msg) > 0) return
             if (real_kind_is_f64(kind_spec, context, reference_index)) then
                 value_kind = VALUE_F64
             else
                 value_kind = VALUE_F32
             end if
         case ('complex')
+            call check_float_kind_supported('complex', kind_spec, line, &
+                                            column, error_msg, context, &
+                                            reference_index)
+            if (len_trim(error_msg) > 0) return
             if (complex_kind_is_c8(kind_spec, context, reference_index)) then
                 value_kind = VALUE_C8
             else
@@ -983,6 +990,64 @@
         resolved = .true.
         value = context%symbols(symbol_index)%i32_constant
     end subroutine resolve_kind_parameter_value
+
+    ! Reject a real/complex kind selector whose value has no exact machine
+    ! representation in the direct LIRIC session (real kinds 4 and 8 only).
+    ! Silently narrowing real(16)/complex(16) to a supported width would change
+    ! the program's arithmetic, so the requested kind is reported instead.
+    ! Only kind selectors that resolve to a definite value - numeric literals
+    ! and declared integer parameters - are judged here; symbolic kind names
+    ! keep their existing classification.
+    subroutine check_float_kind_supported(base, kind_spec, line, column, &
+                                          error_msg, context, reference_index)
+        character(len=*), intent(in) :: base
+        character(len=*), intent(in) :: kind_spec
+        integer, intent(in) :: line, column
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lowering_context_t), intent(in), optional :: context
+        integer, intent(in), optional :: reference_index
+        logical :: resolved, has_value
+        integer(c_int64_t) :: kind_value
+        character(len=32) :: kind_text
+
+        call set_empty(error_msg)
+        if (len_trim(kind_spec) == 0) return
+        has_value = .false.
+        kind_value = 0_c_int64_t
+        if (is_integer_literal_text(kind_spec)) then
+            read (kind_spec, *) kind_value
+            has_value = .true.
+        else if (present(context)) then
+            call resolve_kind_parameter_value(context, kind_spec, resolved, &
+                                              kind_value, reference_index)
+            has_value = resolved
+        end if
+        if (.not. has_value) return
+        if (kind_value == 4_c_int64_t) return
+        if (kind_value == 8_c_int64_t) return
+        write (kind_text, '(I0)') kind_value
+        call unsupported_feature_error(trim(base)//' kind', line, column, &
+            'direct LIRIC session supports '//trim(base)// &
+            ' kinds 4 (single) and 8 (double); kind '// &
+            trim(adjustl(kind_text))//' is not supported', error_msg)
+    end subroutine check_float_kind_supported
+
+    ! True when text is a plain unsigned decimal integer literal.
+    logical function is_integer_literal_text(text) result(is_literal)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: trimmed
+        integer :: i
+
+        trimmed = trim(adjustl(text))
+        is_literal = len(trimmed) > 0
+        if (.not. is_literal) return
+        do i = 1, len(trimmed)
+            if (trimmed(i:i) < '0' .or. trimmed(i:i) > '9') then
+                is_literal = .false.
+                return
+            end if
+        end do
+    end function is_integer_literal_text
 
     ! Returns true when the real kind spec selects f64 (kind 8). Bare real
     ! and real(4)/c_float/real32 are f32; a declared "integer, parameter"

--- a/src/session_program_lowering_functions.inc
+++ b/src/session_program_lowering_functions.inc
@@ -801,6 +801,10 @@
             end if
         case ('real')
             ! Classify by kind: bare real and real(4) are f32; real(8) is f64.
+            call check_float_kind_supported('real', kind_spec, node%line, &
+                                            node%column, error_msg, context, &
+                                            reference_index)
+            if (len_trim(error_msg) > 0) return
             if (real_kind_is_f64(kind_spec, context, reference_index)) then
                 value_kind = VALUE_F64
             else if (len_trim(kind_spec) == 0 .and. &
@@ -818,6 +822,10 @@
             value_kind = VALUE_F64
         case ('complex')
             ! Bare complex and complex(4) are two f32s; complex(8) is two f64s.
+            call check_float_kind_supported('complex', kind_spec, node%line, &
+                                            node%column, error_msg, context, &
+                                            reference_index)
+            if (len_trim(error_msg) > 0) return
             if (complex_kind_is_c8(kind_spec, context, reference_index)) then
                 value_kind = VALUE_C8
             else

--- a/test/test_session_unsupported_kind_rejection_compiler.f90
+++ b/test/test_session_unsupported_kind_rejection_compiler.f90
@@ -1,0 +1,97 @@
+program test_session_unsupported_kind_rejection_compiler
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== unsupported numeric kind rejection test ==='
+
+    all_passed = .true.
+    if (.not. test_unsupported_real_kind_rejected()) all_passed = .false.
+    if (.not. test_unsupported_complex_kind_rejected()) all_passed = .false.
+    if (.not. test_unsupported_integer_kind_rejected()) all_passed = .false.
+    if (.not. test_supported_kinds_accepted()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: unsupported numeric kinds are diagnosed, not narrowed'
+
+contains
+
+    logical function test_unsupported_real_kind_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  real(16) :: x'//new_line('a')// &
+            '  x = 1.0'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_unsupported_real_kind_rejected = expect_error_contains( &
+            source, 'unsupported real kind', &
+            '/tmp/ffc_session_reject_kind_real16')
+        if (.not. expect_error_contains(source, 'kind 16 is not supported', &
+            '/tmp/ffc_session_reject_kind_real16b')) then
+            test_unsupported_real_kind_rejected = .false.
+        end if
+    end function test_unsupported_real_kind_rejected
+
+    logical function test_unsupported_complex_kind_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  complex(16) :: z'//new_line('a')// &
+            '  z = (1.0, 2.0)'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_unsupported_complex_kind_rejected = expect_error_contains( &
+            source, 'unsupported complex kind', &
+            '/tmp/ffc_session_reject_kind_complex16')
+        if (.not. expect_error_contains(source, 'kind 16 is not supported', &
+            '/tmp/ffc_session_reject_kind_complex16b')) then
+            test_unsupported_complex_kind_rejected = .false.
+        end if
+    end function test_unsupported_complex_kind_rejected
+
+    logical function test_unsupported_integer_kind_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer(3) :: i'//new_line('a')// &
+            '  i = 1'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_unsupported_integer_kind_rejected = expect_error_contains( &
+            source, 'unsupported integer kind', &
+            '/tmp/ffc_session_reject_kind_integer3')
+        if (.not. expect_error_contains(source, 'kind 3 is not yet supported', &
+            '/tmp/ffc_session_reject_kind_integer3b')) then
+            test_unsupported_integer_kind_rejected = .false.
+        end if
+    end function test_unsupported_integer_kind_rejected
+
+    logical function test_supported_kinds_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer(1) :: a'//new_line('a')// &
+            '  integer(2) :: b'//new_line('a')// &
+            '  integer(4) :: c'//new_line('a')// &
+            '  integer(8) :: d'//new_line('a')// &
+            '  real(4) :: r4'//new_line('a')// &
+            '  real(8) :: r8'//new_line('a')// &
+            '  complex(4) :: c4'//new_line('a')// &
+            '  complex(8) :: c8'//new_line('a')// &
+            '  a = 1'//new_line('a')// &
+            '  b = 2'//new_line('a')// &
+            '  c = 3'//new_line('a')// &
+            '  d = 4'//new_line('a')// &
+            '  r4 = 1.0'//new_line('a')// &
+            '  r8 = 2.0d0'//new_line('a')// &
+            '  c4 = (1.0, 0.0)'//new_line('a')// &
+            '  c8 = (2.0d0, 0.0d0)'//new_line('a')// &
+            '  stop 7'//new_line('a')// &
+            'end program main'
+
+        test_supported_kinds_accepted = expect_exit_status( &
+            source, 7, '/tmp/ffc_session_supported_kinds_ok')
+    end function test_supported_kinds_accepted
+
+end program test_session_unsupported_kind_rejection_compiler


### PR DESCRIPTION
Closes #413.

## Change
`check_float_kind_supported` resolves a real/complex kind selector (integer literal or declared integer parameter) and rejects any value other than 4 or 8 with the requested kind in the diagnostic, before storage/arithmetic lowering. Wired into declaration lowering and function-result/expression typing.

## Preserved invariant
Supported kinds (integer 1/2/4/8, real 4/8, complex 4/8) lower exactly as before; unresolvable symbolic kind names keep their existing classification. No silent narrowing of real(16)/complex(16) to a supported width.

## Evidence
Red (src reverted to origin/main, new test present): `fo test test_session_unsupported_kind_rejection_compiler` -> FAIL, 'unsupported source lowered without diagnostic'.
Green: same command -> 1 passed.
Full `fo` pipeline: only pre-existing failures remain (`test_parity_dashboard` fails identically on clean origin/main with 'stale snapshot manifest digest'; `test_conformance_gauntlet_smoke` passes on rerun, marked FLAKY).