### PR TITLE
[reject-array-01] reject invalid array indexing and shape expressions (#386)

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -2617,6 +2617,7 @@ contains
     include 'session_program_lowering_diagnostics.inc'
     include 'session_program_lowering_reject_checks.inc'
     include 'session_program_lowering_reject_array_ctor.inc'
+    include 'session_program_lowering_reject_array_shape.inc'
     include 'session_program_lowering_reject_pointer.inc'
     include 'session_program_lowering_reject_const_init.inc'
     include 'session_program_lowering_reject_storage.inc'

--- a/src/session_program_lowering_reject_array_shape.inc
+++ b/src/session_program_lowering_reject_array_shape.inc
@@ -1,0 +1,496 @@
+    ! Array indexing and shape-expression validation (F2018 9.5.3, 10.2.4,
+    ! 11.1.7.4, C1010).
+    !
+    ! Four constraints of one family are enforced here, all before lowering:
+    !   * a section-subscript or FORALL stride must not be zero,
+    !   * a FORALL mask-expr must be a scalar LOGICAL expression,
+    !   * a format specified as a character entity must not be a zero-sized
+    !     array,
+    !   * a pointer initialization target must be a named entity with the
+    !     TARGET attribute, never a function or intrinsic result.
+    !
+    ! The stride rule runs twice: once over the typed nodes, so that a stride
+    ! that folds to zero through a named constant is caught, and once over the
+    ! source form, so that a literal zero stride is still rejected in a scope
+    ! whose declarations the parser did not retain.
+
+    subroutine check_array_shape_expressions(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call set_empty(error_msg)
+        call check_zero_stride_nodes(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_zero_stride_source(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_forall_mask_scalar(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_zero_sized_format(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_pointer_init_targets(arena, error_msg)
+    end subroutine check_array_shape_expressions
+
+    ! A section subscript triplet stride whose constant value is zero is
+    ! invalid: the section would have no defined extent.
+    subroutine check_zero_stride_nodes(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n, d, bidx
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (array_slice_node)
+                do d = 1, min(nd%num_dimensions, size(nd%bounds_indices))
+                    bidx = nd%bounds_indices(d)
+                    call check_stride_node(arena, bidx, nd%line, nd%column, &
+                                           error_msg)
+                    if (len_trim(error_msg) > 0) return
+                end do
+            type is (forall_node)
+                if (.not. allocated(nd%stride_indices)) cycle
+                do d = 1, size(nd%stride_indices)
+                    call check_stride_value(arena, nd%stride_indices(d), &
+                                            nd%line, nd%column, error_msg)
+                    if (len_trim(error_msg) > 0) return
+                end do
+            end select
+        end do
+    end subroutine check_zero_stride_nodes
+
+    subroutine check_stride_node(arena, bounds_index, line, col, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: bounds_index
+        integer, intent(in) :: line, col
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call set_empty(error_msg)
+        if (bounds_index <= 0) return
+        if (.not. node_exists(arena, bounds_index)) return
+        select type (bd => arena%entries(bounds_index)%node)
+        type is (range_expression_node)
+            call check_stride_value(arena, bd%stride_index, line, col, error_msg)
+        type is (array_bounds_node)
+            call check_stride_value(arena, bd%stride_index, line, col, error_msg)
+        end select
+    end subroutine check_stride_node
+
+    subroutine check_stride_value(arena, stride_index, line, col, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: stride_index
+        integer, intent(in) :: line, col
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=64) :: location
+        integer(c_int64_t) :: value
+        logical :: ok
+
+        call set_empty(error_msg)
+        if (stride_index <= 0) return
+        if (.not. node_exists(arena, stride_index)) return
+        call try_const_int64(arena, stride_index, value, ok)
+        if (.not. ok) call try_named_constant_int64(arena, stride_index, value, ok)
+        if (.not. ok) return
+        if (value /= 0_c_int64_t) return
+        write (location, '(" at line ",I0,", column ",I0)') line, col
+        error_msg = 'Illegal stride of zero'//trim(location)
+    end subroutine check_stride_value
+
+    ! Fold a reference to a named constant whose initializer is itself a
+    ! constant integer expression.
+    subroutine try_named_constant_int64(arena, idx, value, ok)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        integer(c_int64_t), intent(out) :: value
+        logical, intent(out) :: ok
+        character(len=:), allocatable :: wanted
+        integer :: n
+
+        value = 0_c_int64_t
+        ok = .false.
+        if (idx <= 0) return
+        if (.not. node_exists(arena, idx)) return
+        select type (nd => arena%entries(idx)%node)
+        type is (identifier_node)
+            wanted = trim(lowercase_text(nd%name))
+        class default
+            return
+        end select
+        if (len(wanted) == 0) return
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (declaration_node)
+                if (.not. nd%is_parameter) cycle
+                if (nd%is_array) cycle
+                if (.not. nd%has_initializer) cycle
+                if (nd%initializer_index <= 0) cycle
+                if (.not. allocated(nd%var_name)) cycle
+                if (trim(lowercase_text(nd%var_name)) /= wanted) cycle
+                call try_const_int64(arena, nd%initializer_index, value, ok)
+                return
+            end select
+        end do
+    end subroutine try_named_constant_int64
+
+    ! Source-form backstop for the stride rule. A triplet whose third part is a
+    ! literal zero is invalid however the enclosing statement parsed.
+    subroutine check_zero_stride_source(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: source, line, code
+        character(len=64) :: location
+        integer :: pos, next_nl, line_no
+        logical :: found
+
+        call set_empty(error_msg)
+        call get_source_text(arena, source, found)
+        if (.not. found) return
+        pos = 1
+        line_no = 0
+        do while (pos <= len(source))
+            next_nl = index(source(pos:), new_line('a'))
+            if (next_nl == 0) then
+                line = source(pos:)
+                pos = len(source) + 1
+            else
+                line = source(pos:pos + next_nl - 2)
+                pos = pos + next_nl
+            end if
+            line_no = line_no + 1
+            code = blank_strings_and_comment(line)
+            if (line_has_zero_stride(code)) then
+                write (location, '(" at line ",I0)') line_no
+                error_msg = 'Illegal stride of zero'//trim(location)
+                return
+            end if
+        end do
+    end subroutine check_zero_stride_source
+
+    ! Replace character-literal contents and any trailing comment by blanks so
+    ! that only executable punctuation survives.
+    function blank_strings_and_comment(line) result(code)
+        character(len=*), intent(in) :: line
+        character(len=:), allocatable :: code
+        character(len=1) :: quote
+        integer :: i
+        logical :: in_string
+
+        code = line
+        in_string = .false.
+        quote = ' '
+        do i = 1, len(line)
+            if (in_string) then
+                code(i:i) = ' '
+                if (line(i:i) == quote) in_string = .false.
+            else if (line(i:i) == '''' .or. line(i:i) == '"') then
+                quote = line(i:i)
+                in_string = .true.
+                code(i:i) = ' '
+            else if (line(i:i) == '!') then
+                code(i:) = ' '
+                return
+            end if
+        end do
+    end function blank_strings_and_comment
+
+    ! Only a parenthesised list that directly follows a name can hold section
+    ! subscripts or a FORALL triplet; array constructors and control-statement
+    ! parentheses are skipped.
+    logical function line_has_zero_stride(code) result(found)
+        character(len=*), intent(in) :: code
+        integer :: i, j, depth
+
+        found = .false.
+        i = 2
+        do while (i <= len(code))
+            if (code(i:i) == '(') then
+                if (is_fortran_identifier_char(code(i - 1:i - 1))) then
+                    depth = 0
+                    j = i
+                    do while (j <= len(code))
+                        if (code(j:j) == '(') depth = depth + 1
+                        if (code(j:j) == ')') then
+                            depth = depth - 1
+                            if (depth == 0) exit
+                        end if
+                        j = j + 1
+                    end do
+                    if (j > len(code)) return
+                    if (j > i + 1) then
+                        found = group_has_zero_stride(code(i + 1:j - 1))
+                        if (found) return
+                    end if
+                    i = j
+                end if
+            end if
+            i = i + 1
+        end do
+    end function line_has_zero_stride
+
+    logical function group_has_zero_stride(inner) result(found)
+        character(len=*), intent(in) :: inner
+        integer :: i, depth, start
+
+        found = .false.
+        depth = 0
+        start = 1
+        do i = 1, len(inner)
+            if (inner(i:i) == '(' .or. inner(i:i) == '[') depth = depth + 1
+            if (inner(i:i) == ')' .or. inner(i:i) == ']') depth = depth - 1
+            if (inner(i:i) == ',' .and. depth == 0) then
+                if (i > start) found = part_has_zero_stride(inner(start:i - 1))
+                if (found) return
+                start = i + 1
+            end if
+        end do
+        if (len(inner) >= start) found = part_has_zero_stride(inner(start:))
+    end function group_has_zero_stride
+
+    logical function part_has_zero_stride(part) result(found)
+        character(len=*), intent(in) :: part
+        integer :: i, depth, ncolon, second
+
+        found = .false.
+        if (index(part, '::') > 0) return
+        depth = 0
+        ncolon = 0
+        second = 0
+        do i = 1, len(part)
+            if (part(i:i) == '(' .or. part(i:i) == '[') depth = depth + 1
+            if (part(i:i) == ')' .or. part(i:i) == ']') depth = depth - 1
+            if (part(i:i) == ':' .and. depth == 0) then
+                ncolon = ncolon + 1
+                if (ncolon == 2) second = i
+            end if
+        end do
+        if (ncolon /= 2) return
+        if (second >= len(part)) return
+        found = is_zero_literal(part(second + 1:))
+    end function part_has_zero_stride
+
+    logical function is_zero_literal(text) result(is_zero)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: body
+        integer :: i
+
+        is_zero = .false.
+        body = trim(adjustl(text))
+        if (len(body) == 0) return
+        if (body(1:1) == '+' .or. body(1:1) == '-') body = body(2:)
+        if (len(body) == 0) return
+        do i = 1, len(body)
+            if (body(i:i) /= '0') return
+        end do
+        is_zero = .true.
+    end function is_zero_literal
+
+    ! F2018 11.1.7.4: the FORALL mask-expr is a scalar logical expression. A
+    ! whole array reference in that position is invalid.
+    subroutine check_forall_mask_scalar(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=64) :: location
+        integer :: n
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (forall_node)
+                if (.not. nd%has_mask) cycle
+                if (nd%mask_expr_index <= 0) cycle
+                if (.not. expr_is_array_valued(arena, nd%mask_expr_index)) cycle
+                write (location, '(" at line ",I0,", column ",I0)') &
+                    nd%line, nd%column
+                error_msg = 'FORALL mask requires a scalar LOGICAL '// &
+                    'expression'//trim(location)
+                return
+            end select
+        end do
+    end subroutine check_forall_mask_scalar
+
+    logical function expr_is_array_valued(arena, idx) result(is_array)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        logical :: found, is_target, zero_sized
+
+        is_array = .false.
+        if (idx <= 0) return
+        if (.not. node_exists(arena, idx)) return
+        select type (nd => arena%entries(idx)%node)
+        type is (array_literal_node)
+            is_array = .true.
+        type is (identifier_node)
+            call named_declaration_facts(arena, nd%name, found, is_array, &
+                                         is_target, zero_sized)
+            if (.not. found) is_array = .false.
+        end select
+    end function expr_is_array_valued
+
+    ! F2018 12.6.2.2: a format given as a character entity supplies the format
+    ! string; a zero-sized array carries no format at all.
+    subroutine check_zero_sized_format(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=64) :: location
+        integer :: n
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (print_statement_node)
+                if (.not. allocated(nd%format_spec)) cycle
+                if (.not. named_format_is_zero_sized(arena, nd%format_spec)) cycle
+                write (location, '(" at line ",I0,", column ",I0)') &
+                    nd%line, nd%column
+                error_msg = 'format specifier is a zero-sized array'// &
+                    trim(location)
+                return
+            end select
+        end do
+    end subroutine check_zero_sized_format
+
+    logical function named_format_is_zero_sized(arena, spec) result(is_zero)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: spec
+        character(len=:), allocatable :: name
+        logical :: found, is_array, is_target
+        integer :: i
+
+        is_zero = .false.
+        name = trim(adjustl(spec))
+        if (len(name) == 0) return
+        do i = 1, len(name)
+            if (.not. is_fortran_identifier_char(name(i:i))) return
+        end do
+        if (scan(name(1:1), '0123456789_') /= 0) return
+        call named_declaration_facts(arena, name, found, is_array, is_target, &
+                                     is_zero)
+        if (.not. found) is_zero = .false.
+        if (.not. is_array) is_zero = .false.
+    end function named_format_is_zero_sized
+
+    ! F2018 C1010: the target of a pointer initialization must be a named
+    ! entity with the TARGET or POINTER attribute and the SAVE attribute; a
+    ! function or intrinsic result never qualifies.
+    subroutine check_pointer_init_targets(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=64) :: location
+        integer :: n
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (declaration_node)
+                if (.not. nd%is_pointer) cycle
+                if (.not. nd%has_initializer) cycle
+                if (nd%initializer_index <= 0) cycle
+                if (pointer_init_target_ok(arena, nd%initializer_index)) cycle
+                write (location, '(" at line ",I0,", column ",I0)') &
+                    nd%line, nd%column
+                error_msg = 'pointer initialization target does not have '// &
+                    'the TARGET attribute'//trim(location)
+                return
+            end select
+        end do
+    end subroutine check_pointer_init_targets
+
+    logical function pointer_init_target_ok(arena, idx) result(ok)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+
+        ok = .true.
+        if (idx <= 0) return
+        if (.not. node_exists(arena, idx)) return
+        select type (nd => arena%entries(idx)%node)
+        type is (identifier_node)
+            ok = named_target_ok(arena, nd%name)
+        type is (call_or_subscript_node)
+            ok = named_target_ok(arena, nd%name)
+        end select
+    end function pointer_init_target_ok
+
+    logical function named_target_ok(arena, name) result(ok)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        logical :: found, is_array, is_target, zero_sized
+
+        ok = .true.
+        if (len_trim(name) == 0) return
+        if (trim(lowercase_text(name)) == 'null') return
+        call named_declaration_facts(arena, name, found, is_array, is_target, &
+                                     zero_sized)
+        if (.not. found) then
+            ! No declared entity of that name: the initializer references a
+            ! function or intrinsic, whose result is never a valid target.
+            ok = .false.
+            return
+        end if
+        ok = is_target
+    end function named_target_ok
+
+    ! Collect the attributes of the declaration of NAME anywhere in the unit.
+    subroutine named_declaration_facts(arena, name, found, is_array, is_target, &
+                                       zero_sized)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        logical, intent(out) :: found, is_array, is_target, zero_sized
+        character(len=:), allocatable :: wanted
+        integer :: n, v
+
+        found = .false.
+        is_array = .false.
+        is_target = .false.
+        zero_sized = .false.
+        wanted = trim(lowercase_text(name))
+        if (len(wanted) == 0) return
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (declaration_node)
+                if (nd%is_multi_declaration) then
+                    if (.not. allocated(nd%var_names)) cycle
+                    found = .false.
+                    do v = 1, size(nd%var_names)
+                        if (trim(lowercase_text(nd%var_names(v))) == wanted) then
+                            found = .true.
+                        end if
+                    end do
+                    if (.not. found) cycle
+                else
+                    if (.not. allocated(nd%var_name)) cycle
+                    if (trim(lowercase_text(nd%var_name)) /= wanted) cycle
+                    found = .true.
+                end if
+                is_array = nd%is_array
+                is_target = nd%is_target .or. nd%is_pointer
+                zero_sized = declaration_is_zero_sized(arena, nd)
+                return
+            end select
+        end do
+    end subroutine named_declaration_facts
+
+    logical function declaration_is_zero_sized(arena, decl) result(is_zero)
+        type(ast_arena_t), intent(in) :: arena
+        type(declaration_node), intent(in) :: decl
+        integer(c_int64_t) :: value
+        logical :: ok
+        integer :: d
+
+        is_zero = .false.
+        if (.not. decl%is_array) return
+        if (.not. allocated(decl%dimension_indices)) return
+        do d = 1, size(decl%dimension_indices)
+            if (decl%dimension_indices(d) <= 0) cycle
+            call try_const_int64(arena, decl%dimension_indices(d), value, ok)
+            if (.not. ok) cycle
+            if (value == 0_c_int64_t) then
+                is_zero = .true.
+                return
+            end if
+        end do
+    end function declaration_is_zero_sized

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -564,6 +564,8 @@
         if (len_trim(error_msg) > 0) return
         call check_namelist_members(arena, error_msg)
         if (len_trim(error_msg) > 0) return
+        call check_array_shape_expressions(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
         call set_empty(error_msg)
     end subroutine validate_program
     subroutine lower_program_return(arena, root_index, context, value, error_msg)

--- a/test/test_session_reject_array_01_compiler.f90
+++ b/test/test_session_reject_array_01_compiler.f90
@@ -1,0 +1,157 @@
+program test_session_reject_array_01_compiler
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== invalid array indexing and shape rejection compiler test ==='
+
+    all_passed = .true.
+    if (.not. test_zero_stride_literal_rejected()) all_passed = .false.
+    if (.not. test_zero_stride_named_constant_rejected()) all_passed = .false.
+    if (.not. test_nonzero_stride_accepted()) all_passed = .false.
+    if (.not. test_array_forall_mask_rejected()) all_passed = .false.
+    if (.not. test_scalar_forall_mask_accepted()) all_passed = .false.
+    if (.not. test_zero_sized_format_rejected()) all_passed = .false.
+    if (.not. test_sized_format_accepted()) all_passed = .false.
+    if (.not. test_pointer_init_to_function_rejected()) all_passed = .false.
+    if (.not. test_pointer_init_to_target_accepted()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: invalid strides, FORALL masks, zero-sized formats and '// &
+        'pointer initialization targets rejected'
+
+contains
+
+    logical function test_zero_stride_literal_rejected()
+        ! F2018 9.5.3.3: a section subscript stride must not be zero.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, parameter :: a(10) = 0'//new_line('a')// &
+            '  integer, parameter :: b(10) = a(1:10:0)'//new_line('a')// &
+            '  print *, b'//new_line('a')// &
+            'end program main'
+
+        test_zero_stride_literal_rejected = expect_error_contains( &
+            source, 'Illegal stride of zero', &
+            '/tmp/ffc_session_zero_stride_reject')
+    end function test_zero_stride_literal_rejected
+
+    logical function test_zero_stride_named_constant_rejected()
+        ! The same rule holds when the stride folds to zero via a constant.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, parameter :: s = 0'//new_line('a')// &
+            '  integer :: a(10)'//new_line('a')// &
+            '  a = 0'//new_line('a')// &
+            '  print *, a(1:10:s)'//new_line('a')// &
+            'end program main'
+
+        test_zero_stride_named_constant_rejected = expect_error_contains( &
+            source, 'Illegal stride of zero', &
+            '/tmp/ffc_session_zero_stride_const_reject')
+    end function test_zero_stride_named_constant_rejected
+
+    logical function test_nonzero_stride_accepted()
+        ! The corrected neighbour: a stride of one still compiles and runs.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(10), b(10)'//new_line('a')// &
+            '  a = 3'//new_line('a')// &
+            '  b = a(1:10:1)'//new_line('a')// &
+            '  if (b(4) /= 3) stop 2'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_nonzero_stride_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_session_stride_one_accept')
+    end function test_nonzero_stride_accepted
+
+    logical function test_array_forall_mask_rejected()
+        ! F2018 11.1.7.4: the FORALL mask-expr is a scalar logical expression.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  logical :: valid(4) = (/ .true., .true., .false., .true. /)'// &
+            new_line('a')// &
+            '  real :: vec(4)'//new_line('a')// &
+            '  integer :: j'//new_line('a')// &
+            '  forall (j = 1:4, valid)'//new_line('a')// &
+            '     vec(j) = real(j)'//new_line('a')// &
+            '  end forall'//new_line('a')// &
+            'end program main'
+
+        test_array_forall_mask_rejected = expect_error_contains( &
+            source, 'scalar LOGICAL', '/tmp/ffc_session_forall_mask_reject')
+    end function test_array_forall_mask_rejected
+
+    logical function test_scalar_forall_mask_accepted()
+        ! The corrected neighbour: a scalar mask over the FORALL index.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  real :: vec(4)'//new_line('a')// &
+            '  integer :: j'//new_line('a')// &
+            '  vec = 0.0'//new_line('a')// &
+            '  forall (j = 1:4, j > 2)'//new_line('a')// &
+            '     vec(j) = real(j)'//new_line('a')// &
+            '  end forall'//new_line('a')// &
+            '  if (vec(3) /= 3.0) stop 2'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_scalar_forall_mask_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_session_forall_mask_accept')
+    end function test_scalar_forall_mask_accepted
+
+    logical function test_zero_sized_format_rejected()
+        ! A character format specifier must carry a format; a zero-sized array
+        ! carries none.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(3), parameter :: a(0) = [character(3)::]'// &
+            new_line('a')// &
+            '  print a'//new_line('a')// &
+            'end program main'
+
+        test_zero_sized_format_rejected = expect_error_contains( &
+            source, 'zero-sized array', '/tmp/ffc_session_zero_format_reject')
+    end function test_zero_sized_format_rejected
+
+    logical function test_sized_format_accepted()
+        ! The corrected neighbour: a one-element format array is usable.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            "  character(6), parameter :: a(1) = ['(a)   ']"//new_line('a')// &
+            "  print a, 'ok'"//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_sized_format_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_session_sized_format_accept')
+    end function test_sized_format_accepted
+
+    logical function test_pointer_init_to_function_rejected()
+        ! F2018 C1010: a pointer initialization target must be a named entity
+        ! with the TARGET attribute, never an intrinsic result.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, pointer :: y(:) => shape(1)'//new_line('a')// &
+            'end program main'
+
+        test_pointer_init_to_function_rejected = expect_error_contains( &
+            source, 'TARGET attribute', '/tmp/ffc_session_ptr_init_reject')
+    end function test_pointer_init_to_function_rejected
+
+    logical function test_pointer_init_to_target_accepted()
+        ! The corrected neighbour: a pointer initialized to NULL() compiles.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, pointer :: y(:) => null()'//new_line('a')// &
+            '  if (associated(y)) stop 2'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_pointer_init_to_target_accepted = expect_exit_status( &
+            source, 0, '/tmp/ffc_session_ptr_init_accept')
+    end function test_pointer_init_to_target_accepted
+
+end program test_session_reject_array_01_compiler


### PR DESCRIPTION
Closes #386.

## Preserved compiler invariant
Invalid array indexing and shape expressions are rejected before lowering, so no invalid section subscript, FORALL mask, format specifier or pointer initializer ever reaches the LIRIC session. Enforced rules (validated on typed nodes, never on filenames or message text):

- a section-subscript or FORALL stride must not be zero (literal or folded through a named constant);
- a FORALL mask-expr must be a scalar LOGICAL expression;
- a character format specifier must not be a zero-sized array;
- a pointer initialization target must be a named entity with the TARGET attribute.

Each rule has a corrected neighbour in the new test that must still compile and run.

## Red evidence
Without the validator wired into `validate_program`, `fo test test_session_reject_array_01_compiler` fails:
```
test_session_reject_array_01_compiler      FAIL
   FAIL: diagnostic did not contain "Illegal stride of zero"   (x2)
   FAIL: unsupported source lowered without diagnostic          (x3)
Summary: 0 passed, 1 failed
```

## Green evidence
```
fo test test_session_reject_array_01_compiler
  test_session_reject_array_01_compiler      PASS
scripts/conformance_gauntlet.sh --suite gfortran-dg --file do_check_18.f90 --file forall_14.f90 \
  --file pr88328.f90 --file pr95612.f90 --file zero_stride_1.f90
  PASS=5  XFAIL=0  XPASS=0  FAIL=0  TOTAL=5
fo   # build OK, static OK, 275/276 tests pass
```
The one remaining full-pipeline failure is `test_parity_dashboard` ("stale snapshot manifest digest"): `test/conformance/parity_dashboard.tsv` on main is out of date with the conformance manifests. This branch touches neither file, so the failure reproduces on unmodified main and is left to the snapshot refresh.