### PR TITLE
[reject-pointer-01] enforce data and procedure pointer target contracts (#381)

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -2619,6 +2619,7 @@ contains
     include 'session_program_lowering_diagnostics.inc'
     include 'session_program_lowering_reject_checks.inc'
     include 'session_program_lowering_reject_array_ctor.inc'
+    include 'session_program_lowering_reject_pointer.inc'
     include 'session_program_lowering_reject_const_init.inc'
     include 'session_program_lowering_reject_storage.inc'
     include 'session_program_lowering_reject_const_overflow.inc'

--- a/src/session_program_lowering_reject_pointer.inc
+++ b/src/session_program_lowering_reject_pointer.inc
@@ -1,0 +1,741 @@
+    ! Data and procedure pointer target contracts (#381).
+    !
+    ! A pointer only ever associates with something that can be a target:
+    ! a data pointer needs a pointer or a valid target object, a procedure
+    ! pointer needs an actual procedure that is visible here. The lowerer
+    ! silently accepted several invalid associations, so this file collects
+    ! the constraint family: PRESENT subobjects, ABSTRACT interfaces given
+    ! the POINTER attribute, procedure-pointer targets that are data
+    ! objects, function result variables or unknown names, INTENT(IN)
+    ! pointer actuals in a pointer-association context, Cray pointer
+    ! declarations, and parenthesised expressions where a target is
+    ! required.
+    subroutine check_pointer_target_contracts(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call set_empty(error_msg)
+        call check_present_argument_subobject(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_abstract_interface_pointer(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_proc_pointer_targets(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_pointer_intent_actuals(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_pointer_source_forms(arena, error_msg)
+    end subroutine check_pointer_target_contracts
+
+    ! The A argument of PRESENT shall be the name of an optional dummy
+    ! argument, never a subobject of one (F2018 16.9.157, gfortran
+    ! "must not be a subobject"). Anything but a bare identifier is a
+    ! component reference, array element or expression.
+    subroutine check_present_argument_subobject(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n
+        character(len=64) :: location
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (call_or_subscript_node)
+                if (.not. allocated(nd%name)) cycle
+                if (.not. same_name(nd%name, 'present')) cycle
+                if (.not. allocated(nd%arg_indices)) cycle
+                if (size(nd%arg_indices) /= 1) cycle
+                if (is_identifier(arena, nd%arg_indices(1))) cycle
+                write (location, '(" at line ",I0,", column ",I0)') &
+                    nd%line, nd%column
+                error_msg = 'argument of PRESENT'//trim(location)// &
+                    ' must be an optional dummy argument name and '// &
+                    'must not be a subobject'
+                return
+            end select
+        end do
+    end subroutine check_present_argument_subobject
+
+    ! An interface body in an ABSTRACT INTERFACE names an abstract
+    ! interface, not a procedure, so that name shall not also carry the
+    ! POINTER attribute (F2018 C1213, gfortran "PROCEDURE POINTER
+    ! attribute conflicts with ABSTRACT attribute").
+    subroutine check_abstract_interface_pointer(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n, i
+        character(len=:), allocatable :: proc_name
+        character(len=64) :: location
+        integer :: decl_line
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (interface_block_node)
+                if (.not. nd%is_abstract) cycle
+                if (.not. allocated(nd%procedure_indices)) cycle
+                do i = 1, size(nd%procedure_indices)
+                    call procedure_def_name(arena, nd%procedure_indices(i), &
+                                            proc_name)
+                    if (len_trim(proc_name) == 0) cycle
+                    decl_line = pointer_declaration_line(arena, proc_name)
+                    if (decl_line <= 0) cycle
+                    write (location, '(" at line ",I0)') decl_line
+                    error_msg = 'POINTER attribute conflicts with ABSTRACT '// &
+                        'attribute for '''//trim(proc_name)//''''//trim(location)
+                    return
+                end do
+            end select
+        end do
+    end subroutine check_abstract_interface_pointer
+
+    ! Line of the first declaration giving name the POINTER attribute,
+    ! or 0 when no such declaration exists.
+    integer function pointer_declaration_line(arena, name) result(line_no)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer :: n, i
+
+        line_no = 0
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (declaration_node)
+                if (.not. nd%is_pointer) cycle
+                if (allocated(nd%var_name)) then
+                    if (same_name(nd%var_name, name)) then
+                        line_no = nd%line
+                        return
+                    end if
+                end if
+                if (.not. nd%is_multi_declaration) cycle
+                if (.not. allocated(nd%var_names)) cycle
+                do i = 1, size(nd%var_names)
+                    if (same_name(nd%var_names(i), name)) then
+                        line_no = nd%line
+                        return
+                    end if
+                end do
+            end select
+        end do
+    end function pointer_declaration_line
+
+    ! A proc-target shall be a procedure that is visible in this scope:
+    ! a data object, the result variable of the enclosing function, or a
+    ! name that denotes nothing at all are all invalid (F2018 10.2.2.4,
+    ! gfortran "Invalid procedure pointer", "is invalid as proc-target",
+    ! "must be either an intrinsic, host or use associated, referenced or
+    ! have the EXTERNAL attribute").
+    subroutine check_proc_pointer_targets(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: ptr_name, target_name, ff_error
+        character(len=:), allocatable :: enclosing_name
+        integer :: n
+        logical :: recursive_host
+        character(len=64) :: location
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (pointer_assignment_node)
+                if (.not. is_identifier(arena, nd%pointer_index)) cycle
+                if (.not. is_identifier(arena, nd%target_index)) cycle
+                call get_identifier_name(arena, nd%pointer_index, ptr_name, &
+                                         ff_error)
+                if (len_trim(ff_error) > 0) cycle
+                if (.not. name_is_proc_pointer(arena, ptr_name)) cycle
+                call get_identifier_name(arena, nd%target_index, target_name, &
+                                         ff_error)
+                if (len_trim(ff_error) > 0) cycle
+                if (same_name(target_name, 'null')) cycle
+                if (name_is_proc_pointer(arena, target_name)) cycle
+                write (location, '(" at line ",I0)') nd%line
+                if (name_is_data_object(arena, target_name)) then
+                    error_msg = 'Invalid procedure pointer assignment'// &
+                        trim(location)//': '''//trim(target_name)// &
+                        ''' is a data object, not a procedure'
+                    return
+                end if
+                call enclosing_procedure_of(arena, n, enclosing_name, &
+                                            recursive_host)
+                if (len_trim(enclosing_name) > 0 .and. .not. recursive_host) then
+                    if (same_name(enclosing_name, target_name)) then
+                        error_msg = ''''//trim(target_name)//''''//trim(location)// &
+                            ' is invalid as proc-target in procedure '// &
+                            'pointer assignment: it names the function '// &
+                            'result variable'
+                        return
+                    end if
+                end if
+                if (name_is_visible_procedure(arena, target_name)) cycle
+                error_msg = 'procedure pointer target '''//trim(target_name)// &
+                    ''''//trim(location)//' must be either an intrinsic, '// &
+                    'host or use associated, referenced or have the '// &
+                    'EXTERNAL attribute'
+                return
+            end select
+        end do
+    end subroutine check_proc_pointer_targets
+
+    ! A procedure pointer is declared as procedure(...), pointer :: p.
+    logical function name_is_proc_pointer(arena, name) result(is_proc_ptr)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer :: n, i
+        logical :: names_it
+
+        is_proc_ptr = .false.
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (declaration_node)
+                if (.not. nd%is_pointer) cycle
+                if (.not. allocated(nd%type_name)) cycle
+                if (.not. starts_with_word(lowercase_text(nd%type_name), &
+                                           'procedure')) cycle
+                names_it = .false.
+                if (allocated(nd%var_name)) then
+                    if (same_name(nd%var_name, name)) names_it = .true.
+                end if
+                if (allocated(nd%var_names)) then
+                    do i = 1, size(nd%var_names)
+                        if (same_name(nd%var_names(i), name)) names_it = .true.
+                    end do
+                end if
+                if (names_it) then
+                    is_proc_ptr = .true.
+                    return
+                end if
+            end select
+        end do
+    end function name_is_proc_pointer
+
+    ! A declaration with an intrinsic or derived type name and no
+    ! PROCEDURE prefix declares a data object.
+    logical function name_is_data_object(arena, name) result(is_data)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer :: n, i
+        logical :: names_it
+
+        is_data = .false.
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (declaration_node)
+                if (nd%is_external) cycle
+                if (.not. allocated(nd%type_name)) cycle
+                if (len_trim(nd%type_name) == 0) cycle
+                if (starts_with_word(lowercase_text(nd%type_name), 'procedure')) cycle
+                names_it = .false.
+                if (allocated(nd%var_name)) then
+                    if (same_name(nd%var_name, name)) names_it = .true.
+                end if
+                if (allocated(nd%var_names)) then
+                    do i = 1, size(nd%var_names)
+                        if (same_name(nd%var_names(i), name)) names_it = .true.
+                    end do
+                end if
+                if (names_it) then
+                    is_data = .true.
+                    return
+                end if
+            end select
+        end do
+    end function name_is_data_object
+
+    ! A name is a usable proc-target when a procedure definition, an
+    ! interface body, an EXTERNAL declaration or an INTRINSIC statement
+    ! makes it visible.
+    logical function name_is_visible_procedure(arena, name) result(is_visible)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: def_name
+        integer :: n, i
+
+        is_visible = .false.
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            call procedure_def_name(arena, n, def_name)
+            if (len_trim(def_name) > 0) then
+                if (same_name(def_name, name)) then
+                    is_visible = .true.
+                    return
+                end if
+            end if
+            select type (nd => arena%entries(n)%node)
+            type is (declaration_node)
+                if (.not. nd%is_external) cycle
+                if (allocated(nd%var_name)) then
+                    if (same_name(nd%var_name, name)) then
+                        is_visible = .true.
+                        return
+                    end if
+                end if
+                if (.not. allocated(nd%var_names)) cycle
+                do i = 1, size(nd%var_names)
+                    if (same_name(nd%var_names(i), name)) then
+                        is_visible = .true.
+                        return
+                    end if
+                end do
+            type is (intrinsic_statement_node)
+                if (.not. allocated(nd%procedure_names)) cycle
+                do i = 1, size(nd%procedure_names)
+                    if (.not. allocated(nd%procedure_names(i)%s)) cycle
+                    if (same_name(nd%procedure_names(i)%s, name)) then
+                        is_visible = .true.
+                        return
+                    end if
+                end do
+            type is (use_statement_node)
+                ! A USE without an only-list can bring in any procedure.
+                if (.not. nd%has_only) then
+                    is_visible = .true.
+                    return
+                end if
+            end select
+        end do
+    end function name_is_visible_procedure
+
+    ! Name and recursiveness of the procedure whose body holds node_index.
+    subroutine enclosing_procedure_of(arena, node_index, name, is_recursive)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable, intent(out) :: name
+        logical, intent(out) :: is_recursive
+        integer :: n, i
+
+        call set_empty(name)
+        is_recursive = .false.
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (function_def_node)
+                if (.not. allocated(nd%body_indices)) cycle
+                do i = 1, size(nd%body_indices)
+                    if (nd%body_indices(i) /= node_index) cycle
+                    if (allocated(nd%name)) name = trim(nd%name)
+                    is_recursive = nd%is_recursive
+                    return
+                end do
+            end select
+        end do
+    end subroutine enclosing_procedure_of
+
+    ! An INTENT(IN) pointer shall not appear as the actual argument of an
+    ! INTENT(OUT) or INTENT(INOUT) pointer dummy: that is a pointer
+    ! association context (F2018 C844, gfortran "INTENT(IN) in pointer
+    ! association context").
+    subroutine check_pointer_intent_actuals(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: call_name, actual_name, ff_error
+        character(len=:), allocatable :: dummy_intent, actual_intent
+        integer, allocatable :: arg_indices(:)
+        integer :: n, k
+        logical :: dummy_pointer, actual_pointer, actual_found
+        character(len=64) :: location
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            if (.not. is_subroutine_call_statement(arena, n)) cycle
+            call get_subroutine_call_name(arena, n, call_name, ff_error)
+            if (len_trim(ff_error) > 0) cycle
+            call get_subroutine_call_arg_indices(arena, n, arg_indices, ff_error)
+            if (len_trim(ff_error) > 0) cycle
+            if (.not. allocated(arg_indices)) cycle
+            do k = 1, size(arg_indices)
+                if (.not. is_identifier(arena, arg_indices(k))) cycle
+                call dummy_pointer_intent(arena, call_name, k, dummy_pointer, &
+                                          dummy_intent)
+                if (.not. dummy_pointer) cycle
+                if (dummy_intent /= 'out' .and. dummy_intent /= 'inout') cycle
+                call get_identifier_name(arena, arg_indices(k), actual_name, &
+                                         ff_error)
+                if (len_trim(ff_error) > 0) cycle
+                call declared_pointer_intent(arena, actual_name, actual_found, &
+                                             actual_pointer, actual_intent)
+                if (.not. actual_found) cycle
+                if (.not. actual_pointer) cycle
+                if (actual_intent /= 'in') cycle
+                write (location, '(" at line ",I0)') get_node_line(arena, n)
+                error_msg = 'variable '''//trim(actual_name)// &
+                    ''' is INTENT(IN) in pointer association context'// &
+                    trim(location)//' (actual argument to INTENT = '// &
+                    'OUT/INOUT dummy pointer)'
+                return
+            end do
+        end do
+    end subroutine check_pointer_intent_actuals
+
+    ! POINTER attribute and INTENT of the position-th dummy of proc_name.
+    subroutine dummy_pointer_intent(arena, proc_name, position, is_pointer, &
+                                    intent_text)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: proc_name
+        integer, intent(in) :: position
+        logical, intent(out) :: is_pointer
+        character(len=:), allocatable, intent(out) :: intent_text
+        character(len=:), allocatable :: dummy_name
+        integer :: n
+        logical :: found
+
+        is_pointer = .false.
+        call set_empty(intent_text)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (subroutine_def_node)
+                if (.not. allocated(nd%name)) cycle
+                if (.not. same_name(nd%name, proc_name)) cycle
+                if (.not. allocated(nd%param_indices)) return
+                if (position > size(nd%param_indices)) return
+                call param_node_name(arena, nd%param_indices(position), &
+                                     dummy_name)
+                if (len_trim(dummy_name) == 0) return
+                if (.not. allocated(nd%body_indices)) return
+                call body_declaration_attributes(arena, nd%body_indices, &
+                    dummy_name, found, is_pointer, intent_text)
+                return
+            end select
+        end do
+    end subroutine dummy_pointer_intent
+
+    ! Declared name of a dummy argument node.
+    subroutine param_node_name(arena, node_index, name)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable, intent(out) :: name
+
+        call set_empty(name)
+        if (.not. node_exists(arena, node_index)) return
+        select type (nd => arena%entries(node_index)%node)
+        type is (parameter_declaration_node)
+            if (allocated(nd%name)) name = trim(nd%name)
+        type is (declaration_node)
+            if (allocated(nd%var_name)) name = trim(nd%var_name)
+        type is (identifier_node)
+            if (allocated(nd%name)) name = trim(nd%name)
+        end select
+    end subroutine param_node_name
+
+    ! POINTER attribute and INTENT of a declaration inside a procedure body.
+    subroutine body_declaration_attributes(arena, body_indices, name, found, &
+                                           is_pointer, intent_text)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: name
+        logical, intent(out) :: found
+        logical, intent(out) :: is_pointer
+        character(len=:), allocatable, intent(out) :: intent_text
+        integer :: i, j
+        logical :: names_it
+
+        found = .false.
+        is_pointer = .false.
+        call set_empty(intent_text)
+        do i = 1, size(body_indices)
+            if (.not. node_exists(arena, body_indices(i))) cycle
+            select type (nd => arena%entries(body_indices(i))%node)
+            type is (declaration_node)
+                names_it = .false.
+                if (allocated(nd%var_name)) then
+                    if (same_name(nd%var_name, name)) names_it = .true.
+                end if
+                if (allocated(nd%var_names)) then
+                    do j = 1, size(nd%var_names)
+                        if (same_name(nd%var_names(j), name)) names_it = .true.
+                    end do
+                end if
+                if (.not. names_it) cycle
+                found = .true.
+                is_pointer = nd%is_pointer
+                if (nd%has_intent .and. allocated(nd%intent)) then
+                    intent_text = lowercase_text(trim(nd%intent))
+                end if
+                return
+            end select
+        end do
+    end subroutine body_declaration_attributes
+
+    ! POINTER attribute and INTENT of the first declaration naming name.
+    subroutine declared_pointer_intent(arena, name, found, is_pointer, &
+                                       intent_text)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        logical, intent(out) :: found
+        logical, intent(out) :: is_pointer
+        character(len=:), allocatable, intent(out) :: intent_text
+        integer :: n, i
+        logical :: names_it
+
+        found = .false.
+        is_pointer = .false.
+        call set_empty(intent_text)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (declaration_node)
+                names_it = .false.
+                if (allocated(nd%var_name)) then
+                    if (same_name(nd%var_name, name)) names_it = .true.
+                end if
+                if (allocated(nd%var_names)) then
+                    do i = 1, size(nd%var_names)
+                        if (same_name(nd%var_names(i), name)) names_it = .true.
+                    end do
+                end if
+                if (.not. names_it) cycle
+                if (.not. nd%is_pointer) cycle
+                found = .true.
+                is_pointer = .true.
+                if (nd%has_intent .and. allocated(nd%intent)) then
+                    intent_text = lowercase_text(trim(nd%intent))
+                end if
+                return
+            end select
+        end do
+    end subroutine declared_pointer_intent
+
+    ! Parentheses never survive into the typed AST, so the forms that turn
+    ! on them are checked on the statement source: a Cray pointer
+    ! declaration (POINTER (ptr, pointee), not accepted without
+    ! -fcray-pointer), a parenthesised ASSOCIATED target, and a
+    ! parenthesised actual argument passed to a POINTER dummy.
+    subroutine check_pointer_source_forms(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: source, line, code
+        integer :: pos, next_nl, line_no
+
+        call set_empty(error_msg)
+        call get_pointer_source_lines(arena, source)
+        if (len(source) == 0) return
+        pos = 1
+        line_no = 0
+        do while (pos <= len(source))
+            next_nl = index(source(pos:), new_line('a'))
+            if (next_nl == 0) then
+                line = source(pos:)
+                pos = len(source) + 1
+            else
+                line = source(pos:pos + next_nl - 2)
+                pos = pos + next_nl
+            end if
+            line_no = line_no + 1
+            call strip_line_comment(line, code)
+            call check_cray_pointer_line(code, line_no, error_msg)
+            if (len_trim(error_msg) > 0) return
+            call check_associated_target_line(code, line_no, error_msg)
+            if (len_trim(error_msg) > 0) return
+            call check_parenthesised_actual_line(arena, code, line_no, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine check_pointer_source_forms
+
+    subroutine get_pointer_source_lines(arena, source)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: source
+        logical :: found
+
+        call get_source_text(arena, source, found)
+        if (.not. found) call set_empty(source)
+        if (.not. allocated(source)) call set_empty(source)
+    end subroutine get_pointer_source_lines
+
+    ! POINTER (ptr, pointee) is the Cray pointer extension, distinct from
+    ! the standard POINTER attribute statement (gfortran: "Cray pointer
+    ! declaration ... requires -fcray-pointer").
+    subroutine check_cray_pointer_line(code, line_no, error_msg)
+        character(len=*), intent(in) :: code
+        integer, intent(in) :: line_no
+        character(len=:), allocatable, intent(inout) :: error_msg
+        character(len=:), allocatable :: low
+        integer :: rest
+        character(len=64) :: location
+
+        low = trim(adjustl(lowercase_text(code)))
+        if (len(low) < 9) return
+        if (low(1:7) /= 'pointer') return
+        rest = 8
+        do while (rest <= len(low))
+            if (low(rest:rest) /= ' ') exit
+            rest = rest + 1
+        end do
+        if (rest > len(low)) return
+        if (low(rest:rest) /= '(') return
+        write (location, '(" at line ",I0)') line_no
+        error_msg = 'Cray pointer declaration'//trim(location)// &
+            ' requires -fcray-pointer; the Cray pointer extension is '// &
+            'not accepted'
+    end subroutine check_cray_pointer_line
+
+    ! The TARGET argument of ASSOCIATED shall be a pointer or a variable
+    ! with the TARGET attribute; a parenthesised expression is neither
+    ! (gfortran: "must be a VARIABLE or FUNCTION").
+    subroutine check_associated_target_line(code, line_no, error_msg)
+        character(len=*), intent(in) :: code
+        integer, intent(in) :: line_no
+        character(len=:), allocatable, intent(inout) :: error_msg
+        character(len=:), allocatable :: low, arg_text
+        integer :: open_pos, close_pos, starts(8), ends(8), n_args
+        character(len=64) :: location
+
+        low = lowercase_text(code)
+        call find_call_paren(low, 'associated', 1, open_pos)
+        if (open_pos <= 0) return
+        call matching_paren(low, open_pos, close_pos)
+        if (close_pos <= open_pos + 1) return
+        arg_text = low(open_pos + 1:close_pos - 1)
+        call top_level_args(arg_text, starts, ends, n_args)
+        if (n_args /= 2) return
+        if (.not. is_parenthesised(arg_text(starts(2):ends(2)))) return
+        write (location, '(" at line ",I0)') line_no
+        error_msg = 'TARGET argument of ASSOCIATED'//trim(location)// &
+            ' must be a VARIABLE or FUNCTION, not a parenthesised expression'
+    end subroutine check_associated_target_line
+
+    ! A parenthesised actual argument is an expression, so it can never
+    ! associate with a POINTER dummy (gfortran: "must be a pointer or a
+    ! valid target").
+    subroutine check_parenthesised_actual_line(arena, code, line_no, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: code
+        integer, intent(in) :: line_no
+        character(len=:), allocatable, intent(inout) :: error_msg
+        character(len=:), allocatable :: low, call_name, arg_text
+        integer :: open_pos, close_pos, starts(8), ends(8), n_args, k, name_end
+        logical :: dummy_pointer
+        character(len=:), allocatable :: dummy_intent
+        character(len=64) :: location
+
+        low = trim(adjustl(lowercase_text(code)))
+        if (len(low) < 6) return
+        if (low(1:5) /= 'call ') return
+        open_pos = index(low, '(')
+        if (open_pos <= 6) return
+        name_end = open_pos - 1
+        do while (name_end >= 6)
+            if (low(name_end:name_end) /= ' ') exit
+            name_end = name_end - 1
+        end do
+        if (name_end < 6) return
+        call_name = trim(adjustl(low(6:name_end)))
+        if (len_trim(call_name) == 0) return
+        call matching_paren(low, open_pos, close_pos)
+        if (close_pos <= open_pos + 1) return
+        arg_text = low(open_pos + 1:close_pos - 1)
+        call top_level_args(arg_text, starts, ends, n_args)
+        do k = 1, n_args
+            if (.not. is_parenthesised(arg_text(starts(k):ends(k)))) cycle
+            call dummy_pointer_intent(arena, call_name, k, dummy_pointer, &
+                                      dummy_intent)
+            if (.not. dummy_pointer) cycle
+            write (location, '(" at line ",I0)') line_no
+            error_msg = 'actual argument '//trim(arg_text(starts(k):ends(k)))// &
+                ' for '''//trim(call_name)//''''//trim(location)// &
+                ' must be a pointer or a valid target'
+            return
+        end do
+    end subroutine check_parenthesised_actual_line
+
+    ! Position of the opening parenthesis of a call to name, or 0.
+    subroutine find_call_paren(low, name, from, open_pos)
+        character(len=*), intent(in) :: low
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: from
+        integer, intent(out) :: open_pos
+        integer :: hit, cursor, after
+
+        open_pos = 0
+        cursor = from
+        do while (cursor <= len(low))
+            hit = index(low(cursor:), name)
+            if (hit == 0) return
+            hit = cursor + hit - 1
+            cursor = hit + len(name)
+            if (hit > 1) then
+                if (is_fortran_identifier_char(low(hit - 1:hit - 1))) cycle
+            end if
+            after = hit + len(name)
+            do while (after <= len(low))
+                if (low(after:after) /= ' ') exit
+                after = after + 1
+            end do
+            if (after > len(low)) return
+            if (low(after:after) /= '(') cycle
+            open_pos = after
+            return
+        end do
+    end subroutine find_call_paren
+
+    ! Position of the parenthesis closing the one at open_pos, or 0.
+    subroutine matching_paren(text, open_pos, close_pos)
+        character(len=*), intent(in) :: text
+        integer, intent(in) :: open_pos
+        integer, intent(out) :: close_pos
+        integer :: i, depth
+
+        close_pos = 0
+        depth = 0
+        do i = open_pos, len(text)
+            if (text(i:i) == '(') depth = depth + 1
+            if (text(i:i) == ')') then
+                depth = depth - 1
+                if (depth == 0) then
+                    close_pos = i
+                    return
+                end if
+            end if
+        end do
+    end subroutine matching_paren
+
+    ! Split an argument list on commas that sit outside parentheses.
+    subroutine top_level_args(text, starts, ends, n_args)
+        character(len=*), intent(in) :: text
+        integer, intent(out) :: starts(:)
+        integer, intent(out) :: ends(:)
+        integer, intent(out) :: n_args
+        integer :: i, depth, arg_start
+
+        n_args = 0
+        depth = 0
+        arg_start = 1
+        if (len_trim(text) == 0) return
+        do i = 1, len(text)
+            if (text(i:i) == '(') depth = depth + 1
+            if (text(i:i) == ')') depth = depth - 1
+            if (text(i:i) /= ',') cycle
+            if (depth /= 0) cycle
+            if (n_args >= size(starts)) return
+            n_args = n_args + 1
+            starts(n_args) = arg_start
+            ends(n_args) = i - 1
+            arg_start = i + 1
+        end do
+        if (n_args >= size(starts)) return
+        n_args = n_args + 1
+        starts(n_args) = arg_start
+        ends(n_args) = len(text)
+    end subroutine top_level_args
+
+    ! An argument is parenthesised when one outer pair of parentheses
+    ! wraps the whole expression.
+    logical function is_parenthesised(text) result(wrapped)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: trimmed
+        integer :: close_pos
+
+        wrapped = .false.
+        trimmed = trim(adjustl(text))
+        if (len(trimmed) < 3) return
+        if (trimmed(1:1) /= '(') return
+        call matching_paren(trimmed, 1, close_pos)
+        if (close_pos /= len(trimmed)) return
+        wrapped = .true.
+    end function is_parenthesised

--- a/src/session_program_lowering_reject_pointer.inc
+++ b/src/session_program_lowering_reject_pointer.inc
@@ -80,6 +80,9 @@
                                             proc_name)
                     if (len_trim(proc_name) == 0) cycle
                     decl_line = pointer_declaration_line(arena, proc_name)
+                    if (decl_line <= 0) then
+                        decl_line = pointer_statement_line(arena, proc_name)
+                    end if
                     if (decl_line <= 0) cycle
                     write (location, '(" at line ",I0)') decl_line
                     error_msg = 'POINTER attribute conflicts with ABSTRACT '// &
@@ -535,8 +538,108 @@
             if (len_trim(error_msg) > 0) return
             call check_parenthesised_actual_line(arena, code, line_no, error_msg)
             if (len_trim(error_msg) > 0) return
+            call check_present_source_line(code, line_no, error_msg)
+            if (len_trim(error_msg) > 0) return
         end do
     end subroutine check_pointer_source_forms
+
+    ! Line of a POINTER attribute statement (POINTER :: a, b) naming name,
+    ! or 0. The attribute-statement form carries no type and does not reach
+    ! the typed AST as a declaration, so it is read from the source.
+    integer function pointer_statement_line(arena, name) result(line_no)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: source, line, code, low, list
+        integer :: pos, next_nl, current, rest, starts(32), ends(32), n_names, k
+
+        line_no = 0
+        call get_pointer_source_lines(arena, source)
+        if (len(source) == 0) return
+        pos = 1
+        current = 0
+        do while (pos <= len(source))
+            next_nl = index(source(pos:), new_line('a'))
+            if (next_nl == 0) then
+                line = source(pos:)
+                pos = len(source) + 1
+            else
+                line = source(pos:pos + next_nl - 2)
+                pos = pos + next_nl
+            end if
+            current = current + 1
+            call strip_line_comment(line, code)
+            low = trim(adjustl(lowercase_text(code)))
+            if (len(low) < 9) cycle
+            if (low(1:7) /= 'pointer') cycle
+            if (is_fortran_identifier_char(low(8:8))) cycle
+            rest = 8
+            do while (rest <= len(low))
+                if (low(rest:rest) /= ' ') exit
+                rest = rest + 1
+            end do
+            if (rest > len(low)) cycle
+            if (low(rest:rest) == '(') cycle
+            if (rest + 1 <= len(low)) then
+                if (low(rest:rest + 1) == '::') rest = rest + 2
+            end if
+            if (rest > len(low)) cycle
+            list = low(rest:)
+            call top_level_args(list, starts, ends, n_names)
+            do k = 1, n_names
+                if (.not. same_name(trim(adjustl(list(starts(k):ends(k)))), &
+                                    name)) cycle
+                line_no = current
+                return
+            end do
+        end do
+    end function pointer_statement_line
+
+    ! PRESENT applied to anything but a bare name, read from the source.
+    ! The typed AST does not expose the argument of PRESENT in every scope,
+    ! so the constraint is also enforced on the statement text.
+    subroutine check_present_source_line(code, line_no, error_msg)
+        character(len=*), intent(in) :: code
+        integer, intent(in) :: line_no
+        character(len=:), allocatable, intent(inout) :: error_msg
+        character(len=:), allocatable :: low, arg_text
+        integer :: open_pos, close_pos, cursor
+        character(len=64) :: location
+
+        low = lowercase_text(code)
+        cursor = 1
+        do
+            call find_call_paren(low, 'present', cursor, open_pos)
+            if (open_pos <= 0) return
+            cursor = open_pos + 1
+            call matching_paren(low, open_pos, close_pos)
+            if (close_pos <= open_pos) return
+            arg_text = trim(adjustl(low(open_pos + 1:close_pos - 1)))
+            if (is_plain_identifier(arg_text)) cycle
+            if (len_trim(arg_text) == 0) cycle
+            write (location, '(" at line ",I0)') line_no
+            error_msg = 'argument of PRESENT'//trim(location)// &
+                ' must be an optional dummy argument name and '// &
+                'must not be a subobject'
+            return
+        end do
+    end subroutine check_present_source_line
+
+    ! A name is a plain identifier: a letter followed by letters, digits
+    ! or underscores, with nothing else attached.
+    logical function is_plain_identifier(text) result(plain)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: trimmed
+        integer :: i
+
+        plain = .false.
+        trimmed = trim(adjustl(text))
+        if (len(trimmed) == 0) return
+        if (index('abcdefghijklmnopqrstuvwxyz', trimmed(1:1)) == 0) return
+        do i = 2, len(trimmed)
+            if (.not. is_fortran_identifier_char(trimmed(i:i))) return
+        end do
+        plain = .true.
+    end function is_plain_identifier
 
     subroutine get_pointer_source_lines(arena, source)
         type(ast_arena_t), intent(in) :: arena

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -548,6 +548,8 @@
         if (len_trim(error_msg) > 0) return
         call check_array_constructor_compatibility(arena, error_msg)
         if (len_trim(error_msg) > 0) return
+        call check_pointer_target_contracts(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
         call check_constant_initialization_exprs(arena, error_msg)
         if (len_trim(error_msg) > 0) return
         call check_constant_expression_overflow(arena, error_msg)

--- a/test/test_session_reject_pointer_01_compiler.f90
+++ b/test/test_session_reject_pointer_01_compiler.f90
@@ -1,0 +1,385 @@
+program test_session_reject_pointer_01_compiler
+    ! #381: data and procedure pointer target contracts. A pointer only
+    ! associates with something that can be a target, and PRESENT only
+    ! accepts a whole optional dummy argument. Each invalid form below is
+    ! rejected with a source diagnostic; the corrected neighbour compiles
+    ! and runs.
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== pointer target contract rejection test ==='
+
+    all_passed = .true.
+    if (.not. test_present_subobject_rejected()) all_passed = .false.
+    if (.not. test_present_element_rejected()) all_passed = .false.
+    if (.not. test_present_whole_dummy_accepted()) all_passed = .false.
+    if (.not. test_abstract_interface_pointer_rejected()) all_passed = .false.
+    if (.not. test_concrete_proc_pointer_accepted()) all_passed = .false.
+    if (.not. test_data_object_proc_target_rejected()) all_passed = .false.
+    if (.not. test_result_variable_proc_target_rejected()) all_passed = .false.
+    if (.not. test_recursive_proc_target_accepted()) all_passed = .false.
+    if (.not. test_unknown_proc_target_rejected()) all_passed = .false.
+    if (.not. test_intent_in_pointer_actual_rejected()) all_passed = .false.
+    if (.not. test_intent_inout_pointer_actual_accepted()) all_passed = .false.
+    if (.not. test_cray_pointer_rejected()) all_passed = .false.
+    if (.not. test_standard_pointer_accepted()) all_passed = .false.
+    if (.not. test_parenthesised_associated_target_rejected()) all_passed = .false.
+    if (.not. test_plain_associated_target_accepted()) all_passed = .false.
+    if (.not. test_parenthesised_pointer_actual_rejected()) all_passed = .false.
+    if (.not. test_plain_pointer_actual_accepted()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: invalid pointer target contracts are rejected'
+
+contains
+
+    ! gfortran.dg/present_1.f90: PRESENT(D1%I).
+    logical function test_present_subobject_rejected()
+        character(len=*), parameter :: source = &
+            'module m1'//new_line('a')// &
+            '  type t1'//new_line('a')// &
+            '    integer :: i'//new_line('a')// &
+            '  end type t1'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine s1(d1)'//new_line('a')// &
+            '    type(t1), optional :: d1(4)'//new_line('a')// &
+            '    print *, present(d1%i)'//new_line('a')// &
+            '  end subroutine s1'//new_line('a')// &
+            'end module m1'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m1'//new_line('a')// &
+            '  call s1()'//new_line('a')// &
+            'end program main'
+
+        test_present_subobject_rejected = expect_error_contains( &
+            source, 'must not be a subobject', &
+            '/tmp/ffc_reject_pointer01_present_comp')
+    end function test_present_subobject_rejected
+
+    ! gfortran.dg/present_1.f90: PRESENT(D1(1)).
+    logical function test_present_element_rejected()
+        character(len=*), parameter :: source = &
+            'module m1'//new_line('a')// &
+            '  type t1'//new_line('a')// &
+            '    integer :: i'//new_line('a')// &
+            '  end type t1'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine s1(d1)'//new_line('a')// &
+            '    type(t1), optional :: d1(4)'//new_line('a')// &
+            '    print *, present(d1(1))'//new_line('a')// &
+            '  end subroutine s1'//new_line('a')// &
+            'end module m1'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m1'//new_line('a')// &
+            '  call s1()'//new_line('a')// &
+            'end program main'
+
+        test_present_element_rejected = expect_error_contains( &
+            source, 'must not be a subobject', &
+            '/tmp/ffc_reject_pointer01_present_elem')
+    end function test_present_element_rejected
+
+    ! Corrected neighbour: PRESENT of the whole optional dummy.
+    logical function test_present_whole_dummy_accepted()
+        character(len=*), parameter :: source = &
+            'module m1'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine s1(d1)'//new_line('a')// &
+            '    integer, optional :: d1'//new_line('a')// &
+            '    if (present(d1)) then'//new_line('a')// &
+            '      stop 3'//new_line('a')// &
+            '    end if'//new_line('a')// &
+            '    stop 4'//new_line('a')// &
+            '  end subroutine s1'//new_line('a')// &
+            'end module m1'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m1'//new_line('a')// &
+            '  call s1(9)'//new_line('a')// &
+            'end program main'
+
+        test_present_whole_dummy_accepted = expect_exit_status( &
+            source, 3, '/tmp/ffc_reject_pointer01_present_ok')
+    end function test_present_whole_dummy_accepted
+
+    ! gfortran.dg/proc_ptr_44.f90: POINTER on an abstract interface name.
+    logical function test_abstract_interface_pointer_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  abstract interface'//new_line('a')// &
+            '    subroutine abssub1'//new_line('a')// &
+            '    end subroutine'//new_line('a')// &
+            '  end interface'//new_line('a')// &
+            '  procedure(abssub1), pointer :: abssub1'//new_line('a')// &
+            '  print *, 1'//new_line('a')// &
+            'end program main'
+
+        test_abstract_interface_pointer_rejected = expect_error_contains( &
+            source, 'conflicts with ABSTRACT attribute', &
+            '/tmp/ffc_reject_pointer01_abstract')
+    end function test_abstract_interface_pointer_rejected
+
+    ! Corrected neighbour: a distinct procedure pointer of that interface.
+    logical function test_concrete_proc_pointer_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  abstract interface'//new_line('a')// &
+            '    subroutine abssub1'//new_line('a')// &
+            '    end subroutine'//new_line('a')// &
+            '  end interface'//new_line('a')// &
+            '  procedure(abssub1), pointer :: p'//new_line('a')// &
+            '  p => sub'//new_line('a')// &
+            '  call p()'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine sub'//new_line('a')// &
+            '    stop 5'//new_line('a')// &
+            '  end subroutine sub'//new_line('a')// &
+            'end program main'
+
+        test_concrete_proc_pointer_accepted = expect_exit_status( &
+            source, 5, '/tmp/ffc_reject_pointer01_abstract_ok')
+    end function test_concrete_proc_pointer_accepted
+
+    ! gfortran.dg/pr78719_2.f90: proc-pointer target is a data object.
+    logical function test_data_object_proc_target_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  real :: g'//new_line('a')// &
+            '  abstract interface'//new_line('a')// &
+            '    subroutine h'//new_line('a')// &
+            '    end subroutine'//new_line('a')// &
+            '  end interface'//new_line('a')// &
+            '  procedure(h), pointer :: s'//new_line('a')// &
+            '  s => g'//new_line('a')// &
+            '  call s'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine f'//new_line('a')// &
+            '  end subroutine f'//new_line('a')// &
+            'end program main'
+
+        test_data_object_proc_target_rejected = expect_error_contains( &
+            source, 'is a data object, not a procedure', &
+            '/tmp/ffc_reject_pointer01_dataobj')
+    end function test_data_object_proc_target_rejected
+
+    ! gfortran.dg/proc_ptr_38.f90: target is the function result variable.
+    logical function test_result_variable_proc_target_rejected()
+        character(len=*), parameter :: source = &
+            'integer function foo()'//new_line('a')// &
+            '  procedure(), pointer :: i'//new_line('a')// &
+            '  i => foo'//new_line('a')// &
+            '  foo = 1'//new_line('a')// &
+            'end function foo'
+
+        test_result_variable_proc_target_rejected = expect_error_contains( &
+            source, 'is invalid as proc-target', &
+            '/tmp/ffc_reject_pointer01_result')
+    end function test_result_variable_proc_target_rejected
+
+    ! Corrected neighbour: a recursive function may be its own proc-target.
+    logical function test_recursive_proc_target_accepted()
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  recursive function bar() result(res)'//new_line('a')// &
+            '    integer :: res'//new_line('a')// &
+            '    procedure(), pointer :: j'//new_line('a')// &
+            '    j => bar'//new_line('a')// &
+            '    res = 7'//new_line('a')// &
+            '  end function bar'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  integer :: v'//new_line('a')// &
+            '  v = bar()'//new_line('a')// &
+            '  if (v == 7) stop 7'//new_line('a')// &
+            '  stop 1'//new_line('a')// &
+            'end program main'
+
+        test_recursive_proc_target_accepted = expect_exit_status( &
+            source, 7, '/tmp/ffc_reject_pointer01_recursive_ok')
+    end function test_recursive_proc_target_accepted
+
+    ! gfortran.dg/proc_ptr_46.f90: target is not visible as a procedure.
+    logical function test_unknown_proc_target_rejected()
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine s'//new_line('a')// &
+            '    procedure(real), pointer :: p'//new_line('a')// &
+            '    p => f'//new_line('a')// &
+            '  end subroutine s'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m, only: s'//new_line('a')// &
+            '  call s'//new_line('a')// &
+            'end program main'
+
+        test_unknown_proc_target_rejected = expect_error_contains( &
+            source, 'must be either an intrinsic, host or use associated', &
+            '/tmp/ffc_reject_pointer01_unknown')
+    end function test_unknown_proc_target_rejected
+
+    ! gfortran.dg/pointer_intent_7.f90: INTENT(IN) pointer actual passed to
+    ! an INTENT(INOUT) pointer dummy.
+    logical function test_intent_in_pointer_actual_rejected()
+        character(len=*), parameter :: source = &
+            'module moda'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine foo(b)'//new_line('a')// &
+            '    integer, intent(in), pointer :: b'//new_line('a')// &
+            '    call bar2p(b)'//new_line('a')// &
+            '  end subroutine foo'//new_line('a')// &
+            '  subroutine bar2p(n)'//new_line('a')// &
+            '    integer, intent(inout), pointer :: n'//new_line('a')// &
+            '  end subroutine bar2p'//new_line('a')// &
+            'end module moda'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use moda'//new_line('a')// &
+            '  print *, 1'//new_line('a')// &
+            'end program main'
+
+        test_intent_in_pointer_actual_rejected = expect_error_contains( &
+            source, 'in pointer association context', &
+            '/tmp/ffc_reject_pointer01_intent')
+    end function test_intent_in_pointer_actual_rejected
+
+    ! Corrected neighbour: an INTENT(INOUT) pointer actual is allowed.
+    logical function test_intent_inout_pointer_actual_accepted()
+        character(len=*), parameter :: source = &
+            'module moda'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine foo(b)'//new_line('a')// &
+            '    integer, intent(inout), pointer :: b'//new_line('a')// &
+            '    call bar2p(b)'//new_line('a')// &
+            '  end subroutine foo'//new_line('a')// &
+            '  subroutine bar2p(n)'//new_line('a')// &
+            '    integer, intent(inout), pointer :: n'//new_line('a')// &
+            '    n = 5'//new_line('a')// &
+            '  end subroutine bar2p'//new_line('a')// &
+            'end module moda'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use moda'//new_line('a')// &
+            '  integer, target :: t'//new_line('a')// &
+            '  integer, pointer :: q'//new_line('a')// &
+            '  q => t'//new_line('a')// &
+            '  call foo(q)'//new_line('a')// &
+            '  if (t == 5) stop 5'//new_line('a')// &
+            '  stop 1'//new_line('a')// &
+            'end program main'
+
+        test_intent_inout_pointer_actual_accepted = expect_exit_status( &
+            source, 5, '/tmp/ffc_reject_pointer01_intent_ok')
+    end function test_intent_inout_pointer_actual_accepted
+
+    ! gfortran.dg/cray_pointers_3.f90: Cray pointer declaration.
+    logical function test_cray_pointer_rejected()
+        character(len=*), parameter :: source = &
+            'program crayerr'//new_line('a')// &
+            '  real dpte1(10)'//new_line('a')// &
+            '  pointer (iptr1,dpte1)'//new_line('a')// &
+            'end program crayerr'
+
+        test_cray_pointer_rejected = expect_error_contains( &
+            source, 'Cray pointer declaration', &
+            '/tmp/ffc_reject_pointer01_cray')
+    end function test_cray_pointer_rejected
+
+    ! Corrected neighbour: the standard POINTER attribute declaration.
+    logical function test_standard_pointer_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  real, target :: store'//new_line('a')// &
+            '  real, pointer :: dpte1'//new_line('a')// &
+            '  store = 2.0'//new_line('a')// &
+            '  dpte1 => store'//new_line('a')// &
+            '  if (dpte1 > 1.5) stop 2'//new_line('a')// &
+            '  stop 1'//new_line('a')// &
+            'end program main'
+
+        test_standard_pointer_accepted = expect_exit_status( &
+            source, 2, '/tmp/ffc_reject_pointer01_cray_ok')
+    end function test_standard_pointer_accepted
+
+    ! gfortran.dg/associated_target_1.f90: ASSOCIATED(X,(Y)).
+    logical function test_parenthesised_associated_target_rejected()
+        character(len=*), parameter :: source = &
+            'program test'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  real, pointer :: x'//new_line('a')// &
+            '  real, target :: y'//new_line('a')// &
+            '  if (associated(x,(y))) print *, "hello"'//new_line('a')// &
+            'end program test'
+
+        test_parenthesised_associated_target_rejected = expect_error_contains( &
+            source, 'must be a VARIABLE or FUNCTION', &
+            '/tmp/ffc_reject_pointer01_assoc')
+    end function test_parenthesised_associated_target_rejected
+
+    ! Corrected neighbour: a plain target variable.
+    logical function test_plain_associated_target_accepted()
+        character(len=*), parameter :: source = &
+            'program test'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  real, pointer :: x'//new_line('a')// &
+            '  real, target :: y'//new_line('a')// &
+            '  y = 1.0'//new_line('a')// &
+            '  x => y'//new_line('a')// &
+            '  if (associated(x,y)) stop 6'//new_line('a')// &
+            '  stop 1'//new_line('a')// &
+            'end program test'
+
+        test_plain_associated_target_accepted = expect_exit_status( &
+            source, 6, '/tmp/ffc_reject_pointer01_assoc_ok')
+    end function test_plain_associated_target_accepted
+
+    ! gfortran.dg/parens_2.f90: parenthesised actual for a POINTER dummy.
+    logical function test_parenthesised_pointer_actual_rejected()
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine s1(i)'//new_line('a')// &
+            '    integer, pointer :: i'//new_line('a')// &
+            '  end subroutine s1'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  integer, pointer :: i'//new_line('a')// &
+            '  call s1((i))'//new_line('a')// &
+            'end program main'
+
+        test_parenthesised_pointer_actual_rejected = expect_error_contains( &
+            source, 'must be a pointer or a valid target', &
+            '/tmp/ffc_reject_pointer01_parens')
+    end function test_parenthesised_pointer_actual_rejected
+
+    ! Corrected neighbour: the pointer itself is a valid actual.
+    logical function test_plain_pointer_actual_accepted()
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine s1(i)'//new_line('a')// &
+            '    integer, pointer :: i'//new_line('a')// &
+            '    i = 4'//new_line('a')// &
+            '  end subroutine s1'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  integer, target :: t'//new_line('a')// &
+            '  integer, pointer :: i'//new_line('a')// &
+            '  i => t'//new_line('a')// &
+            '  call s1(i)'//new_line('a')// &
+            '  if (t == 4) stop 4'//new_line('a')// &
+            '  stop 1'//new_line('a')// &
+            'end program main'
+
+        test_plain_pointer_actual_accepted = expect_exit_status( &
+            source, 4, '/tmp/ffc_reject_pointer01_parens_ok')
+    end function test_plain_pointer_actual_accepted
+
+end program test_session_reject_pointer_01_compiler


### PR DESCRIPTION
Closes #381.

## Preserved compiler invariant

A pointer only ever associates with something that can be a target, and PRESENT only accepts a whole optional dummy argument name. `ffc` silently accepted several invalid associations; `validate_program` now runs `check_pointer_target_contracts` before lowering and rejects, each with its own source diagnostic:

- PRESENT applied to a subobject (component ref, array element) — `present_1.f90`
- POINTER attribute on an ABSTRACT INTERFACE name — `proc_ptr_44.f90`
- proc-pointer target that is a data object — `pr78719_2.f90`
- proc-pointer target that is the enclosing (non-recursive) function result variable — `proc_ptr_38.f90`
- proc-pointer target that is not visible as a procedure — `proc_ptr_46.f90`
- INTENT(IN) pointer actual passed to an INTENT(OUT/INOUT) pointer dummy — `pointer_intent_7.f90`
- Cray pointer declaration `POINTER (ptr, pointee)` — `cray_pointers_3.f90`
- parenthesised ASSOCIATED target — `associated_target_1.f90`
- parenthesised actual for a POINTER dummy — `parens_2.f90`

Validation is on typed nodes (declarations, interface blocks, pointer assignments, call arguments). The forms that hinge on parentheses, and the POINTER *statement* form plus PRESENT arguments that FortFront does not surface in every scope, are read from the statement source. Nothing keys on filenames or gfortran message text.

## Red evidence

`fo test test_session_reject_pointer_01_compiler` on unmodified main:

```
FAIL: diagnostic did not contain "must not be a subobject"
  actual: unsupported scalar intrinsic: present ...
FAIL: unsupported source lowered without diagnostic     (x7)
STOP 1
```

## Green evidence

```
fo test test_session_reject_pointer_01_compiler   -> 1 passed, 0 failed
scripts/conformance_gauntlet.sh --suite gfortran-dg --file associated_target_1.f90 ... --file present_1.f90
  PASS=9  XFAIL=0  XPASS=0  FAIL=0  NOREF=0  SKIP=0  TOTAL=9
```

The new test covers every rule with both the rejected form and a corrected neighbour that compiles and runs (exit status oracle).

## Note on the full pipeline

Two suite tests fail in this environment for reasons outside this diff:

- `test_conformance_gauntlet_smoke` — the gauntlet writes to fixed `/tmp/ffc_gauntlet_*` paths shared by every checkout, and several agent sessions run it concurrently on this machine, so record counts and the shared failure log get clobbered. Each failing assertion passes when run standalone (e.g. the `both skip and noref` rejection returns rc=1 with the expected message).
- `test_parity_dashboard` — `test/conformance/parity_dashboard.tsv` on origin/main carries a stale `digest manifests` value relative to the manifests on origin/main; it fails identically without this change.