### PR TITLE
[proc-fixed-char-result-01] return fixed-length character function results (#410)

### DIFF
--- a/src/session_program_lowering_character.inc
+++ b/src/session_program_lowering_character.inc
@@ -17,6 +17,19 @@
                 ! other non-constant) keeps the deferred descriptor ABI: the
                 ! length is resolved when the body assigns the result value.
                 if (len_trim(error_msg) > 0) then
+                    ! F2018 10.1.11: a nonconstant result length must be a
+                    ! specification expression. A plain local variable of the
+                    ! same function is not one, so reject it instead of letting
+                    ! the deferred ABI silently invent a width (#410).
+                    if (result_length_is_local_variable(context, node)) then
+                        call unsupported_feature_error( &
+                            'character length declaration', node%line, &
+                            node%column, &
+                            'nonconstant character result length must be a '// &
+                            'specification expression: a local variable of '// &
+                            'the same procedure is not permitted', error_msg)
+                        return
+                    end if
                     if (runtime_character_length(context, node)) then
                         call resolve_len_of_character_length(context, node, &
                             source_index)
@@ -286,6 +299,33 @@
     ! length is only valid for a function result here, lowered through the
     ! deferred descriptor ABI: the actual width comes from the assigned result
     ! value, so the declared expression itself is never evaluated.
+    ! True when a function result's character length is written as a bare
+    ! identifier naming a local variable of the same procedure: not a dummy
+    ! argument, not a named constant, and not host- or module-associated
+    ! storage. Such a length is not a valid specification expression.
+    logical function result_length_is_local_variable(context, node)
+        type(lowering_context_t), intent(in) :: context
+        type(declaration_node), intent(in) :: node
+        character(len=:), allocatable :: expr
+        integer :: symbol_index
+
+        result_length_is_local_variable = .false.
+        if (.not. context%in_internal_function) return
+        if (.not. node%has_character_length) return
+        if (.not. allocated(node%character_length_expr)) return
+        expr = trim(adjustl(node%character_length_expr))
+        if (len(expr) == 0) return
+        if (verify(expr, &
+            'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_') &
+            /= 0) return
+        symbol_index = find_symbol_compat(context, expr)
+        if (symbol_index <= 0) return
+        if (context%symbols(symbol_index)%is_parameter) return
+        if (context%symbols(symbol_index)%has_i32_constant) return
+        if (symbol_has_global_storage(context%symbols(symbol_index))) return
+        result_length_is_local_variable = .true.
+    end function result_length_is_local_variable
+
     logical function runtime_character_length(context, node)
         type(lowering_context_t), intent(in) :: context
         type(declaration_node), intent(in) :: node

--- a/src/session_program_lowering_deferred_char.inc
+++ b/src/session_program_lowering_deferred_char.inc
@@ -95,6 +95,15 @@ integer function resolve_concat_operand(arena, node_index, context, &
         right_is_literal = .false.
         is_self_alias = .false.
 
+        ! A fixed-length result (character(len=N) :: s) uses the descriptor
+        ! return ABI but keeps its declared width: the concatenated value pads
+        ! with blanks or truncates to N instead of taking the operand sum.
+        if (context%symbols(dest_symbol_index)%character_length > 0) then
+            call lower_fixed_width_deferred_concat(arena, node, context, &
+                                                   dest_symbol_index, error_msg)
+            return
+        end if
+
         ! Get the binary // operands from the assignment value.
         if (.not. is_binary_op(arena, node%value_index)) then
             error_msg = 'expected binary // operator for deferred character '// &
@@ -273,6 +282,77 @@ integer function resolve_concat_operand(arena, node_index, context, &
         call set_empty(error_msg)
     end subroutine lower_deferred_concat_assignment
 
+    subroutine lower_fixed_width_deferred_concat(arena, node, context, &
+                                                 dest_symbol_index, error_msg)
+        ! Concatenate into a descriptor-returned destination whose declared
+        ! length is fixed (character(len=N)). The buffer is exactly N content
+        ! bytes plus a trailing null, blank-filled first so a short chain pads
+        ! and an over-long one truncates. The descriptor records N, so LEN and
+        ! the printed bytes match a fixed-length result under gfortran.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(ast_arena_t), intent(in) :: arena
+        type(assignment_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: dest_symbol_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t), allocatable :: data_ops(:), len_ops(:)
+        integer, allocatable :: stat_len(:)
+        type(lr_operand_desc_t) :: buf, offset, null_ptr, size_op
+        character(len=64) :: null_name
+        integer :: count, dest_len
+
+        call set_empty(error_msg)
+        dest_len = context%symbols(dest_symbol_index)%character_length
+        allocate (data_ops(64), len_ops(64), stat_len(64))
+        count = 0
+        call collect_concat_operands(arena, node%value_index, context, data_ops, &
+                                     len_ops, stat_len, count, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (count == 0) then
+            error_msg = 'character concatenation has no operands'
+            return
+        end if
+
+        size_op = i64_immediate(context%session, int(dest_len + 1, c_int64_t))
+        if (context%in_internal_function .and. &
+            dest_symbol_index == context%current_function_result_index) then
+            ! The result outlives the callee frame, so its storage is owned
+            ! heap memory the caller copies from and releases.
+            if (.not. emit_malloc(context%session, size_op, buf, error_msg)) return
+        else
+            if (.not. emit_alloca_bytes(context%session, size_op, buf, &
+                error_msg)) return
+        end if
+        call fill_spaces(context, buf, &
+            i32_immediate(context%session, int(dest_len, c_int64_t)), error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        call emit_concat_copies(context, data_ops, len_ops, stat_len, count, &
+                                dest_len, buf, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        if (.not. emit_i64_binary(context%session, LR_OP_ADD, buf, &
+            i64_immediate(context%session, int(dest_len, c_int64_t)), offset, &
+            error_msg)) return
+        context%string_literal_count = context%string_literal_count + 1
+        null_name = ffc_unit_global_name( &
+            context, 'dfcat.term.', context%string_literal_count)
+        call materialize_liric_string(context%session, trim(null_name), '', &
+                                      null_ptr, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_memcpy(context%session, offset, null_ptr, &
+            i64_immediate(context%session, 1_c_int64_t), error_msg)) return
+
+        if (.not. emit_ptr_store(context%session, buf, &
+            context%symbols(dest_symbol_index)%deferred_data, error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+            i64_immediate(context%session, int(dest_len, c_int64_t)), &
+            context%symbols(dest_symbol_index)%deferred_length, error_msg)) return
+
+        context%symbols(dest_symbol_index)%value = buf
+        context%symbols(dest_symbol_index)%has_character_value = .true.
+    end subroutine lower_fixed_width_deferred_concat
+
     subroutine materialize_concat_literal(context, text, data_op, len_op, &
                                           error_msg)
         use, intrinsic :: iso_c_binding, only: c_int64_t
@@ -324,7 +404,12 @@ integer function resolve_concat_operand(arena, node_index, context, &
         fixed_length = context%symbols(dest_symbol_index)%character_length
         if (fixed_length > 0) then
             allocate (character(len=fixed_length) :: stored_text)
-            stored_text = literal_text
+            ! stored_text is deferred-length allocatable, so a whole-variable
+            ! assignment would reallocate it to the literal's own length and
+            ! drop the blank padding. Assign through a substring reference so
+            ! the declared width N is preserved: shorter literals pad with
+            ! blanks, longer ones truncate.
+            stored_text(1:fixed_length) = literal_text
             call materialize_concat_literal(context, stored_text, data_op, &
                                             len_op, error_msg)
         else

--- a/test/test_session_fixed_char_function_result_compiler.f90
+++ b/test/test_session_fixed_char_function_result_compiler.f90
@@ -1,0 +1,202 @@
+program test_session_fixed_char_function_result_compiler
+    ! #410: a fixed-length CHARACTER function result (character(len=N) :: s)
+    ! returns exactly its declared length N. A shorter value pads with blanks,
+    ! a longer one truncates, embedded blanks survive, and LEN of the result is
+    ! N. Each program's LEN and printed bytes must match gfortran. The negative
+    ! case checks that a nonconstant result length taken from a local variable
+    ! is rejected as an invalid specification expression.
+    use session_program_lowering, only: lower_program_to_liric_exe
+    use fortfront_compiler, only: compiler_frontend_options_t, &
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session fixed-length character result compiler test ==='
+
+    all_passed = .true.
+
+    ! A value shorter than the declared length pads with blanks; LEN is N.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  character(len=8) :: r'//new_line('a')// &
+        '  r = short()'//new_line('a')// &
+        '  print *, len(r), "[", r, "]"'//new_line('a')// &
+        '  print *, len(short()), "[", short(), "]"'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function short() result(s)'//new_line('a')// &
+        '    character(len=8) :: s'//new_line('a')// &
+        '    s = "Hi"'//new_line('a')// &
+        '  end function short'//new_line('a')// &
+        'end program main', &
+        'pad_short')) all_passed = .false.
+
+    ! A value of exactly the declared length is returned unchanged.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  print *, len(exact()), "[", exact(), "]"'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function exact() result(s)'//new_line('a')// &
+        '    character(len=3) :: s'//new_line('a')// &
+        '    s = "abc"'//new_line('a')// &
+        '  end function exact'//new_line('a')// &
+        'end program main', &
+        'exact')) all_passed = .false.
+
+    ! A longer value truncates to the declared length.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  print *, len(trunc()), "[", trunc(), "]"'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function trunc() result(s)'//new_line('a')// &
+        '    character(len=4) :: s'//new_line('a')// &
+        '    s = "abcdefgh"'//new_line('a')// &
+        '  end function trunc'//new_line('a')// &
+        'end program main', &
+        'truncate')) all_passed = .false.
+
+    ! A concatenated value pads to the declared length and keeps embedded
+    ! blanks.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  character(len=12) :: r'//new_line('a')// &
+        '  r = embed("a b")'//new_line('a')// &
+        '  print *, len(r), "[", r, "]"'//new_line('a')// &
+        '  print *, len(embed("a b")), "[", embed("a b"), "]"'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function embed(x) result(s)'//new_line('a')// &
+        '    character(len=*), intent(in) :: x'//new_line('a')// &
+        '    character(len=12) :: s'//new_line('a')// &
+        '    s = x // "  c"'//new_line('a')// &
+        '  end function embed'//new_line('a')// &
+        'end program main', &
+        'concat_pad')) all_passed = .false.
+
+    ! Negative: a result length taken from a local variable is not a valid
+    ! specification expression and must be diagnosed, not silently lowered.
+    if (.not. rejects_lowering( &
+        'program main'//new_line('a')// &
+        '  print *, bad()'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function bad() result(s)'//new_line('a')// &
+        '    integer :: n'//new_line('a')// &
+        '    character(len=n) :: s'//new_line('a')// &
+        '    s = "abc"'//new_line('a')// &
+        '  end function bad'//new_line('a')// &
+        'end program main', &
+        'local_length')) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: fixed-length character results keep their declared length'
+
+contains
+
+    logical function matches_gfortran(source, stem)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: stem
+        type(compiler_frontend_result_t) :: frontend_result
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: base, src, exe, ref, ffc_out, ref_out
+        integer :: unit, exit_stat, status
+
+        matches_gfortran = .false.
+        base = '/tmp/ffc_fixedcharfn_'//trim(stem)
+        src = base//'.f90'
+        exe = base//'.ffc'
+        ref = base//'.gf'
+        ffc_out = base//'.ffc.out'
+        ref_out = base//'.gf.out'
+
+        if (.not. lower_source(source, stem, exe, frontend_result, error_msg)) &
+            return
+
+        open (newunit=unit, file=src, status='replace', action='write')
+        write (unit, '(A)') source
+        close (unit)
+        call execute_command_line('gfortran -w '//src//' -o '//ref, &
+            exitstat=exit_stat)
+        if (exit_stat /= 0) then
+            print *, 'FAIL[', trim(stem), ']: gfortran rejected source'
+            return
+        end if
+
+        call execute_command_line(exe//' > '//ffc_out//' 2>&1', exitstat=exit_stat)
+        call execute_command_line(ref//' > '//ref_out//' 2>&1', exitstat=exit_stat)
+        call execute_command_line('diff '//ffc_out//' '//ref_out// &
+            ' > /dev/null 2>&1', exitstat=status)
+        if (status /= 0) then
+            print *, 'FAIL[', trim(stem), ']: ffc output differs from gfortran'
+            call execute_command_line('diff '//ffc_out//' '//ref_out)
+            return
+        end if
+        call execute_command_line('rm -f '//src//' '//exe//' '//ref// &
+            ' '//ffc_out//' '//ref_out)
+        matches_gfortran = .true.
+    end function matches_gfortran
+
+    logical function rejects_lowering(source, stem)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: stem
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: frontend_result
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: exe
+
+        rejects_lowering = .false.
+        exe = '/tmp/ffc_fixedcharfn_'//trim(stem)//'.ffc'
+
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        call compile_frontend_from_string(source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            rejects_lowering = .true.
+            return
+        end if
+
+        call lower_program_to_liric_exe(frontend_result%arena, &
+            frontend_result%root_index, exe, error_msg)
+        if (len_trim(error_msg) == 0) then
+            print *, 'FAIL[', trim(stem), ']: invalid result length was accepted'
+            return
+        end if
+        if (index(error_msg, 'specification expression') == 0) then
+            print *, 'FAIL[', trim(stem), ']: unexpected diagnostic: ', &
+                trim(error_msg)
+            return
+        end if
+        rejects_lowering = .true.
+    end function rejects_lowering
+
+    logical function lower_source(source, stem, exe, frontend_result, error_msg)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: stem
+        character(len=*), intent(in) :: exe
+        type(compiler_frontend_result_t), intent(out) :: frontend_result
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(compiler_frontend_options_t) :: options
+
+        lower_source = .false.
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        call compile_frontend_from_string(source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            print *, 'FAIL[', trim(stem), ']: FortFront rejected source: ', &
+                trim(frontend_result%diagnostic_text)
+            return
+        end if
+
+        call lower_program_to_liric_exe(frontend_result%arena, &
+            frontend_result%root_index, exe, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL[', trim(stem), ']: ffc lowering failed: ', &
+                trim(error_msg)
+            return
+        end if
+        lower_source = .true.
+    end function lower_source
+
+end program test_session_fixed_char_function_result_compiler


### PR DESCRIPTION
Closes #410.

## Preserved compiler invariant

A fixed-length CHARACTER function result (`character(len=N) :: s`) travels
through the canonical `{data, length}` descriptor return ABI, but its
descriptor length is always the declared width `N` — never the width of the
value that happened to be assigned. Shorter values pad with blanks, longer
values truncate, embedded blanks survive, and result storage is still
heap-owned when it is the function result, so the caller's copy-and-release
path is unchanged.

## Bugs fixed

- The literal-assignment path padded into a `character(len=:), allocatable`
  buffer and then did a whole-variable assignment, which reallocated the
  buffer to the literal's own length and dropped the padding. It now assigns
  through a substring reference.
- The concatenation-assignment path sized the destination from the operand
  sum, so a short chain never padded and an over-long one never truncated.
  A fixed-width destination now blank-fills an `N`-byte buffer, copies
  operands clamped to `N`, and records `N` in the descriptor.
- A nonconstant result length naming a plain local variable of the same
  procedure was silently absorbed by the deferred ABI. It is not a
  specification expression (F2018 10.1.11) and is now diagnosed.

## Red evidence (new test on unmodified sources)

```
FAIL[pad_short]: ffc output differs from gfortran
<            8 [Hi]          >            8 [Hi      ]
<            2 [Hi]          >            8 [Hi      ]
FAIL[truncate]: ffc output differs from gfortran
<            8 [abcdefgh]    >            4 [abcd]
FAIL[concat_pad]: ffc output differs from gfortran
<           12 [a b  c]      >           12 [a b  c      ]
FAIL[local_length]: invalid result length was accepted
```

## Green evidence

```
test_session_fixed_char_function_result_co PASS       0.62s
```

Plus the neighbouring character-result suites
(`test_session_character_function_result_compiler`,
`test_session_char_result_compare_compiler`,
`test_session_module_char_result_compiler`,
`test_session_character_fixed_ops_compiler`,
`test_session_deferred_char_compiler`) all pass.

Full `fo` pipeline: Static OK, Build OK, suite green except
`test_parity_dashboard`, which fails identically on unmodified `origin/main`
in this environment (verified in a clean baseline worktree), and
`test_conformance_gauntlet_smoke`, which is flaky under concurrent runs
sharing fixed `/tmp` paths and passes on rerun.