### PR TITLE
[derived-pointer-01] lower scalar pointer components (#401)

### DIFF
--- a/src/session_program_lowering_derived_ctor.inc
+++ b/src/session_program_lowering_derived_ctor.inc
@@ -177,6 +177,7 @@
         do c = 1, context%derived_types(type_index)%component_count
             if (component_is_allocatable(context, type_index, c) .or. &
                 component_is_alloc_array(context, type_index, c)) return
+            if (component_is_pointer(context, type_index, c)) return
             nested_type = context%derived_types(type_index)% &
                           component_type_index(c)
             if (nested_type /= 0) then

--- a/src/session_program_lowering_derived_type_ops.inc
+++ b/src/session_program_lowering_derived_type_ops.inc
@@ -47,7 +47,8 @@
             component_slot_width = 4
             return
         end if
-        if (component_is_allocatable(context, type_index, comp_index)) then
+        if (component_is_allocatable(context, type_index, comp_index) .or. &
+            component_is_pointer(context, type_index, comp_index)) then
             component_slot_width = 2
             return
         end if
@@ -105,6 +106,34 @@
         component_is_allocatable = &
             context%derived_types(type_index)%component_is_allocatable(comp_index)
     end function component_is_allocatable
+
+    logical function component_is_pointer(context, type_index, comp_index)
+        ! True for a scalar data-pointer component (inline target address).
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: type_index
+        integer, intent(in) :: comp_index
+
+        component_is_pointer = .false.
+        if (.not. allocated(context%derived_types(type_index)% &
+                            component_is_pointer)) return
+        component_is_pointer = &
+            context%derived_types(type_index)%component_is_pointer(comp_index)
+    end function component_is_pointer
+
+    logical function component_is_indirect(context, type_index, comp_index)
+        ! True when the component's slot holds an address and its value is
+        ! reached by loading that address: a scalar allocatable or a scalar
+        ! data pointer.
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: type_index
+        integer, intent(in) :: comp_index
+
+        component_is_indirect = &
+            component_is_allocatable(context, type_index, comp_index)
+        if (component_is_indirect) return
+        component_is_indirect = &
+            component_is_pointer(context, type_index, comp_index)
+    end function component_is_indirect
 
     integer function component_kind(context, type_index, comp_index)
         ! Scalar value kind of a component; VALUE_I32 when not yet recorded.
@@ -209,7 +238,7 @@
                 end do
                 cycle
             end if
-            if (component_is_allocatable(context, type_index, c)) then
+            if (component_is_indirect(context, type_index, c)) then
                 call null_allocatable_component_slots(context, symbol_index, &
                                                       outer_slots, abs_slot, 2, &
                                                       error_msg)
@@ -1485,7 +1514,7 @@
                                              'derived type component assignment target')
         if (len_trim(error_msg) > 0) return
 
-        if (component_access_is_allocatable(arena, target, context)) then
+        if (component_access_is_indirect(arena, target, context)) then
             call store_allocatable_component_value(context, component_address, &
                                                    comp_kind, value, error_msg)
             return
@@ -2065,7 +2094,7 @@
                                              'derived type component expression')
         if (len_trim(error_msg) > 0) return
 
-        if (component_access_is_allocatable(arena, node, context)) then
+        if (component_access_is_indirect(arena, node, context)) then
             call load_allocatable_component_value(context, component_address, &
                                                   comp_kind, value, error_msg)
             return
@@ -2109,6 +2138,25 @@
         if (component_index <= 0) return
         is_alloc = component_is_alloc_array(context, type_index, component_index)
     end function component_access_is_alloc_array
+
+    logical function component_access_is_indirect(arena, node, context) &
+            result(is_indirect)
+        ! True when a component_access node names a scalar component whose
+        ! value is reached through an inline address slot (allocatable or
+        ! data pointer).
+        type(ast_arena_t), intent(in) :: arena
+        type(component_access_node), intent(in) :: node
+        type(lowering_context_t), intent(in) :: context
+        integer :: type_index, component_index
+
+        is_indirect = .false.
+        type_index = component_base_type_index(arena, node%base_expr_index, context)
+        if (type_index <= 0) return
+        component_index = find_derived_component(context, type_index, &
+                                                 node%component_name)
+        if (component_index <= 0) return
+        is_indirect = component_is_indirect(context, type_index, component_index)
+    end function component_access_is_indirect
 
     subroutine load_allocatable_component_value(context, slot_address, comp_kind, &
                                                 value, error_msg)

