### PR TITLE
[reject-alloc-01] reject invalid allocation and pointer definition targets (#380)

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -2589,4 +2589,5 @@ contains
     include 'session_program_lowering_reject_checks.inc'
     include 'session_program_lowering_reject_const_init.inc'
     include 'session_program_lowering_reject_const_overflow.inc'
+    include 'session_program_lowering_reject_alloc.inc'
 end module session_program_lowering

--- a/src/session_program_lowering_reject_alloc.inc
+++ b/src/session_program_lowering_reject_alloc.inc
@@ -1,0 +1,626 @@
+    ! Allocation and pointer definition-target validation (#380).
+    !
+    ! Five constraint checks share one family: an entity that is allocated,
+    ! deallocated, pointed at, or passed where the callee may define or
+    ! reassociate it must actually carry the attributes that make that legal.
+    ! All of them run before lowering, on typed declarations and resolved
+    ! callee signatures, so an invalid target never reaches code generation.
+    subroutine check_alloc_pointer_targets(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call check_polymorphic_entity_attributes(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_deferred_length_attributes(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_pointer_shape_specs(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_alloc_definition_contexts(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_argument_definition_contexts(arena, error_msg)
+    end subroutine check_alloc_pointer_targets
+
+    ! F2018 C708: a CLASS entity takes its dynamic type from somewhere else, so
+    ! it must be a dummy argument, allocatable or a pointer. This covers both
+    ! local/module entities and derived-type components, whose declarations live
+    ! in the same arena.
+    subroutine check_polymorphic_entity_attributes(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n
+        character(len=:), allocatable :: low, name
+        character(len=64) :: location
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (decl => arena%entries(n)%node)
+            type is (declaration_node)
+                if (decl%is_allocatable) cycle
+                if (decl%is_pointer) cycle
+                if (.not. allocated(decl%type_name)) cycle
+                low = trim(lowercase_text(decl%type_name))
+                if (len(low) < 7) cycle
+                if (low(1:6) /= 'class(') cycle
+                if (low == 'class(*)') cycle
+                if (decl_names_include_dummy(arena, decl)) cycle
+                name = decl_display_name(decl)
+                write (location, '(" at line ",I0,", column ",I0)') &
+                    decl%line, decl%column
+                error_msg = 'CLASS entity '''//name//''' must be dummy, '// &
+                    'allocatable or pointer'//trim(location)
+                return
+            end select
+        end do
+    end subroutine check_polymorphic_entity_attributes
+
+    ! F2018 C723: a deferred character length (len=:) is only meaningful when
+    ! the entity can acquire a length, i.e. when it is allocatable or a pointer.
+    subroutine check_deferred_length_attributes(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n
+        character(len=:), allocatable :: name
+        character(len=64) :: location
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (decl => arena%entries(n)%node)
+            type is (declaration_node)
+                if (decl%is_allocatable) cycle
+                if (decl%is_pointer) cycle
+                if (.not. decl%has_character_length) cycle
+                if (.not. allocated(decl%character_length_expr)) cycle
+                if (trim(adjustl(decl%character_length_expr)) /= ':') cycle
+                if (decl_names_have_pointer_attr(arena, decl)) cycle
+                name = decl_display_name(decl)
+                write (location, '(" at line ",I0,", column ",I0)') &
+                    decl%line, decl%column
+                error_msg = 'entity '''//name//''' with deferred character '// &
+                    'length must have the POINTER or ALLOCATABLE attribute'// &
+                    trim(location)
+                return
+            end select
+        end do
+    end subroutine check_deferred_length_attributes
+
+    ! F2018 C832: a POINTER array is deferred-shape; an explicit-shape or
+    ! assumed-size spec on a pointer has no valid meaning.
+    subroutine check_pointer_shape_specs(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n, d
+        character(len=:), allocatable :: name
+        character(len=64) :: location
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (decl => arena%entries(n)%node)
+            type is (declaration_node)
+                if (.not. decl%is_pointer) cycle
+                if (.not. decl%is_array) cycle
+                if (.not. allocated(decl%dimension_indices)) cycle
+                do d = 1, size(decl%dimension_indices)
+                    if (dim_is_assumed_shape(arena, &
+                                             decl%dimension_indices(d))) cycle
+                    name = decl_display_name(decl)
+                    write (location, '(" at line ",I0,", column ",I0)') &
+                        decl%line, decl%column
+                    error_msg = 'POINTER array '''//name//''' must have a '// &
+                        'deferred shape or assumed rank'//trim(location)
+                    return
+                end do
+            end select
+        end do
+    end subroutine check_pointer_shape_specs
+
+    ! F2018 C932/C866: the allocate-object of ALLOCATE or DEALLOCATE appears in a
+    ! variable definition context, so an INTENT(IN) dummy can never be one.
+    subroutine check_alloc_definition_contexts(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (function_def_node)
+                if (.not. allocated(nd%body_indices)) cycle
+                call check_scope_alloc_targets(arena, nd%body_indices, error_msg)
+            type is (subroutine_def_node)
+                if (.not. allocated(nd%body_indices)) cycle
+                call check_scope_alloc_targets(arena, nd%body_indices, error_msg)
+            end select
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine check_alloc_definition_contexts
+
+    subroutine check_scope_alloc_targets(arena, body_indices, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i, v
+
+        call set_empty(error_msg)
+        do i = 1, size(body_indices)
+            if (.not. node_exists(arena, body_indices(i))) cycle
+            select type (stmt => arena%entries(body_indices(i))%node)
+            type is (allocate_statement_node)
+                if (.not. allocated(stmt%var_indices)) cycle
+                do v = 1, size(stmt%var_indices)
+                    call check_definable_target(arena, body_indices, &
+                        stmt%var_indices(v), 'ALLOCATE', error_msg)
+                    if (len_trim(error_msg) > 0) return
+                end do
+            type is (deallocate_statement_node)
+                if (.not. allocated(stmt%var_indices)) cycle
+                do v = 1, size(stmt%var_indices)
+                    call check_definable_target(arena, body_indices, &
+                        stmt%var_indices(v), 'DEALLOCATE', error_msg)
+                    if (len_trim(error_msg) > 0) return
+                end do
+            end select
+        end do
+    end subroutine check_scope_alloc_targets
+
+    subroutine check_definable_target(arena, body_indices, target_index, &
+                                      context_name, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        integer, intent(in) :: target_index
+        character(len=*), intent(in) :: context_name
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: name
+        character(len=64) :: location
+        integer :: decl_index, line, column
+
+        call set_empty(error_msg)
+        call target_base_name(arena, target_index, name)
+        if (len_trim(name) == 0) return
+        call scope_decl_for_name(arena, body_indices, name, decl_index)
+        if (decl_index <= 0) return
+        line = 0
+        column = 0
+        select type (decl => arena%entries(decl_index)%node)
+        type is (declaration_node)
+            if (.not. decl%has_intent) return
+            if (.not. allocated(decl%intent)) return
+            if (trim(lowercase_text(decl%intent)) /= 'in') return
+            line = decl%line
+            column = decl%column
+        class default
+            return
+        end select
+        line = get_node_line(arena, target_index)
+        column = get_node_column(arena, target_index)
+        write (location, '(" at line ",I0,", column ",I0)') line, column
+        error_msg = 'INTENT(IN) dummy argument '''//trim(name)// &
+            ''' cannot appear in a variable definition context ('// &
+            context_name//' object)'//trim(location)
+    end subroutine check_definable_target
+
+    ! Actual arguments must carry the attributes the dummy relies on: an
+    ! ALLOCATABLE or POINTER dummy can be (re)associated by the callee, and an
+    ! INTENT(OUT)/INTENT(INOUT) dummy is defined by it, so the actual must be a
+    ! definable object with the matching attribute. In a PURE procedure a
+    ! host- or use-associated variable is never definable through a dummy.
+    subroutine check_argument_definition_contexts(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (program_node)
+                if (.not. allocated(nd%body_indices)) cycle
+                call check_scope_call_arguments(arena, nd%body_indices, &
+                                                .false., error_msg)
+            type is (function_def_node)
+                if (.not. allocated(nd%body_indices)) cycle
+                call check_scope_call_arguments(arena, nd%body_indices, &
+                    prefix_has_pure(nd%prefix_keywords), error_msg)
+            type is (subroutine_def_node)
+                if (.not. allocated(nd%body_indices)) cycle
+                call check_scope_call_arguments(arena, nd%body_indices, &
+                    prefix_has_pure(nd%prefix_keywords), error_msg)
+            end select
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine check_argument_definition_contexts
+
+    logical function prefix_has_pure(prefix_keywords) result(is_pure)
+        character(len=16), allocatable, intent(in) :: prefix_keywords(:)
+        integer :: i
+
+        is_pure = .false.
+        if (.not. allocated(prefix_keywords)) return
+        do i = 1, size(prefix_keywords)
+            if (trim(lowercase_text(prefix_keywords(i))) == 'pure') then
+                is_pure = .true.
+                return
+            end if
+        end do
+    end function prefix_has_pure
+
+    subroutine check_scope_call_arguments(arena, body_indices, in_pure, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        logical, intent(in) :: in_pure
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: call_name, sub_err
+        integer, allocatable :: arg_indices(:)
+        integer :: i
+
+        call set_empty(error_msg)
+        do i = 1, size(body_indices)
+            if (.not. node_exists(arena, body_indices(i))) cycle
+            if (.not. is_subroutine_call_statement(arena, body_indices(i))) cycle
+            call get_subroutine_call_name(arena, body_indices(i), call_name, &
+                                          sub_err)
+            if (len_trim(sub_err) > 0) cycle
+            if (len_trim(call_name) == 0) cycle
+            call get_subroutine_call_arg_indices(arena, body_indices(i), &
+                                                 arg_indices, sub_err)
+            if (len_trim(sub_err) > 0) cycle
+            if (.not. allocated(arg_indices)) cycle
+            call check_call_actual_attributes(arena, body_indices, call_name, &
+                                              arg_indices, in_pure, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine check_scope_call_arguments
+
+    subroutine check_call_actual_attributes(arena, body_indices, callee_name, &
+                                            arg_indices, in_pure, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: callee_name
+        integer, intent(in) :: arg_indices(:)
+        logical, intent(in) :: in_pure
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, allocatable :: callee_params(:), callee_body(:)
+        character(len=:), allocatable :: dummy_name
+        logical :: found
+        logical :: dummy_alloc, dummy_ptr, dummy_definable
+        integer :: a, decl_index
+
+        call set_empty(error_msg)
+        call procedure_signature(arena, callee_name, callee_params, &
+                                 callee_body, found)
+        if (.not. found) return
+        do a = 1, min(size(arg_indices), size(callee_params))
+            call param_name_at(arena, callee_params(a), dummy_name)
+            if (len_trim(dummy_name) == 0) cycle
+            call scope_decl_for_name(arena, callee_body, dummy_name, decl_index)
+            if (decl_index <= 0) cycle
+            dummy_alloc = .false.
+            dummy_ptr = .false.
+            dummy_definable = .false.
+            select type (decl => arena%entries(decl_index)%node)
+            type is (declaration_node)
+                dummy_alloc = decl%is_allocatable
+                dummy_ptr = decl%is_pointer
+                if (decl%has_intent) then
+                    if (allocated(decl%intent)) then
+                        dummy_definable = &
+                            trim(lowercase_text(decl%intent)) == 'out' .or. &
+                            trim(lowercase_text(decl%intent)) == 'inout'
+                    end if
+                end if
+            class default
+                cycle
+            end select
+            call check_one_actual(arena, body_indices, arg_indices(a), &
+                dummy_name, dummy_alloc, dummy_ptr, dummy_definable, in_pure, &
+                error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine check_call_actual_attributes
+
+    subroutine check_one_actual(arena, body_indices, actual_index, dummy_name, &
+                                dummy_alloc, dummy_ptr, dummy_definable, &
+                                in_pure, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        integer, intent(in) :: actual_index
+        character(len=*), intent(in) :: dummy_name
+        logical, intent(in) :: dummy_alloc, dummy_ptr, dummy_definable
+        logical, intent(in) :: in_pure
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: name
+        character(len=64) :: location
+        integer :: decl_index
+        logical :: actual_alloc, actual_ptr, is_literal
+
+        call set_empty(error_msg)
+        if (.not. node_exists(arena, actual_index)) return
+        write (location, '(" at line ",I0,", column ",I0)') &
+            get_node_line(arena, actual_index), &
+            get_node_column(arena, actual_index)
+        is_literal = .false.
+        select type (nd => arena%entries(actual_index)%node)
+        type is (literal_node)
+            is_literal = .true.
+        end select
+        if (is_literal) then
+            if (dummy_definable .or. dummy_alloc .or. dummy_ptr) then
+                error_msg = 'constant actual argument for dummy '''// &
+                    trim(dummy_name)//''' cannot appear in a variable '// &
+                    'definition context'//trim(location)
+            end if
+            return
+        end if
+        call target_base_name(arena, actual_index, name)
+        if (len_trim(name) == 0) return
+        call scope_decl_for_name(arena, body_indices, name, decl_index)
+        if (decl_index <= 0) then
+            if (.not. in_pure) return
+            if (.not. (dummy_ptr .or. dummy_definable)) return
+            call module_decl_for_name(arena, name, decl_index)
+            if (decl_index <= 0) return
+            error_msg = 'variable '''//trim(name)//''' is not local to this '// &
+                'PURE procedure and cannot appear in a variable definition '// &
+                'context'//trim(location)
+            return
+        end if
+        actual_alloc = .false.
+        actual_ptr = .false.
+        select type (decl => arena%entries(decl_index)%node)
+        type is (declaration_node)
+            actual_alloc = decl%is_allocatable
+            actual_ptr = decl%is_pointer
+        class default
+            return
+        end select
+        if (dummy_alloc) then
+            if (.not. actual_alloc) then
+                error_msg = 'actual argument for ALLOCATABLE dummy '''// &
+                    trim(dummy_name)//''' must be ALLOCATABLE'//trim(location)
+                return
+            end if
+        end if
+        if (dummy_ptr) then
+            if (.not. actual_ptr) then
+                error_msg = 'actual argument for POINTER dummy '''// &
+                    trim(dummy_name)//''' must be a pointer'//trim(location)
+                return
+            end if
+        end if
+    end subroutine check_one_actual
+
+    ! --- shared lookups -------------------------------------------------
+
+    function decl_display_name(decl) result(name)
+        type(declaration_node), intent(in) :: decl
+        character(len=:), allocatable :: name
+
+        name = ''
+        if (allocated(decl%var_name)) then
+            name = trim(decl%var_name)
+            if (len(name) > 0) return
+        end if
+        if (allocated(decl%var_names)) then
+            if (size(decl%var_names) > 0) name = trim(decl%var_names(1))
+        end if
+    end function decl_display_name
+
+    logical function decl_names_include_dummy(arena, decl) result(is_dummy)
+        type(ast_arena_t), intent(in) :: arena
+        type(declaration_node), intent(in) :: decl
+        integer :: i
+
+        is_dummy = .false.
+        if (allocated(decl%var_name)) then
+            is_dummy = name_is_dummy_anywhere(arena, trim(decl%var_name))
+            if (is_dummy) return
+        end if
+        if (.not. allocated(decl%var_names)) return
+        do i = 1, size(decl%var_names)
+            is_dummy = name_is_dummy_anywhere(arena, trim(decl%var_names(i)))
+            if (is_dummy) return
+        end do
+    end function decl_names_include_dummy
+
+    ! A POINTER or ALLOCATABLE attribute statement (`pointer good`) is a
+    ! separate declaration node for the same name; consult those before
+    ! rejecting an entity for missing the attribute.
+    logical function decl_names_have_pointer_attr(arena, decl) result(has_attr)
+        type(ast_arena_t), intent(in) :: arena
+        type(declaration_node), intent(in) :: decl
+        integer :: i
+
+        has_attr = .false.
+        if (allocated(decl%var_name)) then
+            has_attr = name_has_pointer_attr_stmt(arena, trim(decl%var_name))
+            if (has_attr) return
+        end if
+        if (.not. allocated(decl%var_names)) return
+        do i = 1, size(decl%var_names)
+            has_attr = name_has_pointer_attr_stmt(arena, &
+                                                  trim(decl%var_names(i)))
+            if (has_attr) return
+        end do
+    end function decl_names_have_pointer_attr
+
+    logical function name_has_pointer_attr_stmt(arena, name) result(has_attr)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer :: n
+
+        has_attr = .false.
+        if (len_trim(name) == 0) return
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (decl => arena%entries(n)%node)
+            type is (declaration_node)
+                if (.not. decl%is_pointer) then
+                    if (.not. decl%is_allocatable) cycle
+                end if
+                if (.not. decl_declares_name(decl, name)) cycle
+                has_attr = .true.
+                return
+            end select
+        end do
+    end function name_has_pointer_attr_stmt
+
+    logical function decl_declares_name(decl, name) result(declares)
+        type(declaration_node), intent(in) :: decl
+        character(len=*), intent(in) :: name
+        integer :: i
+
+        declares = .false.
+        if (allocated(decl%var_name)) then
+            if (same_name(decl%var_name, name)) then
+                declares = .true.
+                return
+            end if
+        end if
+        if (.not. allocated(decl%var_names)) return
+        do i = 1, size(decl%var_names)
+            if (same_name(trim(decl%var_names(i)), name)) then
+                declares = .true.
+                return
+            end if
+        end do
+    end function decl_declares_name
+
+    logical function name_is_dummy_anywhere(arena, name) result(is_dummy)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer :: n
+
+        is_dummy = .false.
+        if (len_trim(name) == 0) return
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (function_def_node)
+                if (.not. allocated(nd%param_indices)) cycle
+                is_dummy = params_contain_name(arena, nd%param_indices, name)
+            type is (subroutine_def_node)
+                if (.not. allocated(nd%param_indices)) cycle
+                is_dummy = params_contain_name(arena, nd%param_indices, name)
+            end select
+            if (is_dummy) return
+        end do
+    end function name_is_dummy_anywhere
+
+    logical function params_contain_name(arena, param_indices, name) &
+            result(found)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: param_indices(:)
+        character(len=*), intent(in) :: name
+        integer :: p
+        character(len=:), allocatable :: pname
+
+        found = .false.
+        do p = 1, size(param_indices)
+            call param_name_at(arena, param_indices(p), pname)
+            if (len_trim(pname) == 0) cycle
+            if (same_name(pname, name)) then
+                found = .true.
+                return
+            end if
+        end do
+    end function params_contain_name
+
+    subroutine param_name_at(arena, param_index, name)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: param_index
+        character(len=:), allocatable, intent(out) :: name
+
+        name = ''
+        if (.not. node_exists(arena, param_index)) return
+        select type (pn => arena%entries(param_index)%node)
+        type is (parameter_declaration_node)
+            if (allocated(pn%name)) name = trim(pn%name)
+        type is (declaration_node)
+            name = decl_display_name(pn)
+        type is (identifier_node)
+            if (allocated(pn%name)) name = trim(pn%name)
+        end select
+    end subroutine param_name_at
+
+    subroutine procedure_signature(arena, name, param_indices, body_indices, &
+                                   found)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer, allocatable, intent(out) :: param_indices(:)
+        integer, allocatable, intent(out) :: body_indices(:)
+        logical, intent(out) :: found
+        integer :: n
+
+        found = .false.
+        allocate (param_indices(0))
+        allocate (body_indices(0))
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (subroutine_def_node)
+                if (.not. allocated(nd%name)) cycle
+                if (.not. same_name(nd%name, name)) cycle
+                if (allocated(nd%param_indices)) param_indices = nd%param_indices
+                if (allocated(nd%body_indices)) body_indices = nd%body_indices
+                found = .true.
+                return
+            end select
+        end do
+    end subroutine procedure_signature
+
+    subroutine scope_decl_for_name(arena, indices, name, decl_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        character(len=*), intent(in) :: name
+        integer, intent(out) :: decl_index
+        integer :: i
+
+        decl_index = 0
+        if (len_trim(name) == 0) return
+        do i = 1, size(indices)
+            if (.not. node_exists(arena, indices(i))) cycle
+            select type (decl => arena%entries(indices(i))%node)
+            type is (declaration_node)
+                if (.not. decl_declares_name(decl, name)) cycle
+                decl_index = indices(i)
+                return
+            end select
+        end do
+    end subroutine scope_decl_for_name
+
+    subroutine module_decl_for_name(arena, name, decl_index)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer, intent(out) :: decl_index
+        integer :: n
+
+        decl_index = 0
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (module_node)
+                if (.not. allocated(nd%declaration_indices)) cycle
+                call scope_decl_for_name(arena, nd%declaration_indices, name, &
+                                         decl_index)
+            end select
+            if (decl_index > 0) return
+        end do
+    end subroutine module_decl_for_name
+
+    subroutine target_base_name(arena, node_index, name)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable, intent(out) :: name
+
+        name = ''
+        if (.not. node_exists(arena, node_index)) return
+        select type (nd => arena%entries(node_index)%node)
+        type is (identifier_node)
+            if (allocated(nd%name)) name = trim(nd%name)
+        type is (call_or_subscript_node)
+            if (allocated(nd%name)) name = trim(nd%name)
+        end select
+    end subroutine target_base_name

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -550,6 +550,8 @@
         if (len_trim(error_msg) > 0) return
         call check_constant_expression_overflow(arena, error_msg)
         if (len_trim(error_msg) > 0) return
+        call check_alloc_pointer_targets(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
         call set_empty(error_msg)
     end subroutine validate_program
     subroutine lower_program_return(arena, root_index, context, value, error_msg)

--- a/test/test_session_reject_alloc_01_compiler.f90
+++ b/test/test_session_reject_alloc_01_compiler.f90
@@ -1,0 +1,308 @@
+program test_session_reject_alloc_01_compiler
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== allocation and pointer definition target rejection test ==='
+
+    all_passed = .true.
+    if (.not. test_class_entity_rejected()) all_passed = .false.
+    if (.not. test_class_component_rejected()) all_passed = .false.
+    if (.not. test_class_dummy_accepted()) all_passed = .false.
+    if (.not. test_deferred_length_rejected()) all_passed = .false.
+    if (.not. test_deferred_length_allocatable_accepted()) all_passed = .false.
+    if (.not. test_pointer_explicit_shape_rejected()) all_passed = .false.
+    if (.not. test_pointer_deferred_shape_accepted()) all_passed = .false.
+    if (.not. test_allocate_intent_in_rejected()) all_passed = .false.
+    if (.not. test_deallocate_intent_in_rejected()) all_passed = .false.
+    if (.not. test_allocate_intent_inout_accepted()) all_passed = .false.
+    if (.not. test_nonallocatable_actual_rejected()) all_passed = .false.
+    if (.not. test_nonpointer_actual_rejected()) all_passed = .false.
+    if (.not. test_pointer_actual_accepted()) all_passed = .false.
+    if (.not. test_constant_actual_rejected()) all_passed = .false.
+    if (.not. test_constant_actual_intent_in_accepted()) all_passed = .false.
+    if (.not. test_pure_nonlocal_actual_rejected()) all_passed = .false.
+    if (.not. test_pure_local_actual_accepted()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: invalid allocation and pointer targets are rejected'
+
+contains
+
+    logical function test_class_entity_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type t'//new_line('a')// &
+            '    integer :: i'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            '  class(t) :: o'//new_line('a')// &
+            'end program main'
+
+        test_class_entity_rejected = expect_error_contains(source, &
+            'must be dummy, allocatable or pointer', &
+            '/tmp/ffc_reject_alloc_01_class_entity')
+    end function test_class_entity_rejected
+
+    logical function test_class_component_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type object_t'//new_line('a')// &
+            '    integer :: i'//new_line('a')// &
+            '  end type object_t'//new_line('a')// &
+            '  type container_t'//new_line('a')// &
+            '    class(object_t) :: v'//new_line('a')// &
+            '  end type container_t'//new_line('a')// &
+            'end program main'
+
+        test_class_component_rejected = expect_error_contains(source, &
+            'must be dummy, allocatable or pointer', &
+            '/tmp/ffc_reject_alloc_01_class_component')
+    end function test_class_component_rejected
+
+    logical function test_class_dummy_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type t'//new_line('a')// &
+            '    integer :: i'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            '  type(t) :: v'//new_line('a')// &
+            '  v%i = 3'//new_line('a')// &
+            '  call show(v)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine show(o)'//new_line('a')// &
+            '    class(t), intent(in) :: o'//new_line('a')// &
+            '    stop o%i'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end program main'
+
+        test_class_dummy_accepted = expect_exit_status(source, 3, &
+            '/tmp/ffc_reject_alloc_01_class_dummy')
+    end function test_class_dummy_accepted
+
+    logical function test_deferred_length_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:) :: b'//new_line('a')// &
+            'end program main'
+
+        test_deferred_length_rejected = expect_error_contains(source, &
+            'must have the POINTER or ALLOCATABLE attribute', &
+            '/tmp/ffc_reject_alloc_01_deferred_len')
+    end function test_deferred_length_rejected
+
+    logical function test_deferred_length_allocatable_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: s'//new_line('a')// &
+            '  s = ''ok'''//new_line('a')// &
+            '  stop len(s)'//new_line('a')// &
+            'end program main'
+
+        test_deferred_length_allocatable_accepted = expect_exit_status(source, &
+            2, '/tmp/ffc_reject_alloc_01_deferred_len_ok')
+    end function test_deferred_length_allocatable_accepted
+
+    logical function test_pointer_explicit_shape_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine bnds(a)'//new_line('a')// &
+            '    integer, pointer, intent(in) :: a(1:2)'//new_line('a')// &
+            '  end subroutine bnds'//new_line('a')// &
+            'end program main'
+
+        test_pointer_explicit_shape_rejected = expect_error_contains(source, &
+            'must have a deferred shape or assumed rank', &
+            '/tmp/ffc_reject_alloc_01_ptr_shape')
+    end function test_pointer_explicit_shape_rejected
+
+    logical function test_pointer_deferred_shape_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, target :: a(3)'//new_line('a')// &
+            '  integer, pointer :: p(:)'//new_line('a')// &
+            '  a = 2'//new_line('a')// &
+            '  p => a'//new_line('a')// &
+            '  stop p(2)'//new_line('a')// &
+            'end program main'
+
+        test_pointer_deferred_shape_accepted = expect_exit_status(source, 2, &
+            '/tmp/ffc_reject_alloc_01_ptr_shape_ok')
+    end function test_pointer_deferred_shape_accepted
+
+    logical function test_allocate_intent_in_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine init2(x)'//new_line('a')// &
+            '    integer, allocatable, intent(in) :: x(:)'//new_line('a')// &
+            '    allocate(x(3))'//new_line('a')// &
+            '  end subroutine init2'//new_line('a')// &
+            'end program main'
+
+        test_allocate_intent_in_rejected = expect_error_contains(source, &
+            'cannot appear in a variable definition context (ALLOCATE object)', &
+            '/tmp/ffc_reject_alloc_01_alloc_intent_in')
+    end function test_allocate_intent_in_rejected
+
+    logical function test_deallocate_intent_in_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine kill(x)'//new_line('a')// &
+            '    integer, allocatable, intent(in) :: x(:)'//new_line('a')// &
+            '    deallocate(x)'//new_line('a')// &
+            '  end subroutine kill'//new_line('a')// &
+            'end program main'
+
+        test_deallocate_intent_in_rejected = expect_error_contains(source, &
+            'cannot appear in a variable definition context '// &
+            '(DEALLOCATE object)', &
+            '/tmp/ffc_reject_alloc_01_dealloc_intent_in')
+    end function test_deallocate_intent_in_rejected
+
+    logical function test_allocate_intent_inout_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, allocatable :: m(:)'//new_line('a')// &
+            '  call grow(m)'//new_line('a')// &
+            '  stop size(m)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine grow(x)'//new_line('a')// &
+            '    integer, allocatable, intent(inout) :: x(:)'//new_line('a')// &
+            '    allocate(x(3))'//new_line('a')// &
+            '  end subroutine grow'//new_line('a')// &
+            'end program main'
+
+        test_allocate_intent_inout_accepted = expect_exit_status(source, 3, &
+            '/tmp/ffc_reject_alloc_01_alloc_inout_ok')
+    end function test_allocate_intent_inout_accepted
+
+    logical function test_nonallocatable_actual_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(5)'//new_line('a')// &
+            '  a = 1'//new_line('a')// &
+            '  call init(a)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine init(x)'//new_line('a')// &
+            '    integer, allocatable, intent(out) :: x(:)'//new_line('a')// &
+            '  end subroutine init'//new_line('a')// &
+            'end program main'
+
+        test_nonallocatable_actual_rejected = expect_error_contains(source, &
+            'must be ALLOCATABLE', &
+            '/tmp/ffc_reject_alloc_01_actual_alloc')
+    end function test_nonallocatable_actual_rejected
+
+    logical function test_nonpointer_actual_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: b'//new_line('a')// &
+            '  b = 1'//new_line('a')// &
+            '  call foo(b)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine foo(p)'//new_line('a')// &
+            '    integer, pointer, intent(in) :: p'//new_line('a')// &
+            '  end subroutine foo'//new_line('a')// &
+            'end program main'
+
+        test_nonpointer_actual_rejected = expect_error_contains(source, &
+            'must be a pointer', &
+            '/tmp/ffc_reject_alloc_01_actual_pointer')
+    end function test_nonpointer_actual_rejected
+
+    logical function test_pointer_actual_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, target :: a'//new_line('a')// &
+            '  integer, pointer :: p'//new_line('a')// &
+            '  a = 7'//new_line('a')// &
+            '  p => a'//new_line('a')// &
+            '  call foo(p)'//new_line('a')// &
+            '  stop a'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine foo(q)'//new_line('a')// &
+            '    integer, pointer, intent(in) :: q'//new_line('a')// &
+            '  end subroutine foo'//new_line('a')// &
+            'end program main'
+
+        test_pointer_actual_accepted = expect_exit_status(source, 7, &
+            '/tmp/ffc_reject_alloc_01_actual_pointer_ok')
+    end function test_pointer_actual_accepted
+
+    logical function test_constant_actual_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  call s(''y'')'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine s(x)'//new_line('a')// &
+            '    character(8), intent(out) :: x'//new_line('a')// &
+            '  end subroutine s'//new_line('a')// &
+            'end program main'
+
+        test_constant_actual_rejected = expect_error_contains(source, &
+            'constant actual argument', &
+            '/tmp/ffc_reject_alloc_01_const_actual')
+    end function test_constant_actual_rejected
+
+    logical function test_constant_actual_intent_in_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  call s(''y'')'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine s(x)'//new_line('a')// &
+            '    character(len=*), intent(in) :: x'//new_line('a')// &
+            '    stop len(x)'//new_line('a')// &
+            '  end subroutine s'//new_line('a')// &
+            'end program main'
+
+        test_constant_actual_intent_in_accepted = expect_exit_status(source, 1, &
+            '/tmp/ffc_reject_alloc_01_const_actual_ok')
+    end function test_constant_actual_intent_in_accepted
+
+    logical function test_pure_nonlocal_actual_rejected()
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '  integer, pointer :: x'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'pure subroutine foo()'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  call bar(x)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  pure subroutine bar(y)'//new_line('a')// &
+            '    integer, pointer, intent(inout) :: y'//new_line('a')// &
+            '  end subroutine bar'//new_line('a')// &
+            'end subroutine foo'
+
+        test_pure_nonlocal_actual_rejected = expect_error_contains(source, &
+            'is not local to this PURE procedure', &
+            '/tmp/ffc_reject_alloc_01_pure_nonlocal')
+    end function test_pure_nonlocal_actual_rejected
+
+    logical function test_pure_local_actual_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: r'//new_line('a')// &
+            '  r = 0'//new_line('a')// &
+            '  call bump(r)'//new_line('a')// &
+            '  stop r'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  pure subroutine bump(y)'//new_line('a')// &
+            '    integer, intent(out) :: y'//new_line('a')// &
+            '    integer :: z'//new_line('a')// &
+            '    z = 9'//new_line('a')// &
+            '    call setit(z)'//new_line('a')// &
+            '    y = z'//new_line('a')// &
+            '  end subroutine bump'//new_line('a')// &
+            '  pure subroutine setit(w)'//new_line('a')// &
+            '    integer, intent(inout) :: w'//new_line('a')// &
+            '  end subroutine setit'//new_line('a')// &
+            'end program main'
+
+        test_pure_local_actual_accepted = expect_exit_status(source, 9, &
+            '/tmp/ffc_reject_alloc_01_pure_local_ok')
+    end function test_pure_local_actual_accepted
+
+end program test_session_reject_alloc_01_compiler


### PR DESCRIPTION
Closes #380.

## Preserved invariant

An entity that is allocated, deallocated, pointed at, or passed where the
callee may define or reassociate it must carry the attributes that make
that legal. Five checks run pre-lowering on typed declarations and
resolved callee signatures (never on filenames or message text):

- CLASS entity, including a derived-type component, must be a dummy
  argument, allocatable or pointer (F2018 C708).
- deferred character length (`len=:`) requires POINTER or ALLOCATABLE;
  a separate `pointer x` attribute statement satisfies it.
- POINTER array must have a deferred shape or assumed rank.
- ALLOCATE/DEALLOCATE object may not be an INTENT(IN) dummy.
- an actual argument must be ALLOCATABLE/POINTER when the dummy is, a
  constant may not feed a definable dummy, and a PURE procedure may not
  pass a non-local variable into a POINTER or INTENT(OUT/INOUT) dummy.

## Red evidence (before)

```
scripts/conformance_gauntlet.sh --suite gfortran-dg --file allocatable_dummy_2.f90 ... --file pure_formal_3.f90
  FAIL: allocatable_dummy_2.f90 (negative test accepted)   [x10]
  PASS=0  XFAIL=0  XPASS=0  FAIL=10
```

`test_session_reject_alloc_01_compiler` did not exist; every negative
form above compiled and exited 0.

## Green evidence (after)

```
fo test test_session_reject_alloc_01_compiler   PASS  (17 cases: 8 rejections, 9 corrected neighbours)
scripts/conformance_gauntlet.sh --suite gfortran-dg --file ... (all ten)
  PASS=10  XFAIL=0  XPASS=0  FAIL=0
fo   Static: OK, Build: OK, suite green
```

Each fixture now exits nonzero with a rule-specific diagnostic, e.g.
`pointer_target_3.f90:9: actual argument for POINTER dummy 'p' must be a
pointer`, and each rule has a corrected neighbour that still compiles and
runs to the expected exit status.

Two suite tests, `test_conformance_gauntlet_smoke` and
`test_parity_dashboard`, fail only inside a git worktree: the dashboard
generator derives the corpus parent from `dirname $PROJECT_DIR`, so it
looks for `fortfront` under `.wt/`. Both were confirmed failing the same
way on unmodified `origin/main` in a worktree, and both pass here when
run individually.