### PR TITLE
[interface-body-01] preserve bodies after interface blocks (refs #357)

### DIFF
--- a/test/conformance/fail_owners_lfortran.txt
+++ b/test/conformance/fail_owners_lfortran.txt
@@ -3,6 +3,5 @@
 block_data_02.f90 # owner=lazy-fortran/ffc#463; reason=lower structured DATA initialization
 common_18.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
 implicit_interface_38b.f90 # owner=lazy-fortran/ffc#353; reason=register positional alternate-return slots
-interface_29.f90 # owner=lazy-fortran/ffc#357; reason=preserve bodies after interface blocks
 modules_58_module.f90 # owner=lazy-fortran/ffc#358; reason=lower multi-object ALLOCATE
 pointer_13.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities

--- a/test/test_session_interface_external_call_compiler.f90
+++ b/test/test_session_interface_external_call_compiler.f90
@@ -42,5 +42,39 @@ program test_session_interface_external_call_compiler
         'end program', 0, &
         '/tmp/ffc_session_interface_external_call_test')) stop 1
 
+    ! An INTERFACE block inside the specification part of a module procedure
+    ! only declares signatures; it must not terminate the procedure. The
+    ! declarations and executable statements that follow it stay part of the
+    ! body, and the program unit after the module is still compiled.
+    if (.not. expect_exit_status( &
+        'module bench_mod'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '    subroutine run(x)'//new_line('a')// &
+        '        interface'//new_line('a')// &
+        '            integer function f()'//new_line('a')// &
+        '            end function f'//new_line('a')// &
+        '        end interface'//new_line('a')// &
+        '        integer :: x'//new_line('a')// &
+        '        if (x /= 1) error stop'//new_line('a')// &
+        '        print *, x'//new_line('a')// &
+        '    end subroutine run'//new_line('a')// &
+        '    integer function twice(y)'//new_line('a')// &
+        '        interface'//new_line('a')// &
+        '            subroutine sub(a)'//new_line('a')// &
+        '                integer, intent(in) :: a'//new_line('a')// &
+        '            end subroutine sub'//new_line('a')// &
+        '        end interface'//new_line('a')// &
+        '        integer, intent(in) :: y'//new_line('a')// &
+        '        twice = 2 * y'//new_line('a')// &
+        '    end function twice'//new_line('a')// &
+        'end module bench_mod'//new_line('a')// &
+        'program p'//new_line('a')// &
+        '    use bench_mod'//new_line('a')// &
+        '    implicit none'//new_line('a')// &
+        '    call run(1)'//new_line('a')// &
+        '    if (twice(3) /= 6) error stop'//new_line('a')// &
+        'end program p', 0, &
+        '/tmp/ffc_session_interface_unused_body_test')) stop 1
+
     print *, 'PASS: external functions called through explicit interfaces'
 end program test_session_interface_external_call_compiler


### PR DESCRIPTION
Closes #357.

## Invariant
An INTERFACE block in the specification part of a module-contained procedure only declares signatures. It must not terminate the procedure body, and the program units after the module must still be compiled and run.

## Change
- `test/test_session_interface_external_call_compiler.f90`: new behavioral case covering the `interface_29` shape — a module subroutine and a module function each holding an unused INTERFACE block, followed by declarations and executable statements, called from a main program (exit status 0 oracle).
- `test/conformance/fail_owners_lfortran.txt`: drop the now-stale `interface_29.f90` FAIL-ownership entry.

## Evidence
Red: the case was recorded as a FAIL owned by #357 (frontend dropped every program unit after the module, so no main was emitted — lazy-fortran/fortfront#2928).
Green with fortfront main (#2928/#2933 landed):
- `fo test test_session_interface_external_call_compiler` -> 1 passed
- `scripts/conformance_gauntlet.sh --suite lfortran --file interface_29.f90` -> PASS=1 FAIL=0
- full `fo`: Static OK, Build OK. Remaining test failures (`test_fortfront_corpus_conformance`, `test_session_reject_io_01_compiler`) reproduce unchanged on a clean origin/main worktree; `test_parity_dashboard` and `test_conformance_gauntlet_smoke` are the known worktree/`/tmp` environment failures. This PR touches no `src/`.