### PR TITLE
[derived-alloc-assign-01] deep-copy allocatable derived components (#365)

### DIFF
--- a/src/session_program_lowering_derived_ctor.inc
+++ b/src/session_program_lowering_derived_ctor.inc
@@ -81,7 +81,100 @@
             if (.not. emit_i32_store(context%session, val, dst_addr, error_msg)) &
                 return
         end do
+        call deep_copy_alloc_components(context, dest_index, src_index, &
+                                        type_index, error_msg)
     end subroutine lower_derived_scalar_copy
+
+    subroutine deep_copy_alloc_components(context, dest_index, src_index, &
+                                          type_index, error_msg)
+        ! Give the destination independent ownership of every allocatable
+        ! component the raw slot copy left aliasing the source: allocate fresh
+        ! storage of the same byte span, copy the contents, and overwrite the
+        ! destination's inline data pointer. An unallocated source component
+        ! leaves the copied null pointer in place.
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: dest_index, src_index, type_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: c, elem_bytes, inner_bytes
+        logical :: is_array_comp
+
+        call set_empty(error_msg)
+        do c = 1, context%derived_types(type_index)%component_count
+            is_array_comp = component_is_alloc_array(context, type_index, c)
+            if (.not. is_array_comp .and. &
+                .not. component_is_allocatable(context, type_index, c)) cycle
+            elem_bytes = int(allocatable_elem_size( &
+                             component_kind(context, type_index, c)))
+            if (is_array_comp) then
+                inner_bytes = alloc_derived_inner_bytes(context, type_index, c)
+                if (inner_bytes > 0) elem_bytes = inner_bytes
+            end if
+            call deep_copy_one_alloc_component(context, dest_index, src_index, &
+                type_index, c, is_array_comp, elem_bytes, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine deep_copy_alloc_components
+
+    subroutine deep_copy_one_alloc_component(context, dest_index, src_index, &
+            type_index, comp_index, is_array_comp, elem_bytes, error_msg)
+        ! Reallocate and copy one allocatable component under a runtime null
+        ! guard: when the source pointer is null the destination keeps the null
+        ! the slot copy already stored.
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: dest_index, src_index, type_index, comp_index
+        logical, intent(in) :: is_array_comp
+        integer, intent(in) :: elem_bytes
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: src_desc, dst_desc, src_data, new_data
+        type(lr_operand_desc_t) :: extent64, bytes64, condition
+        integer(c_int32_t) :: copy_block, merge_block
+        integer :: slot
+
+        slot = component_start_slot(context, type_index, comp_index)
+        if (.not. emit_i32_array_element_addr(context%session, &
+                context%symbols(src_index)%array_size, &
+                context%symbols(src_index)%element_address, &
+                i32_immediate(context%session, int(slot, c_int64_t)), &
+                src_desc, error_msg)) return
+        if (.not. emit_i32_array_element_addr(context%session, &
+                context%symbols(dest_index)%array_size, &
+                context%symbols(dest_index)%element_address, &
+                i32_immediate(context%session, int(slot, c_int64_t)), &
+                dst_desc, error_msg)) return
+        if (.not. emit_ptr_load(context%session, src_desc, src_data, error_msg)) &
+            return
+        if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, src_data, &
+                null_ptr_operand(context), condition, error_msg)) return
+
+        copy_block = create_liric_block(context%session)
+        merge_block = create_liric_block(context%session)
+        if (.not. emit_liric_condbr(context%session, condition, copy_block, &
+                merge_block, error_msg)) return
+
+        if (.not. set_liric_block(context%session, copy_block, error_msg)) return
+        context%current_block_id = copy_block
+        context%current_block_terminated = .false.
+        if (is_array_comp) then
+            if (.not. emit_i64_load_at(context%session, src_desc, 8_c_int64_t, &
+                    extent64, error_msg)) return
+            if (.not. emit_i64_binary(context%session, LR_OP_MUL, extent64, &
+                    i64_immediate(context%session, int(elem_bytes, c_int64_t)), &
+                    bytes64, error_msg)) return
+        else
+            bytes64 = i64_immediate(context%session, int(elem_bytes, c_int64_t))
+        end if
+        if (.not. emit_malloc(context%session, bytes64, new_data, error_msg)) return
+        if (.not. emit_memcpy(context%session, new_data, src_data, bytes64, &
+                error_msg)) return
+        if (.not. emit_ptr_store(context%session, new_data, dst_desc, error_msg)) &
+            return
+        if (.not. emit_liric_br(context%session, merge_block, error_msg)) return
+
+        if (.not. set_liric_block(context%session, merge_block, error_msg)) return
+        context%current_block_id = merge_block
+        context%current_block_terminated = .false.
+        call set_empty(error_msg)
+    end subroutine deep_copy_one_alloc_component
 
     subroutine lower_derived_constructor_assignment(arena, call_index, context, &
             symbol_index, type_index, handled, error_msg)

