### PR TITLE
[reject-namelist-01] enforce NAMELIST member constraints (#389)

### DIFF
--- a/src/session_program_lowering_io_typecheck.inc
+++ b/src/session_program_lowering_io_typecheck.inc
@@ -711,3 +711,356 @@
             is_dec = .false.
         end select
     end function is_dec_io_spec
+
+    ! NAMELIST transfer-statement constraints (#389). A group object that is
+    ! polymorphic, or of a derived type with ALLOCATABLE or POINTER components,
+    ! requires a defined input/output procedure; an INTENT(IN) group object
+    ! cannot be read. The group list is taken from the source text (see
+    ! check_namelist_members); the second positional item of a data transfer
+    ! statement is a namelist group name whenever the source declares that
+    ! group.
+    subroutine check_namelist_transfers(arena, source, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: source
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: group
+        integer :: n
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (read_statement_node)
+                call namelist_transfer_group(nd%namelist_group, nd%format_spec, &
+                                             source, nd%line, group)
+                if (len_trim(group) == 0) cycle
+                call check_namelist_transfer_group(arena, source, group, .true., &
+                                                   nd%line, error_msg)
+            type is (write_statement_node)
+                call namelist_transfer_group(nd%namelist_group, nd%format_spec, &
+                                             source, nd%line, group)
+                if (len_trim(group) == 0) cycle
+                call check_namelist_transfer_group(arena, source, group, .false., &
+                                                   nd%line, error_msg)
+            end select
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine check_namelist_transfers
+
+    subroutine namelist_transfer_group(nml_spec, format_spec, source, line, group)
+        character(len=:), allocatable, intent(in) :: nml_spec
+        character(len=:), allocatable, intent(in) :: format_spec
+        character(len=*), intent(in) :: source
+        integer, intent(in) :: line
+        character(len=:), allocatable, intent(out) :: group
+        character(len=:), allocatable :: candidate
+
+        group = ''
+        if (allocated(nml_spec)) then
+            if (len_trim(nml_spec) > 0) then
+                group = trim(nml_spec)
+                return
+            end if
+        end if
+        candidate = ''
+        if (allocated(format_spec)) candidate = trim(format_spec)
+        if (len_trim(candidate) == 0) then
+            ! A bare positional group name is not always kept on the typed node,
+            ! so recover it from the transfer statement itself.
+            call namelist_source_control_item(source, line, candidate)
+        end if
+        if (len_trim(candidate) == 0) return
+        if (.not. namelist_source_has_group(source, trim(candidate))) return
+        group = trim(candidate)
+    end subroutine namelist_transfer_group
+
+    ! Second control-list item of the data transfer statement on `line`, which
+    ! is the format or namelist group name in positional form.
+    subroutine namelist_source_control_item(source, line, item)
+        character(len=*), intent(in) :: source
+        integer, intent(in) :: line
+        character(len=:), allocatable, intent(out) :: item
+        character(len=:), allocatable :: text
+        integer :: lp, comma, close_pos, eq_pos
+
+        item = ''
+        call namelist_source_line(source, line, text)
+        text = trim(adjustl(strip_data_source_comment(text)))
+        lp = index(text, '(')
+        if (lp == 0) return
+        comma = index(text(lp + 1:), ',')
+        if (comma == 0) return
+        text = text(lp + comma + 1:)
+        close_pos = index(text, ')')
+        if (close_pos == 0) return
+        text = text(1:close_pos - 1)
+        comma = index(text, ',')
+        if (comma > 0) text = text(1:comma - 1)
+        eq_pos = index(text, '=')
+        if (eq_pos > 0) text = text(eq_pos + 1:)
+        item = trim(adjustl(text))
+        if (verify(item, 'abcdefghijklmnopqrstuvwxyz' &
+                   //'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_') /= 0) item = ''
+    end subroutine namelist_source_control_item
+
+    subroutine namelist_source_line(source, line, text)
+        character(len=*), intent(in) :: source
+        integer, intent(in) :: line
+        character(len=:), allocatable, intent(out) :: text
+        integer :: pos, next_nl, current
+
+        text = ''
+        if (line < 1) return
+        pos = 1
+        current = 1
+        do while (pos <= len(source))
+            next_nl = index(source(pos:), new_line('a'))
+            if (next_nl == 0) then
+                if (current == line) text = source(pos:)
+                return
+            end if
+            if (current == line) then
+                text = source(pos:pos + next_nl - 2)
+                return
+            end if
+            pos = pos + next_nl
+            current = current + 1
+        end do
+    end subroutine namelist_source_line
+
+    logical function namelist_source_has_group(source, name) result(has_group)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: stmt, group
+        integer :: pos, line_no, stmt_line, n, p
+        logical :: found, ok
+
+        has_group = .false.
+        pos = 1
+        line_no = 1
+        do
+            call namelist_next_statement(source, pos, line_no, stmt, stmt_line, &
+                                         found)
+            if (.not. found) exit
+            n = len_trim(stmt)
+            p = 9
+            call namelist_take_group(stmt, n, p, group, ok)
+            if (.not. ok) cycle
+            if (same_name(group, name)) then
+                has_group = .true.
+                return
+            end if
+        end do
+    end function namelist_source_has_group
+
+    subroutine check_namelist_transfer_group(arena, source, group, is_read, &
+                                             line, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: group
+        logical, intent(in) :: is_read
+        integer, intent(in) :: line
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: stmt, this_group, member
+        integer :: pos, line_no, stmt_line, n, p
+        logical :: found, ok, new_group, in_group
+
+        call set_empty(error_msg)
+        pos = 1
+        line_no = 1
+        do
+            call namelist_next_statement(source, pos, line_no, stmt, stmt_line, &
+                                         found)
+            if (.not. found) exit
+            n = len_trim(stmt)
+            p = 9
+            new_group = .true.
+            in_group = .false.
+            do
+                if (new_group) then
+                    call namelist_take_group(stmt, n, p, this_group, ok)
+                    if (.not. ok) exit
+                    in_group = same_name(this_group, group)
+                    new_group = .false.
+                end if
+                call namelist_take_member(stmt, n, p, member, new_group, ok)
+                if (.not. ok) exit
+                if (in_group .and. len_trim(member) > 0) then
+                    call check_namelist_transfer_member(arena, source, member, &
+                        group, is_read, line, error_msg)
+                    if (len_trim(error_msg) > 0) return
+                end if
+                if (p > n) exit
+            end do
+        end do
+    end subroutine check_namelist_transfer_group
+
+    subroutine check_namelist_transfer_member(arena, source, name, group, &
+                                              is_read, line, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: name
+        character(len=*), intent(in) :: group
+        logical, intent(in) :: is_read
+        integer, intent(in) :: line
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: base, low
+        character(len=32) :: location
+        integer :: decl_index
+
+        call set_empty(error_msg)
+        decl_index = namelist_find_declaration(arena, name, huge(1))
+        if (decl_index == 0) return
+        write (location, '(" at line ",I0)') line
+        select type (decl => arena%entries(decl_index)%node)
+        type is (declaration_node)
+            if (allocated(decl%type_name)) then
+                low = trim(lowercase_text(decl%type_name))
+                if (index(low, 'class(') == 1) then
+                    error_msg = 'NAMELIST object '''//trim(name)// &
+                        ''' in namelist '''//trim(group)//''' is polymorphic'// &
+                        ' and requires a defined input/output procedure'// &
+                        trim(location)
+                    return
+                end if
+                base = namelist_derived_base_name(decl%type_name)
+                if (len_trim(base) > 0) then
+                    if (namelist_type_needs_dtio(arena, source, base, 0)) then
+                        error_msg = 'NAMELIST object '''//trim(name)// &
+                            ''' in namelist '''//trim(group)//''' has '// &
+                            'ALLOCATABLE or POINTER components and thus '// &
+                            'requires a defined input/output procedure'// &
+                            trim(location)
+                        return
+                    end if
+                end if
+            end if
+            if (.not. is_read) return
+            if (.not. decl%has_intent) return
+            if (.not. allocated(decl%intent)) return
+            if (trim(lowercase_text(decl%intent)) == 'in') then
+                error_msg = 'NAMELIST object '''//trim(name)//''' in namelist '''// &
+                    trim(group)//''' is INTENT(IN) and cannot be read'// &
+                    trim(location)
+            end if
+        end select
+    end subroutine check_namelist_transfer_member
+
+    ! A derived type needs a defined input/output procedure for namelist
+    ! transfer when it has, directly or through a component, an ALLOCATABLE or
+    ! POINTER component. Types defined in another program unit of the same file
+    ! reach the arena without their component list, so the type definition is
+    ! also read from the source text.
+    recursive logical function namelist_type_needs_dtio(arena, source, name, &
+            depth) result(needs)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: depth
+        character(len=:), allocatable :: base
+        integer :: t, i
+
+        needs = .false.
+        if (depth > 8) return
+        t = namelist_find_derived_type(arena, name)
+        if (t == 0) then
+            needs = namelist_source_type_needs_dtio(source, name, depth)
+            return
+        end if
+        select type (td => arena%entries(t)%node)
+        type is (derived_type_node)
+            if (.not. allocated(td%component_indices)) then
+                needs = namelist_source_type_needs_dtio(source, name, depth)
+                return
+            end if
+            do i = 1, size(td%component_indices)
+                if (.not. node_exists(arena, td%component_indices(i))) cycle
+                select type (comp => arena%entries(td%component_indices(i))%node)
+                type is (declaration_node)
+                    if (comp%is_allocatable .or. comp%is_pointer) then
+                        needs = .true.
+                        return
+                    end if
+                    if (.not. allocated(comp%type_name)) cycle
+                    base = namelist_derived_base_name(comp%type_name)
+                    if (len_trim(base) == 0) cycle
+                    needs = namelist_type_needs_dtio(arena, source, base, &
+                                                     depth + 1)
+                    if (needs) return
+                end select
+            end do
+        end select
+    end function namelist_type_needs_dtio
+
+    ! Same question answered from the source text: walk the type definition
+    ! block of `name` and report an ALLOCATABLE or POINTER component, recursing
+    ! into derived-type components.
+    recursive logical function namelist_source_type_needs_dtio(source, name, &
+            depth) result(needs)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: depth
+        character(len=:), allocatable :: text, low, attrs, base
+        integer :: pos, next_nl, sep
+        logical :: inside
+
+        needs = .false.
+        if (depth > 8) return
+        pos = 1
+        inside = .false.
+        do while (pos <= len(source))
+            next_nl = index(source(pos:), new_line('a'))
+            if (next_nl == 0) then
+                text = source(pos:)
+                pos = len(source) + 1
+            else
+                text = source(pos:pos + next_nl - 2)
+                pos = pos + next_nl
+            end if
+            low = trim(adjustl(lowercase_text( &
+                               strip_data_source_comment(text))))
+            if (.not. inside) then
+                inside = namelist_type_header_names(low, name)
+                cycle
+            end if
+            if (index(low, 'end type') == 1) return
+            if (index(low, 'contains') == 1) return
+            sep = index(low, '::')
+            if (sep == 0) cycle
+            attrs = low(1:sep - 1)
+            if (index(attrs, 'allocatable') > 0 .or. &
+                index(attrs, 'pointer') > 0) then
+                needs = .true.
+                return
+            end if
+            base = namelist_derived_base_name(attrs)
+            if (len_trim(base) == 0) cycle
+            if (same_name(base, name)) cycle
+            needs = namelist_source_type_needs_dtio(source, base, depth + 1)
+            if (needs) return
+        end do
+    end function namelist_source_type_needs_dtio
+
+    ! True when the lowercased statement is the type definition header of
+    ! `name`, in either `type name`, `type :: name`, or `type, attrs :: name`
+    ! form.
+    logical function namelist_type_header_names(low, name) result(is_header)
+        character(len=*), intent(in) :: low
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: rest
+        integer :: sep
+
+        is_header = .false.
+        if (len(low) < 5) return
+        if (low(1:4) /= 'type') return
+        if (low(5:5) /= ' ' .and. low(5:5) /= ',' .and. low(5:5) /= ':') return
+        rest = trim(adjustl(low(5:)))
+        sep = index(rest, '::')
+        if (sep > 0) then
+            rest = trim(adjustl(rest(sep + 2:)))
+        else if (len(rest) > 0) then
+            if (rest(1:1) == ',') return
+        end if
+        if (index(rest, '(') > 0) rest = rest(1:index(rest, '(') - 1)
+        is_header = same_name(trim(rest), name)
+    end function namelist_type_header_names

--- a/src/session_program_lowering_namelist.inc
+++ b/src/session_program_lowering_namelist.inc
@@ -380,3 +380,633 @@
             end if
         end do
     end function upcase
+
+
+    ! NAMELIST member constraints (#389).
+    !
+    ! A namelist group object must be a variable that is declared before the
+    ! NAMELIST statement, must not have the PROCEDURE attribute, and must not
+    ! be PRIVATE while the group itself is public; a group object of a derived
+    ! type with use-associated PRIVATE components may not appear at all. The
+    ! group list itself must be syntactically complete. The transfer-statement
+    ! constraints (polymorphic or ALLOCATABLE/POINTER-component object without
+    ! a defined input/output procedure, INTENT(IN) object read) live in
+    ! session_program_lowering_io_typecheck.inc.
+    !
+    ! The group lists are read from the source text: FortFront drops a NAMELIST
+    ! statement that appears inside a procedure, so the typed nodes alone would
+    ! leave those scopes unchecked. Every member is then resolved against the
+    ! typed declaration, derived type, and procedure nodes of the arena.
+    subroutine check_namelist_members(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: source, stmt
+        integer :: pos, line_no, stmt_line
+        logical :: found
+
+        call set_empty(error_msg)
+        call get_source_text(arena, source, found)
+        if (.not. found) return
+        pos = 1
+        line_no = 1
+        do
+            call namelist_next_statement(source, pos, line_no, stmt, stmt_line, &
+                                         found)
+            if (.not. found) exit
+            call check_namelist_statement(arena, source, stmt, stmt_line, &
+                                          error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+        call check_namelist_transfers(arena, source, error_msg)
+    end subroutine check_namelist_members
+
+    ! Next NAMELIST statement in the source, with continuation lines joined.
+    ! `pos` and `line_no` carry the scan state; `found` is false at end of
+    ! source.
+    subroutine namelist_next_statement(source, pos, line_no, stmt, stmt_line, &
+                                       found)
+        character(len=*), intent(in) :: source
+        integer, intent(inout) :: pos
+        integer, intent(inout) :: line_no
+        character(len=:), allocatable, intent(out) :: stmt
+        integer, intent(out) :: stmt_line
+        logical, intent(out) :: found
+        character(len=:), allocatable :: line, text
+        integer :: next_nl, n
+
+        found = .false.
+        stmt = ''
+        stmt_line = 0
+        do while (pos <= len(source))
+            next_nl = index(source(pos:), new_line('a'))
+            if (next_nl == 0) then
+                line = source(pos:)
+                pos = len(source) + 1
+            else
+                line = source(pos:pos + next_nl - 2)
+                pos = pos + next_nl
+            end if
+            stmt_line = line_no
+            line_no = line_no + 1
+            text = trim(adjustl(strip_data_source_comment(line)))
+            if (.not. is_namelist_statement_text(text)) cycle
+            found = .true.
+            stmt = text
+            ! Join continuation lines so the whole group list is one string.
+            do while (len_trim(stmt) > 0)
+                n = len_trim(stmt)
+                if (stmt(n:n) /= '&') exit
+                stmt = stmt(1:n - 1)
+                if (pos > len(source)) exit
+                next_nl = index(source(pos:), new_line('a'))
+                if (next_nl == 0) then
+                    line = source(pos:)
+                    pos = len(source) + 1
+                else
+                    line = source(pos:pos + next_nl - 2)
+                    pos = pos + next_nl
+                end if
+                line_no = line_no + 1
+                text = trim(adjustl(strip_data_source_comment(line)))
+                if (len(text) > 0) then
+                    if (text(1:1) == '&') text = text(2:)
+                end if
+                stmt = trim(stmt)//' '//trim(text)
+            end do
+            return
+        end do
+    end subroutine namelist_next_statement
+
+    logical function is_namelist_statement_text(text) result(is_nml)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: low
+
+        is_nml = .false.
+        low = trim(lowercase_text(text))
+        if (len(low) < 9) return
+        if (low(1:8) /= 'namelist') return
+        is_nml = low(9:9) == ' ' .or. low(9:9) == '/'
+    end function is_namelist_statement_text
+
+    ! Walk `namelist /group/ a, b [[,] /group2/ c]` and validate every member.
+    subroutine check_namelist_statement(arena, source, stmt, stmt_line, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: stmt
+        integer, intent(in) :: stmt_line
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: group, member
+        integer :: p, n
+        logical :: new_group, ok
+
+        call set_empty(error_msg)
+        n = len_trim(stmt)
+        p = 9
+        group = ''
+        new_group = .true.
+        do
+            if (new_group) then
+                call namelist_take_group(stmt, n, p, group, ok)
+                if (.not. ok) then
+                    error_msg = namelist_syntax_error(stmt_line)
+                    return
+                end if
+                new_group = .false.
+            end if
+            call namelist_take_member(stmt, n, p, member, new_group, ok)
+            if (.not. ok) then
+                error_msg = namelist_syntax_error(stmt_line)
+                return
+            end if
+            if (len_trim(member) > 0) then
+                call check_namelist_member(arena, source, member, group, &
+                                           stmt_line, error_msg)
+                if (len_trim(error_msg) > 0) return
+            end if
+            if (p > n) exit
+        end do
+    end subroutine check_namelist_statement
+
+    function namelist_syntax_error(stmt_line) result(msg)
+        integer, intent(in) :: stmt_line
+        character(len=:), allocatable :: msg
+        character(len=32) :: location
+
+        write (location, '(" at line ",I0)') stmt_line
+        msg = 'Syntax error in NAMELIST statement'//trim(location)
+    end function namelist_syntax_error
+
+    ! Consume `/group/`, leaving p on the first member character.
+    subroutine namelist_take_group(stmt, n, p, group, ok)
+        character(len=*), intent(in) :: stmt
+        integer, intent(in) :: n
+        integer, intent(inout) :: p
+        character(len=:), allocatable, intent(out) :: group
+        logical, intent(out) :: ok
+        integer :: close_pos
+
+        ok = .false.
+        group = ''
+        do while (p <= n)
+            if (stmt(p:p) /= ' ' .and. stmt(p:p) /= ',') exit
+            p = p + 1
+        end do
+        if (p > n) return
+        if (stmt(p:p) /= '/') return
+        close_pos = index(stmt(p + 1:n), '/')
+        if (close_pos <= 1) return
+        group = trim(adjustl(stmt(p + 1:p + close_pos - 1)))
+        p = p + close_pos + 1
+        ok = len_trim(group) > 0
+    end subroutine namelist_take_group
+
+    ! Consume one member name. `new_group` reports that a `/group/` follows.
+    ! An empty item, or a list that ends on a separator, is a syntax error.
+    subroutine namelist_take_member(stmt, n, p, member, new_group, ok)
+        character(len=*), intent(in) :: stmt
+        integer, intent(in) :: n
+        integer, intent(inout) :: p
+        character(len=:), allocatable, intent(out) :: member
+        logical, intent(out) :: new_group
+        logical, intent(out) :: ok
+        integer :: start
+
+        ok = .false.
+        new_group = .false.
+        member = ''
+        do while (p <= n)
+            if (stmt(p:p) /= ' ') exit
+            p = p + 1
+        end do
+        if (p > n) return
+        if (stmt(p:p) == '/') then
+            new_group = .true.
+            ok = .true.
+            return
+        end if
+        if (stmt(p:p) == ',') return
+        start = p
+        do while (p <= n)
+            if (stmt(p:p) == ',' .or. stmt(p:p) == '/') exit
+            p = p + 1
+        end do
+        member = trim(adjustl(stmt(start:p - 1)))
+        if (len_trim(member) == 0) return
+        ok = .true.
+        if (p > n) return
+        if (stmt(p:p) == '/') then
+            new_group = .true.
+            return
+        end if
+        ! Separator consumed; a trailing separator with nothing after it, or a
+        ! second separator, is invalid.
+        p = p + 1
+        do while (p <= n)
+            if (stmt(p:p) /= ' ') exit
+            p = p + 1
+        end do
+        if (p > n) then
+            ok = .false.
+            return
+        end if
+        if (stmt(p:p) == ',') ok = .false.
+        if (stmt(p:p) == '/') new_group = .true.
+    end subroutine namelist_take_member
+
+    subroutine check_namelist_member(arena, source, name, group, stmt_line, &
+                                     error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: name
+        character(len=*), intent(in) :: group
+        integer, intent(in) :: stmt_line
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=32) :: location
+        integer :: decl_index, later_index
+
+        call set_empty(error_msg)
+        write (location, '(" at line ",I0)') stmt_line
+        decl_index = namelist_find_declaration(arena, name, stmt_line)
+        if (decl_index == 0) then
+            later_index = namelist_find_declaration(arena, name, huge(1))
+            if (later_index /= 0) then
+                error_msg = 'NAMELIST object '''//trim(name)//''' must be '// &
+                    'declared before the namelist group '''//trim(group)// &
+                    ''''//trim(location)
+                return
+            end if
+            if (namelist_name_is_procedure(arena, name)) then
+                error_msg = 'PROCEDURE attribute conflicts with NAMELIST '// &
+                    'object '''//trim(name)//''' in group '''//trim(group)// &
+                    ''''//trim(location)
+            end if
+            return
+        end if
+        if (namelist_declaration_is_private(arena, decl_index, name)) then
+            error_msg = 'NAMELIST object '''//trim(name)//''' was declared '// &
+                'PRIVATE and cannot be member of PUBLIC namelist '''// &
+                trim(group)//''''//trim(location)
+            return
+        end if
+        if (namelist_member_has_private_components(arena, source, decl_index, &
+                                                   stmt_line)) then
+            error_msg = 'NAMELIST object '''//trim(name)//''' has '// &
+                'use-associated PRIVATE components and cannot be a member '// &
+                'of namelist '''//trim(group)//''''//trim(location)
+        end if
+    end subroutine check_namelist_member
+
+    ! Arena index of a declaration of `name` that appears at or before
+    ! `max_line`, or 0 when the name has no such declaration in this file.
+    integer function namelist_find_declaration(arena, name, max_line) &
+            result(decl_index)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: max_line
+        integer :: n
+
+        decl_index = 0
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (decl => arena%entries(n)%node)
+            type is (declaration_node)
+                if (decl%line > max_line) cycle
+                if (namelist_decl_declares(decl, name)) then
+                    decl_index = n
+                    return
+                end if
+            end select
+        end do
+    end function namelist_find_declaration
+
+    logical function namelist_decl_declares(decl, name) result(declares)
+        type(declaration_node), intent(in) :: decl
+        character(len=*), intent(in) :: name
+        integer :: k
+
+        declares = .false.
+        if (allocated(decl%var_name)) then
+            if (same_name(decl%var_name, name)) declares = .true.
+        end if
+        if (.not. decl%is_multi_declaration) return
+        if (.not. allocated(decl%var_names)) return
+        do k = 1, size(decl%var_names)
+            if (same_name(decl%var_names(k), name)) declares = .true.
+        end do
+    end function namelist_decl_declares
+
+    ! A namelist group object that is a function or subroutine name carries the
+    ! PROCEDURE attribute, which conflicts with the namelist object attribute.
+    logical function namelist_name_is_procedure(arena, name) result(is_proc)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer :: n
+
+        is_proc = .false.
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (function_def_node)
+                if (allocated(nd%name)) then
+                    if (same_name(nd%name, name)) is_proc = .true.
+                end if
+            type is (subroutine_def_node)
+                if (allocated(nd%name)) then
+                    if (same_name(nd%name, name)) is_proc = .true.
+                end if
+            end select
+            if (is_proc) return
+        end do
+    end function namelist_name_is_procedure
+
+    ! A module entity is PRIVATE through the attribute form or through a
+    ! visibility statement of its module. A NAMELIST group with no
+    ! accessibility statement of its own is public, so a private member is
+    ! invalid. Outside a module nothing is private.
+    logical function namelist_declaration_is_private(arena, decl_index, name) &
+            result(is_private)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: decl_index
+        character(len=*), intent(in) :: name
+        integer :: mod_index
+
+        is_private = .false.
+        mod_index = namelist_owner_module(arena, decl_index)
+        if (mod_index == 0) return
+        select type (decl => arena%entries(decl_index)%node)
+        type is (declaration_node)
+            if (allocated(decl%accessibility)) then
+                if (trim(lowercase_text(decl%accessibility)) == 'private') then
+                    is_private = .true.
+                    return
+                end if
+            end if
+        end select
+        select type (mod_nd => arena%entries(mod_index)%node)
+        type is (module_node)
+            is_private = module_symbol_is_private(arena, mod_nd, name)
+        end select
+    end function namelist_declaration_is_private
+
+    ! Arena index of the module whose specification part holds this node, or 0.
+    integer function namelist_owner_module(arena, node_index) result(owner)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        integer :: n, i
+
+        owner = 0
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (module_node)
+                if (.not. allocated(nd%declaration_indices)) cycle
+                do i = 1, size(nd%declaration_indices)
+                    if (nd%declaration_indices(i) == node_index) then
+                        owner = n
+                        return
+                    end if
+                end do
+            end select
+        end do
+    end function namelist_owner_module
+
+    ! True when the declared entity is of a derived type that carries, directly
+    ! or through a component, a PRIVATE component defined in another module: a
+    ! type whose components are inaccessible wherever it is use-associated
+    ! cannot be a namelist group object.
+    logical function namelist_member_has_private_components(arena, source, &
+            decl_index, stmt_line) result(bad)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: source
+        integer, intent(in) :: decl_index
+        integer, intent(in) :: stmt_line
+        character(len=:), allocatable :: base, here
+        integer :: mod_index
+
+        bad = .false.
+        mod_index = namelist_owner_module(arena, decl_index)
+        select type (decl => arena%entries(decl_index)%node)
+        type is (declaration_node)
+            if (.not. allocated(decl%type_name)) return
+            base = namelist_derived_base_name(decl%type_name)
+            if (len_trim(base) == 0) return
+            bad = namelist_type_private_components(arena, base, mod_index, 0)
+            if (bad) return
+            ! A type defined in another program unit of the same file can reach
+            ! the arena without its component list, so fall back to the source.
+            call namelist_source_module_at(source, stmt_line, here)
+            bad = namelist_source_type_private(source, base, here, 0)
+        end select
+    end function namelist_member_has_private_components
+
+    ! Name of the module whose body contains `line`, or '' outside a module.
+    subroutine namelist_source_module_at(source, line, mod_name)
+        character(len=*), intent(in) :: source
+        integer, intent(in) :: line
+        character(len=:), allocatable, intent(out) :: mod_name
+        character(len=:), allocatable :: low
+        integer :: pos, next_nl, current
+
+        mod_name = ''
+        pos = 1
+        current = 1
+        do while (pos <= len(source))
+            next_nl = index(source(pos:), new_line('a'))
+            if (next_nl == 0) then
+                low = source(pos:)
+                pos = len(source) + 1
+            else
+                low = source(pos:pos + next_nl - 2)
+                pos = pos + next_nl
+            end if
+            if (current >= line) return
+            current = current + 1
+            low = trim(adjustl(lowercase_text(strip_data_source_comment(low))))
+            if (index(low, 'end module') == 1) then
+                mod_name = ''
+            else if (index(low, 'module ') == 1) then
+                low = trim(adjustl(low(8:)))
+                if (index(low, 'procedure ') /= 1) mod_name = low
+            end if
+        end do
+    end subroutine namelist_source_module_at
+
+    ! True when the type `name` is defined in a module other than `here` and
+    ! carries, directly or through a component, a PRIVATE component.
+    recursive logical function namelist_source_type_private(source, name, here, &
+            depth) result(bad)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: name
+        character(len=*), intent(in) :: here
+        integer, intent(in) :: depth
+        character(len=:), allocatable :: low, cur_mod, owner, attrs, base
+        integer :: pos, next_nl, sep
+        logical :: inside, foreign
+
+        bad = .false.
+        if (depth > 8) return
+        pos = 1
+        cur_mod = ''
+        owner = ''
+        inside = .false.
+        foreign = .false.
+        do while (pos <= len(source))
+            next_nl = index(source(pos:), new_line('a'))
+            if (next_nl == 0) then
+                low = source(pos:)
+                pos = len(source) + 1
+            else
+                low = source(pos:pos + next_nl - 2)
+                pos = pos + next_nl
+            end if
+            low = trim(adjustl(lowercase_text(strip_data_source_comment(low))))
+            if (.not. inside) then
+                if (index(low, 'end module') == 1) then
+                    cur_mod = ''
+                else if (index(low, 'module ') == 1) then
+                    owner = trim(adjustl(low(8:)))
+                    if (index(owner, 'procedure ') /= 1) cur_mod = owner
+                end if
+                if (.not. namelist_type_header_names(low, name)) cycle
+                inside = .true.
+                foreign = len_trim(cur_mod) > 0
+                if (foreign) foreign = .not. same_name(cur_mod, here)
+                cycle
+            end if
+            if (index(low, 'end type') == 1) return
+            if (index(low, 'contains') == 1) return
+            if (foreign .and. trim(low) == 'private') then
+                bad = .true.
+                return
+            end if
+            sep = index(low, '::')
+            if (sep == 0) cycle
+            attrs = low(1:sep - 1)
+            if (foreign .and. index(attrs, 'private') > 0) then
+                bad = .true.
+                return
+            end if
+            base = namelist_derived_base_name(attrs)
+            if (len_trim(base) == 0) cycle
+            if (same_name(base, name)) cycle
+            bad = namelist_source_type_private(source, base, here, depth + 1)
+            if (bad) return
+        end do
+    end function namelist_source_type_private
+
+    ! 'type(tp1)' or 'class(tp1)' -> 'tp1'; an intrinsic type -> ''.
+    function namelist_derived_base_name(type_name) result(base)
+        character(len=*), intent(in) :: type_name
+        character(len=:), allocatable :: base
+        character(len=:), allocatable :: low
+        integer :: lp, rp
+
+        base = ''
+        low = trim(lowercase_text(type_name))
+        if (index(low, 'type(') /= 1 .and. index(low, 'class(') /= 1) return
+        lp = index(low, '(')
+        rp = index(low, ')', back=.true.)
+        if (rp <= lp + 1) return
+        base = trim(adjustl(low(lp + 1:rp - 1)))
+    end function namelist_derived_base_name
+
+    recursive logical function namelist_type_private_components(arena, name, &
+            mod_index, depth) result(bad)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: mod_index
+        integer, intent(in) :: depth
+        integer :: t, owner
+
+        bad = .false.
+        if (depth > 8) return
+        t = namelist_find_derived_type(arena, name)
+        if (t == 0) return
+        owner = namelist_owner_module(arena, t)
+        select type (td => arena%entries(t)%node)
+        type is (derived_type_node)
+            if (.not. allocated(td%component_indices)) return
+            if (owner /= 0 .and. owner /= mod_index) then
+                if (namelist_components_private(arena, td%component_indices)) then
+                    bad = .true.
+                    return
+                end if
+            end if
+            bad = namelist_components_private_nested(arena, td%component_indices, &
+                                                     mod_index, depth)
+        end select
+    end function namelist_type_private_components
+
+    logical function namelist_components_private(arena, components) result(bad)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: components(:)
+        integer :: i
+
+        bad = .false.
+        do i = 1, size(components)
+            if (.not. node_exists(arena, components(i))) cycle
+            select type (comp => arena%entries(components(i))%node)
+            type is (declaration_node)
+                if (.not. allocated(comp%accessibility)) cycle
+                if (trim(lowercase_text(comp%accessibility)) == 'private') then
+                    bad = .true.
+                    return
+                end if
+            type is (visibility_statement_node)
+                ! A bare PRIVATE statement in the component part makes every
+                ! component of the type private.
+                if (comp%has_list) cycle
+                if (comp%is_private) then
+                    bad = .true.
+                    return
+                end if
+            end select
+        end do
+    end function namelist_components_private
+
+    recursive logical function namelist_components_private_nested(arena, &
+            components, mod_index, depth) result(bad)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: components(:)
+        integer, intent(in) :: mod_index
+        integer, intent(in) :: depth
+        character(len=:), allocatable :: base
+        integer :: i
+
+        bad = .false.
+        do i = 1, size(components)
+            if (.not. node_exists(arena, components(i))) cycle
+            select type (comp => arena%entries(components(i))%node)
+            type is (declaration_node)
+                if (.not. allocated(comp%type_name)) cycle
+                base = namelist_derived_base_name(comp%type_name)
+                if (len_trim(base) == 0) cycle
+                bad = namelist_type_private_components(arena, base, mod_index, &
+                                                       depth + 1)
+                if (bad) return
+            end select
+        end do
+    end function namelist_components_private_nested
+
+    integer function namelist_find_derived_type(arena, name) result(idx)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer :: n
+
+        idx = 0
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (td => arena%entries(n)%node)
+            type is (derived_type_node)
+                if (.not. allocated(td%name)) cycle
+                if (.not. same_name(td%name, name)) cycle
+                ! A type can appear both as a forward entry and as the entry
+                ! that carries the component list; prefer the latter.
+                if (allocated(td%component_indices)) then
+                    idx = n
+                    return
+                end if
+                if (idx == 0) idx = n
+            end select
+        end do
+    end function namelist_find_derived_type

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -562,6 +562,8 @@
         if (len_trim(error_msg) > 0) return
         call check_io_control_source(arena, error_msg)
         if (len_trim(error_msg) > 0) return
+        call check_namelist_members(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
         call set_empty(error_msg)
     end subroutine validate_program
     subroutine lower_program_return(arena, root_index, context, value, error_msg)

--- a/test/conformance/fail_owners_gfortran_dg.txt
+++ b/test/conformance/fail_owners_gfortran_dg.txt
@@ -161,14 +161,6 @@ module_equivalence_6.f90 # owner=lazy-fortran/ffc#370; reason=fold named constan
 module_procedure_2.f90 # owner=lazy-fortran/fortfront#2883; reason=enforce explicit-interface declaration rules
 module_procedure_4.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
 modulo_1.f90 # owner=lazy-fortran/ffc#453; reason=owns typed intrinsic arguments, validation, and result kind
-namelist_1.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member constraints
-namelist_2.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member constraints
-namelist_33.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member constraints
-namelist_4.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member constraints
-namelist_75.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member constraints
-namelist_92.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member constraints
-namelist_93.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member constraints
-namelist_98.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member constraints
 namelist_use.f90 # owner=lazy-fortran/ffc#436; reason=owns scalar NAMELIST groups and omitted/order-independent member conversion
 non_module_public.f90 # owner=lazy-fortran/fortfront#2895; reason=reject duplicate or incompatible declaration attributes
 old_style_init.f90 # owner=lazy-fortran/ffc#383; reason=enforce DATA object and initializer restrictions
@@ -240,7 +232,6 @@ pr96087.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables from ru
 pr96099_1.f90 # owner=lazy-fortran/fortfront#2891; reason=reject malformed type and SELECT TYPE syntax
 pr96099_2.f90 # owner=lazy-fortran/fortfront#2891; reason=reject malformed type and SELECT TYPE syntax
 pr96102.f90 # owner=lazy-fortran/fortfront#2888; reason=reject local and host-associated name collisions
-pr99368.f90 # owner=lazy-fortran/ffc#389; reason=enforce NAMELIST member constraints
 present_1.f90 # owner=lazy-fortran/ffc#381; reason=enforce data and procedure pointer target contracts
 print_fmt_2.f90 # owner=lazy-fortran/fortfront#2897; reason=reject unclassifiable execution expressions
 private_type_6.f90 # owner=lazy-fortran/ffc#390; reason=enforce derived-type definition constraints

--- a/test/test_session_reject_namelist_01_compiler.f90
+++ b/test/test_session_reject_namelist_01_compiler.f90
@@ -1,0 +1,312 @@
+program test_session_reject_namelist_01_compiler
+    use ffc_test_support, only: expect_error_contains, expect_no_error
+    implicit none
+
+    logical :: all_passed
+    character(len=*), parameter :: nl = new_line('a')
+
+    print *, '=== NAMELIST member constraint rejection test ==='
+
+    all_passed = .true.
+    if (.not. test_private_member_rejected()) all_passed = .false.
+    if (.not. test_intent_in_read_rejected()) all_passed = .false.
+    if (.not. test_private_components_rejected()) all_passed = .false.
+    if (.not. test_procedure_member_rejected()) all_passed = .false.
+    if (.not. test_syntax_error_rejected()) all_passed = .false.
+    if (.not. test_allocatable_component_rejected()) all_passed = .false.
+    if (.not. test_polymorphic_member_rejected()) all_passed = .false.
+    if (.not. test_late_declaration_rejected()) all_passed = .false.
+    if (.not. test_public_member_accepted()) all_passed = .false.
+    if (.not. test_intent_inout_read_accepted()) all_passed = .false.
+    if (.not. test_public_components_accepted()) all_passed = .false.
+    if (.not. test_variable_member_accepted()) all_passed = .false.
+    if (.not. test_well_formed_list_accepted()) all_passed = .false.
+    if (.not. test_plain_component_type_accepted()) all_passed = .false.
+    if (.not. test_nonpolymorphic_member_accepted()) all_passed = .false.
+    if (.not. test_early_declaration_accepted()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: NAMELIST member constraints enforced'
+
+contains
+
+    logical function test_private_member_rejected()
+        character(len=:), allocatable :: source
+
+        source = 'module m'//nl// &
+                 '  public'//nl// &
+                 '  integer, private :: x'//nl// &
+                 '  namelist /n/ x'//nl// &
+                 'end module m'//nl// &
+                 'program main'//nl// &
+                 '  use m'//nl// &
+                 'end program main'
+        test_private_member_rejected = expect_error_contains(source, &
+            'cannot be member of PUBLIC namelist', &
+            '/tmp/ffc_nml389_private_member')
+    end function test_private_member_rejected
+
+    logical function test_intent_in_read_rejected()
+        character(len=:), allocatable :: source
+
+        source = 'subroutine s(x)'//nl// &
+                 '  integer, intent(in) :: x'//nl// &
+                 '  namelist /n/ x'//nl// &
+                 '  read(*,n)'//nl// &
+                 'end subroutine s'//nl// &
+                 'program main'//nl// &
+                 'end program main'
+        test_intent_in_read_rejected = expect_error_contains(source, &
+            'is INTENT(IN) and cannot be read', &
+            '/tmp/ffc_nml389_intent_in')
+    end function test_intent_in_read_rejected
+
+    logical function test_private_components_rejected()
+        character(len=:), allocatable :: source
+
+        source = 'module types'//nl// &
+                 '  type :: tp4'//nl// &
+                 '    private'//nl// &
+                 '    real :: x'//nl// &
+                 '  end type tp4'//nl// &
+                 'end module types'//nl// &
+                 'module nml'//nl// &
+                 '  use types'//nl// &
+                 '  type(tp4) :: t4'//nl// &
+                 '  namelist /b/ t4'//nl// &
+                 'end module nml'//nl// &
+                 'program main'//nl// &
+                 '  use nml'//nl// &
+                 'end program main'
+        test_private_components_rejected = expect_error_contains(source, &
+            'use-associated PRIVATE components', &
+            '/tmp/ffc_nml389_private_components')
+    end function test_private_components_rejected
+
+    logical function test_procedure_member_rejected()
+        character(len=:), allocatable :: source
+
+        source = 'module m1'//nl// &
+                 'contains'//nl// &
+                 '  integer function g1()'//nl// &
+                 '    namelist /nml1/ g2'//nl// &
+                 '    g1 = 1'//nl// &
+                 '  end function g1'//nl// &
+                 '  integer function g2()'//nl// &
+                 '    g2 = 1'//nl// &
+                 '  end function g2'//nl// &
+                 'end module m1'//nl// &
+                 'program main'//nl// &
+                 '  use m1'//nl// &
+                 'end program main'
+        test_procedure_member_rejected = expect_error_contains(source, &
+            'PROCEDURE attribute conflicts', &
+            '/tmp/ffc_nml389_procedure_member')
+    end function test_procedure_member_rejected
+
+    logical function test_syntax_error_rejected()
+        character(len=:), allocatable :: source
+
+        source = 'program main'//nl// &
+                 '  integer :: bar, baz'//nl// &
+                 '  namelist /foo/ bar, baz'//nl// &
+                 '  namelist /foo/ baz, ,'//nl// &
+                 'end program main'
+        test_syntax_error_rejected = expect_error_contains(source, &
+            'Syntax error in NAMELIST', &
+            '/tmp/ffc_nml389_syntax')
+    end function test_syntax_error_rejected
+
+    logical function test_allocatable_component_rejected()
+        character(len=:), allocatable :: source
+
+        source = 'module ma'//nl// &
+                 '  implicit none'//nl// &
+                 '  type :: ta'//nl// &
+                 '    integer, allocatable :: array(:)'//nl// &
+                 '  end type ta'//nl// &
+                 'end module ma'//nl// &
+                 'program main'//nl// &
+                 '  use ma'//nl// &
+                 '  type(ta) :: x'//nl// &
+                 '  namelist /nml/ x'//nl// &
+                 '  write(*, nml)'//nl// &
+                 'end program main'
+        test_allocatable_component_rejected = expect_error_contains(source, &
+            'has ALLOCATABLE or POINTER components', &
+            '/tmp/ffc_nml389_alloc_component')
+    end function test_allocatable_component_rejected
+
+    logical function test_polymorphic_member_rejected()
+        character(len=:), allocatable :: source
+
+        source = 'module mb'//nl// &
+                 '  implicit none'//nl// &
+                 '  type :: tb'//nl// &
+                 '    integer :: i'//nl// &
+                 '  end type tb'//nl// &
+                 'end module mb'//nl// &
+                 'program main'//nl// &
+                 '  use mb'//nl// &
+                 '  class(tb), allocatable :: x'//nl// &
+                 '  namelist /nml/ x'//nl// &
+                 '  read(*, nml)'//nl// &
+                 'end program main'
+        test_polymorphic_member_rejected = expect_error_contains(source, &
+            'is polymorphic and requires a defined input/output procedure', &
+            '/tmp/ffc_nml389_polymorphic')
+    end function test_polymorphic_member_rejected
+
+    logical function test_late_declaration_rejected()
+        character(len=:), allocatable :: source
+
+        source = 'program main'//nl// &
+                 '  implicit none'//nl// &
+                 '  real :: x'//nl// &
+                 '  namelist /grp/ x, q'//nl// &
+                 '  integer :: q'//nl// &
+                 '  x = 1.0'//nl// &
+                 '  q = 3'//nl// &
+                 'end program main'
+        test_late_declaration_rejected = expect_error_contains(source, &
+            'must be declared before the namelist group', &
+            '/tmp/ffc_nml389_late_decl')
+    end function test_late_declaration_rejected
+
+    logical function test_public_member_accepted()
+        character(len=:), allocatable :: source
+
+        source = 'module m'//nl// &
+                 '  public'//nl// &
+                 '  integer :: x'//nl// &
+                 '  namelist /n/ x'//nl// &
+                 'end module m'//nl// &
+                 'program main'//nl// &
+                 '  use m'//nl// &
+                 '  x = 1'//nl// &
+                 'end program main'
+        test_public_member_accepted = expect_no_error(source, &
+            '/tmp/ffc_nml389_public_member')
+    end function test_public_member_accepted
+
+    logical function test_intent_inout_read_accepted()
+        character(len=:), allocatable :: source
+
+        source = 'subroutine s(x)'//nl// &
+                 '  integer, intent(inout) :: x'//nl// &
+                 '  namelist /n/ x'//nl// &
+                 '  read(*,n)'//nl// &
+                 'end subroutine s'//nl// &
+                 'program main'//nl// &
+                 'end program main'
+        test_intent_inout_read_accepted = expect_no_error(source, &
+            '/tmp/ffc_nml389_intent_inout')
+    end function test_intent_inout_read_accepted
+
+    logical function test_public_components_accepted()
+        character(len=:), allocatable :: source
+
+        source = 'module types'//nl// &
+                 '  type :: tp4'//nl// &
+                 '    real :: x'//nl// &
+                 '  end type tp4'//nl// &
+                 'end module types'//nl// &
+                 'module nml'//nl// &
+                 '  use types'//nl// &
+                 '  type(tp4) :: t4'//nl// &
+                 '  namelist /b/ t4'//nl// &
+                 'end module nml'//nl// &
+                 'program main'//nl// &
+                 '  use nml'//nl// &
+                 'end program main'
+        test_public_components_accepted = expect_no_error(source, &
+            '/tmp/ffc_nml389_public_components')
+    end function test_public_components_accepted
+
+    logical function test_variable_member_accepted()
+        character(len=:), allocatable :: source
+
+        source = 'module m1'//nl// &
+                 'contains'//nl// &
+                 '  integer function g1()'//nl// &
+                 '    integer :: g2'//nl// &
+                 '    namelist /nml1/ g2'//nl// &
+                 '    g2 = 1'//nl// &
+                 '    g1 = g2'//nl// &
+                 '  end function g1'//nl// &
+                 'end module m1'//nl// &
+                 'program main'//nl// &
+                 '  use m1'//nl// &
+                 'end program main'
+        test_variable_member_accepted = expect_no_error(source, &
+            '/tmp/ffc_nml389_variable_member')
+    end function test_variable_member_accepted
+
+    logical function test_well_formed_list_accepted()
+        character(len=:), allocatable :: source
+
+        source = 'program main'//nl// &
+                 '  integer :: bar, baz'//nl// &
+                 '  namelist /foo/ bar, baz'//nl// &
+                 '  namelist /foo2/ baz'//nl// &
+                 '  bar = 1'//nl// &
+                 '  baz = 2'//nl// &
+                 'end program main'
+        test_well_formed_list_accepted = expect_no_error(source, &
+            '/tmp/ffc_nml389_well_formed')
+    end function test_well_formed_list_accepted
+
+    logical function test_plain_component_type_accepted()
+        character(len=:), allocatable :: source
+
+        source = 'module ma'//nl// &
+                 '  implicit none'//nl// &
+                 '  type :: ta'//nl// &
+                 '    integer :: array(4)'//nl// &
+                 '  end type ta'//nl// &
+                 'end module ma'//nl// &
+                 'program main'//nl// &
+                 '  use ma'//nl// &
+                 '  type(ta) :: x'//nl// &
+                 '  namelist /nml/ x'//nl// &
+                 '  write(*, nml)'//nl// &
+                 'end program main'
+        test_plain_component_type_accepted = expect_no_error(source, &
+            '/tmp/ffc_nml389_plain_component')
+    end function test_plain_component_type_accepted
+
+    logical function test_nonpolymorphic_member_accepted()
+        character(len=:), allocatable :: source
+
+        source = 'module mb'//nl// &
+                 '  implicit none'//nl// &
+                 '  type :: tb'//nl// &
+                 '    integer :: i'//nl// &
+                 '  end type tb'//nl// &
+                 'end module mb'//nl// &
+                 'program main'//nl// &
+                 '  use mb'//nl// &
+                 '  type(tb) :: x'//nl// &
+                 '  namelist /nml/ x'//nl// &
+                 '  read(*, nml)'//nl// &
+                 'end program main'
+        test_nonpolymorphic_member_accepted = expect_no_error(source, &
+            '/tmp/ffc_nml389_nonpolymorphic')
+    end function test_nonpolymorphic_member_accepted
+
+    logical function test_early_declaration_accepted()
+        character(len=:), allocatable :: source
+
+        source = 'program main'//nl// &
+                 '  implicit none'//nl// &
+                 '  real :: x'//nl// &
+                 '  integer :: q'//nl// &
+                 '  namelist /grp/ x, q'//nl// &
+                 '  x = 1.0'//nl// &
+                 '  q = 3'//nl// &
+                 'end program main'
+        test_early_declaration_accepted = expect_no_error(source, &
+            '/tmp/ffc_nml389_early_decl')
+    end function test_early_declaration_accepted
+
+end program test_session_reject_namelist_01_compiler


### PR DESCRIPTION
Closes #389.

## Preserved compiler invariant

A NAMELIST group object must be a variable that is accessible wherever the
group is, declared before the group, and transferable without a defined
input/output procedure. This change rejects every violation of that family
with a rule-specific source diagnostic instead of silently lowering:

- PRIVATE module entity in a public group
- object of a type with use-associated PRIVATE components
- procedure name used as a group object
- object declared after the NAMELIST statement
- malformed group list (`namelist /foo/ a, ,`)
- data transfer of a polymorphic object, or of an object whose type has
  ALLOCATABLE or POINTER components, without a defined input/output procedure
- READ of an INTENT(IN) group object

Corrected neighbours of each rule still compile, so the change rejects the
invalid form only.

## Red evidence

On unmodified main, `fo test test_session_reject_namelist_01_compiler` fails
with eight `FAIL: unsupported source lowered without diagnostic` — one per
rejection case (`Summary: 0 passed, 1 failed`).

## Green evidence

- `fo test test_session_reject_namelist_01_compiler` → `1 passed, 0 failed`
- `scripts/conformance_gauntlet.sh --suite gfortran-dg` over `namelist_1.f90`,
  `namelist_2.f90`, `namelist_33.f90`, `namelist_4.f90`, `namelist_75.f90`,
  `namelist_92.f90`, `namelist_93.f90`, `namelist_98.f90`, `pr99368.f90`
  → `PASS=9 XPASS=0 FAIL=0`; their `fail_owners_gfortran_dg.txt` entries are
  removed accordingly.
- Full `fo`: build clean, 271 tests, only the pre-existing
  `test_parity_dashboard` failure remains. It fails identically on unmodified
  main (the recorded `digest manifests` in `parity_dashboard.tsv` already does
  not match the manifests on main, before and after this change).