### PR TITLE
[save-local-01] persist saved arrays and DATA-initialized locals (#466)

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -539,13 +539,11 @@ contains
             return
         end if
         if (node%is_array) then
-            ! Saved arrays need per-element static storage the array path does
-            ! not provide; keep them xfail with a clean diagnostic (#1541).
-            if (node%is_save) then
-                call unsupported_feature_error('saved array declaration', &
-                    node%line, node%column, &
-                    'direct LIRIC session supports the save attribute on '// &
-                    'scalar integer, real, and logical locals only', error_msg)
+            ! A saved array lives in one static global emitted by the pre-pass,
+            ! so bind it there instead of allocating call-local storage (#466).
+            if (node%is_save .and. .not. node%is_allocatable) then
+                call lower_saved_array_declaration(context%arena, node, &
+                                                   node_index, context, error_msg)
                 return
             end if
             call declaration_value_kind(node, value_kind, error_msg, context, &

--- a/src/session_program_lowering_data.inc
+++ b/src/session_program_lowering_data.inc
@@ -127,6 +127,13 @@
             error_msg = 'data statement target was not declared: '//trim(name)
             return
         end if
+        if (context%symbols(sym)%is_static_data_initialized) then
+            ! The values already live in the saved local's static bytes; consume
+            ! them so later objects keep their place in the value list (#466).
+            call skip_static_data_values(arena, node, cursor, sym, context, &
+                                         error_msg)
+            return
+        end if
         if (context%symbols(sym)%is_array) then
             asz = context%symbols(sym)%array_size
             do k = 0, asz - 1
@@ -140,6 +147,27 @@
                                                   context, error_msg)
         end if
     end subroutine lower_data_object
+
+    subroutine skip_static_data_values(arena, node, cursor, sym, context, &
+                                       error_msg)
+        !! Advance the value cursor past the values belonging to a saved local
+        !! whose DATA initializer was folded into its static global.
+        type(ast_arena_t), intent(in) :: arena
+        type(data_statement_node), intent(in) :: node
+        type(data_value_cursor_t), intent(inout) :: cursor
+        integer, intent(in) :: sym
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: k, count, vidx
+
+        call set_empty(error_msg)
+        count = 1
+        if (context%symbols(sym)%is_array) count = context%symbols(sym)%array_size
+        do k = 1, count
+            call next_data_value(arena, node, cursor, context, vidx, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine skip_static_data_values
 
     subroutine store_next_data_value_to_scalar(arena, node, cursor, sym, name, &
                                                context, error_msg)

--- a/src/session_program_lowering_save.inc
+++ b/src/session_program_lowering_save.inc
@@ -26,8 +26,14 @@
             select type (decl => arena%entries(n)%node)
             type is (declaration_node)
                 if (.not. decl%is_save) cycle
-                if (decl%is_parameter .or. decl%is_array .or. &
-                    decl%is_pointer .or. decl%is_target) cycle
+                if (decl%is_parameter .or. decl%is_pointer .or. &
+                    decl%is_target .or. decl%is_allocatable) cycle
+                if (decl%is_array) then
+                    call emit_saved_array_globals(arena, decl, n, context, &
+                                                  error_msg)
+                    if (len_trim(error_msg) > 0) return
+                    cycle
+                end if
                 call emit_saved_decl_globals(decl, n, context, error_msg)
                 if (len_trim(error_msg) > 0) return
             end select
@@ -102,8 +108,9 @@
         logical(c_bool) :: c_false_local
 
         c_false_local = .false.
-        call fold_saved_initializer(node, context, value_kind, take_initializer, &
-                                    init_i32, init_f32, init_f64, error_msg)
+        call fold_saved_initializer(node, node_index, name, context, value_kind, &
+                                    take_initializer, init_i32, init_f32, &
+                                    init_f64, error_msg)
         if (len_trim(error_msg) > 0) return
         gname = saved_local_global_name(node_index, name)
         call to_c_chars(gname, c_name)
@@ -205,6 +212,8 @@
         context%symbols(sym_idx)%address%payload = int(global_id, c_int64_t)
         context%symbols(sym_idx)%address%typ = lr_type_ptr_s(context%session%handle)
         context%symbols(sym_idx)%address%global_offset = 0_c_int64_t
+        context%symbols(sym_idx)%is_static_data_initialized = &
+            saved_local_has_data_values(context%arena, node_index, name, context)
         call set_empty(error_msg)
     end subroutine bind_saved_scalar
 
@@ -220,14 +229,17 @@
         gname = '.ffc.save.'//trim(idx_text)//'.'//name
     end function saved_local_global_name
 
-    subroutine fold_saved_initializer(node, context, value_kind, take_initializer, &
-                                      init_i32, init_f32, init_f64, error_msg)
+    subroutine fold_saved_initializer(node, node_index, name, context, &
+                                      value_kind, take_initializer, init_i32, &
+                                      init_f32, init_f64, error_msg)
         ! Fold a saved scalar's literal initializer into raw initial bytes. An
         ! absent initializer (plain `save`) starts at zero. Only literal
         ! initializers fold; anything else keeps the unit xfail.
         use, intrinsic :: iso_c_binding, only: c_int32_t, c_int64_t, c_float, &
                                                c_double
         type(declaration_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: name
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: value_kind
         logical, intent(in) :: take_initializer
@@ -244,7 +256,14 @@
         init_f64 = 0.0_c_double
         call set_empty(error_msg)
         if (.not. take_initializer) return
-        if (.not. node%has_initializer .or. node%initializer_index <= 0) return
+        if (.not. node%has_initializer .or. node%initializer_index <= 0) then
+            ! A saved scalar may take its value from a DATA statement instead;
+            ! fold it here so it is applied once, not on every call (#466).
+            call fold_saved_scalar_data(context%arena, node_index, name, &
+                                        context, value_kind, init_i32, &
+                                        init_f32, init_f64, error_msg)
+            return
+        end if
         if (.not. is_literal(context%arena, node%initializer_index)) then
             call unsupported_feature_error('saved local initializer', node%line, &
                 node%column, 'only literal initializers are stored for saved '// &

--- a/src/session_program_lowering_save_static.inc
+++ b/src/session_program_lowering_save_static.inc
@@ -1,0 +1,491 @@
+    ! Static storage for saved locals beyond the scalar case (#466). A saved
+    ! array is one [extent x elem] LIRIC global, exactly like a fixed-size
+    ! module array, so every element keeps its value across calls. A DATA
+    ! initializer for a saved local folds into that global's static bytes and
+    ! its runtime stores are suppressed, so the value is applied once before
+    ! the first executable use instead of on every call.
+
+    subroutine emit_saved_array_globals(arena, node, node_index, context, &
+                                        error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(declaration_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        call set_empty(error_msg)
+        if (node%is_multi_declaration .and. allocated(node%var_names)) then
+            do i = 1, size(node%var_names)
+                call emit_one_saved_array_global(arena, node, node_index, &
+                    trim(node%var_names(i)), context, error_msg)
+                if (len_trim(error_msg) > 0) return
+            end do
+        else if (allocated(node%var_name)) then
+            call emit_one_saved_array_global(arena, node, node_index, &
+                trim(node%var_name), context, error_msg)
+        else
+            error_msg = 'saved array declaration did not expose a variable name'
+        end if
+    end subroutine emit_saved_array_globals
+
+    subroutine emit_one_saved_array_global(arena, node, node_index, name, &
+                                           context, error_msg)
+        ! Create the [extent x elem] global backing one saved array name. The
+        ! static bytes start zeroed, then take a constant array-constructor
+        ! initializer or a DATA value list, whichever the declaration carries.
+        use, intrinsic :: iso_c_binding, only: c_bool, c_char, c_int32_t, &
+                                               c_int64_t, c_loc, c_size_t, &
+                                               c_ptr, c_double, c_float
+        use liric_session_bindings, only: lr_type_i32_s, lr_type_f32_s, &
+                                          lr_type_f64_s, lr_type_array_s
+        type(ast_arena_t), intent(in) :: arena
+        type(declaration_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: name
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: gname, info_err
+        character(kind=c_char), allocatable :: c_name(:)
+        integer(c_int32_t), target, allocatable :: array_i32(:)
+        real(c_float), target, allocatable :: array_f32(:)
+        real(c_double), target, allocatable :: array_f64(:)
+        type(c_ptr) :: elem_type, gtype, init_ptr
+        integer(c_size_t) :: init_size
+        integer(c_int32_t) :: global_id
+        integer :: value_kind, array_size, array_lower
+        logical(c_bool) :: c_false_local
+
+        call set_empty(error_msg)
+        c_false_local = .false.
+        call saved_array_info(arena, node, node_index, context, value_kind, &
+                              array_size, array_lower, error_msg)
+        if (len_trim(error_msg) > 0) return
+        allocate (array_i32(max(array_size, 1)))
+        allocate (array_f32(max(array_size, 1)))
+        allocate (array_f64(max(array_size, 1)))
+        array_i32 = 0_c_int32_t
+        array_f32 = 0.0_c_float
+        array_f64 = 0.0_c_double
+        if (node%has_initializer .and. node%initializer_index > 0) then
+            call fold_module_array_initializer(arena, node_index, value_kind, &
+                array_size, context, array_i32, array_f32, array_f64, info_err)
+            if (len_trim(info_err) > 0) then
+                error_msg = info_err
+                return
+            end if
+        else
+            call fold_saved_data_values(arena, node_index, name, value_kind, &
+                array_size, context, array_i32, array_f32, array_f64, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end if
+        select case (value_kind)
+        case (VALUE_I32, VALUE_LOGICAL)
+            elem_type = lr_type_i32_s(context%session%handle)
+            init_ptr = c_loc(array_i32)
+            init_size = int(array_size, c_size_t)*4_c_size_t
+        case (VALUE_F32)
+            elem_type = lr_type_f32_s(context%session%handle)
+            init_ptr = c_loc(array_f32)
+            init_size = int(array_size, c_size_t)*4_c_size_t
+        case (VALUE_F64)
+            elem_type = lr_type_f64_s(context%session%handle)
+            init_ptr = c_loc(array_f64)
+            init_size = int(array_size, c_size_t)*8_c_size_t
+        case default
+            call unsupported_feature_error('saved array declaration', &
+                node%line, node%column, 'direct LIRIC session supports the '// &
+                'save attribute on integer, real, and logical arrays only', &
+                error_msg)
+            return
+        end select
+        gname = saved_local_global_name(node_index, name)
+        call to_c_chars(gname, c_name)
+        gtype = lr_type_array_s(context%session%handle, elem_type, &
+                                int(array_size, c_int64_t))
+        global_id = lr_session_global(context%session%handle, c_name, gtype, &
+                                      c_false_local, init_ptr, init_size)
+        if (global_id < 0_c_int32_t) then
+            error_msg = 'LIRIC could not create saved array global: '//gname
+            return
+        end if
+        call set_empty(error_msg)
+    end subroutine emit_one_saved_array_global
+
+    subroutine saved_array_info(arena, node, node_index, context, value_kind, &
+                                array_size, array_lower, error_msg)
+        ! Shape and element kind of a supported saved array. Any out-of-scope
+        ! form keeps the unit xfail with a saved-array diagnostic.
+        type(ast_arena_t), intent(in) :: arena
+        type(declaration_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(out) :: value_kind
+        integer, intent(out) :: array_size
+        integer, intent(out) :: array_lower
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: info_err
+
+        call module_array_variable_info(arena, node_index, context, value_kind, &
+                                        array_size, array_lower, info_err)
+        if (len_trim(info_err) > 0) then
+            call unsupported_feature_error('saved array declaration', &
+                node%line, node%column, trim(info_err), error_msg)
+            return
+        end if
+        if (array_size <= 0) then
+            call unsupported_feature_error('saved array declaration', &
+                node%line, node%column, 'saved array extent must be a '// &
+                'positive compile-time constant', error_msg)
+            return
+        end if
+        call set_empty(error_msg)
+    end subroutine saved_array_info
+
+    subroutine lower_saved_array_declaration(arena, node, node_index, context, &
+                                             error_msg)
+        ! Body-side binding: the backing global already exists from the pre-pass,
+        ! so bind each name onto it as an addressed array reference. Re-entering
+        ! the same declaration rebinds the same global rather than allocating a
+        ! second slot.
+        type(ast_arena_t), intent(in) :: arena
+        type(declaration_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        call set_empty(error_msg)
+        if (node%is_multi_declaration .and. allocated(node%var_names)) then
+            do i = 1, size(node%var_names)
+                call bind_saved_array(arena, node, node_index, &
+                    trim(node%var_names(i)), context, error_msg)
+                if (len_trim(error_msg) > 0) return
+            end do
+        else if (allocated(node%var_name)) then
+            call bind_saved_array(arena, node, node_index, trim(node%var_name), &
+                                  context, error_msg)
+        else
+            error_msg = 'saved array declaration did not expose a variable name'
+        end if
+    end subroutine lower_saved_array_declaration
+
+    subroutine bind_saved_array(arena, node, node_index, name, context, error_msg)
+        use, intrinsic :: iso_c_binding, only: c_char, c_int32_t, c_int64_t
+        type(ast_arena_t), intent(in) :: arena
+        type(declaration_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: name
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: gname
+        character(kind=c_char), allocatable :: c_name(:)
+        integer(c_int32_t) :: global_id
+        integer :: sym_idx, existing_idx, value_kind, array_size, array_lower
+
+        call saved_array_info(arena, node, node_index, context, value_kind, &
+                              array_size, array_lower, error_msg)
+        if (len_trim(error_msg) > 0) return
+        gname = saved_local_global_name(node_index, name)
+        call to_c_chars(gname, c_name)
+        global_id = lr_session_intern(context%session%handle, c_name)
+        if (global_id < 0_c_int32_t) then
+            error_msg = 'saved array global not found: '//gname
+            return
+        end if
+        existing_idx = find_symbol_compat(context, name)
+        if (existing_idx > 0) then
+            sym_idx = existing_idx
+        else
+            call grow_symbols(context)
+            sym_idx = context%symbol_count + 1
+            context%symbol_count = sym_idx
+        end if
+        context%symbols(sym_idx) = symbol_t()
+        context%symbols(sym_idx)%name = name
+        context%symbols(sym_idx)%value_kind = value_kind
+        context%symbols(sym_idx)%has_address = .true.
+        context%symbols(sym_idx)%is_reference = .true.
+        context%symbols(sym_idx)%is_array = .true.
+        context%symbols(sym_idx)%array_rank = 1
+        context%symbols(sym_idx)%array_size = array_size
+        context%symbols(sym_idx)%array_lower_bound = array_lower
+        context%symbols(sym_idx)%array_dim_sizes(1) = array_size
+        context%symbols(sym_idx)%array_dim_lowers(1) = array_lower
+        context%symbols(sym_idx)%address%kind = LR_OP_KIND_GLOBAL
+        context%symbols(sym_idx)%address%payload = int(global_id, c_int64_t)
+        context%symbols(sym_idx)%address%typ = lr_type_ptr_s(context%session%handle)
+        context%symbols(sym_idx)%address%global_offset = 0_c_int64_t
+        context%symbols(sym_idx)%element_address = context%symbols(sym_idx)%address
+        context%symbols(sym_idx)%is_static_data_initialized = &
+            saved_local_has_data_values(arena, node_index, name, context)
+        call set_empty(error_msg)
+    end subroutine bind_saved_array
+
+    ! ---- DATA initializers for saved locals -------------------------------
+
+    logical function saved_local_has_data_values(arena, node_index, name, context)
+        ! Whether a DATA statement in the declaration's own scope names this
+        ! saved local. Such a value is folded into the static global, so the
+        ! body walk must not re-apply it on every call.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: name
+        type(lowering_context_t), intent(in) :: context
+        integer, allocatable :: value_indices(:)
+        character(len=:), allocatable :: err
+
+        allocate (value_indices(0))
+        call saved_local_data_value_indices(arena, node_index, name, context, &
+                                            value_indices, err)
+        saved_local_has_data_values = size(value_indices) > 0
+    end function saved_local_has_data_values
+
+    subroutine saved_local_data_value_indices(arena, node_index, name, context, &
+                                              value_indices, error_msg)
+        ! Collect the DATA value expressions that initialise `name`, searching
+        ! the DATA statements of the scope that owns the declaration. Only flat
+        ! object lists of plain identifiers are matched; anything else leaves
+        ! the list empty so the ordinary runtime DATA path stays in charge.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: name
+        type(lowering_context_t), intent(in) :: context
+        integer, allocatable, intent(out) :: value_indices(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, allocatable :: body(:)
+        integer :: i
+
+        call set_empty(error_msg)
+        allocate (value_indices(0))
+        call saved_scope_body(arena, node_index, body)
+        if (size(body) == 0) return
+        do i = 1, size(body)
+            if (.not. is_data_statement_at(arena, body(i))) cycle
+            select type (dnode => arena%entries(body(i))%node)
+            type is (data_statement_node)
+                call data_values_for_name(arena, dnode, body, name, context, &
+                                          value_indices, error_msg)
+                if (len_trim(error_msg) > 0) return
+                if (size(value_indices) > 0) return
+            end select
+        end do
+    end subroutine saved_local_data_value_indices
+
+    subroutine saved_scope_body(arena, node_index, body)
+        ! Statement list of the program unit that owns a declaration node.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        integer, allocatable, intent(out) :: body(:)
+        integer :: parent_index
+
+        allocate (body(0))
+        if (node_index <= 0) return
+        if (.not. node_exists(arena, node_index)) return
+        parent_index = arena%entries(node_index)%parent_index
+        if (parent_index <= 0) return
+        if (.not. node_exists(arena, parent_index)) return
+        select type (parent => arena%entries(parent_index)%node)
+        type is (subroutine_def_node)
+            if (allocated(parent%body_indices)) body = parent%body_indices
+        type is (function_def_node)
+            if (allocated(parent%body_indices)) body = parent%body_indices
+        type is (program_node)
+            if (allocated(parent%body_indices)) body = parent%body_indices
+        end select
+    end subroutine saved_scope_body
+
+    subroutine data_values_for_name(arena, dnode, body, name, context, &
+                                    value_indices, error_msg)
+        ! Walk one DATA statement's flat object list, consuming as many values
+        ! as each object needs, and return the slice belonging to `name`.
+        type(ast_arena_t), intent(in) :: arena
+        type(data_statement_node), intent(in) :: dnode
+        integer, intent(in) :: body(:)
+        character(len=*), intent(in) :: name
+        type(lowering_context_t), intent(in) :: context
+        integer, allocatable, intent(inout) :: value_indices(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: obj_name, name_err
+        integer :: oi, vpos, count, k
+
+        call set_empty(error_msg)
+        if (.not. allocated(dnode%object_indices)) return
+        if (.not. allocated(dnode%value_indices)) return
+        vpos = 0
+        do oi = 1, size(dnode%object_indices)
+            call identifier_name(arena, dnode%object_indices(oi), obj_name, &
+                                 name_err)
+            if (len_trim(name_err) > 0) return
+            call scope_object_element_count(arena, body, obj_name, context, count)
+            if (count <= 0) return
+            if (vpos + count > size(dnode%value_indices)) return
+            if (same_name(obj_name, name)) then
+                deallocate (value_indices)
+                allocate (value_indices(count))
+                do k = 1, count
+                    value_indices(k) = dnode%value_indices(vpos + k)
+                end do
+                return
+            end if
+            vpos = vpos + count
+        end do
+    end subroutine data_values_for_name
+
+    subroutine scope_object_element_count(arena, body, name, context, count)
+        ! Element count a DATA object consumes: its declared extent for an
+        ! array, one for a scalar, zero when the scope does not declare it.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body(:)
+        character(len=*), intent(in) :: name
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(out) :: count
+        integer :: i, j
+
+        count = 0
+        do i = 1, size(body)
+            if (.not. node_exists(arena, body(i))) cycle
+            select type (decl => arena%entries(body(i))%node)
+            type is (declaration_node)
+                if (decl%is_multi_declaration .and. allocated(decl%var_names)) then
+                    do j = 1, size(decl%var_names)
+                        if (.not. same_name(decl%var_names(j), name)) cycle
+                        call declared_element_count(decl, context, count)
+                        return
+                    end do
+                else if (allocated(decl%var_name)) then
+                    if (same_name(decl%var_name, name)) then
+                        call declared_element_count(decl, context, count)
+                        return
+                    end if
+                end if
+            end select
+        end do
+    end subroutine scope_object_element_count
+
+    subroutine declared_element_count(decl, context, count)
+        type(declaration_node), intent(in) :: decl
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(out) :: count
+        integer :: lower, extent
+        character(len=:), allocatable :: bounds_err
+
+        count = 1
+        if (.not. decl%is_array) return
+        count = 0
+        if (.not. allocated(decl%dimension_indices)) return
+        if (size(decl%dimension_indices) /= 1) return
+        call get_array_bounds(decl, context, lower, extent, bounds_err)
+        if (len_trim(bounds_err) > 0) return
+        if (extent <= 0) return
+        count = extent
+    end subroutine declared_element_count
+
+    subroutine fold_saved_data_values(arena, node_index, name, value_kind, &
+                                      array_size, context, array_i32, array_f32, &
+                                      array_f64, error_msg)
+        ! Fold the DATA values naming this saved local into its static element
+        ! buffer. A missing or partial value list leaves the zero fill.
+        use, intrinsic :: iso_c_binding, only: c_int32_t, c_int64_t, c_float, &
+                                               c_double
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: value_kind
+        integer, intent(in) :: array_size
+        type(lowering_context_t), intent(in) :: context
+        integer(c_int32_t), intent(inout), allocatable :: array_i32(:)
+        real(c_float), intent(inout), allocatable :: array_f32(:)
+        real(c_double), intent(inout), allocatable :: array_f64(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, allocatable :: value_indices(:)
+        integer :: i
+
+        call set_empty(error_msg)
+        allocate (value_indices(0))
+        call saved_local_data_value_indices(arena, node_index, name, context, &
+                                            value_indices, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (size(value_indices) == 0) return
+        if (size(value_indices) /= array_size) then
+            error_msg = 'saved DATA value count does not match '//trim(name)
+            return
+        end if
+        do i = 1, array_size
+            call fold_saved_data_element(arena, value_indices(i), value_kind, &
+                array_i32(i), array_f32(i), array_f64(i), error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine fold_saved_data_values
+
+    subroutine fold_saved_data_element(arena, vidx, value_kind, out_i32, out_f32, &
+                                       out_f64, error_msg)
+        ! One DATA literal folded into the static bytes of a saved local.
+        use, intrinsic :: iso_c_binding, only: c_int32_t, c_int64_t, c_float, &
+                                               c_double
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: vidx
+        integer, intent(in) :: value_kind
+        integer(c_int32_t), intent(inout) :: out_i32
+        real(c_float), intent(inout) :: out_f32
+        real(c_double), intent(inout) :: out_f64
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: lit_value, lit_type, lit_err
+        integer(c_int64_t) :: iconst
+        integer :: io_stat
+
+        call set_empty(error_msg)
+        if (.not. is_literal(arena, vidx)) then
+            error_msg = 'only literal DATA values initialise a saved local'
+            return
+        end if
+        call get_literal_info(arena, vidx, lit_value, lit_type, lit_err)
+        if (len_trim(lit_err) > 0) then
+            error_msg = lit_err
+            return
+        end if
+        select case (value_kind)
+        case (VALUE_I32)
+            call parse_i32_literal(lit_value, iconst, error_msg)
+            if (len_trim(error_msg) > 0) return
+            out_i32 = int(iconst, c_int32_t)
+        case (VALUE_LOGICAL)
+            out_i32 = logical_literal_to_i32(lit_value)
+        case (VALUE_F32)
+            read (lit_value, *, iostat=io_stat) out_f32
+            if (io_stat /= 0) error_msg = 'malformed real DATA value: '//lit_value
+        case (VALUE_F64)
+            read (lit_value, *, iostat=io_stat) out_f64
+            if (io_stat /= 0) error_msg = 'malformed real DATA value: '//lit_value
+        case default
+            error_msg = 'unsupported kind for a saved DATA initializer'
+        end select
+    end subroutine fold_saved_data_element
+
+    subroutine fold_saved_scalar_data(arena, node_index, name, context, &
+                                      value_kind, init_i32, init_f32, init_f64, &
+                                      error_msg)
+        ! A saved scalar without a declaration initializer may still take a DATA
+        ! value; fold it into the static bytes of its backing global so it is
+        ! applied once instead of on every call.
+        use, intrinsic :: iso_c_binding, only: c_int32_t, c_float, c_double
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: name
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: value_kind
+        integer(c_int32_t), intent(inout) :: init_i32
+        real(c_float), intent(inout) :: init_f32
+        real(c_double), intent(inout) :: init_f64
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, allocatable :: value_indices(:)
+
+        call set_empty(error_msg)
+        allocate (value_indices(0))
+        call saved_local_data_value_indices(arena, node_index, name, context, &
+                                            value_indices, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (size(value_indices) /= 1) return
+        call fold_saved_data_element(arena, value_indices(1), value_kind, &
+                                     init_i32, init_f32, init_f64, error_msg)
+    end subroutine fold_saved_scalar_data

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -1106,6 +1106,7 @@
     include 'session_program_lowering_module_vars.inc'
     include 'session_program_lowering_submodules.inc'
     include 'session_program_lowering_save.inc'
+    include 'session_program_lowering_save_static.inc'
     include 'session_program_lowering_common.inc'
     include 'session_program_lowering_equivalence.inc'
     include 'session_program_lowering_block_concurrent.inc'

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -234,6 +234,11 @@ module session_program_lowering_types
         ! its own program-unit declaration, reached before or after the
         ! COMMON statement in source order, must not reallocate storage.
         logical :: is_common_bound = .false.
+        ! Bound to a saved-local global whose DATA values were folded into the
+        ! static bytes (#466). The body walk consumes the matching DATA values
+        ! without storing them, so the initializer applies once rather than on
+        ! every call.
+        logical :: is_static_data_initialized = .false.
         integer :: character_length = 0
         logical :: has_character_value = .false.
         logical :: is_array = .false.

--- a/test/test_session_save_attribute_compiler.f90
+++ b/test/test_session_save_attribute_compiler.f90
@@ -11,6 +11,10 @@ program test_session_save_attribute_compiler
     if (.not. test_saved_counter_prints()) all_passed = .false.
     if (.not. test_distinct_procedures_separate_storage()) all_passed = .false.
     if (.not. test_real_saved_accumulates()) all_passed = .false.
+    if (.not. test_saved_array_counter_persists()) all_passed = .false.
+    if (.not. test_saved_array_zero_start()) all_passed = .false.
+    if (.not. test_saved_data_initializer_applies_once()) all_passed = .false.
+    if (.not. test_saved_data_array_applies_once()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: save attribute gives scalar locals persistent storage'
@@ -100,5 +104,91 @@ contains
         test_real_saved_accumulates = expect_output( &
             source, expected, '/tmp/ffc_session_save_real')
     end function test_real_saved_accumulates
+
+    logical function test_saved_array_counter_persists()
+        ! A saved array keeps every element across calls: element 1 counts the
+        ! calls while element 2 accumulates from its initializer.
+        character(len=*), parameter :: source = &
+            'subroutine bump()'//new_line('a')// &
+            '  integer, save :: c(3) = (/ 0, 100, 7 /)'//new_line('a')// &
+            '  c(1) = c(1) + 1'//new_line('a')// &
+            '  c(2) = c(2) + 10'//new_line('a')// &
+            '  print *, c(1), c(2), c(3)'//new_line('a')// &
+            'end subroutine bump'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  call bump()'//new_line('a')// &
+            '  call bump()'//new_line('a')// &
+            'end program main'
+        character(len=*), parameter :: expected = &
+            '           1         110           7'//new_line('a')// &
+            '           2         120           7'//new_line('a')
+
+        test_saved_array_counter_persists = expect_output( &
+            source, expected, '/tmp/ffc_session_save_array')
+    end function test_saved_array_counter_persists
+
+    logical function test_saved_array_zero_start()
+        ! A saved array without an initializer starts zeroed and persists.
+        character(len=*), parameter :: source = &
+            'subroutine acc(v)'//new_line('a')// &
+            '  real, intent(in) :: v'//new_line('a')// &
+            '  real, save :: s(2)'//new_line('a')// &
+            '  s(1) = s(1) + v'//new_line('a')// &
+            '  print *, s(1)'//new_line('a')// &
+            'end subroutine acc'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  call acc(1.5)'//new_line('a')// &
+            '  call acc(2.5)'//new_line('a')// &
+            'end program main'
+        character(len=*), parameter :: expected = &
+            '   1.50000000    '//new_line('a')// &
+            '   4.00000000    '//new_line('a')
+
+        test_saved_array_zero_start = expect_output( &
+            source, expected, '/tmp/ffc_session_save_array_zero')
+    end function test_saved_array_zero_start
+
+    logical function test_saved_data_initializer_applies_once()
+        ! A DATA initializer for a saved local applies once before first use;
+        ! re-applying it on each call would print 11 twice.
+        character(len=*), parameter :: source = &
+            'subroutine bump()'//new_line('a')// &
+            '  integer, save :: c'//new_line('a')// &
+            '  data c /10/'//new_line('a')// &
+            '  c = c + 1'//new_line('a')// &
+            '  print *, c'//new_line('a')// &
+            'end subroutine bump'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  call bump()'//new_line('a')// &
+            '  call bump()'//new_line('a')// &
+            'end program main'
+        character(len=*), parameter :: expected = &
+            '          11'//new_line('a')//'          12'//new_line('a')
+
+        test_saved_data_initializer_applies_once = expect_output( &
+            source, expected, '/tmp/ffc_session_save_data')
+    end function test_saved_data_initializer_applies_once
+
+    logical function test_saved_data_array_applies_once()
+        ! DATA over a saved array element list applies once; the accumulating
+        ! element keeps its value across calls.
+        character(len=*), parameter :: source = &
+            'subroutine bump()'//new_line('a')// &
+            '  integer, save :: c(2)'//new_line('a')// &
+            '  data c /5, 6/'//new_line('a')// &
+            '  c(1) = c(1) + 1'//new_line('a')// &
+            '  print *, c(1), c(2)'//new_line('a')// &
+            'end subroutine bump'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  call bump()'//new_line('a')// &
+            '  call bump()'//new_line('a')// &
+            'end program main'
+        character(len=*), parameter :: expected = &
+            '           6           6'//new_line('a')// &
+            '           7           6'//new_line('a')
+
+        test_saved_data_array_applies_once = expect_output( &
+            source, expected, '/tmp/ffc_session_save_data_array')
+    end function test_saved_data_array_applies_once
 
 end program test_session_save_attribute_compiler


### PR DESCRIPTION
Closes #466.

## What changed

- Saved local **arrays** are no longer rejected. Each one gets a single
  `[extent x elem]` LIRIC global emitted by the SAVE pre-pass, so all elements
  keep their values across calls. New `src/session_program_lowering_save_static.inc`.
- A **DATA** initializer naming a saved local folds into that global's static
  bytes; the body walk consumes the matching value list without emitting runtime
  stores (`is_static_data_initialized` on `symbol_t`). The initializer is applied
  once before the first executable use instead of on every call.
- Re-encountering the same declaration rebinds the existing symbol
  (`find_symbol_compat`) rather than allocating a second storage slot.

## Preserved compiler invariant

One storage record per saved entity, per procedure. Binding identity, declared
kind, array bounds, and initialization order are unchanged; module-variable
storage, thread-local/coarray storage, and the public ABI / descriptor layout
are untouched. Saved allocatables, pointers, targets and parameters still take
the previous paths. Non-integer/real/logical saved arrays keep a clean
`unsupported_feature_error` diagnostic.

## Red evidence

`fo test test_session_save_attribute_compiler` with the src changes stashed
(tests only, on the base commit):

```
test_session_save_attribute_compiler       FAIL       0.09s
 FAIL: unsupported saved array declaration at line 2, column 3: direct LIRIC
       session supports the save attribute on scalar integer, real, and
       logical locals only
 FAIL: output mismatch
   expected:           11
          12
   actual:             11
          11
 FAIL: unsupported saved array declaration at line 2, column 3: ...
Summary: 0 passed, 1 failed
```

The `11 / 11` mismatch is the DATA initializer being re-applied on every call.

## Green evidence

```
test_session_save_attribute_compiler       PASS       0.11s
test_session_save_module_shadow_compiler   PASS       0.08s
test_conformance_gauntlet_smoke            PASS     368.52s
```

Full `fo` pipeline: build, lint, format clean; 264/265 tests pass.
`test_parity_dashboard` fails with `ERROR: stale snapshot manifest digest` — it
fails identically on a clean `origin/main` worktree with no changes applied, so
it is a pre-existing snapshot-staleness failure unrelated to this PR.

## Adjacent gap (not fixed here)

A standalone `SAVE` statement (blanket `save`, or `save :: c` as its own
statement) is silently dropped: fortfront's AST only carries `is_save` as a
declaration attribute and never emits a node for the statement form. Honoring
blanket SAVE therefore needs a fortfront change and is out of scope for this
ffc-only issue.