### PR TITLE
[reject-generic-01] reject malformed and ambiguous generic interfaces (#378)

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -2623,4 +2623,5 @@ contains
     include 'session_program_lowering_reject_const_overflow.inc'
     include 'session_program_lowering_reject_alloc.inc'
     include 'session_program_lowering_reject_result.inc'
+    include 'session_program_lowering_reject_generic.inc'
 end module session_program_lowering

--- a/src/session_program_lowering_reject_checks.inc
+++ b/src/session_program_lowering_reject_checks.inc
@@ -38,8 +38,10 @@
             result(same)
         type(ast_arena_t), intent(in) :: arena
         character(len=*), intent(in) :: name_a, name_b
-        integer :: count_a, count_b, pos, vk_a, vk_b
-        logical :: char_a, char_b
+        integer :: count_a, count_b, pos
+        integer :: kind_a, kind_b, rank_a, rank_b
+        logical :: known_a, known_b, proc_a, proc_b, any_a, any_b
+        character(len=:), allocatable :: base_a, base_b
 
         same = .false.
         count_a = arena_proc_param_count(arena, name_a)
@@ -47,20 +49,286 @@
         if (count_a < 0 .or. count_b < 0) return
         if (count_a /= count_b) return
         do pos = 1, count_a
-            if (callee_dummy_is_array(arena, name_a, pos)) return
-            if (callee_dummy_is_array(arena, name_b, pos)) return
-            char_a = callee_dummy_is_character(arena, name_a, pos)
-            char_b = callee_dummy_is_character(arena, name_b, pos)
-            if (char_a .neqv. char_b) return
-            if (.not. char_a) then
-                vk_a = callee_dummy_value_kind(arena, name_a, pos)
-                vk_b = callee_dummy_value_kind(arena, name_b, pos)
-                if (vk_a == 0 .or. vk_b == 0) return
-                if (vk_a /= vk_b) return
+            call dummy_signature(arena, name_a, pos, known_a, base_a, kind_a, &
+                                 rank_a, proc_a, any_a)
+            call dummy_signature(arena, name_b, pos, known_b, base_b, kind_b, &
+                                 rank_b, proc_b, any_b)
+            if (.not. known_a) return
+            if (.not. known_b) return
+            ! A procedure dummy is never distinguished from another procedure
+            ! dummy by the type of its result (F2018 C1514 applies TKR only to
+            ! data objects), so such a position cannot resolve the generic.
+            if (proc_a .neqv. proc_b) return
+            if (proc_a) cycle
+            ! An unlimited polymorphic dummy is type compatible with every
+            ! actual argument, so it distinguishes nothing.
+            if (any_a .or. any_b) cycle
+            if (rank_a /= rank_b) return
+            if (base_a /= base_b) return
+            if (kind_a /= 0 .and. kind_b /= 0) then
+                if (kind_a /= kind_b) return
             end if
         end do
         same = .true.
     end function specifics_indistinguishable
+
+    ! Type, kind and rank facts about the pos-th dummy argument of the
+    ! procedure proc_name, as needed by the generic-ambiguity rule. known is
+    ! false whenever the procedure or the dummy position cannot be resolved
+    ! statically; callers must then claim no ambiguity.
+    subroutine dummy_signature(arena, proc_name, pos, known, base_name, &
+                               kind_value, rank, is_proc, is_any)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: proc_name
+        integer, intent(in) :: pos
+        logical, intent(out) :: known
+        character(len=:), allocatable, intent(out) :: base_name
+        integer, intent(out) :: kind_value
+        integer, intent(out) :: rank
+        logical, intent(out) :: is_proc
+        logical, intent(out) :: is_any
+        integer :: n
+        character(len=:), allocatable :: node_type
+        type(function_def_node), pointer :: fn_node
+        type(subroutine_def_node), pointer :: sb_node
+
+        known = .false.
+        base_name = ''
+        kind_value = 0
+        rank = 0
+        is_proc = .false.
+        is_any = .false.
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            node_type = get_node_type_at(arena, n)
+            if (node_type == 'subroutine_def_node' .or. &
+                node_type == 'subroutine_def') then
+                sb_node => get_node_as_subroutine_def(arena, n)
+                if (.not. associated(sb_node)) cycle
+                if (.not. allocated(sb_node%name)) cycle
+                if (.not. same_name(sb_node%name, proc_name)) cycle
+                call dummy_signature_at(arena, sb_node%param_indices, &
+                                        sb_node%body_indices, pos, known, &
+                                        base_name, kind_value, rank, is_proc, &
+                                        is_any)
+                call refine_dummy_signature(arena, proc_name, pos, kind_value, &
+                                            rank)
+                return
+            else if (node_type == 'function_def_node' .or. &
+                     node_type == 'function_def') then
+                fn_node => get_node_as_function_def(arena, n)
+                if (.not. associated(fn_node)) cycle
+                if (.not. allocated(fn_node%name)) cycle
+                if (.not. same_name(fn_node%name, proc_name)) cycle
+                call dummy_signature_at(arena, fn_node%param_indices, &
+                                        fn_node%body_indices, pos, known, &
+                                        base_name, kind_value, rank, is_proc, &
+                                        is_any)
+                call refine_dummy_signature(arena, proc_name, pos, kind_value, &
+                                            rank)
+                return
+            end if
+        end do
+    end subroutine dummy_signature
+
+    ! Fill in rank and kind from the lowerer's own dummy queries when the
+    ! declaration node did not carry them.
+    subroutine refine_dummy_signature(arena, proc_name, pos, kind_value, rank)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: proc_name
+        integer, intent(in) :: pos
+        integer, intent(inout) :: kind_value
+        integer, intent(inout) :: rank
+
+        if (rank == 0) then
+            if (callee_dummy_is_array(arena, proc_name, pos)) rank = 1
+        end if
+        if (kind_value == 0) then
+            kind_value = callee_dummy_value_kind(arena, proc_name, pos)
+        end if
+    end subroutine refine_dummy_signature
+
+    subroutine dummy_signature_at(arena, param_indices, body_indices, pos, &
+                                  known, base_name, kind_value, rank, &
+                                  is_proc, is_any)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: param_indices(:)
+        integer, allocatable, intent(in) :: body_indices(:)
+        integer, intent(in) :: pos
+        logical, intent(out) :: known
+        character(len=:), allocatable, intent(out) :: base_name
+        integer, intent(out) :: kind_value
+        integer, intent(out) :: rank
+        logical, intent(out) :: is_proc
+        logical, intent(out) :: is_any
+        character(len=:), allocatable :: name, name_err
+        logical :: unresolved
+
+        known = .false.
+        base_name = ''
+        kind_value = 0
+        rank = 0
+        is_proc = .false.
+        is_any = .false.
+        unresolved = .false.
+        if (.not. allocated(param_indices)) return
+        if (pos < 1 .or. pos > size(param_indices)) return
+        call parameter_name(arena, param_indices(pos), name, name_err)
+        if (len_trim(name_err) > 0) return
+        if (len_trim(name) == 0) return
+        if (trim(name) == '*') then
+            ! An alternate-return dummy carries no type; two of them in the
+            ! same position are indistinguishable.
+            known = .true.
+            base_name = '*'
+            return
+        end if
+        select type (pn => arena%entries(param_indices(pos))%node)
+        type is (parameter_declaration_node)
+            if (allocated(pn%type_name)) then
+                if (len_trim(pn%type_name) > 0) then
+                    base_name = normalized_base_type(pn%type_name)
+                    is_any = base_name == 'class(*)'
+                    if (pn%is_array) then
+                        rank = 1
+                        if (allocated(pn%dimension_indices)) then
+                            rank = size(pn%dimension_indices)
+                        end if
+                    end if
+                    if (pn%has_kind) then
+                        kind_value = pn%kind_value
+                        if (pn%kind_value <= 0) return
+                    end if
+                    known = .true.
+                    return
+                end if
+            end if
+        end select
+        call dummy_decl_signature(arena, body_indices, name, known, base_name, &
+                                  kind_value, rank, is_proc, is_any, unresolved)
+        if (unresolved) then
+            known = .false.
+            return
+        end if
+        if (known) return
+        ! No declaration in the body: implicit typing gives this dummy the
+        ! default type for its initial letter.
+        base_name = implicit_base_type(name)
+        known = len_trim(base_name) > 0
+    end subroutine dummy_signature_at
+
+    ! unresolved reports a KIND selector that is not a literal - the declared
+    ! kind is then unknown, and no distinguishability claim may rest on it.
+    subroutine dummy_decl_signature(arena, body_indices, param_name, found, &
+                                    base_name, kind_value, rank, is_proc, &
+                                    is_any, unresolved)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: param_name
+        logical, intent(out) :: found
+        character(len=:), allocatable, intent(out) :: base_name
+        integer, intent(out) :: kind_value
+        integer, intent(out) :: rank
+        logical, intent(out) :: is_proc
+        logical, intent(out) :: is_any
+        logical, intent(out) :: unresolved
+        integer :: i, k
+        logical :: names_it
+
+        found = .false.
+        base_name = ''
+        kind_value = 0
+        rank = 0
+        is_proc = .false.
+        is_any = .false.
+        unresolved = .false.
+        if (.not. allocated(body_indices)) return
+        do i = 1, size(body_indices)
+            if (.not. node_exists(arena, body_indices(i))) cycle
+            select type (decl => arena%entries(body_indices(i))%node)
+            type is (declaration_node)
+                names_it = .false.
+                if (allocated(decl%var_name)) then
+                    if (same_name(decl%var_name, param_name)) names_it = .true.
+                end if
+                if (decl%is_multi_declaration .and. allocated(decl%var_names)) then
+                    do k = 1, size(decl%var_names)
+                        if (same_name(decl%var_names(k), param_name)) then
+                            names_it = .true.
+                        end if
+                    end do
+                end if
+                if (.not. names_it) cycle
+                if (decl%is_external) is_proc = .true.
+                if (decl%is_array) then
+                    if (allocated(decl%dimension_indices)) then
+                        rank = max(rank, size(decl%dimension_indices))
+                    else
+                        rank = max(rank, 1)
+                    end if
+                end if
+                if (allocated(decl%type_name)) then
+                    if (len_trim(decl%type_name) > 0) then
+                        base_name = normalized_base_type(decl%type_name)
+                        is_any = base_name == 'class(*)'
+                        found = .true.
+                    end if
+                end if
+                if (decl%has_kind) then
+                    kind_value = decl%kind_value
+                    if (decl%kind_value <= 0) unresolved = .true.
+                end if
+            end select
+        end do
+        if (is_proc) found = .true.
+    end subroutine dummy_decl_signature
+
+    ! Collapse a declared type string to the form that decides generic
+    ! distinguishability. CLASS(T) and TYPE(T) name the same declared type; the
+    ! kind selector is kept, because two specifics of the same type but
+    ! different kind are distinguishable.
+    function normalized_base_type(type_name) result(base)
+        character(len=*), intent(in) :: type_name
+        character(len=:), allocatable :: base
+
+        base = squeeze_blanks(lowercase_text(trim(adjustl(type_name))))
+        if (base == 'class(*)') return
+        if (len(base) > 6) then
+            if (base(1:6) == 'class(') base = 'type('//base(7:)
+        end if
+    end function normalized_base_type
+
+    ! The type name without its kind or length selector.
+    function base_type_root(base) result(root)
+        character(len=*), intent(in) :: base
+        character(len=:), allocatable :: root
+        integer :: lp
+
+        root = trim(base)
+        if (root == 'class(*)') return
+        if (len(root) > 5) then
+            if (root(1:5) == 'type(') return
+        end if
+        lp = index(root, '(')
+        if (lp > 1) root = root(1:lp - 1)
+    end function base_type_root
+
+    ! Default implicit type of a name: integer for I-N, real otherwise.
+    function implicit_base_type(name) result(base)
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: base
+        character(len=1) :: first
+
+        base = ''
+        if (len_trim(name) == 0) return
+        first = lowercase_text(name(1:1))
+        if (first < 'a' .or. first > 'z') return
+        if (first >= 'i' .and. first <= 'n') then
+            base = 'integer'
+        else
+            base = 'real'
+        end if
+    end function implicit_base_type
 
     integer function arena_proc_param_count(arena, proc_name) result(count)
         type(ast_arena_t), intent(in) :: arena

--- a/src/session_program_lowering_reject_generic.inc
+++ b/src/session_program_lowering_reject_generic.inc
@@ -1,0 +1,1261 @@
+    ! Malformed and ambiguous generic interfaces (#378).
+    !
+    ! FortFront keeps a generic interface block in the typed AST only when
+    ! every interface body parses and every name resolves. The forms rejected
+    ! here are dropped or merged before that point - a GENERIC binding with no
+    ! binding list, an interface body terminated by a bare END, a MODULE
+    ! PROCEDURE naming something that is not a module procedure, a generic name
+    ! colliding with a contained procedure, and use association that makes a
+    ! referenced name ambiguous - so the source text is the earliest layer that
+    ! still holds enough information. Type, kind and rank questions are still
+    ! answered from the typed AST through dummy_signature.
+    subroutine check_generic_interface_forms(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: source
+        character(len=512), allocatable :: lines(:)
+        integer :: count
+        logical :: found
+
+        call set_empty(error_msg)
+        call get_source_text(arena, source, found)
+        if (.not. found) return
+        if (len_trim(source) == 0) return
+        call generic_source_lines(source, lines, count)
+        if (count == 0) return
+        call check_generic_binding_syntax(lines, count, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_implicit_interface_ambiguity(lines, count, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_module_procedure_targets(lines, count, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_generic_name_collisions(lines, count, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_use_shadows_program_unit(lines, count, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_ambiguous_use_association(lines, count, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_typebound_generic_inheritance(arena, lines, count, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_intrinsic_assignment_redefinition(arena, lines, count, &
+                                                    error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_generic_call_resolves(arena, lines, count, error_msg)
+    end subroutine check_generic_interface_forms
+
+    ! Source text split into comment-stripped, lowercased, left-adjusted lines.
+    subroutine generic_source_lines(source, lines, count)
+        character(len=*), intent(in) :: source
+        character(len=512), allocatable, intent(out) :: lines(:)
+        integer, intent(out) :: count
+        character(len=:), allocatable :: raw, stripped
+        integer :: pos, nl, total, i
+
+        total = 1
+        do i = 1, len(source)
+            if (source(i:i) == new_line('a')) total = total + 1
+        end do
+        allocate (lines(total))
+        lines = ''
+        count = 0
+        pos = 1
+        do while (pos <= len(source))
+            if (count >= total) exit
+            nl = index(source(pos:), new_line('a'))
+            if (nl == 0) then
+                raw = source(pos:)
+                pos = len(source) + 1
+            else
+                raw = source(pos:pos + nl - 2)
+                pos = pos + nl
+            end if
+            call strip_line_comment(raw, stripped)
+            count = count + 1
+            lines(count) = adjustl(lowercase_text(stripped))
+        end do
+    end subroutine generic_source_lines
+
+    ! True when the statement text opens with the keyword kw as a whole word.
+    logical function stmt_starts(line, kw) result(yes)
+        character(len=*), intent(in) :: line
+        character(len=*), intent(in) :: kw
+        character(len=:), allocatable :: text
+
+        yes = .false.
+        text = trim(line)
+        if (len(text) < len(kw)) return
+        if (text(1:len(kw)) /= kw) return
+        if (len(text) == len(kw)) then
+            yes = .true.
+            return
+        end if
+        yes = .not. is_fortran_identifier_char(text(len(kw) + 1:len(kw) + 1))
+    end function stmt_starts
+
+    ! The first identifier in text at or after position from.
+    function identifier_after(text, from) result(name)
+        character(len=*), intent(in) :: text
+        integer, intent(in) :: from
+        character(len=:), allocatable :: name
+        integer :: i, s, e
+
+        name = ''
+        s = 0
+        do i = max(1, from), len_trim(text)
+            if (is_fortran_identifier_char(text(i:i))) then
+                s = i
+                exit
+            end if
+        end do
+        if (s == 0) return
+        e = s
+        do i = s, len_trim(text)
+            if (.not. is_fortran_identifier_char(text(i:i))) exit
+            e = i
+        end do
+        name = text(s:e)
+    end function identifier_after
+
+    subroutine append_owned_name(tab, owners, n, name, owner)
+        character(len=64), intent(inout) :: tab(:)
+        integer, intent(inout) :: owners(:)
+        integer, intent(inout) :: n
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: owner
+
+        if (len_trim(name) == 0) return
+        if (n >= size(tab)) return
+        n = n + 1
+        tab(n) = name
+        owners(n) = owner
+    end subroutine append_owned_name
+
+    ! Whether name appears in tab; owner < 0 matches any owner.
+    logical function owned_name_present(tab, owners, n, name, owner) result(yes)
+        character(len=64), intent(in) :: tab(:)
+        integer, intent(in) :: owners(:)
+        integer, intent(in) :: n
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: owner
+        integer :: i
+
+        yes = .false.
+        do i = 1, n
+            if (trim(tab(i)) /= trim(name)) cycle
+            if (owner >= 0) then
+                if (owners(i) /= owner) cycle
+            end if
+            yes = .true.
+            return
+        end do
+    end function owned_name_present
+
+    ! Interface nesting depth and enclosing named-generic name per line.
+    subroutine interface_regions(lines, count, depth, iface_name)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        integer, allocatable, intent(out) :: depth(:)
+        character(len=64), allocatable, intent(out) :: iface_name(:)
+        integer :: i, level
+        character(len=64) :: current
+        character(len=:), allocatable :: text, word
+
+        allocate (depth(count))
+        allocate (iface_name(count))
+        level = 0
+        current = ''
+        do i = 1, count
+            text = trim(lines(i))
+            if (stmt_starts(text, 'end')) then
+                word = identifier_after(text, 4)
+                if (word == 'interface') then
+                    level = 0
+                    current = ''
+                end if
+            else if (stmt_starts(text, 'interface')) then
+                level = 1
+                current = identifier_after(text, 10)
+            else if (stmt_starts(text, 'abstract')) then
+                if (identifier_after(text, 9) == 'interface') then
+                    level = 1
+                    current = ''
+                end if
+            end if
+            depth(i) = level
+            iface_name(i) = current
+        end do
+    end subroutine interface_regions
+
+    ! A generic interface name proper: OPERATOR and ASSIGNMENT specifications
+    ! are handled by their own rules.
+    logical function is_plain_generic_name(name) result(yes)
+        character(len=*), intent(in) :: name
+
+        yes = len_trim(name) > 0
+        if (.not. yes) return
+        if (trim(name) == 'operator') yes = .false.
+        if (trim(name) == 'assignment') yes = .false.
+        if (trim(name) == 'read') yes = .false.
+        if (trim(name) == 'write') yes = .false.
+    end function is_plain_generic_name
+
+    ! F2018 R749: a generic binding is GENERIC [, access-spec] ::
+    ! generic-spec => binding-name-list. A binding with no specification or no
+    ! binding list names nothing and cannot be resolved.
+    subroutine check_generic_binding_syntax(lines, count, error_msg)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: text, rest, spec
+        character(len=64) :: location
+        integer :: i, p
+
+        call set_empty(error_msg)
+        do i = 1, count
+            text = trim(lines(i))
+            if (.not. stmt_starts(text, 'generic')) cycle
+            rest = trim(adjustl(text(8:)))
+            write (location, '(" at line ",I0)') i
+            if (len(rest) == 0) then
+                error_msg = 'malformed GENERIC binding: no generic '// &
+                    'specification'//trim(location)
+                return
+            end if
+            if (rest(1:1) /= ',' .and. rest(1:1) /= ':') cycle
+            p = index(rest, '::')
+            if (p == 0) then
+                error_msg = 'malformed GENERIC binding: missing "::"'// &
+                    trim(location)
+                return
+            end if
+            spec = trim(adjustl(rest(p + 2:)))
+            if (len(spec) == 0) then
+                error_msg = 'malformed GENERIC binding: no generic '// &
+                    'specification'//trim(location)
+                return
+            end if
+            if (index(spec, '=>') == 0) then
+                error_msg = 'malformed GENERIC binding: no binding name list'// &
+                    trim(location)
+                return
+            end if
+        end do
+    end subroutine check_generic_binding_syntax
+
+    ! The procedure name and implicit-typing signature of an interface body
+    ! header. ok is false when the line is not a procedure header.
+    subroutine interface_body_header(text, name, signature, ok)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable, intent(out) :: name
+        character(len=:), allocatable, intent(out) :: signature
+        logical, intent(out) :: ok
+        character(len=:), allocatable :: args, item
+        integer :: p, lp, rp, start, i
+
+        ok = .false.
+        name = ''
+        signature = ''
+        if (stmt_starts(text, 'subroutine')) then
+            p = 11
+        else if (stmt_starts(text, 'function')) then
+            p = 9
+        else
+            p = index(text, ' function ')
+            if (p == 0) return
+            p = p + 9
+        end if
+        name = identifier_after(text, p)
+        if (len_trim(name) == 0) return
+        ok = .true.
+        lp = index(text, '(')
+        rp = index(text, ')', back=.true.)
+        if (lp == 0) return
+        if (rp <= lp) return
+        args = text(lp + 1:rp - 1)
+        if (len_trim(args) == 0) return
+        start = 1
+        do i = 1, len(args) + 1
+            if (i <= len(args)) then
+                if (args(i:i) /= ',') cycle
+            end if
+            item = trim(adjustl(args(start:i - 1)))
+            if (len(signature) > 0) signature = signature//','
+            if (item == '*') then
+                signature = signature//'*'
+            else
+                signature = signature//implicit_base_type(item)
+            end if
+            start = i + 1
+        end do
+    end subroutine interface_body_header
+
+    ! Two interface bodies of the same generic whose dummy arguments are all
+    ! implicitly typed are distinguished by nothing when their implicit types
+    ! agree position by position (F2018 C1514). Such bodies carry no
+    ! specification part, so the typed AST cannot tell them apart either.
+    subroutine check_implicit_interface_ambiguity(lines, count, error_msg)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, parameter :: MAXB = 128
+        character(len=64) :: bname(MAXB), bsig(MAXB), bgen(MAXB)
+        integer :: bline(MAXB)
+        integer, allocatable :: depth(:)
+        character(len=64), allocatable :: iface_name(:)
+        character(len=:), allocatable :: text, name, signature
+        character(len=64) :: location
+        integer :: i, j, k, nb, spec_lines
+        logical :: ok
+
+        call set_empty(error_msg)
+        call interface_regions(lines, count, depth, iface_name)
+        nb = 0
+        i = 0
+        do while (i < count)
+            i = i + 1
+            if (depth(i) /= 1) cycle
+            if (.not. is_plain_generic_name(iface_name(i))) cycle
+            text = trim(lines(i))
+            call interface_body_header(text, name, signature, ok)
+            if (.not. ok) cycle
+            spec_lines = 0
+            j = i + 1
+            do while (j <= count)
+                if (stmt_starts(trim(lines(j)), 'end')) exit
+                if (len_trim(lines(j)) > 0) spec_lines = spec_lines + 1
+                j = j + 1
+            end do
+            if (spec_lines == 0 .and. nb < MAXB) then
+                nb = nb + 1
+                bname(nb) = name
+                bsig(nb) = signature
+                bgen(nb) = iface_name(i)
+                bline(nb) = i
+            end if
+            i = j
+        end do
+        do j = 1, nb - 1
+            do k = j + 1, nb
+                if (bgen(j) /= bgen(k)) cycle
+                if (bsig(j) /= bsig(k)) cycle
+                write (location, '(" at line ",I0)') bline(k)
+                error_msg = 'ambiguous interfaces '//trim(bname(j))//' and '// &
+                    trim(bname(k))//' in generic interface '//trim(bgen(j))// &
+                    trim(location)
+                return
+            end do
+        end do
+    end subroutine check_implicit_interface_ambiguity
+
+    ! Append every comma-separated identifier of rest to the table.
+    subroutine append_name_list(tab, owners, n, rest, owner)
+        character(len=64), intent(inout) :: tab(:)
+        integer, intent(inout) :: owners(:)
+        integer, intent(inout) :: n
+        character(len=*), intent(in) :: rest
+        integer, intent(in) :: owner
+        character(len=:), allocatable :: item
+        integer :: i, start
+
+        start = 1
+        do i = 1, len_trim(rest) + 1
+            if (i <= len_trim(rest)) then
+                if (rest(i:i) /= ',') cycle
+            end if
+            item = identifier_after(rest(start:i - 1), 1)
+            call append_owned_name(tab, owners, n, item, owner)
+            start = i + 1
+        end do
+    end subroutine append_name_list
+
+    ! Program-unit index per line: MODULE and PROGRAM units partition the file.
+    subroutine program_unit_ids(lines, count, ids)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        integer, allocatable, intent(out) :: ids(:)
+        character(len=:), allocatable :: text, word
+        integer :: i, unit
+
+        allocate (ids(count))
+        unit = 1
+        do i = 1, count
+            text = trim(lines(i))
+            if (stmt_starts(text, 'module')) then
+                word = identifier_after(text, 7)
+                if (word /= 'procedure' .and. word /= 'subroutine' .and. &
+                    word /= 'function' .and. len_trim(word) > 0) unit = unit + 1
+            else if (stmt_starts(text, 'program')) then
+                unit = unit + 1
+            else if (stmt_starts(text, 'submodule')) then
+                unit = unit + 1
+            end if
+            ids(i) = unit
+            if (stmt_starts(text, 'end')) then
+                word = identifier_after(text, 4)
+                if (word == 'module' .or. word == 'program' .or. &
+                    word == 'submodule') unit = unit + 1
+            end if
+        end do
+    end subroutine program_unit_ids
+
+    ! Collect the procedure definitions, interface bodies, generic names and
+    ! EXTERNAL declarations of the whole file, tagged by program unit.
+    subroutine collect_procedure_tables(lines, count, defs, def_owner, ndef, &
+                                        bodies, body_owner, nbody, gens, &
+                                        gen_owner, ngen, exts, ext_owner, next)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=64), intent(inout) :: defs(:), bodies(:), gens(:), exts(:)
+        integer, intent(inout) :: def_owner(:), body_owner(:), gen_owner(:), &
+                                  ext_owner(:)
+        integer, intent(out) :: ndef, nbody, ngen, next
+        integer, allocatable :: depth(:), ids(:)
+        character(len=64), allocatable :: iface_name(:)
+        character(len=:), allocatable :: text, name, signature
+        logical :: ok
+        integer :: i
+
+        call interface_regions(lines, count, depth, iface_name)
+        call program_unit_ids(lines, count, ids)
+        ndef = 0
+        nbody = 0
+        ngen = 0
+        next = 0
+        do i = 1, count
+            text = trim(lines(i))
+            if (stmt_starts(text, 'external')) then
+                call append_name_list(exts, ext_owner, next, text(9:), ids(i))
+                cycle
+            end if
+            if (stmt_starts(text, 'interface')) then
+                name = identifier_after(text, 10)
+                if (is_plain_generic_name(name)) then
+                    call append_owned_name(gens, gen_owner, ngen, name, ids(i))
+                end if
+                cycle
+            end if
+            if (stmt_starts(text, 'end')) cycle
+            if (stmt_starts(text, 'module')) cycle
+            call interface_body_header(text, name, signature, ok)
+            if (.not. ok) cycle
+            if (depth(i) == 1) then
+                call append_owned_name(bodies, body_owner, nbody, name, ids(i))
+            else
+                call append_owned_name(defs, def_owner, ndef, name, ids(i))
+            end if
+        end do
+    end subroutine collect_procedure_tables
+
+    ! F2018 C1507: a MODULE PROCEDURE statement in a generic interface may only
+    ! name a module procedure. A name that the file declares EXTERNAL, declares
+    ! through an interface body, or uses as a generic name is not one.
+    subroutine check_module_procedure_targets(lines, count, error_msg)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, parameter :: MAXN = 512
+        character(len=64) :: defs(MAXN), bodies(MAXN), gens(MAXN), exts(MAXN)
+        integer :: def_owner(MAXN), body_owner(MAXN), gen_owner(MAXN), &
+                   ext_owner(MAXN)
+        character(len=64) :: targets(MAXN)
+        integer :: target_owner(MAXN)
+        integer, allocatable :: depth(:)
+        character(len=64), allocatable :: iface_name(:)
+        character(len=:), allocatable :: text
+        character(len=64) :: location
+        integer :: ndef, nbody, ngen, next, ntarget, i, k
+        logical :: bad
+
+        call set_empty(error_msg)
+        call interface_regions(lines, count, depth, iface_name)
+        call collect_procedure_tables(lines, count, defs, def_owner, ndef, &
+                                      bodies, body_owner, nbody, gens, &
+                                      gen_owner, ngen, exts, ext_owner, next)
+        do i = 1, count
+            if (depth(i) /= 1) cycle
+            if (.not. is_plain_generic_name(iface_name(i))) cycle
+            text = trim(lines(i))
+            if (.not. stmt_starts(text, 'module')) cycle
+            if (identifier_after(text, 7) /= 'procedure') cycle
+            ntarget = 0
+            call append_name_list(targets, target_owner, ntarget, &
+                                  text(index(text, 'procedure') + 9:), 0)
+            do k = 1, ntarget
+                if (owned_name_present(defs, def_owner, ndef, targets(k), -1)) &
+                    cycle
+                bad = owned_name_present(exts, ext_owner, next, targets(k), -1)
+                if (.not. bad) bad = owned_name_present(bodies, body_owner, &
+                                                        nbody, targets(k), -1)
+                if (.not. bad) bad = owned_name_present(gens, gen_owner, ngen, &
+                                                        targets(k), -1)
+                if (.not. bad) cycle
+                write (location, '(" at line ",I0)') i
+                error_msg = 'MODULE PROCEDURE '//trim(targets(k))// &
+                    ' in generic interface '//trim(iface_name(i))// &
+                    ' is not a module procedure'//trim(location)
+                return
+            end do
+        end do
+    end subroutine check_module_procedure_targets
+
+    ! Specific procedure names listed by the generic interface block whose
+    ! header is at line header_line.
+    subroutine generic_block_specifics(lines, count, header_line, specs, nspec)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        integer, intent(in) :: header_line
+        character(len=64), intent(inout) :: specs(:)
+        integer, intent(out) :: nspec
+        integer :: owners(size(specs))
+        character(len=:), allocatable :: text, name, signature
+        integer :: i
+        logical :: ok
+
+        nspec = 0
+        do i = header_line + 1, count
+            text = trim(lines(i))
+            if (stmt_starts(text, 'end')) then
+                if (identifier_after(text, 4) == 'interface') return
+            end if
+            if (stmt_starts(text, 'module')) then
+                if (identifier_after(text, 7) == 'procedure') then
+                    call append_name_list(specs, owners, nspec, &
+                                          text(index(text, 'procedure') + 9:), 0)
+                end if
+                cycle
+            end if
+            call interface_body_header(text, name, signature, ok)
+            if (ok) call append_owned_name(specs, owners, nspec, name, 0)
+        end do
+    end subroutine generic_block_specifics
+
+    ! A generic name and a procedure defined in the same scoping unit may only
+    ! share a name when that procedure is one of the generic's own specifics
+    ! (F2018 15.4.3.4.1). Otherwise the name is already defined as a generic.
+    subroutine check_generic_name_collisions(lines, count, error_msg)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, parameter :: MAXN = 512
+        character(len=64) :: defs(MAXN), bodies(MAXN), gens(MAXN), exts(MAXN)
+        integer :: def_owner(MAXN), body_owner(MAXN), gen_owner(MAXN), &
+                   ext_owner(MAXN)
+        character(len=64) :: specs(MAXN)
+        integer, allocatable :: depth(:), ids(:)
+        character(len=64), allocatable :: iface_name(:)
+        character(len=:), allocatable :: text, name
+        character(len=64) :: location
+        integer :: ndef, nbody, ngen, next, nspec, i, k
+
+        call set_empty(error_msg)
+        call interface_regions(lines, count, depth, iface_name)
+        call program_unit_ids(lines, count, ids)
+        call collect_procedure_tables(lines, count, defs, def_owner, ndef, &
+                                      bodies, body_owner, nbody, gens, &
+                                      gen_owner, ngen, exts, ext_owner, next)
+        do i = 1, count
+            text = trim(lines(i))
+            if (.not. stmt_starts(text, 'interface')) cycle
+            name = identifier_after(text, 10)
+            if (.not. is_plain_generic_name(name)) cycle
+            if (.not. owned_name_present(defs, def_owner, ndef, name, ids(i))) &
+                cycle
+            call generic_block_specifics(lines, count, i, specs, nspec)
+            do k = 1, nspec
+                if (trim(specs(k)) == trim(name)) return
+            end do
+            write (location, '(" at line ",I0)') i
+            error_msg = trim(name)//' is already defined as a generic '// &
+                'interface and cannot also name a procedure in the same '// &
+                'scoping unit'//trim(location)
+            return
+        end do
+    end subroutine check_generic_name_collisions
+
+    ! Names a module in this file makes accessible: its generic names, its
+    ! interface bodies, and the procedures it defines.
+    subroutine module_export_table(lines, count, mods, nmod, names, owner, nname)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=64), intent(inout) :: mods(:)
+        integer, intent(out) :: nmod
+        character(len=64), intent(inout) :: names(:)
+        integer, intent(inout) :: owner(:)
+        integer, intent(out) :: nname
+        integer, allocatable :: depth(:)
+        character(len=64), allocatable :: iface_name(:)
+        character(len=:), allocatable :: text, name, signature
+        integer :: i, current
+        logical :: ok
+
+        call interface_regions(lines, count, depth, iface_name)
+        nmod = 0
+        nname = 0
+        current = 0
+        do i = 1, count
+            text = trim(lines(i))
+            if (stmt_starts(text, 'end')) then
+                if (identifier_after(text, 4) == 'module') current = 0
+                cycle
+            end if
+            if (stmt_starts(text, 'module')) then
+                name = identifier_after(text, 7)
+                if (name /= 'procedure' .and. name /= 'subroutine' .and. &
+                    name /= 'function' .and. len_trim(name) > 0) then
+                    if (nmod < size(mods)) then
+                        nmod = nmod + 1
+                        mods(nmod) = name
+                        current = nmod
+                    end if
+                end if
+                cycle
+            end if
+            if (current == 0) cycle
+            if (stmt_starts(text, 'interface')) then
+                name = identifier_after(text, 10)
+                if (is_plain_generic_name(name)) then
+                    call append_owned_name(names, owner, nname, name, current)
+                end if
+                cycle
+            end if
+            call interface_body_header(text, name, signature, ok)
+            if (ok) call append_owned_name(names, owner, nname, name, current)
+        end do
+    end subroutine module_export_table
+
+    ! The module index of a USE statement's module, or 0.
+    integer function used_module_index(text, mods, nmod) result(idx)
+        character(len=*), intent(in) :: text
+        character(len=64), intent(in) :: mods(:)
+        integer, intent(in) :: nmod
+        character(len=:), allocatable :: name
+        integer :: i
+
+        idx = 0
+        name = identifier_after(text, 4)
+        do i = 1, nmod
+            if (trim(mods(i)) == trim(name)) then
+                idx = i
+                return
+            end if
+        end do
+    end function used_module_index
+
+    ! A USE statement must not make accessible a name that is also the name of
+    ! the current program unit; the two entities then collide in the same
+    ! scope. The enclosing unit is the nearest preceding unit header, since a
+    ! USE statement stands at the head of the specification part.
+    subroutine check_use_shadows_program_unit(lines, count, error_msg)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, parameter :: MAXN = 512
+        character(len=64) :: mods(MAXN), names(MAXN)
+        integer :: owner(MAXN)
+        integer, allocatable :: depth(:)
+        character(len=64), allocatable :: iface_name(:)
+        character(len=:), allocatable :: text, unit_name, signature, hname
+        character(len=64) :: location
+        integer :: nmod, nname, i, j, midx
+        logical :: ok
+
+        call set_empty(error_msg)
+        call interface_regions(lines, count, depth, iface_name)
+        call module_export_table(lines, count, mods, nmod, names, owner, nname)
+        if (nmod == 0) return
+        do i = 1, count
+            if (depth(i) /= 0) cycle
+            text = trim(lines(i))
+            if (.not. stmt_starts(text, 'use')) cycle
+            midx = used_module_index(text, mods, nmod)
+            if (midx == 0) cycle
+            unit_name = ''
+            do j = i - 1, 1, -1
+                if (depth(j) /= 0) cycle
+                hname = trim(lines(j))
+                if (stmt_starts(hname, 'module')) exit
+                if (stmt_starts(hname, 'program')) exit
+                if (stmt_starts(hname, 'end')) exit
+                call interface_body_header(hname, unit_name, signature, ok)
+                if (ok) exit
+                unit_name = ''
+            end do
+            if (len_trim(unit_name) == 0) cycle
+            if (.not. owned_name_present(names, owner, nname, unit_name, midx)) &
+                cycle
+            write (location, '(" at line ",I0)') i
+            error_msg = trim(unit_name)//' from module '//trim(mods(midx))// &
+                ' is also the name of the current program unit'//trim(location)
+            return
+        end do
+    end subroutine check_use_shadows_program_unit
+
+    ! True when name occurs as a whole word on the line.
+    logical function line_references_name(line, name) result(yes)
+        character(len=*), intent(in) :: line
+        character(len=*), intent(in) :: name
+        integer :: p, base
+
+        yes = .false.
+        base = 0
+        do
+            p = index(line(base + 1:), trim(name))
+            if (p == 0) return
+            p = base + p
+            base = p
+            if (p > 1) then
+                if (is_fortran_identifier_char(line(p - 1:p - 1))) cycle
+            end if
+            if (p + len_trim(name) <= len(line)) then
+                if (is_fortran_identifier_char(line(p + len_trim(name): &
+                                                    p + len_trim(name)))) cycle
+            end if
+            yes = .true.
+            return
+        end do
+    end function line_references_name
+
+    ! Two modules that make the same name accessible to one scoping unit leave
+    ! that name ambiguous; referencing it is an error (F2018 19.5.1.4).
+    subroutine check_ambiguous_use_association(lines, count, error_msg)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, parameter :: MAXN = 512
+        character(len=64) :: mods(MAXN), names(MAXN)
+        integer :: owner(MAXN)
+        integer, allocatable :: depth(:), region(:)
+        character(len=64), allocatable :: iface_name(:)
+        integer :: nmod, nname, i, j, k, midx, first, last
+        integer :: used(64), nused
+        character(len=:), allocatable :: text
+        character(len=64) :: location
+
+        call set_empty(error_msg)
+        call interface_regions(lines, count, depth, iface_name)
+        call module_export_table(lines, count, mods, nmod, names, owner, nname)
+        if (nmod < 2) return
+        call scoping_regions(lines, count, depth, region)
+        first = 1
+        do while (first <= count)
+            last = first
+            do while (last < count)
+                if (region(last + 1) /= region(first)) exit
+                last = last + 1
+            end do
+            nused = 0
+            do i = first, last
+                if (depth(i) /= 0) cycle
+                text = trim(lines(i))
+                if (.not. stmt_starts(text, 'use')) cycle
+                if (index(text, 'only') > 0) cycle
+                midx = used_module_index(text, mods, nmod)
+                if (midx == 0) cycle
+                if (nused < size(used)) then
+                    nused = nused + 1
+                    used(nused) = midx
+                end if
+            end do
+            if (nused >= 2) then
+                do j = 1, nname
+                    if (.not. any(used(1:nused) == owner(j))) cycle
+                    do k = 1, nname
+                        if (k == j) cycle
+                        if (trim(names(k)) /= trim(names(j))) cycle
+                        if (owner(k) == owner(j)) cycle
+                        if (.not. any(used(1:nused) == owner(k))) cycle
+                        call ambiguous_reference_line(lines, first, last, &
+                                                      names(j), i)
+                        if (i == 0) cycle
+                        write (location, '(" at line ",I0)') i
+                        error_msg = 'ambiguous reference to '//trim(names(j))// &
+                            ': it is use associated from more than one '// &
+                            'module'//trim(location)
+                        return
+                    end do
+                end do
+            end if
+            first = last + 1
+        end do
+    end subroutine check_ambiguous_use_association
+
+    ! The first line of the region that references name outside a USE
+    ! statement, or 0.
+    subroutine ambiguous_reference_line(lines, first, last, name, found_line)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: first, last
+        character(len=*), intent(in) :: name
+        integer, intent(out) :: found_line
+        integer :: i
+        character(len=:), allocatable :: text
+
+        found_line = 0
+        do i = first, last
+            text = trim(lines(i))
+            if (stmt_starts(text, 'use')) cycle
+            if (.not. line_references_name(text, name)) cycle
+            found_line = i
+            return
+        end do
+    end subroutine ambiguous_reference_line
+
+    ! Region index per line: a new region starts at every program unit header
+    ! and after every unit END statement, so each scoping unit gets its own.
+    subroutine scoping_regions(lines, count, depth, region)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        integer, intent(in) :: depth(:)
+        integer, allocatable, intent(out) :: region(:)
+        character(len=:), allocatable :: text, name, signature
+        integer :: i, current
+        logical :: ok
+
+        allocate (region(count))
+        current = 1
+        do i = 1, count
+            text = trim(lines(i))
+            if (depth(i) == 0) then
+                if (stmt_starts(text, 'program') .or. &
+                    stmt_starts(text, 'module')) then
+                    current = current + 1
+                else
+                    call interface_body_header(text, name, signature, ok)
+                    if (ok) current = current + 1
+                end if
+            end if
+            region(i) = current
+            if (depth(i) == 0 .and. stmt_starts(text, 'end')) then
+                current = current + 1
+            end if
+        end do
+    end subroutine scoping_regions
+
+    ! A derived type that extends another must not bind the same generic
+    ! operator when the inherited and the new specific are not distinguishable:
+    ! an actual of the extension type matches both (F2018 C1514).
+    subroutine check_typebound_generic_inheritance(arena, lines, count, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, parameter :: MAXT = 128
+        character(len=64) :: tname(MAXT), tparent(MAXT)
+        character(len=64) :: gspec(MAXT), gtarget(MAXT)
+        integer :: gtype(MAXT), gline(MAXT)
+        character(len=:), allocatable :: text
+        character(len=64) :: location
+        integer :: i, j, k, nt, ng
+
+        call set_empty(error_msg)
+        call collect_type_generics(lines, count, tname, tparent, nt, gspec, &
+                                   gtarget, gtype, gline, ng)
+        do j = 1, ng
+            do k = 1, ng
+                if (j == k) cycle
+                if (gspec(j) /= gspec(k)) cycle
+                if (gtype(j) == gtype(k)) cycle
+                if (.not. type_extends_type(tname, tparent, nt, gtype(j), &
+                                            gtype(k))) cycle
+                if (.not. bindings_indistinguishable(arena, trim(gtarget(j)), &
+                                                     trim(gtarget(k)), tname, &
+                                                     tparent, nt)) cycle
+                write (location, '(" at line ",I0)') gline(j)
+                error_msg = 'type-bound generic '//trim(gspec(j))//' of type '// &
+                    trim(tname(gtype(j)))//' and the binding inherited from '// &
+                    trim(tname(gtype(k)))//' are ambiguous'//trim(location)
+                return
+            end do
+        end do
+    end subroutine check_typebound_generic_inheritance
+
+    ! Like specifics_indistinguishable, but a declared type and any of its
+    ! extensions do not distinguish two bindings: an actual of the extension
+    ! type is type compatible with both dummies.
+    logical function bindings_indistinguishable(arena, name_a, name_b, tname, &
+                                                tparent, nt) result(same)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name_a, name_b
+        character(len=64), intent(in) :: tname(:), tparent(:)
+        integer, intent(in) :: nt
+        integer :: count_a, count_b, pos
+        integer :: kind_a, kind_b, rank_a, rank_b
+        logical :: known_a, known_b, proc_a, proc_b, any_a, any_b
+        character(len=:), allocatable :: base_a, base_b
+
+        same = .false.
+        count_a = arena_proc_param_count(arena, name_a)
+        count_b = arena_proc_param_count(arena, name_b)
+        if (count_a < 0 .or. count_b < 0) return
+        if (count_a /= count_b) return
+        do pos = 1, count_a
+            call dummy_signature(arena, name_a, pos, known_a, base_a, kind_a, &
+                                 rank_a, proc_a, any_a)
+            call dummy_signature(arena, name_b, pos, known_b, base_b, kind_b, &
+                                 rank_b, proc_b, any_b)
+            if (.not. known_a) return
+            if (.not. known_b) return
+            if (proc_a .neqv. proc_b) return
+            if (proc_a) cycle
+            if (any_a .or. any_b) cycle
+            if (rank_a /= rank_b) return
+            if (base_a == base_b) cycle
+            if (.not. base_types_related(base_a, base_b, tname, tparent, nt)) &
+                return
+        end do
+        same = .true.
+    end function bindings_indistinguishable
+
+    ! Whether two declared derived types are related by type extension.
+    logical function base_types_related(base_a, base_b, tname, tparent, nt) &
+            result(related)
+        character(len=*), intent(in) :: base_a, base_b
+        character(len=64), intent(in) :: tname(:), tparent(:)
+        integer, intent(in) :: nt
+        integer :: ia, ib
+
+        related = .false.
+        ia = declared_type_index(base_a, tname, nt)
+        ib = declared_type_index(base_b, tname, nt)
+        if (ia == 0 .or. ib == 0) return
+        related = type_extends_type(tname, tparent, nt, ia, ib)
+        if (.not. related) then
+            related = type_extends_type(tname, tparent, nt, ib, ia)
+        end if
+    end function base_types_related
+
+    ! Index in the collected type table of the declared type spec type(x).
+    integer function declared_type_index(base, tname, nt) result(idx)
+        character(len=*), intent(in) :: base
+        character(len=64), intent(in) :: tname(:)
+        integer, intent(in) :: nt
+        character(len=:), allocatable :: name
+        integer :: i
+
+        idx = 0
+        if (len_trim(base) < 6) return
+        if (base(1:5) /= 'type(') return
+        name = identifier_after(base, 6)
+        do i = 1, nt
+            if (trim(tname(i)) /= trim(name)) cycle
+            idx = i
+            return
+        end do
+    end function declared_type_index
+
+    subroutine collect_type_generics(lines, count, tname, tparent, nt, gspec, &
+                                     gtarget, gtype, gline, ng)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=64), intent(inout) :: tname(:), tparent(:)
+        integer, intent(out) :: nt
+        character(len=64), intent(inout) :: gspec(:), gtarget(:)
+        integer, intent(inout) :: gtype(:), gline(:)
+        integer, intent(out) :: ng
+        character(len=:), allocatable :: text, spec
+        integer :: i, p, current
+
+        nt = 0
+        ng = 0
+        current = 0
+        do i = 1, count
+            text = trim(lines(i))
+            if (stmt_starts(text, 'end')) then
+                if (identifier_after(text, 4) == 'type') current = 0
+                cycle
+            end if
+            if (stmt_starts(text, 'type')) then
+                p = index(text, '::')
+                if (p == 0) cycle
+                if (nt >= size(tname)) cycle
+                nt = nt + 1
+                tname(nt) = identifier_after(text, p + 2)
+                tparent(nt) = ''
+                p = index(text, 'extends(')
+                if (p > 0) tparent(nt) = identifier_after(text, p + 8)
+                current = nt
+                cycle
+            end if
+            if (current == 0) cycle
+            if (.not. stmt_starts(text, 'generic')) cycle
+            p = index(text, '::')
+            if (p == 0) cycle
+            spec = trim(adjustl(text(p + 2:)))
+            p = index(spec, '=>')
+            if (p == 0) cycle
+            if (ng >= size(gspec)) cycle
+            ng = ng + 1
+            gspec(ng) = squeeze_blanks(spec(1:p - 1))
+            gtarget(ng) = identifier_after(spec(p + 2:), 1)
+            gtype(ng) = current
+            gline(ng) = i
+        end do
+    end subroutine collect_type_generics
+
+    function squeeze_blanks(text) result(packed)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: packed
+        integer :: i
+
+        packed = ''
+        do i = 1, len_trim(text)
+            if (text(i:i) == ' ') cycle
+            packed = packed//text(i:i)
+        end do
+    end function squeeze_blanks
+
+    ! Whether type child is an extension of type ancestor.
+    recursive logical function type_extends_type(tname, tparent, nt, child, &
+                                                 ancestor) result(yes)
+        character(len=64), intent(in) :: tname(:), tparent(:)
+        integer, intent(in) :: nt, child, ancestor
+        integer :: i
+
+        yes = .false.
+        if (child < 1 .or. child > nt) return
+        if (len_trim(tparent(child)) == 0) return
+        do i = 1, nt
+            if (trim(tname(i)) /= trim(tparent(child))) cycle
+            if (i == ancestor) then
+                yes = .true.
+                return
+            end if
+            yes = type_extends_type(tname, tparent, nt, i, ancestor)
+            return
+        end do
+    end function type_extends_type
+
+    ! F2018 C1503: a defined assignment must not redefine an assignment that
+    ! is already defined intrinsically for its two operands.
+    subroutine check_intrinsic_assignment_redefinition(arena, lines, count, &
+                                                       error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, parameter :: MAXN = 64
+        character(len=64) :: specs(MAXN)
+        character(len=:), allocatable :: text, base_l, base_r
+        character(len=64) :: location
+        integer :: i, k, nspec, kind_l, kind_r, rank_l, rank_r
+        logical :: known_l, known_r, proc_l, proc_r, any_l, any_r
+
+        call set_empty(error_msg)
+        do i = 1, count
+            text = trim(lines(i))
+            if (.not. stmt_starts(text, 'interface')) cycle
+            if (identifier_after(text, 10) /= 'assignment') cycle
+            call generic_block_specifics(lines, count, i, specs, nspec)
+            do k = 1, nspec
+                call dummy_signature(arena, trim(specs(k)), 1, known_l, base_l, &
+                                     kind_l, rank_l, proc_l, any_l)
+                call dummy_signature(arena, trim(specs(k)), 2, known_r, base_r, &
+                                     kind_r, rank_r, proc_r, any_r)
+                if (.not. known_l) cycle
+                if (.not. known_r) cycle
+                if (proc_l .or. proc_r) cycle
+                if (rank_l /= rank_r) cycle
+                if (.not. intrinsic_assignment_defined(base_type_root(base_l), &
+                                                       base_type_root(base_r))) &
+                    cycle
+                write (location, '(" at line ",I0)') i
+                error_msg = trim(specs(k))//' would redefine an INTRINSIC '// &
+                    'type assignment between '//base_l//' and '//base_r// &
+                    trim(location)
+                return
+            end do
+        end do
+    end subroutine check_intrinsic_assignment_redefinition
+
+    logical function intrinsic_assignment_defined(base_l, base_r) result(yes)
+        character(len=*), intent(in) :: base_l, base_r
+
+        yes = .false.
+        if (is_numeric_base_type(base_l) .and. is_numeric_base_type(base_r)) then
+            yes = .true.
+            return
+        end if
+        if (base_l == 'character' .and. base_r == 'character') yes = .true.
+        if (base_l == 'logical' .and. base_r == 'logical') yes = .true.
+    end function intrinsic_assignment_defined
+
+    logical function is_numeric_base_type(base) result(yes)
+        character(len=*), intent(in) :: base
+
+        yes = base == 'integer' .or. base == 'real' .or. base == 'complex'
+    end function is_numeric_base_type
+
+    ! A reference to a generic name must match one of its specific procedures
+    ! (F2018 15.5.5). Only calls whose actual arguments are all literal
+    ! constants are judged, so a mismatch is beyond doubt.
+    subroutine check_generic_call_resolves(arena, lines, count, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, parameter :: MAXN = 64
+        character(len=64) :: specs(MAXN), actuals(MAXN)
+        character(len=:), allocatable :: text, callee
+        character(len=64) :: location
+        integer :: i, j, nspec, nactual, header
+        logical :: matched, resolvable
+
+        call set_empty(error_msg)
+        do i = 1, count
+            text = trim(lines(i))
+            if (.not. stmt_starts(text, 'call')) cycle
+            callee = identifier_after(text, 5)
+            if (len_trim(callee) == 0) cycle
+            call generic_header_line(lines, count, callee, header)
+            if (header == 0) cycle
+            call literal_actual_types(text, actuals, nactual)
+            if (nactual <= 0) cycle
+            call generic_block_specifics(lines, count, header, specs, nspec)
+            if (nspec == 0) cycle
+            call generic_call_matches(arena, specs, nspec, actuals, nactual, &
+                                      matched, resolvable)
+            if (.not. resolvable) cycle
+            if (matched) cycle
+            write (location, '(" at line ",I0)') i
+            error_msg = 'no specific subroutine of the generic interface '// &
+                trim(callee)//' matches this reference'//trim(location)
+            return
+        end do
+    end subroutine check_generic_call_resolves
+
+    subroutine generic_header_line(lines, count, name, header)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=*), intent(in) :: name
+        integer, intent(out) :: header
+        character(len=:), allocatable :: text
+        integer :: i
+
+        header = 0
+        do i = 1, count
+            text = trim(lines(i))
+            if (.not. stmt_starts(text, 'interface')) cycle
+            if (identifier_after(text, 10) /= trim(name)) cycle
+            header = i
+            return
+        end do
+    end subroutine generic_header_line
+
+    ! Base types of a call's actual arguments when every one is a literal
+    ! constant; nactual is -1 otherwise.
+    subroutine literal_actual_types(text, actuals, nactual)
+        character(len=*), intent(in) :: text
+        character(len=64), intent(inout) :: actuals(:)
+        integer, intent(out) :: nactual
+        character(len=:), allocatable :: args, item, base
+        integer :: lp, rp, i, start
+
+        nactual = -1
+        lp = index(text, '(')
+        rp = index(text, ')', back=.true.)
+        if (lp == 0) return
+        if (rp <= lp) return
+        args = text(lp + 1:rp - 1)
+        if (len_trim(args) == 0) return
+        nactual = 0
+        start = 1
+        do i = 1, len(args) + 1
+            if (i <= len(args)) then
+                if (args(i:i) /= ',') cycle
+            end if
+            item = trim(adjustl(args(start:i - 1)))
+            base = literal_base_type(item)
+            if (len_trim(base) == 0) then
+                nactual = -1
+                return
+            end if
+            if (nactual >= size(actuals)) then
+                nactual = -1
+                return
+            end if
+            nactual = nactual + 1
+            actuals(nactual) = base
+            start = i + 1
+        end do
+    end subroutine literal_actual_types
+
+    function literal_base_type(item) result(base)
+        character(len=*), intent(in) :: item
+        character(len=:), allocatable :: base
+        integer :: i
+        logical :: has_digit, has_dot, has_other
+
+        base = ''
+        if (len_trim(item) == 0) return
+        if (item(1:1) == '''' .or. item(1:1) == '"') then
+            base = 'character'
+            return
+        end if
+        if (item == '.true.' .or. item == '.false.') then
+            base = 'logical'
+            return
+        end if
+        has_digit = .false.
+        has_dot = .false.
+        has_other = .false.
+        do i = 1, len_trim(item)
+            select case (item(i:i))
+            case ('0':'9')
+                has_digit = .true.
+            case ('.')
+                has_dot = .true.
+            case ('+', '-')
+                continue
+            case default
+                has_other = .true.
+            end select
+        end do
+        if (has_other) return
+        if (.not. has_digit) return
+        if (has_dot) then
+            base = 'real'
+        else
+            base = 'integer'
+        end if
+    end function literal_base_type
+
+    subroutine generic_call_matches(arena, specs, nspec, actuals, nactual, &
+                                    matched, resolvable)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=64), intent(in) :: specs(:)
+        integer, intent(in) :: nspec
+        character(len=64), intent(in) :: actuals(:)
+        integer, intent(in) :: nactual
+        logical, intent(out) :: matched, resolvable
+        character(len=:), allocatable :: base
+        integer :: k, pos, params, kind_value, rank
+        logical :: known, is_proc, is_any, fits
+
+        matched = .false.
+        resolvable = .false.
+        do k = 1, nspec
+            params = arena_proc_param_count(arena, trim(specs(k)))
+            if (params < 0) return
+            resolvable = .true.
+            if (params /= nactual) cycle
+            fits = .true.
+            do pos = 1, nactual
+                call dummy_signature(arena, trim(specs(k)), pos, known, base, &
+                                     kind_value, rank, is_proc, is_any)
+                if (.not. known) return
+                if (is_proc) return
+                if (is_any) cycle
+                if (rank /= 0) then
+                    fits = .false.
+                    exit
+                end if
+                if (base_type_root(base) /= trim(actuals(pos))) then
+                    fits = .false.
+                    exit
+                end if
+            end do
+            if (fits) then
+                matched = .true.
+                return
+            end if
+        end do
+    end subroutine generic_call_matches

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -556,6 +556,8 @@
         if (len_trim(error_msg) > 0) return
         call check_alloc_pointer_targets(arena, error_msg)
         if (len_trim(error_msg) > 0) return
+        call check_generic_interface_forms(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
         call check_storage_association_restrictions(arena, error_msg)
         if (len_trim(error_msg) > 0) return
         call check_result_and_entry_rules(arena, error_msg)

--- a/test/test_session_operator_overload_compiler.f90
+++ b/test/test_session_operator_overload_compiler.f90
@@ -75,24 +75,30 @@ contains
 
     logical function test_overloaded_assignment()
         ! interface assignment(=) routes `x = rhs` to assign_doubled(x, rhs).
+        ! The left-hand side is a derived type: F2018 C1503 forbids redefining
+        ! an assignment that is already defined intrinsically, so an
+        ! integer = integer defined assignment would not be conforming.
         character(len=*), parameter :: source = &
             'module am'//new_line('a')// &
             '  implicit none'//new_line('a')// &
+            '  type :: box_t'//new_line('a')// &
+            '    integer :: val = 0'//new_line('a')// &
+            '  end type box_t'//new_line('a')// &
             '  interface assignment(=)'//new_line('a')// &
             '    module procedure assign_doubled'//new_line('a')// &
             '  end interface'//new_line('a')// &
             'contains'//new_line('a')// &
             '  subroutine assign_doubled(lhs, rhs)'//new_line('a')// &
-            '    integer, intent(out) :: lhs'//new_line('a')// &
+            '    type(box_t), intent(out) :: lhs'//new_line('a')// &
             '    integer, intent(in) :: rhs'//new_line('a')// &
-            '    lhs = rhs * 2'//new_line('a')// &
+            '    lhs%val = rhs * 2'//new_line('a')// &
             '  end subroutine assign_doubled'//new_line('a')// &
             'end module am'//new_line('a')// &
             'program main'//new_line('a')// &
             '  use am'//new_line('a')// &
-            '  integer :: x'//new_line('a')// &
+            '  type(box_t) :: x'//new_line('a')// &
             '  x = 21'//new_line('a')// &
-            '  stop x'//new_line('a')// &
+            '  stop x%val'//new_line('a')// &
             'end program main'
 
         ! x = 21 dispatches to assign_doubled -> 21 * 2 = 42

--- a/test/test_session_reject_generic_01_compiler.f90
+++ b/test/test_session_reject_generic_01_compiler.f90
@@ -1,0 +1,580 @@
+program test_session_reject_generic_01_compiler
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== malformed and ambiguous generic interface rejection ==='
+
+    all_passed = .true.
+    if (.not. test_malformed_generic_binding()) all_passed = .false.
+    if (.not. test_implicit_interface_ambiguity()) all_passed = .false.
+    if (.not. test_module_procedure_target()) all_passed = .false.
+    if (.not. test_generic_name_collision()) all_passed = .false.
+    if (.not. test_use_shadows_program_unit()) all_passed = .false.
+    if (.not. test_ambiguous_use_association()) all_passed = .false.
+    if (.not. test_typebound_generic_inheritance()) all_passed = .false.
+    if (.not. test_intrinsic_assignment_redefinition()) all_passed = .false.
+    if (.not. test_generic_call_without_specific()) all_passed = .false.
+    if (.not. test_allocatable_pointer_ambiguity()) all_passed = .false.
+    if (.not. test_unlimited_polymorphic_ambiguity()) all_passed = .false.
+    if (.not. test_generic_identifier_accepted()) all_passed = .false.
+    if (.not. test_distinguishable_implicit_interfaces()) all_passed = .false.
+    if (.not. test_module_procedure_accepted()) all_passed = .false.
+    if (.not. test_distinct_generic_and_specific()) all_passed = .false.
+    if (.not. test_use_without_shadowing()) all_passed = .false.
+    if (.not. test_unambiguous_use_association()) all_passed = .false.
+    if (.not. test_unrelated_derived_type_specifics()) all_passed = .false.
+    if (.not. test_derived_type_assignment_accepted()) all_passed = .false.
+    if (.not. test_generic_call_with_specific()) all_passed = .false.
+    if (.not. test_kind_distinguishable_specifics()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: malformed and ambiguous generic interfaces rejected'
+
+contains
+
+    logical function test_malformed_generic_binding()
+        !! gfortran.dg/generic_29.f90: a GENERIC binding needs a generic
+        !! specification and a binding name list; "generic ::" names nothing.
+        character(len=*), parameter :: source = &
+            'program p'//new_line('a')// &
+            '   type t'//new_line('a')// &
+            '   contains'//new_line('a')// &
+            '      generic ::'//new_line('a')// &
+            '   end type'//new_line('a')// &
+            'end'
+
+        test_malformed_generic_binding = expect_error_contains( &
+            source, 'malformed GENERIC binding', &
+            '/tmp/ffc_reject_generic_01_r1')
+    end function test_malformed_generic_binding
+
+    logical function test_implicit_interface_ambiguity()
+        !! gfortran.dg/pr95584.f90: two interface bodies whose dummies are all
+        !! implicitly typed the same way cannot resolve the generic.
+        character(len=*), parameter :: source = &
+            'program p'//new_line('a')// &
+            '   interface s'//new_line('a')// &
+            '      subroutine g(x, *)'//new_line('a')// &
+            '      end'//new_line('a')// &
+            '      subroutine h(y, *)'//new_line('a')// &
+            '      end'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'end'
+
+        test_implicit_interface_ambiguity = expect_error_contains( &
+            source, 'ambiguous interfaces', &
+            '/tmp/ffc_reject_generic_01_r2')
+    end function test_implicit_interface_ambiguity
+
+    logical function test_module_procedure_target()
+        !! gfortran.dg/generic_14.f90: MODULE PROCEDURE may only name a module
+        !! procedure, never an EXTERNAL procedure.
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   external ext_sub'//new_line('a')// &
+            '   interface gen'//new_line('a')// &
+            '      module procedure ext_sub'//new_line('a')// &
+            '   end interface gen'//new_line('a')// &
+            'end module'//new_line('a')// &
+            'end'
+
+        test_module_procedure_target = expect_error_contains( &
+            source, 'is not a module procedure', &
+            '/tmp/ffc_reject_generic_01_r3')
+    end function test_module_procedure_target
+
+    logical function test_generic_name_collision()
+        !! gfortran.dg/invalid_procedure_name.f90: a contained procedure cannot
+        !! take the name of a generic interface of the same scoping unit.
+        character(len=*), parameter :: source = &
+            'interface i1'//new_line('a')// &
+            '   subroutine s1(i)'//new_line('a')// &
+            '   end subroutine s1'//new_line('a')// &
+            'end interface i1'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine i1(i)'//new_line('a')// &
+            'end subroutine i1'//new_line('a')// &
+            'end'
+
+        test_generic_name_collision = expect_error_contains( &
+            source, 'already defined as a generic', &
+            '/tmp/ffc_reject_generic_01_r4')
+    end function test_generic_name_collision
+
+    logical function test_use_shadows_program_unit()
+        !! gfortran.dg/interface_3.f90: a USE must not make accessible a name
+        !! that is also the name of the current program unit.
+        character(len=*), parameter :: source = &
+            'module test_mod'//new_line('a')// &
+            '   interface'//new_line('a')// &
+            '      subroutine my_sub(a)'//new_line('a')// &
+            '         real a'//new_line('a')// &
+            '      end subroutine'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'subroutine my_sub(a)'//new_line('a')// &
+            '   use test_mod'//new_line('a')// &
+            '   real a'//new_line('a')// &
+            '   print *, a'//new_line('a')// &
+            'end subroutine'
+
+        test_use_shadows_program_unit = expect_error_contains( &
+            source, 'name of the current program unit', &
+            '/tmp/ffc_reject_generic_01_r5')
+    end function test_use_shadows_program_unit
+
+    logical function test_ambiguous_use_association()
+        !! gfortran.dg/generic_11.f90: a name use associated from two modules is
+        !! ambiguous and must not be referenced.
+        character(len=*), parameter :: source = &
+            'module m_foo'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine foo'//new_line('a')// &
+            '      print *, ''foo'''//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'module m_bar'//new_line('a')// &
+            '   interface foo'//new_line('a')// &
+            '      module procedure bar'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine bar'//new_line('a')// &
+            '      print *, ''bar'''//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'use m_foo'//new_line('a')// &
+            'use m_bar'//new_line('a')// &
+            'call foo'//new_line('a')// &
+            'end'
+
+        test_ambiguous_use_association = expect_error_contains( &
+            source, 'ambiguous reference', &
+            '/tmp/ffc_reject_generic_01_r6')
+    end function test_ambiguous_use_association
+
+    logical function test_typebound_generic_inheritance()
+        !! gfortran.dg/typebound_operator_14.f90: an extension type must not bind
+        !! a generic operator that is indistinguishable from the inherited one.
+        character(len=*), parameter :: source = &
+            'module m_sort'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   type, abstract :: sort_t'//new_line('a')// &
+            '   contains'//new_line('a')// &
+            '      generic :: operator(.gt.) => gt_cmp'//new_line('a')// &
+            '      procedure :: gt_cmp'//new_line('a')// &
+            '   end type'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   logical function gt_cmp(a, b)'//new_line('a')// &
+            '      class(sort_t), intent(in) :: a, b'//new_line('a')// &
+            '      gt_cmp = .true.'//new_line('a')// &
+            '   end function'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'module test'//new_line('a')// &
+            '   use m_sort'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   type, extends(sort_t) :: sort_int_t'//new_line('a')// &
+            '      integer :: i'//new_line('a')// &
+            '   contains'//new_line('a')// &
+            '      generic :: operator(.gt.) => gt_cmp_int'//new_line('a')// &
+            '      procedure :: gt_cmp_int'//new_line('a')// &
+            '   end type'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   logical function gt_cmp_int(a, b) result(cmp)'//new_line('a')// &
+            '      class(sort_int_t), intent(in) :: a, b'//new_line('a')// &
+            '      cmp = a%i > b%i'//new_line('a')// &
+            '   end function'//new_line('a')// &
+            'end module'
+
+        test_typebound_generic_inheritance = expect_error_contains( &
+            source, 'are ambiguous', &
+            '/tmp/ffc_reject_generic_01_r7')
+    end function test_typebound_generic_inheritance
+
+    logical function test_intrinsic_assignment_redefinition()
+        !! gfortran.dg/redefined_intrinsic_assignment.f90: ASSIGNMENT(=) must not
+        !! redefine an assignment that is already defined intrinsically.
+        character(len=*), parameter :: source = &
+            'module m1'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   interface assignment(=)'//new_line('a')// &
+            '      module procedure t1'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine t1(i, j)'//new_line('a')// &
+            '      integer, intent(out) :: i'//new_line('a')// &
+            '      integer, intent(in) :: j'//new_line('a')// &
+            '      i = -j'//new_line('a')// &
+            '   end subroutine t1'//new_line('a')// &
+            'end module m1'
+
+        test_intrinsic_assignment_redefinition = expect_error_contains( &
+            source, 'redefine an INTRINSIC', &
+            '/tmp/ffc_reject_generic_01_r8')
+    end function test_intrinsic_assignment_redefinition
+
+    logical function test_generic_call_without_specific()
+        !! gfortran.dg/generic_5.f90: a generic reference must match one of its
+        !! specific procedures.
+        character(len=*), parameter :: source = &
+            'module ice_gfortran'//new_line('a')// &
+            '   interface ice'//new_line('a')// &
+            '      module procedure ice_i'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine ice_i(i)'//new_line('a')// &
+            '      integer, intent(in) :: i'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'program p'//new_line('a')// &
+            '   use ice_gfortran'//new_line('a')// &
+            '   call ice(23.0)'//new_line('a')// &
+            'end program'
+
+        test_generic_call_without_specific = expect_error_contains( &
+            source, 'no specific subroutine', &
+            '/tmp/ffc_reject_generic_01_r9')
+    end function test_generic_call_without_specific
+
+    logical function test_allocatable_pointer_ambiguity()
+        !! gfortran.dg/generic_32.f90: ALLOCATABLE and POINTER do not distinguish
+        !! two specifics of the same type, kind and rank.
+        character(len=*), parameter :: source = &
+            'interface gen'//new_line('a')// &
+            '   subroutine suba(a)'//new_line('a')// &
+            '      real, allocatable :: a(:)'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            '   subroutine subp(p)'//new_line('a')// &
+            '      real, pointer, intent(in) :: p(:)'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'end'
+
+        test_allocatable_pointer_ambiguity = expect_error_contains( &
+            source, 'ambiguous interfaces', &
+            '/tmp/ffc_reject_generic_01_r10')
+    end function test_allocatable_pointer_ambiguity
+
+    logical function test_unlimited_polymorphic_ambiguity()
+        !! gfortran.dg/generic_34.f90: an unlimited polymorphic dummy is type
+        !! compatible with every actual argument, so it distinguishes nothing.
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '   type :: t'//new_line('a')// &
+            '   end type'//new_line('a')// &
+            '   interface sub'//new_line('a')// &
+            '      module procedure s1'//new_line('a')// &
+            '      module procedure s2'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine s1(x)'//new_line('a')// &
+            '      type(t) :: x'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            '   subroutine s2(x)'//new_line('a')// &
+            '      class(*), allocatable :: x'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module'
+
+        test_unlimited_polymorphic_ambiguity = expect_error_contains( &
+            source, 'ambiguous interfaces', &
+            '/tmp/ffc_reject_generic_01_r11')
+    end function test_unlimited_polymorphic_ambiguity
+
+    logical function test_generic_identifier_accepted()
+        !! Corrected neighbour of generic_29: a well formed GENERIC binding
+        !! passes this rule; what is left is the unrelated unsupported
+        !! type-bound procedure diagnostic, never a malformed-GENERIC one.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type :: t'//new_line('a')// &
+            '    integer :: n'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    generic :: g => f1, f2'//new_line('a')// &
+            '  end type t'//new_line('a')// &
+            '  type(t) :: x'//new_line('a')// &
+            '  x%n = 1'//new_line('a')// &
+            '  stop x%n'//new_line('a')// &
+            'end program main'
+
+        test_generic_identifier_accepted = expect_error_contains( &
+            source, 'type-bound procedure', &
+            '/tmp/ffc_reject_generic_01_wellformed')
+    end function test_generic_identifier_accepted
+
+    logical function test_distinguishable_implicit_interfaces()
+        !! Corrected neighbour of pr95584: implicit typing makes x real and n
+        !! integer, so the two interface bodies are distinguishable.
+        character(len=*), parameter :: source = &
+            'program p'//new_line('a')// &
+            '   interface s'//new_line('a')// &
+            '      subroutine g(x, *)'//new_line('a')// &
+            '      end subroutine'//new_line('a')// &
+            '      subroutine h(n, *)'//new_line('a')// &
+            '      end subroutine'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            '   print *, ''ok'''//new_line('a')// &
+            '   stop 0'//new_line('a')// &
+            'end program'
+
+        test_distinguishable_implicit_interfaces = expect_exit_status( &
+            source, 0, '/tmp/ffc_reject_generic_01_n2')
+    end function test_distinguishable_implicit_interfaces
+
+    logical function test_module_procedure_accepted()
+        !! Corrected neighbour of generic_14: MODULE PROCEDURE naming a real
+        !! module procedure is accepted.
+        character(len=*), parameter :: source = &
+            'module m3'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   interface gen'//new_line('a')// &
+            '      module procedure ok3'//new_line('a')// &
+            '   end interface gen'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine ok3(a)'//new_line('a')// &
+            '      integer, intent(in) :: a'//new_line('a')// &
+            '      print *, a'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'program p'//new_line('a')// &
+            '   use m3'//new_line('a')// &
+            '   call gen(5)'//new_line('a')// &
+            '   stop 0'//new_line('a')// &
+            'end program'
+
+        test_module_procedure_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_reject_generic_01_n3')
+    end function test_module_procedure_accepted
+
+    logical function test_distinct_generic_and_specific()
+        !! Corrected neighbour of invalid_procedure_name: the generic and its
+        !! specific have different names.
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   interface i1'//new_line('a')// &
+            '      module procedure s1'//new_line('a')// &
+            '   end interface i1'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine s1(i)'//new_line('a')// &
+            '      integer, intent(in) :: i'//new_line('a')// &
+            '      print *, i'//new_line('a')// &
+            '   end subroutine s1'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'program p'//new_line('a')// &
+            '   use m'//new_line('a')// &
+            '   call i1(9)'//new_line('a')// &
+            '   stop 0'//new_line('a')// &
+            'end program'
+
+        test_distinct_generic_and_specific = expect_exit_status( &
+            source, 0, '/tmp/ffc_reject_generic_01_q4')
+    end function test_distinct_generic_and_specific
+
+    logical function test_use_without_shadowing()
+        !! Corrected neighbour of interface_3: the used module exports no name
+        !! that clashes with the enclosing program unit.
+        character(len=*), parameter :: source = &
+            'module test_mod'//new_line('a')// &
+            '   interface'//new_line('a')// &
+            '      subroutine other_sub(a)'//new_line('a')// &
+            '         real a'//new_line('a')// &
+            '      end subroutine'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'module use_mod'//new_line('a')// &
+            '   use test_mod'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine my_sub(a)'//new_line('a')// &
+            '      real, intent(in) :: a'//new_line('a')// &
+            '      print *, a'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'program p'//new_line('a')// &
+            '   use use_mod'//new_line('a')// &
+            '   call my_sub(2.5)'//new_line('a')// &
+            '   stop 0'//new_line('a')// &
+            'end program'
+
+        test_use_without_shadowing = expect_exit_status( &
+            source, 0, '/tmp/ffc_reject_generic_01_q5')
+    end function test_use_without_shadowing
+
+    logical function test_unambiguous_use_association()
+        !! Corrected neighbour of generic_11: the two modules export different
+        !! names, so both references resolve.
+        character(len=*), parameter :: source = &
+            'module ma'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine foo_a()'//new_line('a')// &
+            '      print *, ''a'''//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'module mb'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   interface foo_b'//new_line('a')// &
+            '      module procedure bar_b'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine bar_b()'//new_line('a')// &
+            '      print *, ''b'''//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'program p'//new_line('a')// &
+            '   use ma'//new_line('a')// &
+            '   use mb'//new_line('a')// &
+            '   call foo_a'//new_line('a')// &
+            '   call foo_b'//new_line('a')// &
+            '   stop 0'//new_line('a')// &
+            'end program'
+
+        test_unambiguous_use_association = expect_exit_status( &
+            source, 0, '/tmp/ffc_reject_generic_01_n5')
+    end function test_unambiguous_use_association
+
+    logical function test_unrelated_derived_type_specifics()
+        !! Corrected neighbour of typebound_operator_14: specifics taking two
+        !! unrelated derived types stay distinguishable.
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   type :: alpha_t'//new_line('a')// &
+            '      integer :: i = 0'//new_line('a')// &
+            '   end type'//new_line('a')// &
+            '   type :: beta_t'//new_line('a')// &
+            '      real :: r = 0.0'//new_line('a')// &
+            '   end type'//new_line('a')// &
+            '   interface show'//new_line('a')// &
+            '      module procedure show_alpha'//new_line('a')// &
+            '      module procedure show_beta'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine show_alpha(a)'//new_line('a')// &
+            '      type(alpha_t), intent(in) :: a'//new_line('a')// &
+            '      print *, a%i'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            '   subroutine show_beta(b)'//new_line('a')// &
+            '      type(beta_t), intent(in) :: b'//new_line('a')// &
+            '      print *, b%r'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'program p'//new_line('a')// &
+            '   use m'//new_line('a')// &
+            '   type(alpha_t) :: a'//new_line('a')// &
+            '   type(beta_t) :: b'//new_line('a')// &
+            '   a%i = 1'//new_line('a')// &
+            '   b%r = 2.0'//new_line('a')// &
+            '   call show(a)'//new_line('a')// &
+            '   call show(b)'//new_line('a')// &
+            '   stop 0'//new_line('a')// &
+            'end program'
+
+        test_unrelated_derived_type_specifics = expect_exit_status( &
+            source, 0, '/tmp/ffc_reject_generic_01_q7')
+    end function test_unrelated_derived_type_specifics
+
+    logical function test_derived_type_assignment_accepted()
+        !! Corrected neighbour of redefined_intrinsic_assignment: assigning an
+        !! integer to a derived type is not an intrinsic assignment.
+        character(len=*), parameter :: source = &
+            'module m6'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   type :: pair_t'//new_line('a')// &
+            '      integer :: a = 0'//new_line('a')// &
+            '   end type'//new_line('a')// &
+            '   interface assignment(=)'//new_line('a')// &
+            '      module procedure pair_from_int'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine pair_from_int(p, i)'//new_line('a')// &
+            '      type(pair_t), intent(out) :: p'//new_line('a')// &
+            '      integer, intent(in) :: i'//new_line('a')// &
+            '      p%a = i'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'program p'//new_line('a')// &
+            '   use m6'//new_line('a')// &
+            '   type(pair_t) :: q'//new_line('a')// &
+            '   q = 4'//new_line('a')// &
+            '   print *, q%a'//new_line('a')// &
+            '   stop 0'//new_line('a')// &
+            'end program'
+
+        test_derived_type_assignment_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_reject_generic_01_n6')
+    end function test_derived_type_assignment_accepted
+
+    logical function test_generic_call_with_specific()
+        !! Corrected neighbour of generic_5: the actual argument matches the one
+        !! specific procedure.
+        character(len=*), parameter :: source = &
+            'module m7'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   interface pick'//new_line('a')// &
+            '      module procedure pick_i'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine pick_i(i)'//new_line('a')// &
+            '      integer, intent(in) :: i'//new_line('a')// &
+            '      print *, i'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'program p'//new_line('a')// &
+            '   use m7'//new_line('a')// &
+            '   call pick(23)'//new_line('a')// &
+            '   stop 0'//new_line('a')// &
+            'end program'
+
+        test_generic_call_with_specific = expect_exit_status( &
+            source, 0, '/tmp/ffc_reject_generic_01_n7')
+    end function test_generic_call_with_specific
+
+    logical function test_kind_distinguishable_specifics()
+        !! Corrected neighbour of generic_32 and generic_34: specifics differing
+        !! in declared type remain distinguishable.
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   interface gen'//new_line('a')// &
+            '      module procedure int_case'//new_line('a')// &
+            '      module procedure real_case'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine int_case(a)'//new_line('a')// &
+            '      integer, intent(in) :: a'//new_line('a')// &
+            '      print *, a'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            '   subroutine real_case(a)'//new_line('a')// &
+            '      real, intent(in) :: a'//new_line('a')// &
+            '      print *, a'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'program p'//new_line('a')// &
+            '   use m'//new_line('a')// &
+            '   call gen(3)'//new_line('a')// &
+            '   stop 0'//new_line('a')// &
+            'end program'
+
+        test_kind_distinguishable_specifics = expect_exit_status( &
+            source, 0, '/tmp/ffc_reject_generic_01_q10')
+    end function test_kind_distinguishable_specifics
+
+end program test_session_reject_generic_01_compiler


### PR DESCRIPTION
Closes #378.

## Preserved compiler invariant

A generic reference must resolve to exactly one specific procedure. Every
form that makes that impossible is now rejected with a rule-specific source
diagnostic, and no form that could be valid in some context is rejected.

Distinguishability (F2018 C1514) is now decided from a real dummy-argument
signature - declared type *with* its kind selector, rank, procedureness and
unlimited polymorphism - instead of scalar value kinds alone. So
ALLOCATABLE/POINTER arrays of the same type and rank, an unlimited
polymorphic dummy against a derived type, and two procedure dummies are
recognised as ambiguous, while kind- and rank-distinct specifics keep
resolving exactly as before.

Nine further forms never reach the typed AST intact (FortFront drops or
merges them), so they are validated from the source text - the earliest
layer that still holds them - with all type, kind and rank questions still
answered from the typed AST:

- a GENERIC binding with no generic specification or no binding list
- interface bodies of one generic whose dummies are all implicitly typed the same
- MODULE PROCEDURE naming an EXTERNAL, an interface body, or a generic name
- a generic name colliding with a procedure of the same scoping unit
- USE making accessible a name that is also the current program unit's name
- a name use associated from two modules and then referenced
- a type-bound generic indistinguishable from the one it inherits
- ASSIGNMENT(=) redefining an intrinsic type assignment
- a generic reference no specific procedure accepts

`test_session_operator_overload_compiler` encoded a non-conforming
`integer = integer` defined assignment; its left-hand side is now a derived
type, which is what F2018 C1503 permits. The test still checks the same
dispatch behaviour.

## Red evidence

On unmodified main, `fo test test_session_reject_generic_01_compiler`:

```
test_session_reject_generic_01_compiler    FAIL
   FAIL: unsupported source lowered without diagnostic     (x 10)
   FAIL: diagnostic did not contain "no specific subroutine"
Summary: 0 passed, 1 failed, 0 skipped
```

and the gauntlet selection:

```
PASS=0  XFAIL=0  XPASS=0  FAIL=13  NOREF=0  SKIP=0  TOTAL=13
```

## Green evidence

```
fo test test_session_reject_generic_01_compiler
  Summary: 1 passed, 0 failed, 0 skipped

scripts/conformance_gauntlet.sh --suite gfortran-dg --file generic_11.f90 ... --file typebound_operator_14.f90
  PASS=13  XFAIL=0  XPASS=0  FAIL=0  NOREF=0  SKIP=0  TOTAL=13
```

Full `fo`: Build OK, Static OK, tests green except `test_parity_dashboard`,
which fails identically on unmodified main (a dashboard-generation script
test over fixture data, unrelated to the compiler).

The 13 negative fixtures stay out of `test/conformance/xfail_gfortran_dg.txt`.