--- a/src/session_program_lowering_derived_types.inc
+++ b/src/session_program_lowering_derived_types.inc
@@ -906,6 +906,7 @@ subroutine collect_component_declaration(component_index, parent_line, &
         integer :: nested_type_index
         logical :: comp_allocatable
         logical :: comp_alloc_array
+        logical :: comp_pointer
         integer :: char_length
         if (.not. node_exists(context%arena, component_index)) then
             error_msg = 'derived type component index does not reference an AST node'
@@ -942,6 +943,19 @@ subroutine collect_component_declaration(component_index, parent_line, &
             ! or character type stores an inline data pointer
             ! (descriptor-in-struct). Array, pointer, and c_ptr allocatables
             ! stay unsupported.
+            ! A scalar data-pointer component of intrinsic numeric/logical
+            ! type stores an inline 8-byte target address; it starts null and
+            ! only `=>` or nullify changes it.
+            comp_pointer = component%is_pointer .and. &
+                           .not. component%is_array .and. &
+                           .not. component%is_allocatable
+            if (comp_pointer) then
+                select case (value_kind)
+                case (VALUE_I32, VALUE_F32, VALUE_F64, VALUE_LOGICAL)
+                case default
+                    comp_pointer = .false.
+                end select
+            end if
             comp_allocatable = component_is_scalar_allocatable(component)
             if (comp_allocatable) then
                 select case (value_kind)
@@ -1017,7 +1031,8 @@ subroutine collect_component_declaration(component_index, parent_line, &
                                                array_size, value_kind, error_msg, &
                                                is_allocatable=comp_allocatable, &
                                                comp_char_length=char_length, &
-                                               is_alloc_array=comp_alloc_array)
+                                               is_alloc_array=comp_alloc_array, &
+                                               is_pointer=comp_pointer)
                     if (len_trim(error_msg) > 0) return
                 end do
             else if (allocated(component%var_name)) then
@@ -1027,7 +1042,8 @@ subroutine collect_component_declaration(component_index, parent_line, &
                                            value_kind, error_msg, &
                                            is_allocatable=comp_allocatable, &
                                            comp_char_length=char_length, &
-                                           is_alloc_array=comp_alloc_array)
+                                           is_alloc_array=comp_alloc_array, &
+                                           is_pointer=comp_pointer)
             else
                 error_msg = 'derived type component declaration did not expose a name'
                 return
@@ -1443,7 +1459,7 @@ subroutine collect_component_declaration(component_index, parent_line, &
                                      has_default, default_value, array_size, &
                                      value_kind, error_msg, comp_type_index, &
                                      is_allocatable, comp_char_length, &
-                                     is_alloc_array)
+                                     is_alloc_array, is_pointer)
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: type_index
         character(len=*), intent(in) :: name
