### PR TITLE
[alternate-return-01] register positional alternate-return slots (refs #353)

### DIFF
--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -217,6 +217,26 @@ contents; the next call through `fp` picks up the new address.
   dummies are supported by-reference integer, real, or logical scalars. General
   top-level external-procedure signatures remain outside this ABI slice.
 
+### Alternate returns
+
+Each `*` in a dummy argument list is a distinct positional alternate-return
+slot, not a named dummy: it occupies no parameter position and takes no
+argument. A subroutine that declares one or more `*` dummies carries one hidden
+trailing `i32`-by-reference selector parameter, appended after the visible
+pointer parameters and after any hidden assumed-shape extent arguments. `return
+n` stores `n` into that slot and returns; a plain `RETURN` (or falling off the
+end) leaves the slot untouched.
+
+The caller allocates the selector slot, stores `0` into it, drops each `*label`
+actual argument from the passed argument list, and passes the slot's address as
+the trailing argument. After the call it loads the selector and branches to the
+block of the `n`-th `*label` argument when the value is `n`; `0` (and any value
+outside `1..n`) falls through to the statement after the `CALL`, as the standard
+requires. Because the branch targets are statement labels, a call with
+alternate-return arguments is lowered only inside a body that carries statement
+labels. `return n` with `n` outside the declared slot count is rejected at
+compile time.
+
 ### Assumed-shape runtime extent (W2)
 
 A rank-1 or rank-2 assumed-shape dummy (`a(:)` or `a(:,:)`) whose actual has no

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -50,7 +50,9 @@ module session_program_lowering
         BINDING_DUMMY_ARGUMENT, BINDING_FUNCTION_RESULT, &
         BINDING_NAMED_CONSTANT, ASSOCIATION_DIRECT, ASSOCIATION_HOST, &
         ASSOCIATION_USE, &
-        BINDING_ASSOCIATE_NAME
+        BINDING_ASSOCIATE_NAME, &
+        get_alternate_return_label, get_return_selector, &
+        is_alternate_return_dummy
     use liric_session_bindings, only: destroy, begin_i32_main, &
         liric_session_t, &
         begin_i32_function, begin_i64_function, begin_void_subroutine, &
@@ -1858,6 +1860,7 @@ contains
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: name, call_name
         integer, allocatable :: arg_indices(:)
+        integer, allocatable :: alt_labels(:)
         type(lr_operand_desc_t), allocatable :: args(:)
         integer, allocatable :: copyback_indices(:)
         integer :: call_arg_count
@@ -1874,6 +1877,9 @@ contains
         call get_subroutine_call_arg_indices(arena, node_index, arg_indices, &
             error_msg)
         if (len_trim(error_msg) > 0) return
+        ! `*label` actual arguments are alternate-return specifiers, not passed
+        ! arguments: split them off before argument analysis (#353).
+        call split_alt_return_args(arena, arg_indices, alt_labels)
         ! Resolve generic -> specific (#249 B7c).
         call_arg_count = 0
         call_arg_kinds = VALUE_I32
@@ -1938,6 +1944,12 @@ contains
         call prepare_reference_args(arena, arg_indices, context, VALUE_I32, &
             call_name, args, copyback_indices, error_msg)
         if (len_trim(error_msg) > 0) return
+        if (size(alt_labels) > 0) then
+            call emit_alt_return_call(arena, node_index, &
+                call_emit_name(arena, call_name, context), args, alt_labels, &
+                copyback_indices, context, error_msg)
+            return
+        end if
         if (.not. emit_call_with_optional_padding(context, &
             call_emit_name(arena, call_name, context), args, error_msg)) &
             return

--- a/src/session_program_lowering_functions_tail.inc
+++ b/src/session_program_lowering_functions_tail.inc
@@ -9,6 +9,9 @@
         type(lowering_context_t) :: context
         type(lr_operand_desc_t) :: value
         integer :: param_count
+        integer :: visible_param_count
+        integer :: altret_count
+        integer :: hidden_altret_count
         integer :: hidden_extent_count
         integer :: table_function_index
         logical :: terminated
@@ -58,6 +61,17 @@
         ! time (an allocatable actual) carries one hidden i64 extent argument
         ! appended after the visible parameters (#W2 runtime-extent ABI).
         hidden_extent_count = callee_hidden_extent_count(context, trim(node%name))
+        ! Each `*` dummy is a positional alternate-return slot, not a passed
+        ! argument: the slots collapse into one hidden trailing selector
+        ! parameter (#353).
+        altret_count = alt_return_slot_count(arena, node%param_indices)
+        visible_param_count = param_count - altret_count
+        hidden_altret_count = 0
+        if (altret_count > 0) hidden_altret_count = 1
+        context%altret_slot_count = altret_count
+        if (altret_count > 0) then
+            context%altret_param_index = visible_param_count + hidden_extent_count
+        end if
         if (present(emit_name_override)) then
             emit_name = trim(emit_name_override)
         else
@@ -65,7 +79,8 @@
                 context%current_proc_node_index, node%name, node%bind_c_clause)
         end if
         if (.not. begin_void_subroutine(context%session, emit_name, &
-                param_count + hidden_extent_count, error_msg)) return
+                visible_param_count + hidden_extent_count + hidden_altret_count, &
+                error_msg)) return
 
         call materialize_host_character_globals(context, error_msg)
         if (len_trim(error_msg) > 0) return
@@ -76,7 +91,8 @@
 
         if (hidden_extent_count > 0) then
             call bind_hidden_extent_params(arena, node%param_indices, context, &
-                                           trim(node%name), param_count, error_msg)
+                                           trim(node%name), visible_param_count, &
+                                           error_msg)
             if (len_trim(error_msg) > 0) return
         end if
 
@@ -1123,6 +1139,7 @@
         character(len=:), allocatable :: name
         integer :: offset
         integer :: i
+        integer :: slot
         integer :: value_kind
         integer :: rvk
 
@@ -1132,7 +1149,12 @@
         rvk = 0
         if (present(return_value_kind)) rvk = return_value_kind
         if (.not. allocated(param_indices)) return
+        slot = 0
         do i = 1, size(param_indices)
+            ! An alternate-return slot is positional, carries no name and no
+            ! passed argument; it never occupies a parameter position (#353).
+            if (is_alternate_return_dummy(arena, param_indices(i))) cycle
+            slot = slot + 1
             call parameter_name(arena, param_indices(i), name, error_msg)
             if (len_trim(error_msg) > 0) return
             value_kind = VALUE_I32
@@ -1149,12 +1171,172 @@
                     end if
                 end if
             end if
-            call define_parameter_symbol(context, name, i - 1 + offset, &
+            call define_parameter_symbol(context, name, slot - 1 + offset, &
                                          value_kind, error_msg, &
                                          parameter_node_index=param_indices(i))
             if (len_trim(error_msg) > 0) return
         end do
     end subroutine define_reference_parameters
+
+    subroutine split_alt_return_args(arena, arg_indices, alt_labels)
+        ! Remove `*label` alternate-return specifiers from an actual argument
+        ! list and report their statement labels in call order (#353).
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(inout) :: arg_indices(:)
+        integer, allocatable, intent(out) :: alt_labels(:)
+        integer, allocatable :: plain(:)
+        integer, allocatable :: labels(:)
+        integer :: i, plain_count, label_count, label
+
+        allocate(alt_labels(0))
+        if (.not. allocated(arg_indices)) return
+        if (size(arg_indices) == 0) return
+        allocate(plain(size(arg_indices)))
+        allocate(labels(size(arg_indices)))
+        plain_count = 0
+        label_count = 0
+        do i = 1, size(arg_indices)
+            label = get_alternate_return_label(arena, arg_indices(i))
+            if (label > 0) then
+                label_count = label_count + 1
+                labels(label_count) = label
+            else
+                plain_count = plain_count + 1
+                plain(plain_count) = arg_indices(i)
+            end if
+        end do
+        if (label_count == 0) return
+        deallocate(alt_labels)
+        allocate(alt_labels(label_count))
+        alt_labels = labels(1:label_count)
+        deallocate(arg_indices)
+        allocate(arg_indices(plain_count))
+        arg_indices = plain(1:plain_count)
+    end subroutine split_alt_return_args
+
+    subroutine emit_alt_return_call(arena, node_index, emit_name, args, &
+                                    alt_labels, copyback_indices, context, &
+                                    error_msg)
+        ! Call a subroutine with alternate-return specifiers: pass a zeroed
+        ! hidden selector slot as the trailing argument, then branch to the
+        ! n-th caller label when the callee stored n (#353). Selector 0 (a
+        ! plain RETURN) falls through to the statement after the CALL.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: emit_name
+        type(lr_operand_desc_t), intent(in) :: args(:)
+        integer, intent(in) :: alt_labels(:)
+        integer, intent(in) :: copyback_indices(:)
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t), allocatable :: call_args(:)
+        type(lr_operand_desc_t) :: slot, selector, ordinal, condition
+        integer(c_int32_t) :: target_block, next_block
+        character(len=16) :: label_text
+        logical :: found
+        integer :: i
+
+        call set_empty(error_msg)
+        if (.not. context%in_labeled_body) then
+            call unsupported_feature_error('alternate return call', &
+                get_node_line(arena, node_index), &
+                get_node_column(arena, node_index), &
+                'a call with alternate-return arguments is only lowered '// &
+                'inside a body carrying statement labels', error_msg)
+            return
+        end if
+        if (.not. emit_i32_alloca(context%session, slot, error_msg)) return
+        if (.not. emit_i32_store(context%session, &
+                i32_immediate(context%session, 0_c_int64_t), slot, &
+                error_msg)) return
+        allocate(call_args(size(args) + 1))
+        if (size(args) > 0) call_args(1:size(args)) = args
+        call_args(size(args) + 1) = slot
+        if (.not. emit_void_call(context%session, emit_name, call_args, &
+                                 error_msg)) return
+        call copy_back_reference_args(context, args, copyback_indices, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_i32_load(context%session, slot, selector, error_msg)) &
+            return
+        do i = 1, size(alt_labels)
+            write (label_text, '(i0)') alt_labels(i)
+            target_block = find_label_block(context, trim(label_text), found)
+            if (.not. found) then
+                error_msg = 'alternate return targets undefined statement '// &
+                            'label: '//trim(label_text)
+                return
+            end if
+            ordinal = i32_immediate(context%session, int(i, c_int64_t))
+            if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, selector, &
+                                          ordinal, condition, error_msg)) return
+            next_block = create_liric_block(context%session)
+            if (.not. emit_liric_condbr(context%session, condition, &
+                                        target_block, next_block, error_msg)) &
+                return
+            if (.not. set_liric_block(context%session, next_block, error_msg)) &
+                return
+            context%current_block_id = next_block
+        end do
+    end subroutine emit_alt_return_call
+
+    subroutine lower_alternate_return(arena, node_index, context, error_msg)
+        ! `return n` inside a subroutine with alternate-return dummies stores
+        ! the selector n into the hidden trailing selector parameter; the
+        ! caller branches on it (#353). A plain RETURN leaves the slot at the
+        ! zero the caller wrote, which means "continue after the CALL".
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        logical :: has_selector
+        integer :: selector_index
+        integer(c_int64_t) :: literal
+        character(len=:), allocatable :: parse_error
+        type(lr_operand_desc_t) :: selector, slot
+
+        call set_empty(error_msg)
+        call get_return_selector(arena, node_index, has_selector, selector_index)
+        if (.not. has_selector) return
+        if (selector_index <= 0) then
+            error_msg = 'alternate return is missing its selector expression'
+            return
+        end if
+        if (context%altret_slot_count <= 0 .or. context%altret_param_index < 0) then
+            error_msg = 'alternate return used in a subroutine that declares '// &
+                        'no alternate-return dummy'
+            return
+        end if
+        call parse_i32_constant(arena, selector_index, literal, 'selector', &
+                                parse_error)
+        if (len_trim(parse_error) == 0) then
+            if (literal < 1_c_int64_t .or. &
+                literal > int(context%altret_slot_count, c_int64_t)) then
+                error_msg = 'alternate return selector is outside the '// &
+                            'declared alternate-return slots'
+                return
+            end if
+        end if
+        call lower_i32_expression(arena, selector_index, context, selector, &
+                                  error_msg)
+        if (len_trim(error_msg) > 0) return
+        slot = ptr_param(context%session, context%altret_param_index)
+        if (.not. emit_i32_store(context%session, selector, slot, error_msg)) &
+            return
+    end subroutine lower_alternate_return
+
+    integer function alt_return_slot_count(arena, param_indices) result(count)
+        ! Number of `*` alternate-return dummies in a dummy argument list.
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: param_indices(:)
+        integer :: i
+
+        count = 0
+        if (.not. allocated(param_indices)) return
+        do i = 1, size(param_indices)
+            if (is_alternate_return_dummy(arena, param_indices(i))) &
+                count = count + 1
+        end do
+    end function alt_return_slot_count
 
     subroutine parameter_name(arena, node_index, name, error_msg)
         type(ast_arena_t), intent(in) :: arena

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -962,6 +962,9 @@
             call lower_deallocate_statement(arena, node, context, error_msg)
         type is (return_node)
             if (context%in_internal_subroutine) then
+                call lower_alternate_return(arena, node_index, context, &
+                                            error_msg)
+                if (len_trim(error_msg) > 0) return
                 if (.not. emit_ret_void(context%session, error_msg)) return
                 context%current_block_terminated = .true.
             else if (context%in_internal_function) then

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -586,6 +586,13 @@ module session_program_lowering_types
         integer :: operator_count = 0
         logical :: in_internal_function = .false.
         logical :: in_internal_subroutine = .false.
+        ! Alternate-return ABI (#353). A subroutine with `*` dummies takes one
+        ! hidden trailing i32-by-reference selector parameter at 0-based
+        ! position altret_param_index; `return n` stores n into it. The caller
+        ! allocates the slot, zeroes it, and branches on the loaded value.
+        ! altret_slot_count is the number of `*` dummies (0 means none).
+        integer :: altret_slot_count = 0
+        integer :: altret_param_index = -1
         ! Name of the contained procedure currently being lowered. Lets an
         ! assumed-shape dummy a(:) recover its extent from the caller's actual.
         character(len=:), allocatable :: current_proc_name

--- a/test/conformance/fail_owners_lfortran.txt
+++ b/test/conformance/fail_owners_lfortran.txt
@@ -2,6 +2,5 @@
 # Entries annotate reports and do not change gauntlet dispositions.
 block_data_02.f90 # owner=lazy-fortran/ffc#463; reason=lower structured DATA initialization
 common_18.f90 # owner=lazy-fortran/ffc#351; reason=preserve mixed-width COMMON byte layout
-implicit_interface_38b.f90 # owner=lazy-fortran/ffc#353; reason=register positional alternate-return slots
 modules_58_module.f90 # owner=lazy-fortran/ffc#358; reason=lower multi-object ALLOCATE
 pointer_13.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities

--- a/test/test_session_alternate_return_compiler.f90
+++ b/test/test_session_alternate_return_compiler.f90
@@ -1,0 +1,77 @@
+program test_session_alternate_return_compiler
+    use ffc_test_support, only: expect_output, expect_error_contains
+    implicit none
+
+    print *, '=== direct session alternate-return compiler test ==='
+
+    ! Two alternate-return slots are distinct positional specifiers: RETURN 1
+    ! branches to the first caller label, RETURN 2 to the second.
+    if (.not. expect_output( &
+        'program main'//new_line('a')// &
+        '    implicit none'//new_line('a')// &
+        '    call s(1, *100, *200)'//new_line('a')// &
+        '    goto 900'//new_line('a')// &
+        '100 print *, 1'//new_line('a')// &
+        '    call s(2, *910, *200)'//new_line('a')// &
+        '    goto 900'//new_line('a')// &
+        '200 print *, 2'//new_line('a')// &
+        '    goto 900'//new_line('a')// &
+        '910 continue'//new_line('a')// &
+        '900 continue'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '    subroutine s(k, *, *)'//new_line('a')// &
+        '        integer, intent(in) :: k'//new_line('a')// &
+        '        if (k == 1) return 1'//new_line('a')// &
+        '        return 2'//new_line('a')// &
+        '    end subroutine s'//new_line('a')// &
+        'end program main', &
+        '           1'//new_line('a')//'           2'//new_line('a'), &
+        '/tmp/ffc_session_altret_two_slots_test')) stop 1
+    print *, 'PASS: two alternate returns branch to distinct labels'
+
+    ! A plain RETURN in a subroutine with alternate-return slots continues at
+    ! the statement after the CALL.
+    if (.not. expect_output( &
+        'program main'//new_line('a')// &
+        '    implicit none'//new_line('a')// &
+        '    call s(0, *100, *200)'//new_line('a')// &
+        '    print *, 7'//new_line('a')// &
+        '    goto 900'//new_line('a')// &
+        '100 print *, 1'//new_line('a')// &
+        '    goto 900'//new_line('a')// &
+        '200 print *, 2'//new_line('a')// &
+        '900 continue'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '    subroutine s(k, *, *)'//new_line('a')// &
+        '        integer, intent(in) :: k'//new_line('a')// &
+        '        if (k == 1) return 1'//new_line('a')// &
+        '        if (k == 2) return 2'//new_line('a')// &
+        '        return'//new_line('a')// &
+        '    end subroutine s'//new_line('a')// &
+        'end program main', &
+        '           7'//new_line('a'), &
+        '/tmp/ffc_session_altret_plain_return_test')) stop 1
+    print *, 'PASS: plain return falls through to the statement after the call'
+
+    ! RETURN 3 with only two alternate-return slots is a diagnostic.
+    if (.not. expect_error_contains( &
+        'program main'//new_line('a')// &
+        '    implicit none'//new_line('a')// &
+        '    call s(1, *100, *200)'//new_line('a')// &
+        '    goto 900'//new_line('a')// &
+        '100 print *, 1'//new_line('a')// &
+        '    goto 900'//new_line('a')// &
+        '200 print *, 2'//new_line('a')// &
+        '900 continue'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '    subroutine s(k, *, *)'//new_line('a')// &
+        '        integer, intent(in) :: k'//new_line('a')// &
+        '        return 3'//new_line('a')// &
+        '    end subroutine s'//new_line('a')// &
+        'end program main', &
+        'alternate return', &
+        '/tmp/ffc_session_altret_out_of_range_test')) stop 1
+    print *, 'PASS: out-of-range alternate return is rejected'
+
+    print *, 'PASS: alternate returns lower through direct LIRIC session'
+end program test_session_alternate_return_compiler


### PR DESCRIPTION
Closes #353.

## What changed

- Each `*` dummy is a distinct **positional** alternate-return slot, not a dummy named `*`. `is_alternate_return_dummy` (FortFront #2933) drives the split; `*` slots no longer occupy parameter positions, so `subroutine s(k, *, *)` no longer trips the duplicate-parameter path.
- ABI: a subroutine with `*` dummies carries one hidden trailing i32-by-reference selector parameter, appended after the visible pointer params and after any hidden assumed-shape extent args. `return n` stores n into it; a plain RETURN leaves it at the caller's zero.
- Caller: `*label` actuals (`get_alternate_return_label`) are split out of the argument list; the caller allocates and zeroes the selector slot, passes its address, then branches to the n-th label's block when the selector is n. 0 / out-of-range falls through, as F2018 15.6.2.6 requires.
- `return n` with a constant n outside the declared slot count is a compile-time diagnostic.
- `docs/RUNTIME_ABI.md`: new "Alternate returns" section.
- `test/conformance/fail_owners_lfortran.txt`: `implicit_interface_38b.f90` promoted (now PASS).

## Preserved invariant

Ordinary dummy ABI is unchanged: with no `*` dummies, `alt_return_slot_count` is 0, no hidden selector param is emitted, and every parameter position is exactly as before. Hidden assumed-shape extent params keep their position relative to the *visible* parameter count.

## Red evidence (before)

`fo test test_session_alternate_return_compiler`:
```
test_session_alternate_return_compiler     FAIL
 FAIL: ffc direct-session lowering only supports integer expressions
```

## Green evidence (after)

```
test_session_alternate_return_compiler     PASS
scripts/conformance_gauntlet.sh --suite lfortran --file implicit_interface_38b.f90
  PASS=1  XFAIL=0  XPASS=0  FAIL=0
```

Full `fo` pipeline: build + lint clean. Three test failures remain, all reproduced independently of this branch:
- `test_parity_dashboard` — resolves sibling repos as `../fortfront`, always fails inside a `.wt/` worktree.
- `test_fortfront_corpus_conformance` — its report shows ffc binaries from *other* agents' worktrees (shared /tmp report paths).
- `test_session_reject_io_01_compiler` — FortFront-main drift: `write (unit=6,end=999) 0` now yields `Zero is not a valid statement label` instead of the END= diagnostic. Reproduced with two other branches' prebuilt ffc binaries, so it predates this change.