### PR TITLE
[bind-char-01] lay out deferred-length allocatable character components (#360)

### DIFF
--- a/src/session_program_lowering_derived_types.inc
+++ b/src/session_program_lowering_derived_types.inc
@@ -851,14 +851,14 @@ subroutine collect_component_declaration(component_index, parent_line, &
             call declaration_value_kind(component, value_kind, error_msg, context)
             if (len_trim(error_msg) > 0) return
             ! A scalar allocatable component of intrinsic numeric/logical type
-            ! stores an inline data pointer (descriptor-in-struct). Array,
-            ! character, pointer, and c_ptr allocatables stay unsupported.
-            comp_allocatable = component%is_allocatable .and. &
-                               .not. component%is_array .and. &
-                               .not. component%is_pointer
+            ! or character type stores an inline data pointer
+            ! (descriptor-in-struct). Array, pointer, and c_ptr allocatables
+            ! stay unsupported.
+            comp_allocatable = component_is_scalar_allocatable(component)
             if (comp_allocatable) then
                 select case (value_kind)
-                case (VALUE_I32, VALUE_F32, VALUE_F64, VALUE_LOGICAL)
+                case (VALUE_I32, VALUE_F32, VALUE_F64, VALUE_LOGICAL, &
+                      VALUE_CHARACTER)
                 case default
                     comp_allocatable = .false.
                 end select
@@ -890,7 +890,7 @@ subroutine collect_component_declaration(component_index, parent_line, &
                 call component_array_count(component, context, array_size, &
                                            error_msg)
                 if (len_trim(error_msg) > 0) return
-            else if (value_kind == VALUE_CHARACTER) then
+            else if (value_kind == VALUE_CHARACTER .and. .not. comp_allocatable) then
                 ! Reuse array_size as the component's slot count: a character
                 ! value occupies ceil((len+1)/4) byte-storage slots at width 1,
                 ! the extra byte holding the load-time NUL terminator.
@@ -1192,6 +1192,13 @@ subroutine collect_component_declaration(component_index, parent_line, &
                     'components are not supported; only scalar', error_msg)
                 return
             end if
+            ! A scalar allocatable character component stores an inline data
+            ! pointer instead of inline bytes, so a deferred length is fine
+            ! at layout time (#360).
+            if (component_is_scalar_allocatable(component)) then
+                call set_empty(error_msg)
+                return
+            end if
             ! A fixed positive length is required; deferred/runtime-length
             ! character components have no static slot footprint.
             call validate_character_component_length(component, context, error_msg)
@@ -1311,6 +1318,14 @@ subroutine collect_component_declaration(component_index, parent_line, &
                        word == 'pass' .or. word == 'private' .or. &
                        word == 'public'
     end function is_proc_component_attribute
+    logical function component_is_scalar_allocatable(component) result(is_scalar)
+        ! True for a scalar (non-array, non-pointer) allocatable component,
+        ! which is laid out as an inline data pointer.
+        type(declaration_node), intent(in) :: component
+
+        is_scalar = component%is_allocatable .and. .not. component%is_array &
+                    .and. .not. component%is_pointer
+    end function component_is_scalar_allocatable
 
     logical function component_alloc_array_rank_one(component) result(is_rank_one)
         ! True when an allocatable array component declares exactly one dimension.

--- a/test/test_session_bindc_module_scalar_compiler.f90
+++ b/test/test_session_bindc_module_scalar_compiler.f90
@@ -9,6 +9,7 @@ program test_session_bindc_module_scalar_compiler
     all_passed = .true.
     if (.not. test_bindc_real_scalar()) all_passed = .false.
     if (.not. test_bindc_integer_scalar()) all_passed = .false.
+    if (.not. test_deferred_char_component_type()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: bind(c) module scalars keep their initializer (#296)'
@@ -50,5 +51,31 @@ contains
         test_bindc_integer_scalar = expect_exit_status( &
             source, 7, '/tmp/ffc_session_bindc_int')
     end function test_bindc_integer_scalar
+
+    logical function test_deferred_char_component_type()
+        ! #360: the binding_label_tests_38 shape. A derived type carrying a
+        ! deferred-length allocatable character component must lay out (as an
+        ! inline data pointer) alongside a bind(c) label, instead of hard
+        ! failing the whole compilation.
+        character(len=*), parameter :: source = &
+            'module api'//new_line('a')// &
+            '  use iso_c_binding'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer(c_int), bind(c) :: handles = 5'//new_line('a')// &
+            '  type :: whizard_api_t'//new_line('a')// &
+            '    character(:), allocatable :: logfile'//new_line('a')// &
+            '    integer :: stat'//new_line('a')// &
+            '  end type whizard_api_t'//new_line('a')// &
+            'end module api'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use api'//new_line('a')// &
+            '  type(whizard_api_t) :: w'//new_line('a')// &
+            '  w%stat = handles'//new_line('a')// &
+            '  stop w%stat'//new_line('a')// &
+            'end program main'
+
+        test_deferred_char_component_type = expect_exit_status( &
+            source, 5, '/tmp/ffc_session_bindc_defchar')
+    end function test_deferred_char_component_type
 
 end program test_session_bindc_module_scalar_compiler


### PR DESCRIPTION
Fixes #360.

## Change

`validate_component_declaration` rejected every CHARACTER component without a
fixed positive declared length. A *scalar allocatable* component is already laid
out as an inline data pointer (descriptor-in-struct), so the deferred length is
irrelevant to its footprint. CHARACTER now joins the intrinsic kinds accepted on
that path, and the byte-slot sizing is skipped for it.

## Preserved compiler invariants

- Fixed-length inline CHARACTER components keep their `ceil((len+1)/4)`
  byte-storage slot layout and NUL-terminator spare byte.
- A non-allocatable deferred or assumed-length CHARACTER component is still
  rejected (`deferred and assumed-length character components are not supported`).
- Reading or writing a deferred-length component still reports the existing
  'derived type character component expression has no fixed length' diagnostic
  rather than miscompiling.

## Red evidence (unmodified main)

```
scripts/conformance_gauntlet.sh --suite gfortran-dg --file binding_label_tests_38.f90
unsupported derived type character component ...: deferred and assumed-length character components are not supported
  FAIL: binding_label_tests_38.f90 (ffc -c failed)
  PASS=0 FAIL=1
```

New case in `test_session_bindc_module_scalar_compiler` with the source patch
stashed:

```
FAIL: unsupported derived type character component at line 6, column 5: ...
Summary: 0 passed, 1 failed
```

## Green evidence

```
scripts/conformance_gauntlet.sh --suite gfortran-dg --file binding_label_tests_38.f90 --ffc build/fo/bin/ffc
  PASS=1  FAIL=0
fo test test_session_bindc_module_scalar_compiler   PASS
fo test test_conformance_gauntlet_smoke             PASS
```

Full `fo` pipeline: build OK, all tests pass except `test_parity_dashboard`,
which is **red on unmodified origin/main as well** (verified by stashing this
patch): the checked-in `parity_dashboard.tsv` snapshot is stale against the
current manifests. Not touched here.

## Adjacent work, not done here

- The parity snapshot needs a refresh: a full four-suite run shows ~45
  `fail_owners_*` entries for files that now PASS (`generate_parity_dashboard.sh`
  reports them as stale metadata). This includes `binding_label_tests_38.f90`
  itself; left to the parity sweep so the manifest digest stays consistent.
- `scripts/conformance_gauntlet.sh` emits `"noref_reason":""` on the
  'gfortran rejects too' NO-REF path (missing `NOREF_RECORD_REASON="reference-rejected"`),
  which makes `validate_parity_report.awk` reject any freshly generated report.
  This currently blocks dashboard regeneration outright.