### PR TITLE
[poly-01] define the scalar polymorphic descriptor ABI (#400)

### DIFF
--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -389,6 +389,44 @@ assigned monotonically as types are collected. Nothing references these
 constants yet; later polymorphism slices compare a value's type pointer
 against them.
 
+## Scalar class descriptor
+
+A polymorphic scalar (`class(t)` dummy, local, or allocatable) is described by
+one 32-byte, 8-byte-aligned descriptor. It is the single canonical convention
+for scalar polymorphism; no lowering path may invent a competing one. The
+Fortran-side definition and its accessors live in
+`src/ffc_polymorphic_descriptor.f90`.
+
+```
+struct ffc_polymorphic_descriptor_t {
+    i8*  data;           // offset  0: address of the value's storage
+    i64  declared_type;  // offset  8: declared type identity
+    i64  dynamic_type;   // offset 16: dynamic type identity
+    i32  ownership;      // offset 24: 0 none, 1 borrowed, 2 owned
+};                       // 32 bytes total (4 bytes tail padding)
+```
+
+- Both identities are the `id` field of the `ffc_type_info_t` constant of the
+  named type. Ids are dense and monotonic within one linked program, so they
+  are stable for the life of that program and are only ever compared for
+  equality. Id `0` is reserved and means "no type": a null descriptor reads as
+  `data == 0, declared_type == 0, dynamic_type == 0, ownership == 0`.
+- `declared_type` is the type written in the declaration and never changes for
+  a given entity. `dynamic_type` is the type of the value currently stored and
+  is what `select type` and type-bound dispatch consult. They are equal for a
+  base value and differ exactly when the value is an extension.
+- A descriptor with a null `data` address but an associated `dynamic_type` is
+  invalid and is rejected when the descriptor is built; an unallocated or
+  unassociated class entity is the fully null descriptor instead.
+- `ownership` records who frees `data`. A class dummy borrows its actual
+  argument's storage: the callee never frees it and the storage outlives the
+  call. An allocatable class value owns its storage; releasing the descriptor
+  yields the address to free exactly once and resets the descriptor, so a
+  borrowed or already released descriptor yields a null address and no double
+  free is possible.
+- The descriptor never aliases the value: `data` points at storage held
+  elsewhere, and copying a descriptor copies a reference, never the value.
+
 ## Module artefact format
 
 `ffc -c <source>.f90` writes one `<modulename>.fmod` next to the object file

--- a/src/ffc_polymorphic_descriptor.f90
+++ b/src/ffc_polymorphic_descriptor.f90
@@ -1,0 +1,171 @@
+module ffc_polymorphic_descriptor
+    ! Canonical scalar class descriptor (#400). One descriptor carries the data
+    ! address, the declared type identity, the dynamic type identity, and the
+    ! ownership of the data. Type identities are the dense per-link-unit type
+    ! info ids documented in docs/RUNTIME_ABI.md; they are stable within one
+    ! linked program and are only ever compared for equality.
+    use, intrinsic :: iso_c_binding, only: c_associated, c_int32_t, c_int64_t, &
+        c_intptr_t, c_null_ptr, c_ptr, c_size_t
+    implicit none
+    private
+
+    public :: polymorphic_descriptor_t
+    public :: set_polymorphic_descriptor_null
+    public :: set_borrowed_polymorphic_descriptor
+    public :: set_owned_polymorphic_descriptor
+    public :: polymorphic_descriptor_declared_type
+    public :: polymorphic_descriptor_dynamic_type
+    public :: polymorphic_descriptor_is_owned
+    public :: polymorphic_descriptor_is_extension
+    public :: release_polymorphic_descriptor
+
+    integer(c_intptr_t), parameter, public :: &
+        POLYMORPHIC_DESCRIPTOR_DATA_OFFSET = 0_c_intptr_t
+    integer(c_intptr_t), parameter, public :: &
+        POLYMORPHIC_DESCRIPTOR_DECLARED_TYPE_OFFSET = 8_c_intptr_t
+    integer(c_intptr_t), parameter, public :: &
+        POLYMORPHIC_DESCRIPTOR_DYNAMIC_TYPE_OFFSET = 16_c_intptr_t
+    integer(c_intptr_t), parameter, public :: &
+        POLYMORPHIC_DESCRIPTOR_OWNERSHIP_OFFSET = 24_c_intptr_t
+    integer(c_size_t), parameter, public :: &
+        POLYMORPHIC_DESCRIPTOR_SIZE = 32_c_size_t
+
+    ! Reserved identity: no type is associated with the descriptor.
+    integer(c_int64_t), parameter, public :: POLYMORPHIC_TYPE_ID_NONE = 0_c_int64_t
+
+    integer(c_int32_t), parameter, public :: POLYMORPHIC_OWNERSHIP_NONE = 0_c_int32_t
+    integer(c_int32_t), parameter, public :: &
+        POLYMORPHIC_OWNERSHIP_BORROWED = 1_c_int32_t
+    integer(c_int32_t), parameter, public :: &
+        POLYMORPHIC_OWNERSHIP_OWNED = 2_c_int32_t
+
+    integer, parameter, public :: POLYMORPHIC_DESCRIPTOR_OK = 0
+    integer, parameter, public :: POLYMORPHIC_DESCRIPTOR_NULL_DATA = 1
+    integer, parameter, public :: POLYMORPHIC_DESCRIPTOR_INVALID_DECLARED_TYPE = 2
+    integer, parameter, public :: POLYMORPHIC_DESCRIPTOR_INVALID_DYNAMIC_TYPE = 3
+
+    type, bind(c) :: polymorphic_descriptor_t
+        type(c_ptr) :: data = c_null_ptr
+        integer(c_int64_t) :: declared_type = POLYMORPHIC_TYPE_ID_NONE
+        integer(c_int64_t) :: dynamic_type = POLYMORPHIC_TYPE_ID_NONE
+        integer(c_int32_t) :: ownership = POLYMORPHIC_OWNERSHIP_NONE
+    end type polymorphic_descriptor_t
+
+contains
+
+    subroutine set_polymorphic_descriptor_null(descriptor)
+        type(polymorphic_descriptor_t), intent(out) :: descriptor
+
+        descriptor%data = c_null_ptr
+        descriptor%declared_type = POLYMORPHIC_TYPE_ID_NONE
+        descriptor%dynamic_type = POLYMORPHIC_TYPE_ID_NONE
+        descriptor%ownership = POLYMORPHIC_OWNERSHIP_NONE
+    end subroutine set_polymorphic_descriptor_null
+
+    subroutine set_borrowed_polymorphic_descriptor(descriptor, data, &
+            declared_type, dynamic_type, status)
+        ! A class dummy borrows its actual argument's storage: the callee never
+        ! frees it and its lifetime is the caller's.
+        type(polymorphic_descriptor_t), intent(out) :: descriptor
+        type(c_ptr), intent(in) :: data
+        integer(c_int64_t), intent(in) :: declared_type
+        integer(c_int64_t), intent(in) :: dynamic_type
+        integer, intent(out) :: status
+
+        call set_associated_descriptor(descriptor, data, declared_type, &
+            dynamic_type, POLYMORPHIC_OWNERSHIP_BORROWED, &
+            status)
+    end subroutine set_borrowed_polymorphic_descriptor
+
+    subroutine set_owned_polymorphic_descriptor(descriptor, data, &
+            declared_type, dynamic_type, status)
+        ! An allocatable class value owns its storage: releasing the descriptor
+        ! hands the data address back exactly once, to be freed by the owner.
+        type(polymorphic_descriptor_t), intent(out) :: descriptor
+        type(c_ptr), intent(in) :: data
+        integer(c_int64_t), intent(in) :: declared_type
+        integer(c_int64_t), intent(in) :: dynamic_type
+        integer, intent(out) :: status
+
+        call set_associated_descriptor(descriptor, data, declared_type, &
+            dynamic_type, POLYMORPHIC_OWNERSHIP_OWNED, &
+            status)
+    end subroutine set_owned_polymorphic_descriptor
+
+    subroutine set_associated_descriptor(descriptor, data, declared_type, &
+            dynamic_type, ownership, status)
+        type(polymorphic_descriptor_t), intent(out) :: descriptor
+        type(c_ptr), intent(in) :: data
+        integer(c_int64_t), intent(in) :: declared_type
+        integer(c_int64_t), intent(in) :: dynamic_type
+        integer(c_int32_t), intent(in) :: ownership
+        integer, intent(out) :: status
+
+        call set_polymorphic_descriptor_null(descriptor)
+        if (declared_type <= POLYMORPHIC_TYPE_ID_NONE) then
+            status = POLYMORPHIC_DESCRIPTOR_INVALID_DECLARED_TYPE
+            return
+        end if
+        if (dynamic_type <= POLYMORPHIC_TYPE_ID_NONE) then
+            status = POLYMORPHIC_DESCRIPTOR_INVALID_DYNAMIC_TYPE
+            return
+        end if
+        ! An associated dynamic type without storage is not a class value.
+        if (.not. c_associated(data)) then
+            status = POLYMORPHIC_DESCRIPTOR_NULL_DATA
+            return
+        end if
+
+        descriptor%data = data
+        descriptor%declared_type = declared_type
+        descriptor%dynamic_type = dynamic_type
+        descriptor%ownership = ownership
+        status = POLYMORPHIC_DESCRIPTOR_OK
+    end subroutine set_associated_descriptor
+
+    pure function polymorphic_descriptor_declared_type(descriptor) result(type_id)
+        type(polymorphic_descriptor_t), intent(in) :: descriptor
+        integer(c_int64_t) :: type_id
+
+        type_id = descriptor%declared_type
+    end function polymorphic_descriptor_declared_type
+
+    pure function polymorphic_descriptor_dynamic_type(descriptor) result(type_id)
+        type(polymorphic_descriptor_t), intent(in) :: descriptor
+        integer(c_int64_t) :: type_id
+
+        type_id = descriptor%dynamic_type
+    end function polymorphic_descriptor_dynamic_type
+
+    pure function polymorphic_descriptor_is_owned(descriptor) result(is_owned)
+        type(polymorphic_descriptor_t), intent(in) :: descriptor
+        logical :: is_owned
+
+        is_owned = descriptor%ownership == POLYMORPHIC_OWNERSHIP_OWNED
+    end function polymorphic_descriptor_is_owned
+
+    pure function polymorphic_descriptor_is_extension(descriptor) result(is_ext)
+        ! True when the value's dynamic type is an extension of its declared
+        ! type, i.e. the two recorded identities differ.
+        type(polymorphic_descriptor_t), intent(in) :: descriptor
+        logical :: is_ext
+
+        is_ext = .false.
+        if (descriptor%declared_type == POLYMORPHIC_TYPE_ID_NONE) return
+        if (descriptor%dynamic_type == POLYMORPHIC_TYPE_ID_NONE) return
+        is_ext = descriptor%declared_type /= descriptor%dynamic_type
+    end function polymorphic_descriptor_is_extension
+
+    function release_polymorphic_descriptor(descriptor) result(data)
+        ! Return the address the caller must free and reset the descriptor, so
+        ! ownership is transferred exactly once and a borrowed or already
+        ! released descriptor yields a null address.
+        type(polymorphic_descriptor_t), intent(inout) :: descriptor
+        type(c_ptr) :: data
+
+        data = c_null_ptr
+        if (polymorphic_descriptor_is_owned(descriptor)) data = descriptor%data
+        call set_polymorphic_descriptor_null(descriptor)
+    end function release_polymorphic_descriptor
+
+end module ffc_polymorphic_descriptor

--- a/test/test_polymorphic_descriptor_layout.f90
+++ b/test/test_polymorphic_descriptor_layout.f90
@@ -1,0 +1,165 @@
+program test_polymorphic_descriptor_layout
+    use ffc_polymorphic_descriptor, only: polymorphic_descriptor_t, &
+        POLYMORPHIC_DESCRIPTOR_DATA_OFFSET, &
+        POLYMORPHIC_DESCRIPTOR_DECLARED_TYPE_OFFSET, &
+        POLYMORPHIC_DESCRIPTOR_DYNAMIC_TYPE_OFFSET, &
+        POLYMORPHIC_DESCRIPTOR_OWNERSHIP_OFFSET, &
+        POLYMORPHIC_DESCRIPTOR_SIZE, POLYMORPHIC_TYPE_ID_NONE, &
+        POLYMORPHIC_OWNERSHIP_NONE, POLYMORPHIC_OWNERSHIP_BORROWED, &
+        POLYMORPHIC_OWNERSHIP_OWNED, POLYMORPHIC_DESCRIPTOR_OK, &
+        POLYMORPHIC_DESCRIPTOR_INVALID_DECLARED_TYPE, &
+        POLYMORPHIC_DESCRIPTOR_INVALID_DYNAMIC_TYPE, &
+        POLYMORPHIC_DESCRIPTOR_NULL_DATA, &
+        set_polymorphic_descriptor_null, set_borrowed_polymorphic_descriptor, &
+        set_owned_polymorphic_descriptor, polymorphic_descriptor_declared_type, &
+        polymorphic_descriptor_dynamic_type, polymorphic_descriptor_is_owned, &
+        polymorphic_descriptor_is_extension, release_polymorphic_descriptor
+    use, intrinsic :: iso_c_binding, only: c_associated, c_int32_t, c_int64_t, &
+        c_intptr_t, c_loc, c_null_ptr, c_ptr, c_sizeof
+    implicit none
+
+    integer(c_int64_t), parameter :: BASE_ID = 1_c_int64_t
+    integer(c_int64_t), parameter :: EXTENSION_ID = 2_c_int64_t
+
+    type(polymorphic_descriptor_t), target :: descriptor
+    integer(c_int32_t), target :: base_storage(4)
+    integer(c_int32_t), target :: extension_storage(8)
+    type(c_ptr) :: released
+    integer(c_intptr_t) :: base_address
+    integer :: status
+
+    call set_polymorphic_descriptor_null(descriptor)
+    call require_layout(descriptor)
+    call require_null_state(descriptor, 'initial null')
+
+    ! A borrowed base value: declared and dynamic identity agree.
+    call set_borrowed_polymorphic_descriptor(descriptor, c_loc(base_storage), &
+        BASE_ID, BASE_ID, status)
+    call require(status == POLYMORPHIC_DESCRIPTOR_OK, 'borrowed base status')
+    call require(polymorphic_descriptor_declared_type(descriptor) == BASE_ID, &
+        'borrowed base declared type')
+    call require(polymorphic_descriptor_dynamic_type(descriptor) == BASE_ID, &
+        'borrowed base dynamic type')
+    call require(.not. polymorphic_descriptor_is_extension(descriptor), &
+        'borrowed base is not an extension')
+    call require(.not. polymorphic_descriptor_is_owned(descriptor), &
+        'borrowed base ownership')
+    released = release_polymorphic_descriptor(descriptor)
+    call require(.not. c_associated(released), 'borrowed base release')
+    call require_null_state(descriptor, 'borrowed base release')
+
+    ! A borrowed extension value: only the dynamic identity differs.
+    call set_borrowed_polymorphic_descriptor(descriptor, &
+        c_loc(extension_storage), BASE_ID, EXTENSION_ID, status)
+    call require(status == POLYMORPHIC_DESCRIPTOR_OK, 'borrowed extension status')
+    call require(polymorphic_descriptor_declared_type(descriptor) == BASE_ID, &
+        'borrowed extension declared type')
+    call require(polymorphic_descriptor_dynamic_type(descriptor) == &
+        EXTENSION_ID, 'borrowed extension dynamic type')
+    call require(polymorphic_descriptor_is_extension(descriptor), &
+        'borrowed extension is an extension')
+    call require(.not. polymorphic_descriptor_is_owned(descriptor), &
+        'borrowed extension ownership')
+    released = release_polymorphic_descriptor(descriptor)
+    call require(.not. c_associated(released), 'borrowed extension release')
+
+    ! An owned extension value: release hands the data address back once.
+    call set_owned_polymorphic_descriptor(descriptor, c_loc(extension_storage), &
+        BASE_ID, EXTENSION_ID, status)
+    call require(status == POLYMORPHIC_DESCRIPTOR_OK, 'owned status')
+    call require(polymorphic_descriptor_is_owned(descriptor), 'owned ownership')
+    call require(polymorphic_descriptor_is_extension(descriptor), &
+        'owned is an extension')
+    released = release_polymorphic_descriptor(descriptor)
+    call require(c_associated(released, c_loc(extension_storage)), 'owned release')
+    call require_null_state(descriptor, 'owned release')
+    released = release_polymorphic_descriptor(descriptor)
+    call require(.not. c_associated(released), 'released descriptor is inert')
+
+    ! A null data address with an associated dynamic type is not a descriptor.
+    call set_borrowed_polymorphic_descriptor(descriptor, c_null_ptr, BASE_ID, &
+        BASE_ID, status)
+    call require(status == POLYMORPHIC_DESCRIPTOR_NULL_DATA, &
+        'borrowed null data status')
+    call require_null_state(descriptor, 'borrowed null data')
+
+    call set_owned_polymorphic_descriptor(descriptor, c_null_ptr, BASE_ID, &
+        EXTENSION_ID, status)
+    call require(status == POLYMORPHIC_DESCRIPTOR_NULL_DATA, &
+        'owned null data status')
+    call require_null_state(descriptor, 'owned null data')
+
+    call set_borrowed_polymorphic_descriptor(descriptor, c_loc(base_storage), &
+        POLYMORPHIC_TYPE_ID_NONE, BASE_ID, status)
+    call require(status == POLYMORPHIC_DESCRIPTOR_INVALID_DECLARED_TYPE, &
+        'missing declared type status')
+    call require_null_state(descriptor, 'missing declared type')
+
+    call set_borrowed_polymorphic_descriptor(descriptor, c_loc(base_storage), &
+        BASE_ID, POLYMORPHIC_TYPE_ID_NONE, status)
+    call require(status == POLYMORPHIC_DESCRIPTOR_INVALID_DYNAMIC_TYPE, &
+        'missing dynamic type status')
+    call require_null_state(descriptor, 'missing dynamic type')
+
+    call set_owned_polymorphic_descriptor(descriptor, c_loc(base_storage), &
+        -3_c_int64_t, BASE_ID, status)
+    call require(status == POLYMORPHIC_DESCRIPTOR_INVALID_DECLARED_TYPE, &
+        'negative declared type status')
+    call require_null_state(descriptor, 'negative declared type')
+
+    call set_owned_polymorphic_descriptor(descriptor, c_loc(base_storage), &
+        BASE_ID, -3_c_int64_t, status)
+    call require(status == POLYMORPHIC_DESCRIPTOR_INVALID_DYNAMIC_TYPE, &
+        'negative dynamic type status')
+    call require_null_state(descriptor, 'negative dynamic type')
+
+    print *, 'PASS: polymorphic descriptor layout and identity'
+
+contains
+
+    subroutine require_layout(value)
+        type(polymorphic_descriptor_t), target, intent(inout) :: value
+        integer(c_intptr_t) :: address
+
+        base_address = transfer(c_loc(value), base_address)
+        address = transfer(c_loc(value%data), address)
+        call require(address - base_address == &
+            POLYMORPHIC_DESCRIPTOR_DATA_OFFSET, 'data offset')
+        address = transfer(c_loc(value%declared_type), address)
+        call require(address - base_address == &
+            POLYMORPHIC_DESCRIPTOR_DECLARED_TYPE_OFFSET, 'declared type offset')
+        address = transfer(c_loc(value%dynamic_type), address)
+        call require(address - base_address == &
+            POLYMORPHIC_DESCRIPTOR_DYNAMIC_TYPE_OFFSET, 'dynamic type offset')
+        address = transfer(c_loc(value%ownership), address)
+        call require(address - base_address == &
+            POLYMORPHIC_DESCRIPTOR_OWNERSHIP_OFFSET, 'ownership offset')
+        call require(c_sizeof(value) == POLYMORPHIC_DESCRIPTOR_SIZE, 'total size')
+    end subroutine require_layout
+
+    subroutine require_null_state(value, label)
+        type(polymorphic_descriptor_t), intent(in) :: value
+        character(len=*), intent(in) :: label
+
+        call require(.not. c_associated(value%data), label//' data')
+        call require(value%declared_type == POLYMORPHIC_TYPE_ID_NONE, &
+            label//' declared type')
+        call require(value%dynamic_type == POLYMORPHIC_TYPE_ID_NONE, &
+            label//' dynamic type')
+        call require(value%ownership == POLYMORPHIC_OWNERSHIP_NONE, &
+            label//' ownership')
+        call require(.not. polymorphic_descriptor_is_owned(value), &
+            label//' not owned')
+    end subroutine require_null_state
+
+    subroutine require(condition, message)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: message
+
+        if (.not. condition) then
+            print *, 'FAIL: ', message
+            stop 1
+        end if
+    end subroutine require
+
+end program test_polymorphic_descriptor_layout


### PR DESCRIPTION
Closes #400.

Defines the single canonical scalar class descriptor: data address, declared
type identity, dynamic type identity, ownership. New
`src/ffc_polymorphic_descriptor.f90`, specified in `docs/RUNTIME_ABI.md`
("Scalar class descriptor").

## Layout (verified by the test, not just asserted)

| field | offset | type |
|---|---|---|
| `data` | 0 | `i8*` |
| `declared_type` | 8 | `i64` |
| `dynamic_type` | 16 | `i64` |
| `ownership` | 24 | `i32` |

Total 32 bytes. `test_polymorphic_descriptor_layout` takes `c_loc` of every
component and checks the byte delta against the exported offset parameters and
`c_sizeof` against `POLYMORPHIC_DESCRIPTOR_SIZE`, so the ABI is checked as
layout, not as behaviour of accessors.

## Invariants preserved

- **Declared vs dynamic type semantics.** `declared_type` is the type written
  in the declaration and never changes for an entity; `dynamic_type` is the
  type of the value currently held and is what `select type` and type-bound
  dispatch will consult. They are equal for a base value and differ exactly
  when the value is an extension; the test covers a base and one extension and
  asserts the pair differs only for the extension.
- **Type identity stability.** Identities are the `id` of the existing
  `ffc_type_info_t` constant: dense and monotonic within one linked program,
  compared only for equality. `0` is reserved as "no type".
- **Ownership and lifetime.** A class dummy borrows: the callee never frees and
  the storage outlives the call. An allocatable class value owns; releasing the
  descriptor yields the address to free exactly once and resets the descriptor,
  so a borrowed or already released descriptor yields a null address. The test
  releases twice and asserts the second release is inert, which is the
  no-double-free property.
- **Negative fixture.** A null data address with an associated dynamic type is
  rejected at construction (`POLYMORPHIC_DESCRIPTOR_NULL_DATA`) and the
  descriptor is left fully null; an unallocated class entity is the null
  descriptor instead. Zero/negative declared or dynamic ids are likewise
  rejected. Every rejection path is asserted to leave the null state.
- **Aliasing.** The descriptor never aliases the value: `data` points at
  storage held elsewhere, and copying a descriptor copies a reference, never
  the value.
- **Dispatch/vtables/finalization:** out of scope for this issue (#419, #420,
  #421 follow). No lowering path is touched, so no existing dispatch,
  allocation, or finalization behaviour changes.

## Evidence

- Before: `fo test test_polymorphic_descriptor_layout` fails on unmodified main
  (`Cannot open module file 'ffc_polymorphic_descriptor.mod'`).
- After: PASS.
- Full `fo`: green except `test_parity_dashboard`, which fails in any `.wt/`
  worktree because the generator resolves `../fortfront` relative to the
  worktree; unrelated to this change.
- Conformance gauntlet (`--suite lfortran`): PASS=853 XFAIL=3364 XPASS=53
  FAIL=9 NOREF=157 SKIP=1, TOTAL=4280. Delta zero: this PR adds an isolated
  module, a test, and documentation, and touches no lowering path, so no corpus
  case can change classification. No XFAIL was added, weakened, or used to hide
  a failure.