### PR TITLE
[reject-io-01] enforce I/O control-list constraints (#385)

### DIFF
--- a/src/session_program_lowering_io_typecheck.inc
+++ b/src/session_program_lowering_io_typecheck.inc
@@ -188,3 +188,526 @@
             end if
         end do
     end function io_spec_upper
+
+    ! I/O control-list constraints (#385). Several invalid control lists never
+    ! reach the typed AST: the parser drops the statement and the program would
+    ! otherwise compile silently. They are validated on the statement text, the
+    ! earliest layer that still holds them, with quote-aware tokenising so no
+    ! valid form is flagged.
+    subroutine check_io_control_source(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: source, stmt
+        logical :: found
+        integer :: pos, line_no, stmt_line
+
+        call set_empty(error_msg)
+        call get_source_text(arena, source, found)
+        if (.not. found) return
+        pos = 1
+        line_no = 0
+        do while (pos <= len(source))
+            call next_io_source_statement(source, pos, line_no, stmt, stmt_line)
+            if (len_trim(stmt) == 0) cycle
+            call check_io_statement_text(stmt, stmt_line, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine check_io_control_source
+
+    ! Take the next logical statement: one source line with its comment removed
+    ! and any '&' continuations appended.
+    subroutine next_io_source_statement(source, pos, line_no, stmt, stmt_line)
+        character(len=*), intent(in) :: source
+        integer, intent(inout) :: pos, line_no
+        character(len=:), allocatable, intent(out) :: stmt
+        integer, intent(out) :: stmt_line
+        character(len=:), allocatable :: line
+        integer :: next_nl, n
+
+        call set_empty(stmt)
+        stmt_line = line_no + 1
+        do while (pos <= len(source))
+            next_nl = index(source(pos:), new_line('a'))
+            if (next_nl == 0) then
+                line = source(pos:)
+                pos = len(source) + 1
+            else if (next_nl == 1) then
+                line = ''
+                pos = pos + 1
+            else
+                line = source(pos:pos + next_nl - 2)
+                pos = pos + next_nl
+            end if
+            line_no = line_no + 1
+            line = strip_data_source_comment(line)
+            line = trim(adjustl(line))
+            n = len(line)
+            if (n > 0) then
+                if (line(1:1) == '&') then
+                    line = trim(adjustl(line(2:)))
+                    n = len(line)
+                end if
+            end if
+            if (n > 0) then
+                if (line(n:n) == '&') then
+                    stmt = stmt//' '//line(1:n - 1)
+                    cycle
+                end if
+            end if
+            stmt = stmt//' '//line
+            return
+        end do
+    end subroutine next_io_source_statement
+
+    subroutine check_io_statement_text(stmt, line_no, error_msg)
+        character(len=*), intent(in) :: stmt
+        integer, intent(in) :: line_no
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: code, low, kw, list, tail
+        character(len=64) :: location
+        integer :: open_p, close_p, n
+
+        call set_empty(error_msg)
+        code = trim(adjustl(stmt))
+        n = len(code)
+        if (n == 0) return
+        write (location, '(" at line ",I0)') line_no
+        if (io_paren_balance(code) /= 0) then
+            error_msg = 'unbalanced parentheses in statement'//trim(location)
+            return
+        end if
+        code = trim(adjustl(strip_statement_label(code)))
+        n = len(code)
+        if (n == 0) return
+        low = lowercase_text(code)
+        kw = leading_io_keyword(low)
+        select case (kw)
+        case ('print')
+            if (code(n:n) == ',') then
+                error_msg = 'output item list required after comma in '// &
+                    'PRINT statement'//trim(location)
+                return
+            end if
+            call check_io_output_items(code(len(kw) + 1:), location, error_msg)
+        case ('write', 'read', 'open', 'inquire', 'close', 'rewind', &
+              'backspace', 'endfile')
+            call io_statement_paren_span(code, open_p, close_p)
+            if (open_p == 0) return
+            if (close_p <= open_p) return
+            list = code(open_p + 1:close_p - 1)
+            call check_io_control_list(list, kw, location, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (kw /= 'write') return
+            tail = code(close_p + 1:)
+            call check_io_output_items(tail, location, error_msg)
+        end select
+    end subroutine check_io_statement_text
+
+    ! Apply every control-list constraint to one comma-separated specifier list.
+    subroutine check_io_control_list(list, kw, location, error_msg)
+        character(len=*), intent(in) :: list, kw, location
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: arg, name, val
+        integer :: n, p, arg_start, arg_end, idx
+        logical :: has_unit
+
+        call set_empty(error_msg)
+        n = len(list)
+        p = 1
+        idx = 0
+        has_unit = .false.
+        do while (p <= n)
+            call next_io_spec_arg(list, n, p, arg_start, arg_end)
+            if (arg_start == 0) exit
+            arg = list(arg_start:arg_end)
+            call split_io_spec_arg(arg, name, val)
+            idx = idx + 1
+            if (len(name) == 0) then
+                if (is_dec_io_spec(lowercase_text(trim(adjustl(arg))))) then
+                    error_msg = io_spec_upper(trim(adjustl(arg)))// &
+                        ' specifier is a DEC extension'//trim(location)
+                    return
+                end if
+                if (idx == 1) then
+                    has_unit = .true.
+                    call check_io_unit_value(val, kw, location, error_msg)
+                    if (len_trim(error_msg) > 0) return
+                end if
+                cycle
+            end if
+            if (name == 'unit') then
+                has_unit = .true.
+                call check_io_unit_value(val, kw, location, error_msg)
+                if (len_trim(error_msg) > 0) return
+                cycle
+            end if
+            if (is_dec_io_spec(name)) then
+                error_msg = io_spec_upper(name)// &
+                    ' specifier is a DEC extension'//trim(location)
+                return
+            end if
+            if (name == 'end' .and. kw == 'write') then
+                error_msg = 'END= specifier is not allowed in an output '// &
+                    'statement'//trim(location)
+                return
+            end if
+            if (.not. is_character_io_spec(name)) cycle
+            if (io_value_is_array(val)) then
+                error_msg = io_spec_upper(name)//' specifier must be scalar'// &
+                    trim(location)
+                return
+            end if
+            if (io_value_nondefault_kind(val)) then
+                error_msg = io_spec_upper(name)//' specifier must be a '// &
+                    'character string of default kind'//trim(location)
+                return
+            end if
+        end do
+        if (kw /= 'write') return
+        if (has_unit) return
+        error_msg = 'UNIT not specified in WRITE statement'//trim(location)
+    end subroutine check_io_control_list
+
+    subroutine check_io_unit_value(val, kw, location, error_msg)
+        character(len=*), intent(in) :: val, kw, location
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: t
+        integer :: i
+        logical :: digits
+
+        call set_empty(error_msg)
+        t = trim(adjustl(val))
+        if (len(t) == 0) return
+        if (kw == 'write') then
+            if (t(1:1) == '''' .or. t(1:1) == '"') then
+                error_msg = 'Invalid form of WRITE statement: a character '// &
+                    'literal cannot be a unit'//trim(location)
+                return
+            end if
+        end if
+        if (t(1:1) /= '-') return
+        if (len(t) < 2) return
+        digits = .true.
+        do i = 2, len(t)
+            if (t(i:i) < '0' .or. t(i:i) > '9') digits = .false.
+        end do
+        if (.not. digits) return
+        error_msg = 'UNIT number cannot be negative'//trim(location)
+    end subroutine check_io_unit_value
+
+    ! A BOZ literal constant has no type and can never be an output item.
+    subroutine check_io_output_items(items, location, error_msg)
+        character(len=*), intent(in) :: items, location
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: low
+        integer :: i, n, close_q
+        character :: c, prev, qc
+        logical :: is_boz
+
+        call set_empty(error_msg)
+        low = lowercase_text(items)
+        n = len(low)
+        i = 1
+        do while (i < n)
+            c = low(i:i)
+            if (c == '''' .or. c == '"') then
+                ! A plain character literal: skip it whole so its content
+                ! cannot be mistaken for a radix prefix.
+                qc = c
+                i = i + 1
+                do while (i <= n)
+                    if (low(i:i) == qc) exit
+                    i = i + 1
+                end do
+                i = i + 1
+                cycle
+            end if
+            if (c /= 'b' .and. c /= 'o' .and. c /= 'z') then
+                i = i + 1
+                cycle
+            end if
+            qc = low(i + 1:i + 1)
+            if (qc /= '''' .and. qc /= '"') then
+                i = i + 1
+                cycle
+            end if
+            is_boz = .true.
+            if (i > 1) then
+                prev = low(i - 1:i - 1)
+                if (prev == '_') is_boz = .false.
+                if (prev >= 'a' .and. prev <= 'z') is_boz = .false.
+                if (prev >= '0' .and. prev <= '9') is_boz = .false.
+            end if
+            close_q = index(low(i + 2:), qc)
+            if (close_q == 0) then
+                i = i + 1
+                cycle
+            end if
+            close_q = i + 1 + close_q
+            if (is_boz) then
+                if (.not. is_boz_digits(low(i + 2:close_q - 1), c)) then
+                    is_boz = .false.
+                end if
+            end if
+            if (is_boz) then
+                error_msg = 'BOZ literal constant cannot appear in an '// &
+                    'output IO list'//trim(location)
+                return
+            end if
+            i = close_q + 1
+        end do
+    end subroutine check_io_output_items
+
+    ! Digits valid for a BOZ radix prefix: binary, octal, or hexadecimal.
+    logical function is_boz_digits(text, radix) result(ok)
+        character(len=*), intent(in) :: text
+        character, intent(in) :: radix
+        integer :: i
+        character :: c
+
+        ok = .false.
+        if (len(text) == 0) return
+        do i = 1, len(text)
+            c = text(i:i)
+            select case (radix)
+            case ('b')
+                if (c /= '0' .and. c /= '1') return
+            case ('o')
+                if (c < '0' .or. c > '7') return
+            case default
+                if (c >= '0' .and. c <= '9') cycle
+                if (c < 'a' .or. c > 'f') return
+            end select
+        end do
+        ok = .true.
+    end function is_boz_digits
+
+    ! Split "name=value" into a lowercased specifier name and its value text.
+    ! A positional item yields an empty name.
+    subroutine split_io_spec_arg(arg, name, val)
+        character(len=*), intent(in) :: arg
+        character(len=:), allocatable, intent(out) :: name, val
+        character(len=:), allocatable :: t, head
+        integer :: eqp, i
+        character :: c
+
+        call set_empty(name)
+        t = trim(adjustl(arg))
+        val = t
+        eqp = io_top_level_equals(t)
+        if (eqp <= 1) return
+        head = trim(adjustl(t(1:eqp - 1)))
+        if (len(head) == 0) return
+        c = head(1:1)
+        if (.not. ((c >= 'a' .and. c <= 'z') .or. (c >= 'A' .and. c <= 'Z'))) &
+            return
+        do i = 2, len(head)
+            c = head(i:i)
+            if (c >= 'a' .and. c <= 'z') cycle
+            if (c >= 'A' .and. c <= 'Z') cycle
+            if (c >= '0' .and. c <= '9') cycle
+            if (c == '_') cycle
+            return
+        end do
+        name = lowercase_text(head)
+        val = trim(adjustl(t(eqp + 1:)))
+    end subroutine split_io_spec_arg
+
+    ! Position of the first '=' outside quotes and nesting, 0 when absent.
+    integer function io_top_level_equals(text) result(eqp)
+        character(len=*), intent(in) :: text
+        integer :: i, depth
+        character :: qc
+
+        eqp = 0
+        depth = 0
+        i = 1
+        do while (i <= len(text))
+            if (text(i:i) == '''' .or. text(i:i) == '"') then
+                qc = text(i:i)
+                i = i + 1
+                do while (i <= len(text))
+                    if (text(i:i) == qc) exit
+                    i = i + 1
+                end do
+            else if (text(i:i) == '(' .or. text(i:i) == '[') then
+                depth = depth + 1
+            else if (text(i:i) == ')' .or. text(i:i) == ']') then
+                if (depth > 0) depth = depth - 1
+            else if (depth == 0 .and. text(i:i) == '=') then
+                eqp = i
+                return
+            end if
+            i = i + 1
+        end do
+    end function io_top_level_equals
+
+    logical function io_value_is_array(val) result(is_array)
+        character(len=*), intent(in) :: val
+        character(len=:), allocatable :: t
+
+        is_array = .false.
+        t = trim(adjustl(val))
+        if (len(t) == 0) return
+        if (t(1:1) == '[') then
+            is_array = .true.
+            return
+        end if
+        if (len(t) < 2) return
+        if (t(1:2) == '(/') is_array = .true.
+    end function io_value_is_array
+
+    ! True when the specifier value is a character value of a kind other than
+    ! default: char(c, k) with k /= 1, or a kind-prefixed literal k_'...'.
+    logical function io_value_nondefault_kind(val) result(bad)
+        character(len=*), intent(in) :: val
+        character(len=:), allocatable :: t, low, inner, arg2, kindtext
+        integer :: n, p, arg_start, arg_end, i, upos
+
+        bad = .false.
+        t = trim(adjustl(val))
+        if (len(t) < 2) return
+        low = lowercase_text(t)
+        upos = index(low, '_')
+        if (upos > 1) then
+            if (low(upos + 1:upos + 1) == '''' .or. &
+                low(upos + 1:upos + 1) == '"') then
+                kindtext = low(1:upos - 1)
+                if (io_text_is_integer(kindtext)) then
+                    if (kindtext /= '1') bad = .true.
+                    return
+                end if
+            end if
+        end if
+        if (len(low) < 6) return
+        if (low(1:5) /= 'char(') return
+        if (low(len(low):len(low)) /= ')') return
+        inner = t(6:len(t) - 1)
+        n = len(inner)
+        p = 1
+        call next_io_spec_arg(inner, n, p, arg_start, arg_end)
+        if (arg_start == 0) return
+        call next_io_spec_arg(inner, n, p, arg_start, arg_end)
+        if (arg_start == 0) return
+        arg2 = trim(adjustl(inner(arg_start:arg_end)))
+        i = io_top_level_equals(arg2)
+        if (i > 0) arg2 = trim(adjustl(arg2(i + 1:)))
+        if (.not. io_text_is_integer(arg2)) return
+        if (arg2 /= '1') bad = .true.
+    end function io_value_nondefault_kind
+
+    logical function io_text_is_integer(text) result(is_int)
+        character(len=*), intent(in) :: text
+        integer :: i
+
+        is_int = .false.
+        if (len_trim(text) == 0) return
+        do i = 1, len_trim(text)
+            if (text(i:i) < '0' .or. text(i:i) > '9') return
+        end do
+        is_int = .true.
+    end function io_text_is_integer
+
+    integer function io_paren_balance(text) result(balance)
+        character(len=*), intent(in) :: text
+        integer :: i
+        character :: qc
+
+        balance = 0
+        i = 1
+        do while (i <= len(text))
+            if (text(i:i) == '''' .or. text(i:i) == '"') then
+                qc = text(i:i)
+                i = i + 1
+                do while (i <= len(text))
+                    if (text(i:i) == qc) exit
+                    i = i + 1
+                end do
+            else if (text(i:i) == '(') then
+                balance = balance + 1
+            else if (text(i:i) == ')') then
+                balance = balance - 1
+            end if
+            i = i + 1
+        end do
+    end function io_paren_balance
+
+    function strip_statement_label(code) result(rest)
+        character(len=*), intent(in) :: code
+        character(len=:), allocatable :: rest
+        integer :: i
+
+        i = 1
+        do while (i <= len(code))
+            if (code(i:i) < '0' .or. code(i:i) > '9') exit
+            i = i + 1
+        end do
+        if (i == 1) then
+            rest = code
+        else
+            rest = code(i:)
+        end if
+    end function strip_statement_label
+
+    function leading_io_keyword(low) result(kw)
+        character(len=*), intent(in) :: low
+        character(len=:), allocatable :: kw
+        integer :: i
+
+        i = 1
+        do while (i <= len(low))
+            if (low(i:i) < 'a' .or. low(i:i) > 'z') exit
+            i = i + 1
+        end do
+        if (i == 1) then
+            kw = ''
+        else
+            kw = low(1:i - 1)
+        end if
+    end function leading_io_keyword
+
+    ! Bounds of the control-list parentheses in an I/O statement.
+    subroutine io_statement_paren_span(code, open_p, close_p)
+        character(len=*), intent(in) :: code
+        integer, intent(out) :: open_p, close_p
+        integer :: i, depth
+        character :: qc
+
+        open_p = 0
+        close_p = 0
+        depth = 0
+        i = 1
+        do while (i <= len(code))
+            if (code(i:i) == '''' .or. code(i:i) == '"') then
+                qc = code(i:i)
+                i = i + 1
+                do while (i <= len(code))
+                    if (code(i:i) == qc) exit
+                    i = i + 1
+                end do
+            else if (code(i:i) == '(') then
+                depth = depth + 1
+                if (depth == 1) open_p = i
+            else if (code(i:i) == ')') then
+                depth = depth - 1
+                if (depth == 0) then
+                    close_p = i
+                    return
+                end if
+            end if
+            i = i + 1
+        end do
+    end subroutine io_statement_paren_span
+
+    ! DEC I/O extension specifiers. Without -fdec they are not Fortran, and the
+    ! standard has no equivalent, so they are rejected rather than ignored.
+    logical function is_dec_io_spec(name) result(is_dec)
+        character(len=*), intent(in) :: name
+
+        select case (trim(name))
+        case ('carriagecontrol', 'share', 'shared', 'noshared', 'readonly')
+            is_dec = .true.
+        case default
+            is_dec = .false.
+        end select
+    end function is_dec_io_spec

--- a/src/session_program_lowering_open_close.inc
+++ b/src/session_program_lowering_open_close.inc
@@ -141,6 +141,16 @@
                               error_msg)
         if (len_trim(error_msg) > 0) return
 
+        ! F2018 12.5.6.12: OPEN with NEWUNIT= must also give FILE= or
+        ! STATUS='SCRATCH'; without either there is nothing to connect to.
+        if (len_trim(nuvar) > 0 .and. len_trim(fpath) == 0) then
+            if (trim(sstr) /= 'scratch') then
+                error_msg = 'NEWUNIT specifier must have FILE= or '// &
+                    'STATUS=''SCRATCH'' in OPEN statement'
+                return
+            end if
+        end if
+
         ! Unit 6 is preconnected to stdout: OPEN reconfigures that connection
         ! rather than opening a distinct file, so its sign mode also governs
         ! PRINT and WRITE(*,...), which share the same connection (#280).

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -560,6 +560,8 @@
         if (len_trim(error_msg) > 0) return
         call check_result_and_entry_rules(arena, error_msg)
         if (len_trim(error_msg) > 0) return
+        call check_io_control_source(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
         call set_empty(error_msg)
     end subroutine validate_program
     subroutine lower_program_return(arena, root_index, context, value, error_msg)

--- a/test/conformance/fail_owners_gfortran_dg.txt
+++ b/test/conformance/fail_owners_gfortran_dg.txt
@@ -145,10 +145,6 @@ interface_operator_2.f90 # owner=lazy-fortran/fortfront#2893; reason=require mat
 interface_operator_3.f90 # owner=lazy-fortran/fortfront#2887; reason=validate USE exports renames and operator imports
 invalid_name.f90 # owner=lazy-fortran/fortfront#2890; reason=reject invalid source and identifier characters
 invalid_procedure_name.f90 # owner=lazy-fortran/ffc#378; reason=reject malformed or ambiguous generic interfaces
-io_constraints_15.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
-io_constraints_16.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
-io_constraints_4.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
-io_invalid_1.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
 iomsg_1.f90 # owner=lazy-fortran/ffc#427; reason=owns stable IOSTAT/IOMSG results for EOF, invalid unit, OPEN, and CLOSE
 iostat_2.f90 # owner=lazy-fortran/ffc#427; reason=owns nonzero status for invalid CLOSE controls
 iso_c_binding_char_1.f90 # owner=lazy-fortran/fortfront#2886; reason=enforce BIND(C) interoperability contracts
@@ -174,8 +170,6 @@ namelist_92.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member con
 namelist_93.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member constraints
 namelist_98.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member constraints
 namelist_use.f90 # owner=lazy-fortran/ffc#436; reason=owns scalar NAMELIST groups and omitted/order-independent member conversion
-negative_unit_check.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
-newunit_6.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
 non_module_public.f90 # owner=lazy-fortran/fortfront#2895; reason=reject duplicate or incompatible declaration attributes
 old_style_init.f90 # owner=lazy-fortran/ffc#383; reason=enforce DATA object and initializer restrictions
 oldstyle_1.f90 # owner=lazy-fortran/ffc#463; reason=lower structured DATA initialization
@@ -203,7 +197,6 @@ pr19936_2.f90 # owner=lazy-fortran/fortfront#2898; reason=reject malformed itera
 pr19936_3.f90 # owner=lazy-fortran/fortfront#2891; reason=reject malformed type and SELECT TYPE syntax
 pr39695_2.f90 # owner=lazy-fortran/ffc#379; reason=enforce function-result and ENTRY rules
 pr39695_3.f90 # owner=lazy-fortran/ffc#379; reason=enforce function-result and ENTRY rules
-pr40839.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
 pr56520.f90 # owner=lazy-fortran/fortfront#2897; reason=reject unclassifiable execution expressions
 pr61669.f90 # owner=lazy-fortran/fortfront#2896; reason=reject constructs in forbidden program sections
 pr66465.f90 # owner=lazy-fortran/ffc#372; reason=lower ASSOCIATED for procedure components
@@ -221,16 +214,12 @@ pr77414.f90 # owner=lazy-fortran/fortfront#2888; reason=reject local and host-as
 pr77583.f90 # owner=lazy-fortran/fortfront#2895; reason=reject duplicate or incompatible declaration attributes
 pr78719_2.f90 # owner=lazy-fortran/ffc#381; reason=enforce data and procedure pointer target contracts
 pr85798.f90 # owner=lazy-fortran/ffc#390; reason=enforce derived-type definition constraints
-pr87922.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
 pr88025.f90 # owner=lazy-fortran/ffc#384; reason=require valid character length expressions
 pr88048.f90 # owner=lazy-fortran/ffc#383; reason=enforce DATA object and initializer restrictions
-pr88269.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
 pr88328.f90 # owner=lazy-fortran/ffc#386; reason=reject invalid array indexing and shape expressions
-pr88552.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
 pr89943_3.f90 # owner=lazy-fortran/fortfront#2900; reason=enforce submodule declaration consistency
 pr89943_4.f90 # owner=lazy-fortran/fortfront#2900; reason=enforce submodule declaration consistency
 pr91564.f90 # owner=lazy-fortran/fortfront#2886; reason=enforce BIND(C) interoperability contracts
-pr91650_1.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
 pr91660_1.f90 # owner=lazy-fortran/fortfront#2891; reason=reject malformed type and SELECT TYPE syntax
 pr91715.f90 # owner=lazy-fortran/fortfront#2891; reason=reject malformed type and SELECT TYPE syntax
 pr91959.f90 # owner=lazy-fortran/fortfront#2890; reason=reject invalid source and identifier characters
@@ -253,7 +242,6 @@ pr96099_2.f90 # owner=lazy-fortran/fortfront#2891; reason=reject malformed type 
 pr96102.f90 # owner=lazy-fortran/fortfront#2888; reason=reject local and host-associated name collisions
 pr99368.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member constraints
 present_1.f90 # owner=lazy-fortran/ffc#381; reason=enforce data and procedure pointer target contracts
-print_2.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
 print_fmt_2.f90 # owner=lazy-fortran/fortfront#2897; reason=reject unclassifiable execution expressions
 private_type_6.f90 # owner=lazy-fortran/ffc#390; reason=enforce derived-type definition constraints
 proc_decl_7.f90 # owner=lazy-fortran/fortfront#2882; reason=reject procedure-call signature mismatches

--- a/test/conformance/xfail_gfortran_dg.txt
+++ b/test/conformance/xfail_gfortran_dg.txt
@@ -750,7 +750,6 @@ f_c_string2.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarati
 fgetc_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 fgetc_2.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 filename_null.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
-filepos1.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
 finalize_13.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
 finalize_14.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 finalize_15.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once
@@ -2107,7 +2106,6 @@ automatic_char_len_1.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime
 bind_c_usage_32.f90 # owner=lazy-fortran/ffc#384; reason=reject invalid interoperable character result length
 bound_simplification_1.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
 dec_exp_3.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
-dec_io_3.f90 # owner=lazy-fortran/ffc#385; reason=enforce I/O control-list constraints
 dec_static_3.f90 # scope=vendor; reason=DEC AUTOMATIC and STATIC extensions
 erfc_scaled_1.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
 fmt_error_6.f90 # owner=lazy-fortran/ffc#391; reason=reject malformed FORMAT descriptors

--- a/test/test_session_reject_io_01_compiler.f90
+++ b/test/test_session_reject_io_01_compiler.f90
@@ -1,0 +1,198 @@
+program test_session_reject_io_01_compiler
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== I/O control-list constraint rejection compiler test ==='
+
+    all_passed = .true.
+    if (.not. test_nondefault_kind_spec_rejected()) all_passed = .false.
+    if (.not. test_array_spec_rejected()) all_passed = .false.
+    if (.not. test_end_in_output_rejected()) all_passed = .false.
+    if (.not. test_write_without_unit_rejected()) all_passed = .false.
+    if (.not. test_character_write_unit_rejected()) all_passed = .false.
+    if (.not. test_negative_unit_rejected()) all_passed = .false.
+    if (.not. test_newunit_without_file_rejected()) all_passed = .false.
+    if (.not. test_boz_output_item_rejected()) all_passed = .false.
+    if (.not. test_print_trailing_comma_rejected()) all_passed = .false.
+    if (.not. test_unbalanced_parens_rejected()) all_passed = .false.
+    if (.not. test_dec_specifier_rejected()) all_passed = .false.
+    if (.not. test_valid_io_accepted()) all_passed = .false.
+    if (.not. test_valid_open_newunit_accepted()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: invalid I/O control lists rejected, valid I/O accepted'
+
+contains
+
+    logical function test_nondefault_kind_spec_rejected()
+        ! A character I/O specifier value must be a default-kind character
+        ! string; char(1000, 4) is kind 4 (gfortran: "must be a character
+        ! string of default kind").
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  open (1, blank=char(1000,4))'//new_line('a')// &
+            'end program main'
+
+        test_nondefault_kind_spec_rejected = expect_error_contains( &
+            source, 'default kind', '/tmp/ffc_io01_kind_reject')
+    end function test_nondefault_kind_spec_rejected
+
+    logical function test_array_spec_rejected()
+        ! An I/O specifier value must be scalar; an array constructor is not.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            "  read (1, asynchronous=['no'])"//new_line('a')// &
+            'end program main'
+
+        test_array_spec_rejected = expect_error_contains( &
+            source, 'must be scalar', '/tmp/ffc_io01_scalar_reject')
+    end function test_array_spec_rejected
+
+    logical function test_end_in_output_rejected()
+        ! END= is only meaningful for input; it is not allowed on WRITE.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  write (unit=6,end=999) 0'//new_line('a')// &
+            '999 continue'//new_line('a')// &
+            'end program main'
+
+        test_end_in_output_rejected = expect_error_contains( &
+            source, 'END=', '/tmp/ffc_io01_end_reject')
+    end function test_end_in_output_rejected
+
+    logical function test_write_without_unit_rejected()
+        ! A WRITE control list must specify a unit.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            "  write(fmt='(a)'), 'abc'"//new_line('a')// &
+            'end program main'
+
+        test_write_without_unit_rejected = expect_error_contains( &
+            source, 'UNIT not specified', '/tmp/ffc_io01_nounit_reject')
+    end function test_write_without_unit_rejected
+
+    logical function test_character_write_unit_rejected()
+        ! A character literal cannot be a WRITE unit: an internal file must be
+        ! a character variable, so write('(a)'), "x" is invalid.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            "  write ('(a)'), 'invalid'"//new_line('a')// &
+            'end program main'
+
+        test_character_write_unit_rejected = expect_error_contains( &
+            source, 'Invalid form of WRITE statement', &
+            '/tmp/ffc_io01_charunit_reject')
+    end function test_character_write_unit_rejected
+
+    logical function test_negative_unit_rejected()
+        ! A unit number is never negative.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  logical :: file_exists'//new_line('a')// &
+            '  inquire(unit=-1,exist=file_exists)'//new_line('a')// &
+            'end program main'
+
+        test_negative_unit_rejected = expect_error_contains( &
+            source, 'cannot be negative', '/tmp/ffc_io01_negunit_reject')
+    end function test_negative_unit_rejected
+
+    logical function test_newunit_without_file_rejected()
+        ! OPEN(NEWUNIT=...) requires FILE= or STATUS='SCRATCH'.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: lun'//new_line('a')// &
+            '  open(newunit=lun)'//new_line('a')// &
+            'end program main'
+
+        test_newunit_without_file_rejected = expect_error_contains( &
+            source, 'NEWUNIT specifier must have', &
+            '/tmp/ffc_io01_newunit_reject')
+    end function test_newunit_without_file_rejected
+
+    logical function test_boz_output_item_rejected()
+        ! A BOZ literal constant has no type and cannot be written out.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            "  print *, z'10110'"//new_line('a')// &
+            'end program main'
+
+        test_boz_output_item_rejected = expect_error_contains( &
+            source, 'output IO list', '/tmp/ffc_io01_boz_reject')
+    end function test_boz_output_item_rejected
+
+    logical function test_print_trailing_comma_rejected()
+        ! A comma after the format must be followed by an output item list.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  print *,'//new_line('a')// &
+            'end program main'
+
+        test_print_trailing_comma_rejected = expect_error_contains( &
+            source, 'output item list', '/tmp/ffc_io01_comma_reject')
+    end function test_print_trailing_comma_rejected
+
+    logical function test_unbalanced_parens_rejected()
+        ! An unbalanced parenthesis in a statement is never valid Fortran.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer(len((c)) :: n'//new_line('a')// &
+            'end program main'
+
+        test_unbalanced_parens_rejected = expect_error_contains( &
+            source, 'unbalanced parenthes', '/tmp/ffc_io01_paren_reject')
+    end function test_unbalanced_parens_rejected
+
+    logical function test_dec_specifier_rejected()
+        ! READONLY and friends are DEC extensions, not Fortran specifiers.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: fd'//new_line('a')// &
+            '  fd = 10'//new_line('a')// &
+            '  open (unit=fd, readonly)'//new_line('a')// &
+            'end program main'
+
+        test_dec_specifier_rejected = expect_error_contains( &
+            source, 'DEC extension', '/tmp/ffc_io01_dec_reject')
+    end function test_dec_specifier_rejected
+
+    logical function test_valid_io_accepted()
+        ! Corrected neighbours of every rejected form above still compile and
+        ! run: default-kind character specifiers, scalar specifiers, a WRITE
+        ! with a unit, a positive unit, and a typed output item.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  logical :: file_exists'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  character(len=20) :: buffer'//new_line('a')// &
+            '  inquire(unit=6,exist=file_exists)'//new_line('a')// &
+            "  write (6,'(a)') 'valid'"//new_line('a')// &
+            "  write (buffer,'(a)') 'internal'"//new_line('a')// &
+            '  i = 42'//new_line('a')// &
+            '  print *, i'//new_line('a')// &
+            "  print '(a)', 'done'"//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_valid_io_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_io01_valid_accept')
+    end function test_valid_io_accepted
+
+    logical function test_valid_open_newunit_accepted()
+        ! OPEN with NEWUNIT and a FILE=, plus a default-kind character
+        ! specifier, remains accepted.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: lun'//new_line('a')// &
+            "  open(newunit=lun, file='/tmp/ffc_io01_scratch.txt', "// &
+            "status='replace')"//new_line('a')// &
+            "  close(lun, status='delete')"//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_valid_open_newunit_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_io01_newunit_accept')
+    end function test_valid_open_newunit_accepted
+
+end program test_session_reject_io_01_compiler


### PR DESCRIPTION
Closes #385.

## Invariant preserved
Invalid I/O control lists are rejected with a rule-specific source diagnostic instead of being silently dropped by the parser; every corrected neighbouring form still compiles and runs with gfortran-matching output.

Rules enforced (validated on statement structure, not filenames or message text):
- character I/O specifier value must be scalar and of default character kind
- `END=` not allowed on an output statement
- `WRITE` must specify a unit; a character literal cannot be a unit
- unit number cannot be negative
- `OPEN(NEWUNIT=...)` requires `FILE=` or `STATUS='SCRATCH'` (F2018 12.5.6.12)
- BOZ literal constants cannot appear in an output item list
- `PRINT fmt,` with an empty output list
- unbalanced control-list parentheses
- DEC-only specifiers (`CARRIAGECONTROL`, `SHARE`, `READONLY`, ...)

## Red evidence
With `src/` at origin/main and the new test in place:
```
test_session_reject_io_01_compiler   FAIL
  FAIL: unsupported source lowered without diagnostic   (x10)
Summary: 0 passed, 1 failed
```

## Green evidence
```
fo test test_session_reject_io_01_compiler   -> 1 passed
scripts/conformance_gauntlet.sh --suite gfortran-dg --file io_constraints_15.f90 ... --file print_2.f90
  PASS=12 XFAIL=0 XPASS=0 FAIL=0 TOTAL=12
```
The 12 negative fixtures are removed from `fail_owners_gfortran_dg.txt`, and `filepos1.f90`/`dec_io_3.f90` from `xfail_gfortran_dg.txt`.

Full `fo` is green except `test_parity_dashboard`, which is already red on origin/main (its recorded manifest digest does not match the manifests on main).