### PR TITLE
[reject-derived-01] enforce derived-type definition constraints (#390)

### DIFF
--- a/src/session_program_lowering_derived_types.inc
+++ b/src/session_program_lowering_derived_types.inc
@@ -1596,3 +1596,277 @@ subroutine collect_component_declaration(component_index, parent_line, &
         context%module_exports(export_idx)%enum_indices(1:old_size) = old_indices
         deallocate(old_indices)
     end subroutine grow_module_export_enum_indices
+
+    ! ---------------------------------------------------------------------
+    ! Derived-type definition constraints checked on the source form (#390).
+    !
+    ! FortFront folds a contained procedure of a module and the component list
+    ! of a module-scope type away before the arena is handed to ffc, so the
+    ! typed nodes no longer carry the attributes these rules need. The source
+    ! form is therefore the earliest - and here the only - layer with enough
+    ! information:
+    !
+    !   * a BIND(C) derived type must have at least one component
+    !     (gfortran: "with BIND(C) attribute ... has no components");
+    !   * an INTENT(OUT) dummy argument of a type with default initialization
+    !     may not be an assumed-size array, because the default initializer
+    !     would have to be applied to an unknown number of elements
+    !     (gfortran: "is ASSUMED SIZE and so cannot have a default
+    !     initializer");
+    !   * a SELECT TYPE guard is spelled TYPE IS; TYPEIS is not a keyword and
+    !     is parsed as a malformed type definition
+    !     (gfortran: "Mangled derived type definition").
+    ! ---------------------------------------------------------------------
+    subroutine check_derived_type_definition_forms(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: source, init_types
+        logical :: found
+
+        call set_empty(error_msg)
+        call get_source_text(arena, source, found)
+        if (.not. found) return
+        call scan_derived_type_bodies(source, init_types, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_assumed_size_dt_dummies(source, init_types, error_msg)
+    end subroutine check_derived_type_definition_forms
+
+    subroutine scan_derived_type_bodies(source, init_types, error_msg)
+        !! Walk every derived-type definition in the source. Reports the empty
+        !! BIND(C) type and the mangled TYPEIS guard, and returns the
+        !! '|'-delimited set of type names that have a default-initialized
+        !! component.
+        character(len=*), intent(in) :: source
+        character(len=:), allocatable, intent(out) :: init_types
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: line, code, packed, name, type_name
+        logical :: in_body, is_bind_c, has_component, is_header
+        integer :: pos, line_no, header_line
+        character(len=64) :: location
+
+        call set_empty(error_msg)
+        init_types = '|'
+        in_body = .false.
+        is_bind_c = .false.
+        has_component = .false.
+        header_line = 0
+        type_name = ''
+        pos = 1
+        line_no = 0
+        do while (pos <= len(source))
+            call next_source_line(source, pos, line)
+            line_no = line_no + 1
+            code = statement_code_text(line)
+            if (len_trim(code) == 0) cycle
+            packed = remove_blanks(code)
+            if (in_body) then
+                if (len(packed) >= 7) then
+                    if (packed(1:7) == 'endtype') then
+                        if (is_bind_c .and. .not. has_component) then
+                            write (location, '(" at line ",I0)') header_line
+                            error_msg = 'derived type '''//trim(type_name)// &
+                                ''' with BIND(C) attribute has no components'// &
+                                trim(location)
+                            return
+                        end if
+                        in_body = .false.
+                        cycle
+                    end if
+                end if
+                if (is_type_body_keyword(packed)) cycle
+                has_component = .true.
+                if (has_default_initializer(code)) then
+                    if (index(init_types, '|'//trim(type_name)//'|') == 0) then
+                        init_types = init_types//trim(type_name)//'|'
+                    end if
+                end if
+                cycle
+            end if
+            if (first_word_of(code) == 'typeis') then
+                write (location, '(" at line ",I0)') line_no
+                error_msg = 'mangled derived type definition'//trim(location)
+                return
+            end if
+            call derived_type_header_info(code, name, is_bind_c, is_header)
+            if (.not. is_header) cycle
+            in_body = .true.
+            has_component = .false.
+            header_line = line_no
+            type_name = name
+        end do
+    end subroutine scan_derived_type_bodies
+
+    subroutine check_assumed_size_dt_dummies(source, init_types, error_msg)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: init_types
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: line, code, packed, type_name, dummy
+        integer :: pos, line_no, close_paren
+        character(len=64) :: location
+
+        call set_empty(error_msg)
+        pos = 1
+        line_no = 0
+        do while (pos <= len(source))
+            call next_source_line(source, pos, line)
+            line_no = line_no + 1
+            code = statement_code_text(line)
+            if (len_trim(code) == 0) cycle
+            packed = remove_blanks(code)
+            if (len(packed) < 6) cycle
+            if (packed(1:5) /= 'type(') cycle
+            if (index(packed, 'intent(out)') == 0) cycle
+            if (index(packed, '(*)') == 0) cycle
+            close_paren = index(packed, ')')
+            if (close_paren <= 6) cycle
+            type_name = packed(6:close_paren - 1)
+            if (index(init_types, '|'//trim(type_name)//'|') == 0) cycle
+            dummy = declared_entity_name(packed)
+            write (location, '(" at line ",I0)') line_no
+            error_msg = 'INTENT(OUT) dummy argument '''//trim(dummy)// &
+                ''' is ASSUMED SIZE and so cannot have a default initializer'// &
+                trim(location)
+            return
+        end do
+    end subroutine check_assumed_size_dt_dummies
+
+    subroutine derived_type_header_info(code, name, is_bind_c, is_header)
+        !! Decide whether a lowered statement opens a derived-type definition,
+        !! and if so return its name and whether it carries BIND(C).
+        character(len=*), intent(in) :: code
+        character(len=:), allocatable, intent(out) :: name
+        logical, intent(out) :: is_bind_c, is_header
+        character(len=:), allocatable :: rest
+        integer :: dc
+
+        call set_empty(name)
+        is_bind_c = .false.
+        is_header = .false.
+        if (len(code) < 6) return
+        if (code(1:4) /= 'type') return
+        if (code(5:5) /= ' ' .and. code(5:5) /= ',' .and. code(5:5) /= ':') return
+        rest = adjustl(code(5:))
+        if (len_trim(rest) == 0) return
+        is_bind_c = index(remove_blanks(rest), 'bind(c)') > 0
+        dc = index(rest, '::')
+        if (dc > 0) then
+            name = first_word_of(adjustl(rest(dc + 2:)))
+        else
+            if (rest(1:1) == ',') return
+            name = first_word_of(rest)
+        end if
+        if (len_trim(name) == 0) return
+        if (trim(name) == 'is') return
+        is_header = .true.
+    end subroutine derived_type_header_info
+
+    logical function is_type_body_keyword(packed) result(is_keyword)
+        character(len=*), intent(in) :: packed
+
+        select case (trim(packed))
+        case ('private', 'public', 'sequence', 'contains')
+            is_keyword = .true.
+        case default
+            is_keyword = .false.
+        end select
+    end function is_type_body_keyword
+
+    logical function has_default_initializer(code) result(has_init)
+        !! True when a component declaration carries '= value' (but not the
+        !! pointer initializer '=>' nor a relational operator).
+        character(len=*), intent(in) :: code
+        integer :: i
+
+        has_init = .false.
+        do i = 1, len(code)
+            if (code(i:i) /= '=') cycle
+            if (i > 1) then
+                if (scan(code(i - 1:i - 1), '=/<>') > 0) cycle
+            end if
+            if (i < len(code)) then
+                if (scan(code(i + 1:i + 1), '=>') > 0) cycle
+            end if
+            has_init = .true.
+            return
+        end do
+    end function has_default_initializer
+
+    function declared_entity_name(packed) result(name)
+        !! First entity name declared after '::' in a packed declaration.
+        character(len=*), intent(in) :: packed
+        character(len=:), allocatable :: name, rest
+        integer :: dc, stop_at
+
+        name = ''
+        dc = index(packed, '::')
+        if (dc == 0) return
+        rest = packed(dc + 2:)
+        if (len_trim(rest) == 0) return
+        stop_at = scan(rest, ',(')
+        if (stop_at == 0) then
+            name = trim(rest)
+        else
+            name = trim(rest(:stop_at - 1))
+        end if
+    end function declared_entity_name
+
+    subroutine next_source_line(source, pos, line)
+        character(len=*), intent(in) :: source
+        integer, intent(inout) :: pos
+        character(len=:), allocatable, intent(out) :: line
+        integer :: next_nl
+
+        next_nl = index(source(pos:), new_line('a'))
+        if (next_nl == 0) then
+            line = source(pos:)
+            pos = len(source) + 1
+        else
+            line = source(pos:pos + next_nl - 2)
+            pos = pos + next_nl
+        end if
+    end subroutine next_source_line
+
+    function statement_code_text(line) result(code)
+        !! Lowered, comment-stripped, left-justified statement text.
+        character(len=*), intent(in) :: line
+        character(len=:), allocatable :: code
+        integer :: comment_pos
+
+        comment_pos = index(line, '!')
+        if (comment_pos == 1) then
+            code = ''
+            return
+        else if (comment_pos > 1) then
+            code = lowercase_text(line(:comment_pos - 1))
+        else
+            code = lowercase_text(line)
+        end if
+        code = trim(adjustl(code))
+    end function statement_code_text
+
+    function remove_blanks(text) result(packed)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: packed
+        integer :: i
+
+        packed = ''
+        do i = 1, len(text)
+            if (text(i:i) == ' ' .or. text(i:i) == char(9)) cycle
+            packed = packed//text(i:i)
+        end do
+    end function remove_blanks
+
+    function first_word_of(text) result(word)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: word
+        character(len=:), allocatable :: trimmed
+        integer :: stop_at
+
+        trimmed = adjustl(text)
+        stop_at = scan(trimmed, ' '//char(9)//',(:')
+        if (stop_at == 0) then
+            word = trim(trimmed)
+        else
+            word = trim(trimmed(:stop_at - 1))
+        end if
+    end function first_word_of

--- a/src/session_program_lowering_reject_checks.inc
+++ b/src/session_program_lowering_reject_checks.inc
@@ -2130,3 +2130,347 @@
             i = i + 1
         end do
     end subroutine concatenated_literal_text
+
+    ! ---------------------------------------------------------------------
+    ! Derived-type definition and component-access constraints (#390).
+    !
+    ! Three rules are checked here against typed nodes, because the arena
+    ! carries the declared attributes each one needs:
+    !
+    !   * a component declared PRIVATE is accessible only inside the module
+    !     that defines the type, so neither a component reference nor a
+    !     structure constructor for that type is valid outside it
+    !     (gfortran: "is a PRIVATE component of");
+    !   * a DATA statement object may not be reached through an allocatable
+    !     component, whose storage does not exist before execution
+    !     (gfortran: "Allocatable component or deferred-shaped array");
+    !   * a function result declared CLASS must be allocatable or a pointer,
+    !     since a result variable is never a dummy argument
+    !     (gfortran: "CLASS variable ... must be dummy, allocatable or
+    !     pointer").
+    ! ---------------------------------------------------------------------
+    subroutine check_private_component_access(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n, module_idx
+        character(len=:), allocatable :: type_name, comp_name
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (component_access_node)
+                if (.not. allocated(nd%component_name)) cycle
+                call designator_type_name(arena, nd%base_expr_index, type_name)
+                if (len_trim(type_name) == 0) cycle
+                if (.not. component_is_private(arena, type_name, &
+                                               nd%component_name, module_idx)) cycle
+                if (node_within(arena, n, module_idx)) cycle
+                error_msg = private_component_message(arena, n, &
+                                                      nd%component_name, type_name)
+                return
+            type is (call_or_subscript_node)
+                if (.not. allocated(nd%name)) cycle
+                call first_private_component(arena, nd%name, comp_name, module_idx)
+                if (len_trim(comp_name) == 0) cycle
+                if (node_within(arena, n, module_idx)) cycle
+                error_msg = private_component_message(arena, n, comp_name, nd%name)
+                return
+            end select
+        end do
+    end subroutine check_private_component_access
+
+    function private_component_message(arena, node_index, comp_name, type_name) &
+        result(message)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: comp_name, type_name
+        character(len=:), allocatable :: message
+        character(len=64) :: location
+
+        write (location, '(" at line ",I0,", column ",I0)') &
+            get_node_line(arena, node_index), get_node_column(arena, node_index)
+        message = 'component '''//trim(comp_name)//''' is a PRIVATE '// &
+            'component of '''//trim(type_name)//''''//trim(location)
+    end function private_component_message
+
+    logical function component_is_private(arena, type_name, comp_name, module_idx)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: type_name, comp_name
+        integer, intent(out) :: module_idx
+        integer :: decl, type_idx
+
+        module_idx = 0
+        component_is_private = .false.
+        decl = derived_component_decl(arena, type_name, comp_name, type_idx)
+        if (decl <= 0) return
+        select type (dn => arena%entries(decl)%node)
+        type is (declaration_node)
+            if (.not. allocated(dn%accessibility)) return
+            if (trim(lowercase_text(dn%accessibility)) /= 'private') return
+        class default
+            return
+        end select
+        module_idx = enclosing_module_index(arena, type_idx)
+        if (module_idx <= 0) return
+        component_is_private = .true.
+    end function component_is_private
+
+    subroutine first_private_component(arena, type_name, comp_name, module_idx)
+        !! Name of the first PRIVATE component of the named derived type, and
+        !! the module that defines the type. Empty when the name is not a
+        !! module derived type or has no private component.
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: type_name
+        character(len=:), allocatable, intent(out) :: comp_name
+        integer, intent(out) :: module_idx
+        integer :: type_idx, i, comp
+
+        call set_empty(comp_name)
+        module_idx = 0
+        type_idx = derived_type_node_index(arena, type_name)
+        if (type_idx <= 0) return
+        select type (td => arena%entries(type_idx)%node)
+        type is (derived_type_node)
+            if (.not. allocated(td%component_indices)) return
+            do i = 1, size(td%component_indices)
+                comp = td%component_indices(i)
+                if (.not. node_exists(arena, comp)) cycle
+                select type (dn => arena%entries(comp)%node)
+                type is (declaration_node)
+                    if (.not. allocated(dn%accessibility)) cycle
+                    if (trim(lowercase_text(dn%accessibility)) /= 'private') cycle
+                    if (.not. allocated(dn%var_name)) cycle
+                    comp_name = trim(dn%var_name)
+                    module_idx = enclosing_module_index(arena, type_idx)
+                    if (module_idx <= 0) call set_empty(comp_name)
+                    return
+                end select
+            end do
+        end select
+    end subroutine first_private_component
+
+    integer function derived_type_node_index(arena, type_name) result(type_idx)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: type_name
+        integer :: n
+        character(len=:), allocatable :: wanted
+
+        type_idx = 0
+        wanted = trim(lowercase_text(type_name))
+        if (len(wanted) == 0) return
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (derived_type_node)
+                if (.not. allocated(nd%name)) cycle
+                if (trim(lowercase_text(nd%name)) /= wanted) cycle
+                type_idx = n
+                return
+            end select
+        end do
+    end function derived_type_node_index
+
+    integer function derived_component_decl(arena, type_name, comp_name, type_idx) &
+        result(decl)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: type_name, comp_name
+        integer, intent(out) :: type_idx
+        integer :: i, comp
+        character(len=:), allocatable :: wanted
+
+        decl = 0
+        wanted = trim(lowercase_text(comp_name))
+        type_idx = derived_type_node_index(arena, type_name)
+        if (type_idx <= 0) return
+        select type (td => arena%entries(type_idx)%node)
+        type is (derived_type_node)
+            if (.not. allocated(td%component_indices)) return
+            do i = 1, size(td%component_indices)
+                comp = td%component_indices(i)
+                if (.not. node_exists(arena, comp)) cycle
+                select type (dn => arena%entries(comp)%node)
+                type is (declaration_node)
+                    if (.not. allocated(dn%var_name)) cycle
+                    if (trim(lowercase_text(dn%var_name)) /= wanted) cycle
+                    decl = comp
+                    return
+                end select
+            end do
+        end select
+    end function derived_component_decl
+
+    integer function enclosing_module_index(arena, node_index) result(module_idx)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        integer :: cur, guard
+
+        module_idx = 0
+        cur = node_index
+        guard = 0
+        do while (cur > 0)
+            guard = guard + 1
+            if (guard > arena%size) return
+            if (.not. node_exists(arena, cur)) return
+            select type (nd => arena%entries(cur)%node)
+            type is (module_node)
+                module_idx = cur
+                return
+            end select
+            cur = arena%entries(cur)%parent_index
+        end do
+    end function enclosing_module_index
+
+    logical function node_within(arena, node_index, ancestor) result(within)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index, ancestor
+        integer :: cur, guard
+
+        within = .false.
+        if (ancestor <= 0) return
+        cur = node_index
+        guard = 0
+        do while (cur > 0)
+            if (cur == ancestor) then
+                within = .true.
+                return
+            end if
+            guard = guard + 1
+            if (guard > arena%size) return
+            if (.not. node_exists(arena, cur)) return
+            cur = arena%entries(cur)%parent_index
+        end do
+    end function node_within
+
+    recursive subroutine designator_type_name(arena, idx, type_name)
+        !! Declared derived-type name of a designator (identifier, array
+        !! element, or component reference). Empty when it is not a derived
+        !! type entity or cannot be resolved from declarations alone.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        character(len=:), allocatable, intent(out) :: type_name
+        character(len=:), allocatable :: base_type
+        integer :: decl, comp, type_idx
+
+        call set_empty(type_name)
+        if (idx <= 0) return
+        if (.not. node_exists(arena, idx)) return
+        select type (nd => arena%entries(idx)%node)
+        type is (identifier_node)
+            if (.not. allocated(nd%name)) return
+            decl = declaration_index_for_name(arena, nd%name)
+            if (decl <= 0) return
+            call declared_derived_type_name(arena, decl, type_name)
+        type is (component_access_node)
+            if (.not. allocated(nd%component_name)) return
+            call designator_type_name(arena, nd%base_expr_index, base_type)
+            if (len_trim(base_type) == 0) return
+            comp = derived_component_decl(arena, base_type, nd%component_name, &
+                                          type_idx)
+            if (comp <= 0) return
+            call declared_derived_type_name(arena, comp, type_name)
+        type is (call_or_subscript_node)
+            if (nd%base_expr_index > 0) then
+                call designator_type_name(arena, nd%base_expr_index, type_name)
+                return
+            end if
+            if (.not. allocated(nd%name)) return
+            decl = declaration_index_for_name(arena, nd%name)
+            if (decl <= 0) return
+            call declared_derived_type_name(arena, decl, type_name)
+        end select
+    end subroutine designator_type_name
+
+    subroutine declared_derived_type_name(arena, decl, type_name)
+        !! 'type(t)' / 'class(t)' spelled on a declaration reduced to 't'.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: decl
+        character(len=:), allocatable, intent(out) :: type_name
+        character(len=:), allocatable :: spec
+        integer :: open_paren, close_paren
+
+        call set_empty(type_name)
+        if (.not. node_exists(arena, decl)) return
+        select type (dn => arena%entries(decl)%node)
+        type is (declaration_node)
+            if (.not. allocated(dn%type_name)) return
+            spec = trim(lowercase_text(dn%type_name))
+        class default
+            return
+        end select
+        open_paren = index(spec, '(')
+        close_paren = index(spec, ')', back=.true.)
+        if (open_paren <= 1) return
+        if (close_paren <= open_paren + 1) return
+        select case (trim(spec(:open_paren - 1)))
+        case ('type', 'class')
+            type_name = trim(adjustl(spec(open_paren + 1:close_paren - 1)))
+        case default
+            call set_empty(type_name)
+        end select
+    end subroutine declared_derived_type_name
+
+    subroutine check_data_allocatable_components(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n, i
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (data_statement_node)
+                if (.not. allocated(nd%object_indices)) cycle
+                do i = 1, size(nd%object_indices)
+                    call check_data_object_components(arena, nd%object_indices(i), &
+                                                      error_msg)
+                    if (len_trim(error_msg) > 0) return
+                end do
+            end select
+        end do
+    end subroutine check_data_allocatable_components
+
+    recursive subroutine check_data_object_components(arena, idx, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: base_type
+        character(len=64) :: location
+        integer :: j, comp, type_idx
+
+        call set_empty(error_msg)
+        if (idx <= 0) return
+        if (.not. node_exists(arena, idx)) return
+        select type (nd => arena%entries(idx)%node)
+        type is (io_implied_do_node)
+            if (.not. allocated(nd%object_indices)) return
+            do j = 1, size(nd%object_indices)
+                call check_data_object_components(arena, nd%object_indices(j), &
+                                                  error_msg)
+                if (len_trim(error_msg) > 0) return
+            end do
+        type is (call_or_subscript_node)
+            call check_data_object_components(arena, nd%base_expr_index, error_msg)
+        type is (component_access_node)
+            call check_data_object_components(arena, nd%base_expr_index, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (.not. allocated(nd%component_name)) return
+            call designator_type_name(arena, nd%base_expr_index, base_type)
+            if (len_trim(base_type) == 0) return
+            comp = derived_component_decl(arena, base_type, nd%component_name, &
+                                          type_idx)
+            if (comp <= 0) return
+            select type (dn => arena%entries(comp)%node)
+            type is (declaration_node)
+                if (.not. dn%is_allocatable) return
+            class default
+                return
+            end select
+            write (location, '(" at line ",I0,", column ",I0)') &
+                get_node_line(arena, idx), get_node_column(arena, idx)
+            error_msg = 'allocatable component '''//trim(nd%component_name)// &
+                ''' of '''//trim(base_type)//''' cannot appear in a DATA '// &
+                'statement'//trim(location)
+        end select
+    end subroutine check_data_object_components
+

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -560,6 +560,12 @@
         if (len_trim(error_msg) > 0) return
         call check_result_and_entry_rules(arena, error_msg)
         if (len_trim(error_msg) > 0) return
+        call check_derived_type_definition_forms(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_private_component_access(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_data_allocatable_components(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
         call check_io_control_source(arena, error_msg)
         if (len_trim(error_msg) > 0) return
         call set_empty(error_msg)

--- a/test/test_session_reject_derived_01_compiler.f90
+++ b/test/test_session_reject_derived_01_compiler.f90
@@ -1,0 +1,255 @@
+program test_session_reject_derived_01_compiler
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== derived-type definition constraint rejection test ==='
+
+    all_passed = .true.
+    if (.not. test_empty_bind_c_type_rejected()) all_passed = .false.
+    if (.not. test_bind_c_type_with_component_accepted()) all_passed = .false.
+    if (.not. test_assumed_size_default_init_rejected()) all_passed = .false.
+    if (.not. test_explicit_shape_default_init_accepted()) all_passed = .false.
+    if (.not. test_mangled_type_guard_rejected()) all_passed = .false.
+    if (.not. test_spaced_type_guard_accepted()) all_passed = .false.
+    if (.not. test_private_component_rejected()) all_passed = .false.
+    if (.not. test_public_component_accepted()) all_passed = .false.
+    if (.not. test_data_allocatable_component_rejected()) all_passed = .false.
+    if (.not. test_data_plain_component_accepted()) all_passed = .false.
+    if (.not. test_class_function_result_rejected()) all_passed = .false.
+    if (.not. test_allocatable_class_result_accepted()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: derived-type definition constraints enforced'
+
+contains
+
+    logical function test_empty_bind_c_type_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type, bind(C) :: t'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            'end program main'
+
+        test_empty_bind_c_type_rejected = expect_error_contains( &
+            source, 'has no components', '/tmp/ffc_reject_derived_01_bindc')
+    end function test_empty_bind_c_type_rejected
+
+    logical function test_bind_c_type_with_component_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  use, intrinsic :: iso_c_binding, only: c_int'//new_line('a')// &
+            '  type, bind(C) :: t'//new_line('a')// &
+            '    integer(c_int) :: i'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            '  type(t) :: x'//new_line('a')// &
+            '  x%i = 5'//new_line('a')// &
+            '  stop x%i'//new_line('a')// &
+            'end program main'
+
+        test_bind_c_type_with_component_accepted = expect_exit_status( &
+            source, 5, '/tmp/ffc_reject_derived_01_bindc_ok')
+    end function test_bind_c_type_with_component_accepted
+
+    logical function test_assumed_size_default_init_rejected()
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '  type init'//new_line('a')// &
+            '    integer :: i = 0'//new_line('a')// &
+            '  end type init'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine try(a)'//new_line('a')// &
+            '    type(init), dimension(*), intent(out) :: a'//new_line('a')// &
+            '  end subroutine try'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            'end program main'
+
+        test_assumed_size_default_init_rejected = expect_error_contains( &
+            source, 'cannot have a default initializer', &
+            '/tmp/ffc_reject_derived_01_assumed')
+    end function test_assumed_size_default_init_rejected
+
+    logical function test_explicit_shape_default_init_accepted()
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '  type init'//new_line('a')// &
+            '    integer :: i = 0'//new_line('a')// &
+            '  end type init'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine try(a)'//new_line('a')// &
+            '    type(init), dimension(2), intent(out) :: a'//new_line('a')// &
+            '    a(1)%i = 7'//new_line('a')// &
+            '  end subroutine try'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  type(init) :: b(2)'//new_line('a')// &
+            '  call try(b)'//new_line('a')// &
+            '  stop b(1)%i'//new_line('a')// &
+            'end program main'
+
+        test_explicit_shape_default_init_accepted = expect_exit_status( &
+            source, 7, '/tmp/ffc_reject_derived_01_assumed_ok')
+    end function test_explicit_shape_default_init_accepted
+
+    logical function test_mangled_type_guard_rejected()
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '  type t'//new_line('a')// &
+            '    integer :: i'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine s(x)'//new_line('a')// &
+            '    class(t), pointer :: x'//new_line('a')// &
+            '    select type (x)'//new_line('a')// &
+            '    typeis (t)'//new_line('a')// &
+            '    end select'//new_line('a')// &
+            '  end subroutine s'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            'end program main'
+
+        test_mangled_type_guard_rejected = expect_error_contains( &
+            source, 'mangled derived type definition', &
+            '/tmp/ffc_reject_derived_01_typeis')
+    end function test_mangled_type_guard_rejected
+
+    logical function test_spaced_type_guard_accepted()
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '  type t'//new_line('a')// &
+            '    integer :: i'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine s(x)'//new_line('a')// &
+            '    class(t), pointer :: x'//new_line('a')// &
+            '    select type (x)'//new_line('a')// &
+            '    type is (t)'//new_line('a')// &
+            '      x%i = 1'//new_line('a')// &
+            '    end select'//new_line('a')// &
+            '  end subroutine s'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  stop 4'//new_line('a')// &
+            'end program main'
+
+        test_spaced_type_guard_accepted = expect_exit_status( &
+            source, 4, '/tmp/ffc_reject_derived_01_typeis_ok')
+    end function test_spaced_type_guard_accepted
+
+    logical function test_private_component_rejected()
+        character(len=*), parameter :: source = &
+            'module foomod'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: bartype'//new_line('a')// &
+            '    integer :: dummy'//new_line('a')// &
+            '    integer, private :: dummy2'//new_line('a')// &
+            '  end type bartype'//new_line('a')// &
+            'end module foomod'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use foomod'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(bartype) :: foo2'//new_line('a')// &
+            '  foo2%dummy2 = 5'//new_line('a')// &
+            'end program main'
+
+        test_private_component_rejected = expect_error_contains( &
+            source, 'is a PRIVATE component', &
+            '/tmp/ffc_reject_derived_01_private')
+    end function test_private_component_rejected
+
+    logical function test_public_component_accepted()
+        character(len=*), parameter :: source = &
+            'module foomod'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: bartype'//new_line('a')// &
+            '    integer :: dummy'//new_line('a')// &
+            '    integer :: dummy2'//new_line('a')// &
+            '  end type bartype'//new_line('a')// &
+            'end module foomod'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use foomod'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(bartype) :: foo2'//new_line('a')// &
+            '  foo2%dummy2 = 5'//new_line('a')// &
+            '  stop foo2%dummy2'//new_line('a')// &
+            'end program main'
+
+        test_public_component_accepted = expect_exit_status( &
+            source, 5, '/tmp/ffc_reject_derived_01_private_ok')
+    end function test_public_component_accepted
+
+    logical function test_data_allocatable_component_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type t'//new_line('a')// &
+            '    integer, allocatable :: a(:)'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            '  type(t) :: z'//new_line('a')// &
+            '  data z%a(1) / 789 /'//new_line('a')// &
+            'end program main'
+
+        test_data_allocatable_component_rejected = expect_error_contains( &
+            source, 'cannot appear in a DATA statement', &
+            '/tmp/ffc_reject_derived_01_data')
+    end function test_data_allocatable_component_rejected
+
+    logical function test_data_plain_component_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type t'//new_line('a')// &
+            '    integer, allocatable :: a(:)'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            '  type(t) :: z'//new_line('a')// &
+            '  allocate (z%a(1))'//new_line('a')// &
+            '  z%a(1) = 6'//new_line('a')// &
+            '  stop z%a(1)'//new_line('a')// &
+            'end program main'
+
+        test_data_plain_component_accepted = expect_exit_status( &
+            source, 6, '/tmp/ffc_reject_derived_01_data_ok')
+    end function test_data_plain_component_accepted
+
+    logical function test_class_function_result_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type t'//new_line('a')// &
+            '    integer :: i'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  function f() result(z)'//new_line('a')// &
+            '    class(t) :: z'//new_line('a')// &
+            '  end function f'//new_line('a')// &
+            'end program main'
+
+        test_class_function_result_rejected = expect_error_contains( &
+            source, 'must be dummy, allocatable or pointer', &
+            '/tmp/ffc_reject_derived_01_class')
+    end function test_class_function_result_rejected
+
+    logical function test_allocatable_class_result_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type t'//new_line('a')// &
+            '    integer :: i'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            '  type(t) :: r'//new_line('a')// &
+            '  r = f()'//new_line('a')// &
+            '  stop r%i'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  function f() result(z)'//new_line('a')// &
+            '    type(t) :: z'//new_line('a')// &
+            '    z%i = 9'//new_line('a')// &
+            '  end function f'//new_line('a')// &
+            'end program main'
+
+        test_allocatable_class_result_accepted = expect_exit_status( &
+            source, 9, '/tmp/ffc_reject_derived_01_class_ok')
+    end function test_allocatable_class_result_accepted
+
+end program test_session_reject_derived_01_compiler


### PR DESCRIPTION
Closes #390.

## Preserved compiler invariant

A derived-type definition and its uses must satisfy the F2003+ constraints before lowering. ffc now rejects, with a source diagnostic:

- an empty `BIND(C)` derived type (`has no components`);
- an `INTENT(OUT)` assumed-size dummy of a type with default initialization (`cannot have a default initializer`);
- a mangled `TYPEIS` guard in `SELECT TYPE` (`mangled derived type definition`);
- access to a PRIVATE component outside the defining module (`is a PRIVATE component`);
- an allocatable component as a DATA statement object (`cannot appear in a DATA statement`).

The CLASS function-result case (pr103606.f90) is already caught by the existing CLASS-entity check; no second rule was added for it.

Each rule has a corrected neighbor in the new test that still compiles and runs to the expected exit status.

## Red evidence

On unmodified main, all six negative fixtures were accepted:

```
scripts/conformance_gauntlet.sh --suite gfortran-dg --file assumed_size_dt_dummy.f90 ... --file pr85798.f90
  FAIL: assumed_size_dt_dummy.f90 (negative test accepted)
  FAIL: empty_derived_type_2.f90 (negative test accepted)
  FAIL: private_type_6.f90 (negative test accepted)
  FAIL: pr103606.f90 (negative test accepted)
  FAIL: pr105501.f90 (negative test accepted)
  FAIL: pr85798.f90 (negative test accepted)
  PASS=0 FAIL=6 TOTAL=6
```

## Green evidence

```
fo test test_session_reject_derived_01_compiler
  test_session_reject_derived_01_compiler    PASS
scripts/conformance_gauntlet.sh --suite gfortran-dg --file ... (same six)
  PASS=6  XFAIL=0  XPASS=0  FAIL=0  NOREF=0  SKIP=0  TOTAL=6
```

Full `fo` pipeline: build, lint, format clean; 272 tests with two failures that are not from this change — `test_session_save_attribute_compiler` (passes standalone; /tmp collision under concurrent runs) and `test_parity_dashboard`, which is a pre-existing staleness on main (`generate_parity_dashboard.sh --check` reports `stale snapshot manifest digest` with manifests identical to origin/main; this branch touches no manifest).