@@ -1460,6 +1476,8 @@ subroutine collect_component_declaration(component_index, parent_line, &
         logical, intent(in), optional :: is_allocatable
         ! True for a rank-1 allocatable array component (inline descriptor).
         logical, intent(in), optional :: is_alloc_array
+        ! True for a scalar data-pointer component (inline target address).
+        logical, intent(in), optional :: is_pointer
         ! Declared length of a VALUE_CHARACTER component; 0 (or absent) for
         ! every other kind.
         integer, intent(in), optional :: comp_char_length
@@ -1497,6 +1515,11 @@ subroutine collect_component_declaration(component_index, parent_line, &
         if (present(is_alloc_array)) &
             context%derived_types(type_index)%component_is_alloc_array( &
                 component_index) = is_alloc_array
+        context%derived_types(type_index)%component_is_pointer(component_index) = &
+            .false.
+        if (present(is_pointer)) &
+            context%derived_types(type_index)%component_is_pointer( &
+                component_index) = is_pointer
         context%derived_types(type_index)%component_char_length(component_index) = 0
         if (present(comp_char_length)) &
             context%derived_types(type_index)%component_char_length(component_index) = &
@@ -1523,6 +1546,7 @@ subroutine collect_component_declaration(component_index, parent_line, &
             allocate(context%derived_types(type_index)%component_type_index(8))
             allocate(context%derived_types(type_index)%component_is_allocatable(8))
             allocate(context%derived_types(type_index)%component_is_alloc_array(8))
+            allocate(context%derived_types(type_index)%component_is_pointer(8))
             allocate(context%derived_types(type_index)%component_char_length(8))
             allocate(context%derived_types(type_index)%component_dim1(8))
             context%derived_types(type_index)%component_has_default = .false.
@@ -1532,6 +1556,7 @@ subroutine collect_component_declaration(component_index, parent_line, &
             context%derived_types(type_index)%component_type_index = 0
             context%derived_types(type_index)%component_is_allocatable = .false.
             context%derived_types(type_index)%component_is_alloc_array = .false.
+            context%derived_types(type_index)%component_is_pointer = .false.
             context%derived_types(type_index)%component_char_length = 0
             context%derived_types(type_index)%component_dim1 = 0
             context%derived_types(type_index)%component_count = 0
@@ -1552,6 +1577,7 @@ subroutine collect_component_declaration(component_index, parent_line, &
             integer, allocatable :: old_ti(:)
             logical, allocatable :: old_ia(:)
             logical, allocatable :: old_iaa(:)
+            logical, allocatable :: old_ip(:)
             integer, allocatable :: old_cl(:)
             integer, allocatable :: old_d1(:)
             associate (dt => context%derived_types(type_index))
@@ -1562,6 +1588,7 @@ subroutine collect_component_declaration(component_index, parent_line, &
                 old_ti = dt%component_type_index
                 old_ia = dt%component_is_allocatable
                 old_iaa = dt%component_is_alloc_array
+                old_ip = dt%component_is_pointer
                 old_cl = dt%component_char_length
                 old_d1 = dt%component_dim1
                 deallocate(dt%component_has_default)
@@ -1571,6 +1598,7 @@ subroutine collect_component_declaration(component_index, parent_line, &
                 deallocate(dt%component_type_index)
                 deallocate(dt%component_is_allocatable)
                 deallocate(dt%component_is_alloc_array)
+                deallocate(dt%component_is_pointer)
                 deallocate(dt%component_char_length)
                 deallocate(dt%component_dim1)
                 allocate(dt%component_has_default(new_size))
@@ -1580,6 +1608,7 @@ subroutine collect_component_declaration(component_index, parent_line, &
                 allocate(dt%component_type_index(new_size))
                 allocate(dt%component_is_allocatable(new_size))
                 allocate(dt%component_is_alloc_array(new_size))
+                allocate(dt%component_is_pointer(new_size))
                 allocate(dt%component_char_length(new_size))
                 allocate(dt%component_dim1(new_size))
                 dt%component_has_default = .false.
@@ -1589,6 +1618,7 @@ subroutine collect_component_declaration(component_index, parent_line, &
                 dt%component_type_index = 0
                 dt%component_is_allocatable = .false.
                 dt%component_is_alloc_array = .false.
+                dt%component_is_pointer = .false.
                 dt%component_char_length = 0
                 dt%component_dim1 = 0
                 dt%component_has_default(1:old_size) = old_hd
@@ -1598,6 +1628,7 @@ subroutine collect_component_declaration(component_index, parent_line, &
                 dt%component_type_index(1:old_size) = old_ti
                 dt%component_is_allocatable(1:old_size) = old_ia
                 dt%component_is_alloc_array(1:old_size) = old_iaa
+                dt%component_is_pointer(1:old_size) = old_ip
                 dt%component_char_length(1:old_size) = old_cl
                 dt%component_dim1(1:old_size) = old_d1
             end associate

--- a/src/session_program_lowering_pointer.inc
+++ b/src/session_program_lowering_pointer.inc
@@ -433,6 +433,12 @@
             call lower_proc_component_assignment(arena, node, context, error_msg)
             return
         end if
+        ! obj%p => t binds a scalar data-pointer component (#401).
+        if (is_data_pointer_component_access(arena, node%pointer_index, context)) &
+        then
+            call lower_data_component_assignment(arena, node, context, error_msg)
+            return
+        end if
         call get_identifier_name(arena, node%pointer_index, ptr_name, error_msg)
         if (len_trim(error_msg) > 0) return
         ptr_index = find_symbol_compat(context, ptr_name)
@@ -619,6 +625,13 @@
             return
         end if
         do i = 1, size(node%pointer_indices)
+            if (is_data_pointer_component_access(arena, node%pointer_indices(i), &
+                                                 context)) then
+                call nullify_data_pointer_component(arena, node%pointer_indices(i), &
+                                                    context, error_msg)
+                if (len_trim(error_msg) > 0) return
+                cycle
+            end if
             call get_identifier_name(arena, node%pointer_indices(i), name, error_msg)
             if (len_trim(error_msg) > 0) return
             symbol_index = find_symbol_compat(context, name)
@@ -661,6 +674,11 @@
         end if
         ! A procedure-pointer component operand has no compile-time association
         ! flag; compare its stored callee address at run time instead (#372).
+        if (is_data_pointer_component_access(arena, arg_indices(1), context)) then
+            call lower_data_pointer_component_associated(arena, arg_indices, &
+                                                         context, value, error_msg)
+            return
+        end if
         if (associated_uses_proc_component(arena, arg_indices, context)) then
             call lower_proc_pointer_associated(arena, arg_indices, context, &
                                                value, error_msg)
@@ -1150,6 +1168,186 @@
             return
         call set_empty(error_msg)
     end subroutine lower_proc_component_assignment
+
+    logical function is_data_pointer_component_access(arena, node_index, context) &
+        result(is_ptr)
+        ! True when node_index is obj%p naming a scalar data-pointer component
+        ! (#401). Unresolvable component references answer .false. so the
+        ! caller's other paths keep their own diagnostics.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(in) :: context
+        integer :: sym, type_index, comp_index
+        character(len=:), allocatable :: comp_name, local_error
+
+        is_ptr = .false.
+        if (node_index <= 0) return
+        if (.not. node_exists(arena, node_index)) return
+        select type (acc => arena%entries(node_index)%node)
+        type is (component_access_node)
+        class default
+            return
+        end select
+        call resolve_component_ref(arena, node_index, context, sym, type_index, &
+                                   comp_index, comp_name, local_error)
+        if (len_trim(local_error) > 0) return
+        is_ptr = component_is_pointer(context, type_index, comp_index)
+    end function is_data_pointer_component_access
+
+    subroutine data_component_slot_address(arena, access_index, context, addr, &
+                                           error_msg)
+        ! Address of the inline slot holding obj%p's target address.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: access_index
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: addr
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: comp_name
+        integer :: sym, type_index, comp_index
+
+        call resolve_component_ref(arena, access_index, context, sym, type_index, &
+                                   comp_index, comp_name, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. component_is_pointer(context, type_index, comp_index)) then
+            error_msg = 'component is not a data pointer: '//trim(comp_name)
+            return
+        end if
+        call component_element_address_at(context, sym, type_index, comp_index, 0, &
+                                          addr, error_msg)
+    end subroutine data_component_slot_address
+
+    subroutine lower_data_component_assignment(arena, node, context, error_msg)
+        ! obj%p => t / obj%p => null(): store the target's address into the
+        ! component's inline pointer slot (#401). Target validation matches the
+        ! whole-variable pointer path: the right side must be a TARGET or a
+        ! pointer with storage, of the component's scalar kind.
+        type(ast_arena_t), intent(in) :: arena
+        type(pointer_assignment_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: slot_addr, target_addr
+
+        call data_component_slot_address(arena, node%pointer_index, context, &
+                                         slot_addr, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (pointer_target_is_null(arena, node%target_index)) then
+            target_addr = null_ptr_operand(context)
+        else
+            call data_pointer_target_address(arena, node%pointer_index, &
+                                             node%target_index, context, &
+                                             target_addr, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end if
+        if (.not. emit_ptr_store(context%session, target_addr, slot_addr, &
+                                 error_msg)) return
+        call set_empty(error_msg)
+    end subroutine lower_data_component_assignment
+
+    subroutine data_pointer_target_address(arena, access_index, target_index, &
+                                           context, target_addr, error_msg)
+        ! Storage address a data-pointer component may adopt: a scalar TARGET
+        ! or pointer variable of the component's kind.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: access_index
+        integer, intent(in) :: target_index
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: target_addr
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: target_name, comp_name
+        integer :: sym, type_index, comp_index, tgt
+
+        call resolve_component_ref(arena, access_index, context, sym, type_index, &
+                                   comp_index, comp_name, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. is_identifier(arena, target_index)) then
+            error_msg = 'direct LIRIC session pointer component assignment '// &
+                        'requires a scalar target variable'
+            return
+        end if
+        call get_identifier_name(arena, target_index, target_name, error_msg)
+        if (len_trim(error_msg) > 0) return
+        tgt = find_symbol_compat(context, target_name)
+        if (tgt <= 0) then
+            error_msg = 'pointer assignment source was not declared: '// &
+                        trim(target_name)
+            return
+        end if
+        if (.not. (context%symbols(tgt)%is_target .or. &
+                   context%symbols(tgt)%is_pointer)) then
+            error_msg = 'right of => is not a target or pointer: '// &
+                        trim(target_name)
+            return
+        end if
+        if (.not. context%symbols(tgt)%has_address) then
+            error_msg = 'pointer assignment source has no storage: '// &
+                        trim(target_name)
+            return
+        end if
+        if (context%symbols(tgt)%is_array .or. context%symbols(tgt)%is_derived) then
+            error_msg = 'pointer component target must be a scalar of '// &
+                        'intrinsic type: '//trim(target_name)
+            return
+        end if
+        if (context%symbols(tgt)%value_kind /= &
+            component_kind(context, type_index, comp_index)) then
+            error_msg = 'pointer and target scalar kinds do not match'
+            return
+        end if
+        target_addr = context%symbols(tgt)%address
+        call set_empty(error_msg)
+    end subroutine data_pointer_target_address
+
+    subroutine nullify_data_pointer_component(arena, access_index, context, &
+                                              error_msg)
+        ! nullify(obj%p): clear the component's inline pointer slot (#401).
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: access_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: slot_addr
+
+        call data_component_slot_address(arena, access_index, context, slot_addr, &
+                                         error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_ptr_store(context%session, null_ptr_operand(context), &
+                                 slot_addr, error_msg)) return
+        call set_empty(error_msg)
+    end subroutine nullify_data_pointer_component
+
+    subroutine lower_data_pointer_component_associated(arena, arg_indices, &
+                                                       context, value, error_msg)
+        ! associated(obj%p) / associated(obj%p, t): run-time comparison of the
+        ! stored target address (#401). F2018 16.9.20: a disassociated pointer
+        ! is never associated with a target, so the identity test is ANDed with
+        ! the non-null test.
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: arg_indices(:)
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: slot_addr, ptr_value, target_addr, nonnull, same
+
+        call data_component_slot_address(arena, arg_indices(1), context, &
+                                         slot_addr, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_ptr_load(context%session, slot_addr, ptr_value, error_msg)) &
+            return
+        if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, ptr_value, &
+                null_ptr_operand(context), nonnull, error_msg)) return
+        if (size(arg_indices) == 1) then
+            value = nonnull
+            call set_empty(error_msg)
+            return
+        end if
+        call data_pointer_target_address(arena, arg_indices(1), arg_indices(2), &
+                                         context, target_addr, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, ptr_value, &
+                target_addr, same, error_msg)) return
+        if (.not. emit_i32_binary(context%session, LR_OP_AND, nonnull, same, &
+                                  value, error_msg)) return
+        call set_empty(error_msg)
+    end subroutine lower_data_pointer_component_associated
 
     subroutine lower_proc_pointer_associated(arena, arg_indices, context, value, &
                                              error_msg)

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -390,6 +390,12 @@ module session_program_lowering_types
         ! its value lives in a separately malloc'd slot reached by loading the
         ! pointer. Null pointer marks it unallocated.
         logical, allocatable :: component_is_allocatable(:)
+        ! True for a scalar data-pointer component (integer/real/logical).
+        ! Such a component stores an 8-byte target address (two i32 slots)
+        ! inline; a null address marks it disassociated. `=>` writes the
+        ! address, intrinsic assignment of the parent copies it, so the
+        ! association travels with the object and never the pointee storage.
+        logical, allocatable :: component_is_pointer(:)
         ! True for a rank-1 allocatable array component (integer/real/logical).
         ! Such a component stores an inline 16-byte descriptor (four i32
         ! slots): an 8-byte data pointer at byte 0 and an i64 element extent

--- a/test/test_session_derived_pointer_component_compiler.f90
+++ b/test/test_session_derived_pointer_component_compiler.f90
@@ -1,0 +1,70 @@
+program test_session_derived_pointer_component
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    print *, '=== direct session derived pointer component compiler test ==='
+
+    ! A scalar pointer component associates with a target, mutates it, and
+    ! reports association until nullify.
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'type box_t'//new_line('a')// &
+        'integer, pointer :: p'//new_line('a')// &
+        'end type box_t'//new_line('a')// &
+        'type(box_t) :: b'//new_line('a')// &
+        'integer, target :: t'//new_line('a')// &
+        't = 5'//new_line('a')// &
+        'b%p => t'//new_line('a')// &
+        'if (.not. associated(b%p)) stop 1'//new_line('a')// &
+        'b%p = 42'//new_line('a')// &
+        'nullify(b%p)'//new_line('a')// &
+        'if (associated(b%p)) stop 2'//new_line('a')// &
+        'stop t'//new_line('a')// &
+        'end program main', 42, &
+        '/tmp/ffc_session_derived_pointer_component_test')) stop 1
+
+    ! A read through the component observes a later write to the target.
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'type box_t'//new_line('a')// &
+        'integer, pointer :: p'//new_line('a')// &
+        'end type box_t'//new_line('a')// &
+        'type(box_t) :: b'//new_line('a')// &
+        'integer, target :: t'//new_line('a')// &
+        'b%p => t'//new_line('a')// &
+        't = 9'//new_line('a')// &
+        'stop b%p'//new_line('a')// &
+        'end program main', 9, &
+        '/tmp/ffc_session_derived_pointer_component_read')) stop 1
+
+    ! Intrinsic assignment of the derived object copies association, not
+    ! pointee storage: c%p aliases the same target as b%p.
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'type box_t'//new_line('a')// &
+        'integer, pointer :: p'//new_line('a')// &
+        'end type box_t'//new_line('a')// &
+        'type(box_t) :: b, c'//new_line('a')// &
+        'integer, target :: t'//new_line('a')// &
+        't = 1'//new_line('a')// &
+        'b%p => t'//new_line('a')// &
+        'c = b'//new_line('a')// &
+        'c%p = 33'//new_line('a')// &
+        'stop t'//new_line('a')// &
+        'end program main', 33, &
+        '/tmp/ffc_session_derived_pointer_component_assign')) stop 1
+
+    ! Association of a pointer component to a non-TARGET is rejected.
+    if (.not. expect_error_contains( &
+        'program main'//new_line('a')// &
+        'type box_t'//new_line('a')// &
+        'integer, pointer :: p'//new_line('a')// &
+        'end type box_t'//new_line('a')// &
+        'type(box_t) :: b'//new_line('a')// &
+        'integer :: i'//new_line('a')// &
+        'b%p => i'//new_line('a')// &
+        'end program main', 'right of => is not a target or pointer', &
+        '/tmp/ffc_session_derived_pointer_component_negative')) stop 1
+
+    print *, 'PASS: scalar derived-type pointer components'
+end program test_session_derived_pointer_component


### PR DESCRIPTION
Closes #401.

## What

A scalar data-pointer component of intrinsic numeric/logical type now lowers to an inline 8-byte address slot pair:

- `obj%p => t` stores the target's address (target validation reuses the whole-variable pointer rules).
- `obj%p => null()` and `nullify(obj%p)` clear the slot.
- `associated(obj%p)` / `associated(obj%p, t)` compare the stored address at run time.
- Reads and writes of `obj%p` go through the stored address (shared with the scalar allocatable component path via `component_is_indirect`).
- A fresh object nulls the slot, so the component starts disassociated.

## Preserved compiler invariant

Intrinsic assignment of the parent object copies the component's address slot, not the pointee storage: association travels with the object and both copies alias the same target. Pointer components are excluded from the plain derived-type constructor path, and associating with a non-TARGET still fails with 'right of => is not a target or pointer'.

Non-goals untouched: pointer arrays, procedure-pointer components (unchanged #372 path), polymorphic targets, coarrays.

## Red evidence

On unmodified main, `fo test test_session_derived_pointer_component_compiler`:

```
test_session_derived_pointer_component_com FAIL       0.01s
 FAIL: AST node is not an identifier
```

## Green evidence

```
test_session_derived_pointer_component_com PASS       0.03s
```

Full `fo` pipeline after rebase onto origin/main: Static OK, Build OK, all tests pass except `test_parity_dashboard`, which fails identically on unmodified origin/main (checked-in snapshot digest `e4fcdad...` vs the manifests' current digest `0d1c40c...`); this branch changes no file under `test/conformance`.