--- a/test/test_session_derived_alloc_component_assignment_compiler.f90
+++ b/test/test_session_derived_alloc_component_assignment_compiler.f90
@@ -1,0 +1,130 @@
+program test_session_derived_alloc_component_assignment_compiler
+    ! Intrinsic assignment of a derived scalar deep-copies its allocatable
+    ! components: after y = x the destination owns its own storage, so writing
+    ! through the source afterwards leaves the destination unchanged. Covers a
+    ! scalar allocatable component, a rank-1 allocatable array component, an
+    ! unallocated component (which stays unallocated in the destination), and a
+    ! generic function result assigned into a declared variable.
+    use ffc_test_support, only: expect_output
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session derived allocatable component assignment test ==='
+
+    all_passed = .true.
+    if (.not. test_scalar_component_deep_copy()) all_passed = .false.
+    if (.not. test_array_component_deep_copy()) all_passed = .false.
+    if (.not. test_unallocated_component_stays_unallocated()) all_passed = .false.
+    if (.not. test_function_result_assignment()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: derived assignment deep-copies allocatable components'
+
+contains
+
+    logical function test_scalar_component_deep_copy()
+        ! b = a copies the scalar allocatable component's value into storage
+        ! owned by b; a%v = 7 afterwards must not reach b%v.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type :: box_t'//new_line('a')// &
+            '    integer, allocatable :: v'//new_line('a')// &
+            '  end type box_t'//new_line('a')// &
+            '  type(box_t) :: a, b'//new_line('a')// &
+            '  allocate(a%v)'//new_line('a')// &
+            '  a%v = 5'//new_line('a')// &
+            '  b = a'//new_line('a')// &
+            '  if (.not. allocated(b%v)) error stop 1'//new_line('a')// &
+            '  a%v = 7'//new_line('a')// &
+            '  print *, b%v'//new_line('a')// &
+            '  print *, a%v'//new_line('a')// &
+            'end program main'
+
+        test_scalar_component_deep_copy = expect_output( &
+            source, '           5'//new_line('a')//'           7'//new_line('a'), &
+            '/tmp/ffc_derived_assign_scalar')
+    end function test_scalar_component_deep_copy
+
+    logical function test_array_component_deep_copy()
+        ! Whole-derived copy of a rank-1 allocatable array component: b owns its
+        ! own elements, so a%v(1) = 99 afterwards leaves b%v(1) at 1.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type :: box_t'//new_line('a')// &
+            '    integer, allocatable :: v(:)'//new_line('a')// &
+            '  end type box_t'//new_line('a')// &
+            '  type(box_t) :: a, b'//new_line('a')// &
+            '  allocate(a%v(3))'//new_line('a')// &
+            '  a%v(1) = 1'//new_line('a')// &
+            '  a%v(2) = 2'//new_line('a')// &
+            '  a%v(3) = 3'//new_line('a')// &
+            '  b = a'//new_line('a')// &
+            '  if (.not. allocated(b%v)) error stop 1'//new_line('a')// &
+            '  if (size(b%v) /= 3) error stop 2'//new_line('a')// &
+            '  a%v(1) = 99'//new_line('a')// &
+            '  print *, b%v(1), b%v(2), b%v(3)'//new_line('a')// &
+            '  print *, a%v(1)'//new_line('a')// &
+            'end program main'
+
+        test_array_component_deep_copy = expect_output( &
+            source, &
+            '           1           2           3'//new_line('a')// &
+            '          99'//new_line('a'), &
+            '/tmp/ffc_derived_assign_array')
+    end function test_array_component_deep_copy
+
+    logical function test_unallocated_component_stays_unallocated()
+        ! An unallocated source component leaves the destination unallocated;
+        ! the destination can then be allocated independently.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type :: box_t'//new_line('a')// &
+            '    integer :: id'//new_line('a')// &
+            '    integer, allocatable :: v(:)'//new_line('a')// &
+            '  end type box_t'//new_line('a')// &
+            '  type(box_t) :: a, b'//new_line('a')// &
+            '  a%id = 11'//new_line('a')// &
+            '  b = a'//new_line('a')// &
+            '  if (allocated(b%v)) error stop 1'//new_line('a')// &
+            '  allocate(b%v(2))'//new_line('a')// &
+            '  b%v(1) = 4'//new_line('a')// &
+            '  b%v(2) = 6'//new_line('a')// &
+            '  if (allocated(a%v)) error stop 2'//new_line('a')// &
+            '  print *, b%id, b%v(1), b%v(2)'//new_line('a')// &
+            'end program main'
+
+        test_unallocated_component_stays_unallocated = expect_output( &
+            source, '          11           4           6'//new_line('a'), &
+            '/tmp/ffc_derived_assign_unalloc')
+    end function test_unallocated_component_stays_unallocated
+
+    logical function test_function_result_assignment()
+        ! A module function result carrying an allocatable array component
+        ! assigns into a declared variable with its own storage.
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '  type :: box_t'//new_line('a')// &
+            '    integer, allocatable :: v(:)'//new_line('a')// &
+            '  end type box_t'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  function make() result(r)'//new_line('a')// &
+            '    type(box_t) :: r'//new_line('a')// &
+            '    allocate(r%v(2))'//new_line('a')// &
+            '    r%v(1) = 4'//new_line('a')// &
+            '    r%v(2) = 5'//new_line('a')// &
+            '  end function make'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  type(box_t) :: b'//new_line('a')// &
+            '  b = make()'//new_line('a')// &
+            '  print *, b%v(1), b%v(2)'//new_line('a')// &
+            'end program main'
+
+        test_function_result_assignment = expect_output( &
+            source, '           4           5'//new_line('a'), &
+            '/tmp/ffc_derived_assign_result')
+    end function test_function_result_assignment
+
+end program test_session_derived_alloc_component_assignment_compiler


### PR DESCRIPTION
Fixes #365.

Intrinsic assignment of a derived type with allocatable components now deep-copies those components instead of copying the descriptor.

Preserved invariant:
- After `b = a`, the destination does not alias source storage. Mutating `a%v` afterwards leaves `b%v` unchanged (previously `b = a; a%v = 7` printed 7 instead of 5).
- An unallocated source component leaves the corresponding destination component unallocated.

Covered by `test_session_derived_alloc_component_assignment_compiler`.

Full `fo` pipeline run locally. Remaining failures (`test_parity_dashboard`, `test_session_reject_io_01_compiler`, `test_fortfront_corpus_conformance`) reproduce on unmodified origin/main and are environmental/pre-existing.