### PR TITLE
[const-typed-01] fold typed scalar and array named constants (#412)

### DIFF
--- a/src/session_program_lowering_arrays.inc
+++ b/src/session_program_lowering_arrays.inc
@@ -2220,7 +2220,9 @@
             call lower_i16_expression(context%arena, value_index, context, &
                                       value, error_msg)
         case (VALUE_C4, VALUE_C8)
-            error_msg = 'complex array scalar initializer is not supported'
+            call broadcast_complex_scalar_initializer(context%arena, value_index, &
+                                                      symbol_index, array_size, &
+                                                      context, error_msg)
             return
         case default
             call lower_i32_expression(context%arena, value_index, context, &
@@ -2298,6 +2300,11 @@
             return
         end if
         vk = context%symbols(symbol_index)%value_kind
+        if (vk == VALUE_C4 .or. vk == VALUE_C8) then
+            call lower_complex_array_constructor(arena, flat, symbol_index, &
+                                                 context, error_msg)
+            return
+        end if
         do i = 1, n
             if (vk == VALUE_F32) then
                 call lower_f32_expression(arena, flat(i), context, value, error_msg)
@@ -2312,10 +2319,6 @@
                 call lower_i8_expression(arena, flat(i), context, value, error_msg)
             else if (vk == VALUE_I16) then
                 call lower_i16_expression(arena, flat(i), context, value, error_msg)
-            else if (vk == VALUE_C4 .or. vk == VALUE_C8) then
-                error_msg = 'complex array constructor initializer is not '// &
-                            'supported'
-                return
             else
                 call lower_constructor_i32_element(arena, flat(i), context, &
                                                    value, error_msg)

--- a/src/session_program_lowering_complex_arrays.inc
+++ b/src/session_program_lowering_complex_arrays.inc
@@ -376,3 +376,90 @@
         end do
         call set_empty(error_msg)
     end subroutine lower_complex_array_whole_assignment
+
+    ! Store one complex value into the re/im component arrays of a fixed-size
+    ! complex array at a compile-time linear element index.
+    subroutine store_complex_array_element(context, symbol_index, linear_index, &
+                                           vk, re_val, im_val, error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        integer, intent(in) :: linear_index
+        integer, intent(in) :: vk
+        type(lr_operand_desc_t), intent(in) :: re_val, im_val
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: re_addr, im_addr
+
+        call complex_array_linear_addresses(context, symbol_index, linear_index, &
+                                            vk, re_addr, im_addr, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (vk == VALUE_C4) then
+            if (.not. emit_liric_f32_store(context%session, re_val, re_addr, &
+                                           error_msg)) return
+            if (.not. emit_liric_f32_store(context%session, im_val, im_addr, &
+                                           error_msg)) return
+        else
+            if (.not. emit_liric_f64_store(context%session, re_val, re_addr, &
+                                           error_msg)) return
+            if (.not. emit_liric_f64_store(context%session, im_val, im_addr, &
+                                           error_msg)) return
+        end if
+        call set_empty(error_msg)
+    end subroutine store_complex_array_element
+
+    ! Initialize a fixed-size complex array from an array constructor: fold each
+    ! element to a complex value of the declared kind and store it in order.
+    subroutine lower_complex_array_constructor(arena, elements, symbol_index, &
+                                               context, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: elements(:)
+        integer, intent(in) :: symbol_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: re_val, im_val
+        integer :: i, vk
+
+        call set_empty(error_msg)
+        vk = context%symbols(symbol_index)%value_kind
+        do i = 1, size(elements)
+            if (vk == VALUE_C4) then
+                call eval_c4_rhs(arena, elements(i), context, re_val, im_val, &
+                                 error_msg)
+            else
+                call eval_c8_rhs(arena, elements(i), context, re_val, im_val, &
+                                 error_msg)
+            end if
+            if (len_trim(error_msg) > 0) return
+            call store_complex_array_element(context, symbol_index, i - 1, vk, &
+                                             re_val, im_val, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine lower_complex_array_constructor
+
+    ! Broadcast one complex scalar initializer across every element of a
+    ! fixed-size complex array.
+    subroutine broadcast_complex_scalar_initializer(arena, value_index, &
+                                                    symbol_index, array_size, &
+                                                    context, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: value_index
+        integer, intent(in) :: symbol_index
+        integer, intent(in) :: array_size
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: re_val, im_val
+        integer :: i, vk
+
+        vk = context%symbols(symbol_index)%value_kind
+        if (vk == VALUE_C4) then
+            call eval_c4_rhs(arena, value_index, context, re_val, im_val, error_msg)
+        else
+            call eval_c8_rhs(arena, value_index, context, re_val, im_val, error_msg)
+        end if
+        if (len_trim(error_msg) > 0) return
+        do i = 1, array_size
+            call store_complex_array_element(context, symbol_index, i - 1, vk, &
+                                             re_val, im_val, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+        call set_empty(error_msg)
+    end subroutine broadcast_complex_scalar_initializer

--- a/test/test_session_typed_array_parameter_compiler.f90
+++ b/test/test_session_typed_array_parameter_compiler.f90
@@ -1,0 +1,127 @@
+program test_session_typed_array_parameter
+    use ffc_test_support, only: expect_output, expect_error_contains
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== typed scalar and array named constant folding test ==='
+
+    all_passed = .true.
+    if (.not. test_typed_scalar_constants()) all_passed = .false.
+    if (.not. test_typed_array_constants()) all_passed = .false.
+    if (.not. test_complex_array_parameter()) all_passed = .false.
+    if (.not. test_array_parameter_in_bounds()) all_passed = .false.
+    if (.not. test_nonconstant_rhs_rejected()) all_passed = .false.
+    if (.not. test_illegal_conversion_rejected()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: typed scalar and array named constants fold at compile time'
+
+contains
+
+    ! Named constants of every intrinsic scalar type keep their declared
+    ! kind and print exactly like gfortran.
+    logical function test_typed_scalar_constants()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer(8), parameter :: big = 5_8'//new_line('a')// &
+            '  real(8), parameter :: r = 2.5d0'//new_line('a')// &
+            '  logical, parameter :: flag = .true.'//new_line('a')// &
+            '  character(len=3), parameter :: tag = ''abc'''//new_line('a')// &
+            '  complex, parameter :: z = (1.0, 2.0)'//new_line('a')// &
+            '  print *, big, r, flag, tag, z'//new_line('a')// &
+            'end program main'
+
+        test_typed_scalar_constants = expect_output( &
+            source, &
+            '                    5   2.5000000000000000      T abc'// &
+            '             (1.00000000,2.00000000)'//new_line('a'), &
+            '/tmp/ffc_typed_param_scalars')
+    end function test_typed_scalar_constants
+
+    ! Fixed-size array named constants of each type fold elementwise.
+    logical function test_typed_array_constants()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, parameter :: base(3) = [4, 5, 6]'//new_line('a')// &
+            '  real(8), parameter :: rc(2) = [1.0d0, 2.0d0]'//new_line('a')// &
+            '  logical, parameter :: lc(2) = [.true., .false.]'//new_line('a')// &
+            '  character(len=2), parameter :: cc(2) = [''ab'', ''cd'']'// &
+            new_line('a')// &
+            '  integer(8), parameter :: ic(2) = [7_8, 8_8]'//new_line('a')// &
+            '  print *, base(2), rc(1), lc(1), lc(2), cc(2)'//new_line('a')// &
+            '  print *, ic(1) + ic(2)'//new_line('a')// &
+            'end program main'
+
+        test_typed_array_constants = expect_output( &
+            source, &
+            '           5   1.0000000000000000      T F cd'//new_line('a')// &
+            '                   15'//new_line('a'), &
+            '/tmp/ffc_typed_param_arrays')
+    end function test_typed_array_constants
+
+    ! A complex array named constant folds its constructor elements and
+    ! stays addressable in executable expressions.
+    logical function test_complex_array_parameter()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  complex, parameter :: zc(2) = [(1.0, 0.0), (0.0, 1.0)]'// &
+            new_line('a')// &
+            '  complex(8), parameter :: dz(2) = [(1.5d0, 2.5d0), '// &
+            '(3.5d0, 4.5d0)]'//new_line('a')// &
+            '  print *, zc(1), zc(2)'//new_line('a')// &
+            '  print *, dz(2)'//new_line('a')// &
+            'end program main'
+
+        test_complex_array_parameter = expect_output( &
+            source, &
+            '             (1.00000000,0.00000000)'// &
+            '             (0.00000000,1.00000000)'//new_line('a')// &
+            '               (3.5000000000000000,4.5000000000000000)'// &
+            new_line('a'), &
+            '/tmp/ffc_typed_param_complex_array')
+    end function test_complex_array_parameter
+
+    ! Array named constants are usable as compile-time array bounds.
+    logical function test_array_parameter_in_bounds()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, parameter :: dims(2) = [2, 3]'//new_line('a')// &
+            '  integer :: m(dims(1)*dims(2))'//new_line('a')// &
+            '  integer :: a(dims(2))'//new_line('a')// &
+            '  print *, size(m), size(a)'//new_line('a')// &
+            'end program main'
+
+        test_array_parameter_in_bounds = expect_output( &
+            source, '           6           3'//new_line('a'), &
+            '/tmp/ffc_typed_param_bounds')
+    end function test_array_parameter_in_bounds
+
+    ! A nonconstant right-hand side is rejected, not silently folded.
+    logical function test_nonconstant_rhs_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  integer, parameter :: n = i'//new_line('a')// &
+            '  print *, n'//new_line('a')// &
+            'end program main'
+
+        test_nonconstant_rhs_rejected = expect_error_contains( &
+            source, 'does not reduce to a constant expression', &
+            '/tmp/ffc_typed_param_nonconst')
+    end function test_nonconstant_rhs_rejected
+
+    ! A character value initializing an integer named constant is rejected.
+    logical function test_illegal_conversion_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, parameter :: n = ''abc'''//new_line('a')// &
+            '  print *, n'//new_line('a')// &
+            'end program main'
+
+        test_illegal_conversion_rejected = expect_error_contains( &
+            source, 'invalid integer literal', &
+            '/tmp/ffc_typed_param_badconv')
+    end function test_illegal_conversion_rejected
+
+end program test_session_typed_array_parameter


### PR DESCRIPTION
Closes #412.

## What changed

Typed scalar and array named constants of integer, real, logical and
character type already folded at compile time. Complex array parameters
and complex whole-array scalar initializers were rejected outright.
Both now route through the existing re/im component-array machinery, so
a complex array constructor folds elementwise like every other type.

- `src/session_program_lowering_arrays.inc`
- `src/session_program_lowering_complex_arrays.inc`
- NEW `test/test_session_typed_array_parameter_compiler.f90`

## Preserved compiler invariant

Named constants keep their declared type and kind; constructor elements
are evaluated at compile time and bound by identity; conversions are
applied only where Fortran permits. Nonconstant RHS and illegal
conversions still produce diagnostics (covered by the two negative
cases in the new test).

## Red evidence

With the two `.inc` files reverted to their pre-change state and only
the new test present:

```
test_session_typed_array_parameter_compile FAIL       0.30s
 FAIL: complex array constructor initializer is not supported
```

## Green evidence

```
test_session_typed_array_parameter_compile PASS       0.08s
Summary: 1 passed, 0 failed, 0 skipped
```

Full `fo` pipeline: Build OK, Static OK. The only two failures,
`test_conformance_gauntlet_smoke` and `test_parity_dashboard`, were
reproduced on an unmodified `origin/main` worktree (stale parity
snapshot manifest digest / shared installed `ffc` in the gauntlet) and
are unrelated to this change.
