### PR TITLE
[proc-component-01] lower ASSOCIATED for procedure-pointer components (#372)

### DIFF
--- a/src/session_program_lowering_derived_type_ops.inc
+++ b/src/session_program_lowering_derived_type_ops.inc
@@ -19,6 +19,9 @@
                             component_value_kind)) return
         if (context%derived_types(type_index)%component_value_kind(comp_index) == &
             VALUE_F64) component_slot_width = 2
+        ! A procedure-pointer component holds an 8-byte callee address (#372).
+        if (context%derived_types(type_index)%component_value_kind(comp_index) == &
+            VALUE_PROC_PTR) component_slot_width = 2
     end function component_slot_width
 
     integer function nested_element_count(context, type_index, comp_index)
@@ -170,6 +173,15 @@
                 cycle
             end if
             if (component_is_allocatable(context, type_index, c)) then
+                call null_allocatable_component_slots(context, symbol_index, &
+                                                      outer_slots, abs_slot, 2, &
+                                                      error_msg)
+                if (len_trim(error_msg) > 0) return
+                cycle
+            end if
+            if (component_kind(context, type_index, c) == VALUE_PROC_PTR) then
+                ! A fresh procedure-pointer component is disassociated: null its
+                ! two address slots so associated() reads false (#372).
                 call null_allocatable_component_slots(context, symbol_index, &
                                                       outer_slots, abs_slot, 2, &
                                                       error_msg)

--- a/src/session_program_lowering_derived_types.inc
+++ b/src/session_program_lowering_derived_types.inc
@@ -842,6 +842,11 @@ subroutine collect_component_declaration(component_index, parent_line, &
                     type_index, nested_type_index, error_msg)
                 return
             end if
+            if (is_proc_pointer_component(component)) then
+                call collect_proc_pointer_component(component, context, &
+                                                    type_index, error_msg)
+                return
+            end if
             call declaration_value_kind(component, value_kind, error_msg, context)
             if (len_trim(error_msg) > 0) return
             ! A scalar allocatable component of intrinsic numeric/logical type
@@ -1123,6 +1128,18 @@ subroutine collect_component_declaration(component_index, parent_line, &
             call set_empty(error_msg)
             return
         end if
+        ! A procedure-pointer component holds a callee address in an inline
+        ! 8-byte slot pair (#372); arrays of them are out of scope.
+        if (is_proc_pointer_component(component)) then
+            if (component%is_array) then
+                call unsupported_feature_error('derived type array component', &
+                    component%line, component%column, 'arrays of procedure '// &
+                    'pointer components are not supported', error_msg)
+                return
+            end if
+            call set_empty(error_msg)
+            return
+        end if
 
         nested_index = declaration_derived_type_index(context, component)
         if (nested_index > 0) then
@@ -1225,6 +1242,74 @@ subroutine collect_component_declaration(component_index, parent_line, &
             character_component_slots = (character_length + 4) / 4
         end if
     end function character_component_slots
+
+    logical function is_proc_pointer_component(component) result(is_proc)
+        ! True for `procedure(iface), pointer :: p` inside a derived type: the
+        ! component stores a callee address rather than a data value (#372).
+        type(declaration_node), intent(in) :: component
+        integer :: n
+
+        ! FortFront reports the component type as "procedure()" or
+        ! "procedure(iface)"; the POINTER attribute is not retained on the
+        ! component node, and a component of procedure type is always a
+        ! procedure pointer.
+        is_proc = .false.
+        if (.not. allocated(component%type_name)) return
+        n = min(9, len_trim(component%type_name))
+        if (n <= 0) return
+        is_proc = lowercase_text(trim(adjustl(component%type_name(1:n)))) == &
+                  'procedure'
+    end function is_proc_pointer_component
+
+    subroutine collect_proc_pointer_component(component, context, type_index, &
+                                              error_msg)
+        ! Record one or more procedure-pointer components. Each occupies an
+        ! inline pointer slot pair (see component_slot_width) that a fresh
+        ! instance nulls, so associated() reads false before any => binding.
+        ! FortFront keeps the component's attribute keywords (nopass, pointer)
+        ! in var_names, so only the entity names are taken from that list.
+        type(declaration_node), intent(in) :: component
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: type_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i, added
+
+        added = 0
+        call set_empty(error_msg)
+        if (allocated(component%var_names)) then
+            do i = 1, size(component%var_names)
+                if (is_proc_component_attribute(component%var_names(i))) cycle
+                call add_derived_component(context, type_index, &
+                                           component%var_names(i), &
+                                           component%line, component%column, &
+                                           .false., 0_c_int64_t, 1, &
+                                           VALUE_PROC_PTR, error_msg)
+                if (len_trim(error_msg) > 0) return
+                added = added + 1
+            end do
+        end if
+        if (added > 0) return
+        if (.not. allocated(component%var_name)) then
+            error_msg = 'derived type component declaration did not expose a name'
+            return
+        end if
+        call add_derived_component(context, type_index, component%var_name, &
+                                   component%line, component%column, &
+                                   .false., 0_c_int64_t, 1, VALUE_PROC_PTR, &
+                                   error_msg)
+    end subroutine collect_proc_pointer_component
+
+    logical function is_proc_component_attribute(text) result(is_attribute)
+        ! True for an attribute keyword FortFront leaves in a procedure
+        ! component's entity list rather than an entity name.
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: word
+
+        word = lowercase_text(trim(adjustl(text)))
+        is_attribute = word == 'nopass' .or. word == 'pointer' .or. &
+                       word == 'pass' .or. word == 'private' .or. &
+                       word == 'public'
+    end function is_proc_component_attribute
 
     logical function component_alloc_array_rank_one(component) result(is_rank_one)
         ! True when an allocatable array component declares exactly one dimension.

--- a/src/session_program_lowering_pointer.inc
+++ b/src/session_program_lowering_pointer.inc
@@ -428,6 +428,11 @@
         character(len=:), allocatable :: ptr_name, target_name
         integer :: ptr_index, target_index
 
+        ! obj%p => proc binds a procedure-pointer component (#372).
+        if (is_proc_pointer_component_access(arena, node%pointer_index, context)) then
+            call lower_proc_component_assignment(arena, node, context, error_msg)
+            return
+        end if
         call get_identifier_name(arena, node%pointer_index, ptr_name, error_msg)
         if (len_trim(error_msg) > 0) return
         ptr_index = find_symbol_compat(context, ptr_name)
@@ -654,6 +659,13 @@
             error_msg = 'associated requires one or two arguments'
             return
         end if
+        ! A procedure-pointer component operand has no compile-time association
+        ! flag; compare its stored callee address at run time instead (#372).
+        if (associated_uses_proc_component(arena, arg_indices, context)) then
+            call lower_proc_pointer_associated(arena, arg_indices, context, &
+                                               value, error_msg)
+            return
+        end if
         if (.not. is_identifier(arena, arg_indices(1))) then
             error_msg = 'associated first argument must be a pointer variable'
             return
@@ -753,6 +765,10 @@
         ! Allocate a ptr slot on the stack; address stores the slot address.
         if (.not. emit_ptr_alloca(context%session, &
                                   context%symbols(idx)%address, error_msg)) return
+        ! A fresh procedure pointer is disassociated: null the slot so a runtime
+        ! association test reads false before any => binding (#372).
+        if (.not. emit_ptr_store(context%session, null_ptr_operand(context), &
+                                 context%symbols(idx)%address, error_msg)) return
         context%symbols(idx)%has_address = .true.
         context%symbol_count = idx
         call set_empty(error_msg)
@@ -782,18 +798,21 @@
             error_msg = 'left of => is not a procedure pointer: '//trim(ptr_name)
             return
         end if
+        ! null() clears the association and nulls the slot.
+        if (pointer_target_is_null(arena, node%target_index)) then
+            context%symbols(ptr_idx)%is_associated = .false.
+            if (.not. emit_ptr_store(context%session, null_ptr_operand(context), &
+                                     context%symbols(ptr_idx)%address, &
+                                     error_msg)) return
+            call set_empty(error_msg)
+            return
+        end if
         if (.not. is_identifier(arena, node%target_index)) then
             error_msg = 'procedure pointer assignment requires a procedure name'
             return
         end if
         call get_identifier_name(arena, node%target_index, target_name, error_msg)
         if (len_trim(error_msg) > 0) return
-        ! null() clears the association.
-        if (same_name(target_name, 'null')) then
-            context%symbols(ptr_idx)%is_associated = .false.
-            call set_empty(error_msg)
-            return
-        end if
         ! Check whether target is another procedure pointer being copied.
         target_idx = find_symbol_compat(context, target_name)
         if (target_idx > 0 .and. context%symbols(target_idx)%is_proc_pointer) then
@@ -930,3 +949,237 @@
                                           error_msg)) return
         call copy_back_reference_args(context, args, copyback_indices, error_msg)
     end subroutine lower_void_proc_ptr_call
+
+    logical function is_proc_pointer_component_access(arena, node_index, context) &
+        result(is_proc)
+        ! True when node_index is obj%p naming a procedure-pointer component
+        ! (#372). Unresolvable component references answer .false. so the
+        ! caller's other paths keep their own diagnostics.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(in) :: context
+        integer :: sym, type_index, comp_index
+        character(len=:), allocatable :: comp_name, local_error
+
+        is_proc = .false.
+        if (node_index <= 0) return
+        if (.not. node_exists(arena, node_index)) return
+        select type (acc => arena%entries(node_index)%node)
+        type is (component_access_node)
+        class default
+            return
+        end select
+        call resolve_component_ref(arena, node_index, context, sym, type_index, &
+                                   comp_index, comp_name, local_error)
+        if (len_trim(local_error) > 0) return
+        is_proc = component_kind(context, type_index, comp_index) == VALUE_PROC_PTR
+    end function is_proc_pointer_component_access
+
+    logical function associated_uses_proc_component(arena, arg_indices, context) &
+        result(uses)
+        ! True when either ASSOCIATED argument is a procedure-pointer component.
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: arg_indices(:)
+        type(lowering_context_t), intent(in) :: context
+
+        uses = .false.
+        if (.not. allocated(arg_indices)) return
+        if (size(arg_indices) < 1 .or. size(arg_indices) > 2) return
+        uses = is_proc_pointer_component_access(arena, arg_indices(1), context)
+        if (uses) return
+        if (size(arg_indices) < 2) return
+        uses = is_proc_pointer_component_access(arena, arg_indices(2), context)
+    end function associated_uses_proc_component
+
+    logical function pointer_target_is_null(arena, node_index) result(is_null)
+        ! True for the null() intrinsic reference on the right of =>, whether it
+        ! reaches us as a bare identifier or as an argumentless call node.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: name, local_error
+
+        is_null = .false.
+        if (node_index <= 0) return
+        if (.not. node_exists(arena, node_index)) return
+        if (is_identifier(arena, node_index)) then
+            call get_identifier_name(arena, node_index, name, local_error)
+            if (len_trim(local_error) > 0) return
+            is_null = same_name(name, 'null')
+            return
+        end if
+        select type (target_node => arena%entries(node_index)%node)
+        type is (call_or_subscript_node)
+            if (.not. allocated(target_node%name)) return
+            is_null = same_name(target_node%name, 'null')
+        end select
+    end function pointer_target_is_null
+
+    subroutine proc_component_slot_address(arena, access_index, context, addr, &
+                                           error_msg)
+        ! Address of the inline pointer slot holding obj%p's callee address.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: access_index
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: addr
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: comp_name
+        integer :: sym, type_index, comp_index
+
+        call resolve_component_ref(arena, access_index, context, sym, type_index, &
+                                   comp_index, comp_name, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (component_kind(context, type_index, comp_index) /= VALUE_PROC_PTR) then
+            error_msg = 'component is not a procedure pointer: '//trim(comp_name)
+            return
+        end if
+        call component_element_address_at(context, sym, type_index, comp_index, 0, &
+                                          addr, error_msg)
+    end subroutine proc_component_slot_address
+
+    subroutine load_proc_pointer_operand(arena, node_index, context, ptr_value, &
+                                         error_msg)
+        ! Callee address currently held by a procedure-pointer entity: either a
+        ! procedure-pointer component obj%p or a scalar procedure pointer.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: ptr_value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: addr
+        character(len=:), allocatable :: name
+        integer :: idx
+
+        if (is_proc_pointer_component_access(arena, node_index, context)) then
+            call proc_component_slot_address(arena, node_index, context, addr, &
+                                             error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (.not. emit_ptr_load(context%session, addr, ptr_value, error_msg)) &
+                return
+            call set_empty(error_msg)
+            return
+        end if
+        if (.not. is_identifier(arena, node_index)) then
+            error_msg = 'expected a procedure pointer variable or component'
+            return
+        end if
+        call get_identifier_name(arena, node_index, name, error_msg)
+        if (len_trim(error_msg) > 0) return
+        idx = find_symbol_compat(context, name)
+        if (idx <= 0) then
+            error_msg = 'procedure pointer was not declared: '//trim(name)
+            return
+        end if
+        if (.not. context%symbols(idx)%is_proc_pointer) then
+            error_msg = 'not a procedure pointer: '//trim(name)
+            return
+        end if
+        if (.not. emit_ptr_load(context%session, context%symbols(idx)%address, &
+                                ptr_value, error_msg)) return
+        call set_empty(error_msg)
+    end subroutine load_proc_pointer_operand
+
+    subroutine proc_target_address(arena, node_index, context, ptr_value, error_msg)
+        ! Callee address of a => target or of ASSOCIATED's second argument: a
+        ! procedure-pointer entity (loaded) or a named procedure (its symbol).
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: ptr_value
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: name
+        character(kind=c_char), allocatable :: c_name(:)
+        integer(c_int32_t) :: symbol_id
+        integer :: idx
+
+        if (is_proc_pointer_component_access(arena, node_index, context)) then
+            call load_proc_pointer_operand(arena, node_index, context, ptr_value, &
+                                           error_msg)
+            return
+        end if
+        if (.not. is_identifier(arena, node_index)) then
+            error_msg = 'procedure pointer target must be a procedure name or '// &
+                        'a procedure pointer'
+            return
+        end if
+        call get_identifier_name(arena, node_index, name, error_msg)
+        if (len_trim(error_msg) > 0) return
+        idx = find_symbol_compat(context, name)
+        if (idx > 0) then
+            if (context%symbols(idx)%is_proc_pointer) then
+                call load_proc_pointer_operand(arena, node_index, context, &
+                                               ptr_value, error_msg)
+                return
+            end if
+            ! A declared data object never has a compatible procedure interface.
+            error_msg = 'procedure pointer target is not a procedure: '//trim(name)
+            return
+        end if
+        call to_c_chars(trim(call_emit_name(context%arena, name, context)), c_name)
+        symbol_id = lr_session_intern(context%session%handle, c_name)
+        if (symbol_id < 0_c_int32_t) then
+            error_msg = 'could not intern procedure symbol: '//trim(name)
+            return
+        end if
+        ptr_value%kind = LR_OP_KIND_GLOBAL
+        ptr_value%payload = int(symbol_id, c_int64_t)
+        ptr_value%typ = lr_type_ptr_s(context%session%handle)
+        ptr_value%global_offset = 0_c_int64_t
+        call set_empty(error_msg)
+    end subroutine proc_target_address
+
+    subroutine lower_proc_component_assignment(arena, node, context, error_msg)
+        ! obj%p => proc / obj%p => other%q / obj%p => null(): store the callee
+        ! address into the component's inline pointer slot (#372).
+        type(ast_arena_t), intent(in) :: arena
+        type(pointer_assignment_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: slot_addr, callee
+
+        call proc_component_slot_address(arena, node%pointer_index, context, &
+                                         slot_addr, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (pointer_target_is_null(arena, node%target_index)) then
+            callee = null_ptr_operand(context)
+        else
+            call proc_target_address(arena, node%target_index, context, callee, &
+                                     error_msg)
+            if (len_trim(error_msg) > 0) return
+        end if
+        if (.not. emit_ptr_store(context%session, callee, slot_addr, error_msg)) &
+            return
+        call set_empty(error_msg)
+    end subroutine lower_proc_component_assignment
+
+    subroutine lower_proc_pointer_associated(arena, arg_indices, context, value, &
+                                             error_msg)
+        ! associated(obj%p) / associated(obj%p, target) with a run-time callee
+        ! address comparison (#372). F2018 16.9.20: a disassociated pointer is
+        ! never associated with a target, so the identity test is ANDed with the
+        ! non-null test.
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: arg_indices(:)
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: ptr_value, target_value, nonnull, same
+
+        call load_proc_pointer_operand(arena, arg_indices(1), context, ptr_value, &
+                                       error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, ptr_value, &
+                null_ptr_operand(context), nonnull, error_msg)) return
+        if (size(arg_indices) == 1) then
+            value = nonnull
+            call set_empty(error_msg)
+            return
+        end if
+        call proc_target_address(arena, arg_indices(2), context, target_value, &
+                                 error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, ptr_value, &
+                target_value, same, error_msg)) return
+        if (.not. emit_i32_binary(context%session, LR_OP_AND, nonnull, same, &
+                                  value, error_msg)) return
+        call set_empty(error_msg)
+    end subroutine lower_proc_pointer_associated

--- a/test/test_session_proc_pointer_component_associated_compiler.f90
+++ b/test/test_session_proc_pointer_component_associated_compiler.f90
@@ -1,0 +1,116 @@
+program test_session_proc_pointer_component_associated
+    ! #372: associated(obj%p) and associated(obj%p, target) for procedure
+    ! pointer components. A fresh component reads as disassociated, a bound
+    ! component reads as associated, and the two-argument form compares the
+    ! stored callee address against the named procedure.
+    use ffc_test_support, only: expect_exit_status, expect_error_contains
+    implicit none
+
+    print *, '=== procedure pointer component associated compiler test ==='
+
+    ! Null component: associated(obj%p) is false before any => binding.
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'implicit none'//new_line('a')// &
+        'type :: handler_t'//new_line('a')// &
+        '  procedure(), pointer :: p => null()'//new_line('a')// &
+        'end type handler_t'//new_line('a')// &
+        'type(handler_t) :: obj'//new_line('a')// &
+        'integer :: code'//new_line('a')// &
+        'code = 0'//new_line('a')// &
+        'if (.not. associated(obj%p)) code = code + 7'//new_line('a')// &
+        'stop code'//new_line('a')// &
+        'end program main', 7, &
+        '/tmp/ffc_proc_comp_assoc_null_test')) stop 1
+
+    ! Bound component: one-argument and two-argument forms.
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'implicit none'//new_line('a')// &
+        'type :: handler_t'//new_line('a')// &
+        '  procedure(), pointer :: p => null()'//new_line('a')// &
+        'end type handler_t'//new_line('a')// &
+        'type(handler_t) :: obj'//new_line('a')// &
+        'integer :: code'//new_line('a')// &
+        'code = 0'//new_line('a')// &
+        'obj%p => double_it'//new_line('a')// &
+        'if (associated(obj%p)) code = code + 1'//new_line('a')// &
+        'if (associated(obj%p, double_it)) code = code + 2'//new_line('a')// &
+        'if (.not. associated(obj%p, triple_it)) code = code + 4'//new_line('a')// &
+        'stop code'//new_line('a')// &
+        'contains'//new_line('a')// &
+        'integer function double_it(x)'//new_line('a')// &
+        'integer, intent(in) :: x'//new_line('a')// &
+        'double_it = x*2'//new_line('a')// &
+        'end function double_it'//new_line('a')// &
+        'integer function triple_it(x)'//new_line('a')// &
+        'integer, intent(in) :: x'//new_line('a')// &
+        'triple_it = x*3'//new_line('a')// &
+        'end function triple_it'//new_line('a')// &
+        'end program main', 7, &
+        '/tmp/ffc_proc_comp_assoc_bound_test')) stop 1
+
+    ! pr66465 shape: a scalar procedure pointer compared against a null
+    ! procedure pointer component. Both are disassociated, so the result is
+    ! false (F2018 16.9.20: a disassociated POINTER argument never matches).
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'implicit none'//new_line('a')// &
+        'type :: handler_t'//new_line('a')// &
+        '  procedure(), pointer :: handler_out => null()'//new_line('a')// &
+        'end type handler_t'//new_line('a')// &
+        'type(handler_t) :: this'//new_line('a')// &
+        'procedure(), pointer :: proc_ptr => null()'//new_line('a')// &
+        'integer :: code'//new_line('a')// &
+        'code = 0'//new_line('a')// &
+        'if (.not. associated(proc_ptr, this%handler_out)) code = 11'// &
+        new_line('a')// &
+        'stop code'//new_line('a')// &
+        'end program main', 11, &
+        '/tmp/ffc_proc_comp_assoc_pr66465_test')) stop 1
+
+    ! Two components bound to the same and to different procedures.
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'implicit none'//new_line('a')// &
+        'type :: handler_t'//new_line('a')// &
+        '  procedure(), pointer :: p => null()'//new_line('a')// &
+        '  procedure(), pointer :: q => null()'//new_line('a')// &
+        'end type handler_t'//new_line('a')// &
+        'type(handler_t) :: obj'//new_line('a')// &
+        'integer :: code'//new_line('a')// &
+        'code = 0'//new_line('a')// &
+        'obj%p => double_it'//new_line('a')// &
+        'obj%q => double_it'//new_line('a')// &
+        'if (associated(obj%p, obj%q)) code = code + 5'//new_line('a')// &
+        'obj%q => null()'//new_line('a')// &
+        'if (.not. associated(obj%q)) code = code + 6'//new_line('a')// &
+        'if (associated(obj%p)) code = code + 8'//new_line('a')// &
+        'stop code'//new_line('a')// &
+        'contains'//new_line('a')// &
+        'integer function double_it(x)'//new_line('a')// &
+        'integer, intent(in) :: x'//new_line('a')// &
+        'double_it = x*2'//new_line('a')// &
+        'end function double_it'//new_line('a')// &
+        'end program main', 19, &
+        '/tmp/ffc_proc_comp_assoc_pair_test')) stop 1
+
+    ! Negative: a data object has no procedure interface, so binding it to a
+    ! procedure-pointer component is diagnosed rather than silently lowered.
+    if (.not. expect_error_contains( &
+        'program main'//new_line('a')// &
+        'implicit none'//new_line('a')// &
+        'type :: handler_t'//new_line('a')// &
+        '  procedure(), pointer :: p => null()'//new_line('a')// &
+        'end type handler_t'//new_line('a')// &
+        'type(handler_t) :: obj'//new_line('a')// &
+        'integer :: n'//new_line('a')// &
+        'n = 1'//new_line('a')// &
+        'obj%p => n'//new_line('a')// &
+        'stop 0'//new_line('a')// &
+        'end program main', &
+        'procedure pointer target is not a procedure', &
+        '/tmp/ffc_proc_comp_assoc_bad_target_test')) stop 1
+
+    print *, 'PASS: procedure pointer component associated'
+end program test_session_proc_pointer_component_associated


### PR DESCRIPTION
Closes #372.

## What changed

Procedure-pointer components (`type t; procedure(), pointer :: p; end type`)
are now a real part of the derived layout and ASSOCIATED reads them:

- `src/session_program_lowering_derived_types.inc`: recognise a component whose
  type spec starts with `procedure` and register it with `VALUE_PROC_PTR`.
  FortFront leaves the component's attribute keywords in the entity-name list,
  so the collector filters those out before taking entity names.
- `src/session_program_lowering_derived_type_ops.inc`: a procedure-pointer
  component spans two i32 slots (an 8-byte callee address) and a freshly
  declared instance nulls those slots, so it reads as disassociated.
- `src/session_program_lowering_pointer.inc`: `obj%p => proc`, `obj%p => other%q`
  and `obj%p => null()` store into that slot; `associated(obj%p)` emits a
  non-null test on the loaded address, and `associated(obj%p, target)` ANDs that
  with an address identity test. Scalar procedure-pointer slots are now nulled
  at declaration and on `=> null()` too, so the same run-time test is valid when
  a scalar pointer is compared against a component.

## Preserved compiler invariant

F2018 16.9.20: a disassociated pointer is never associated with a target. The
two-argument form is therefore `nonnull(p) .and. (p == target)`, never a bare
address equality — two null procedure pointers must compare `.false.`, which is
exactly the pr66465 shape. A data object as the target is rejected with
`procedure pointer target is not a procedure` rather than silently lowered.

## Red / green evidence

New behavioural test `test/test_session_proc_pointer_component_associated_compiler.f90`
compiles and runs five programs and checks exit status / diagnostics.

Red on unmodified main:

```
 === procedure pointer component associated compiler test ===
 FAIL: unsupported scalar type at line 4, column 3: direct LIRIC session only
 supports integer, real, logical, and character scalars
```

Green with this change:

```
test_session_proc_pointer_component_associ PASS       0.14s
```

Full local `fo` pipeline run; the only failure is `test_parity_dashboard`, which
fails identically on unmodified `origin/main` in this worktree (stale snapshot
FortFront revision) and is unrelated to this change.

## Not done here (follow-up)

`gfortran.dg/pr66465.f90` is **not** promoted. Two gaps outside this issue's
scope still block it:

1. FortFront drops the entity name of a procedure component declared with
   `NOPASS` (`procedure(iface), nopass, pointer :: p` parses as entities
   `nopass, pointer` and loses `p`), so the component never reaches the lowerer
   under its own name.
2. `print *, associated(a, b)` is lowered on the integer expression path and
   rejects the component argument; the tests here use the if-condition form.

The fixture stays owned in `test/conformance/fail_owners_gfortran_dg.txt`.
