### PR TITLE
[runtime-01] build backend-qualified LIRIC runtime archives

### DIFF
--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -469,6 +469,69 @@ components = [
   `use, only:` names and rename targets are validated against the records; a
   local rename keeps the recorded remote name for storage and linkage.
 
+## Runtime archives
+
+`ffc` packages its runtime support code into LIRIC runtime archives, one per
+target/backend pair. The archives are data artifacts: nothing links against
+them, and this slice does not load them into an ffc session.
+
+The standalone CMake project in `runtime/` builds them. `runtime/ffc_runtime.c`
+is compiled to LLVM bitcode with `clang -emit-llvm -c`, and
+`liric_runtime_archive` packages that bitcode once per backend.
+
+### Artifact names
+
+Archives are written to a target-qualified directory,
+`<build>/artifacts/<target>/`, so archives for different targets never
+collide. Within it the names are:
+
+| Backend | Artifact |
+|---|---|
+| isel | `ffc-runtime-v2-isel.lrarch` |
+| copy-patch | `ffc-runtime-v2-copy-patch.lrarch` |
+| llvm | `ffc-runtime-v2-llvm.lrarch` (only when LLVM is available) |
+
+`v2` is the artifact naming version. It is bumped when the artifact layout or
+the packaged payload contract changes, and is independent of the LIRIC archive
+format version recorded inside each file.
+
+The LIRIC session backend `default` is an alias for copy-patch and has no
+artifact of its own: a consumer asking for `default` selects
+`ffc-runtime-v2-copy-patch.lrarch`.
+
+The `llvm` artifact is produced only when the configuration opts in with
+`-DFFC_RUNTIME_ENABLE_LLVM=ON` and the LIRIC build exposes the LLVM backend, so
+a LIRIC build without LLVM never silently omits a requested artifact.
+
+### Archive format
+
+Each file is a LIRIC runtime archive. Its header is the 8-byte magic
+`LRARCH1\0`, then little-endian `u32` format version, `u32` backend code,
+`u32` target-name length, `u64` IR text length, and `u64` blob-package length.
+The current format version is 2. The backend code is the LIRIC session backend
+enumerator: 1 for isel, 2 for copy-patch, 3 for LLVM. Because the backend is
+recorded in the file, two archives built for different backends are never
+byte-identical.
+
+### Payload
+
+The archive carries the runtime's LIRIC IR text plus a compiled blob package.
+This slice defines exactly one entry point:
+
+- `int _ffc_runtime_probe(void)` returns 42. It exists so a consumer can
+  confirm end to end that the archive it selected actually resolves.
+
+Runtime entry points for file units, formatted output, IOSTAT/IOMSG, and
+descriptor allocation are added by their own issues.
+
+### Dependencies
+
+`clang` and `liric_runtime_archive` are both required. Either one missing fails
+configuration with a named `ffc runtime dependency missing: <name>` diagnostic;
+neither is silently skipped. The archive tool is located through
+`-DLIRIC_BUILD_DIR=`, the `LIRIC_BUILD_DIR` environment variable, or a sibling
+LIRIC checkout.
+
 ## Unsupported ABI Work
 
 - #53: array descriptors, allocatables, and pointer representation.

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,0 +1,112 @@
+# Backend-qualified LIRIC runtime archives for ffc (issue #374).
+#
+# Produces, under a target-qualified artifact directory, one archive per
+# supported LIRIC backend:
+#
+#   <artifact_dir>/ffc-runtime-v2-isel.lrarch
+#   <artifact_dir>/ffc-runtime-v2-copy-patch.lrarch
+#   <artifact_dir>/ffc-runtime-v2-llvm.lrarch   (only when LLVM is available)
+#
+# The LIRIC session backend `default` is an alias for copy-patch, so it has no
+# archive of its own; a loader asking for `default` selects the copy-patch
+# artifact.
+#
+# This project is deliberately standalone: ffc itself is an fpm project, and
+# this only produces data artifacts, never a library ffc links against.
+
+cmake_minimum_required(VERSION 3.16)
+project(ffc_runtime C)
+
+# Archive naming version. Bumped when the artifact layout or the archive
+# payload contract changes, independent of the LIRIC archive format version
+# recorded inside each file.
+set(FFC_RUNTIME_ARTIFACT_VERSION "v2")
+
+# --- Dependency discovery, each with a named diagnostic ---------------------
+
+find_program(FFC_RUNTIME_CLANG NAMES clang)
+if(NOT FFC_RUNTIME_CLANG)
+    message(FATAL_ERROR
+        "ffc runtime dependency missing: clang. "
+        "clang is required to compile runtime/ffc_runtime.c to LLVM bitcode. "
+        "Install clang or set -DFFC_RUNTIME_CLANG=<path>.")
+endif()
+
+find_program(FFC_RUNTIME_ARCHIVE_TOOL
+    NAMES liric_runtime_archive
+    HINTS
+        ${LIRIC_BUILD_DIR}
+        $ENV{LIRIC_BUILD_DIR}
+        # Sibling LIRIC checkout, both from the primary checkout and from a
+        # git worktree one level deeper.
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../liric/build
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../liric/build
+    NO_DEFAULT_PATH)
+if(NOT FFC_RUNTIME_ARCHIVE_TOOL)
+    find_program(FFC_RUNTIME_ARCHIVE_TOOL NAMES liric_runtime_archive)
+endif()
+if(NOT FFC_RUNTIME_ARCHIVE_TOOL)
+    message(FATAL_ERROR
+        "ffc runtime dependency missing: liric_runtime_archive. "
+        "Build LIRIC first, then re-configure with "
+        "-DLIRIC_BUILD_DIR=<liric-build-dir>.")
+endif()
+
+# --- Target qualification ---------------------------------------------------
+
+# The archive records the LIRIC target it was built for, and the artifact
+# directory repeats it so archives for different targets never collide.
+if(NOT FFC_RUNTIME_TARGET)
+    set(FFC_RUNTIME_TARGET "host")
+endif()
+set(FFC_RUNTIME_ARTIFACT_DIR
+    "${CMAKE_CURRENT_BINARY_DIR}/artifacts/${FFC_RUNTIME_TARGET}")
+file(MAKE_DIRECTORY "${FFC_RUNTIME_ARTIFACT_DIR}")
+
+# --- Runtime bitcode --------------------------------------------------------
+
+set(FFC_RUNTIME_BC "${CMAKE_CURRENT_BINARY_DIR}/ffc_runtime.bc")
+add_custom_command(
+    OUTPUT "${FFC_RUNTIME_BC}"
+    COMMAND "${FFC_RUNTIME_CLANG}" -emit-llvm -c -O1
+            -o "${FFC_RUNTIME_BC}"
+            "${CMAKE_CURRENT_SOURCE_DIR}/ffc_runtime.c"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/ffc_runtime.c"
+    COMMENT "Compiling ffc runtime to LLVM bitcode"
+    VERBATIM)
+
+# --- One archive per backend ------------------------------------------------
+
+# LLVM archives can only be produced when the LIRIC build exposes the LLVM
+# backend. Callers that want it opt in explicitly so a LIRIC build without
+# LLVM does not silently skip a requested artifact.
+set(FFC_RUNTIME_BACKENDS isel copy_patch)
+if(FFC_RUNTIME_ENABLE_LLVM)
+    list(APPEND FFC_RUNTIME_BACKENDS llvm)
+endif()
+
+set(FFC_RUNTIME_ARCHIVES "")
+foreach(backend IN LISTS FFC_RUNTIME_BACKENDS)
+    # Artifact names use a dash; the tool's backend token uses an underscore.
+    string(REPLACE "_" "-" backend_name "${backend}")
+    set(archive
+        "${FFC_RUNTIME_ARTIFACT_DIR}/ffc-runtime-${FFC_RUNTIME_ARTIFACT_VERSION}-${backend_name}.lrarch")
+    if(FFC_RUNTIME_TARGET STREQUAL "host")
+        set(target_args "")
+    else()
+        set(target_args --target "${FFC_RUNTIME_TARGET}")
+    endif()
+    add_custom_command(
+        OUTPUT "${archive}"
+        COMMAND "${FFC_RUNTIME_ARCHIVE_TOOL}"
+                --input-bc "${FFC_RUNTIME_BC}"
+                --backend "${backend}"
+                ${target_args}
+                --output "${archive}"
+        DEPENDS "${FFC_RUNTIME_BC}"
+        COMMENT "Packaging ffc runtime archive for backend ${backend_name}"
+        VERBATIM)
+    list(APPEND FFC_RUNTIME_ARCHIVES "${archive}")
+endforeach()
+
+add_custom_target(ffc_runtime_archives ALL DEPENDS ${FFC_RUNTIME_ARCHIVES})

--- a/runtime/ffc_runtime.c
+++ b/runtime/ffc_runtime.c
@@ -1,0 +1,17 @@
+/* ffc runtime support library.
+ *
+ * This translation unit is compiled to LLVM bitcode and packaged into one
+ * backend-qualified LIRIC runtime archive per target/backend pair
+ * (see runtime/CMakeLists.txt and docs/RUNTIME_ABI.md).
+ *
+ * It currently carries only the probe symbol that lets a consumer confirm it
+ * loaded a real archive. Runtime entry points for file units, formatted
+ * output, IOSTAT/IOMSG, and descriptor allocation are added by their own
+ * issues; this issue only establishes the artifact.
+ */
+
+/* Returns 42. The sole purpose is to give a loader a cheap, unambiguous
+ * end-to-end check that the archive it selected actually resolves. */
+int _ffc_runtime_probe(void) {
+    return 42;
+}

--- a/test/test_runtime_archives.f90
+++ b/test/test_runtime_archives.f90
@@ -1,0 +1,222 @@
+! Issue #374: build backend-qualified LIRIC runtime archives.
+!
+! Behavioral oracle for the runtime artifact production step. It drives the
+! standalone runtime/ CMake project and checks the produced artifacts against
+! their documented contract rather than against the patch:
+!
+!   * one archive per backend, at the documented target-qualified path
+!   * each archive is nonempty and carries the LIRIC archive magic and a
+!     nonzero format version
+!   * each archive records the backend it was built for, so the artifacts are
+!     genuinely backend-qualified and not copies of one another
+!   * the packaged runtime IR defines the probe symbol
+!   * a missing tool dependency fails with a named diagnostic
+program test_runtime_archives
+    implicit none
+
+    character(len=*), parameter :: build_dir = '/tmp/ffc_runtime_374_build'
+    character(len=*), parameter :: artifact_dir = &
+        build_dir//'/artifacts/host'
+    integer :: failures
+
+    failures = 0
+
+    print *, '=== ffc runtime archive tests (#374) ==='
+
+    call configure_and_build(failures)
+    if (failures == 0) then
+        call check_archive('isel', 1, failures)
+        call check_archive('copy-patch', 2, failures)
+        call check_probe_symbol(failures)
+        call check_backend_qualification(failures)
+    end if
+    call check_missing_tool_diagnostic(failures)
+
+    if (failures /= 0) then
+        print *, 'FAIL: ', failures, ' runtime archive check(s) failed'
+        stop 1
+    end if
+    print *, 'PASS: runtime archive contract'
+
+contains
+
+    subroutine run(cmd, exit_stat)
+        character(len=*), intent(in) :: cmd
+        integer, intent(out) :: exit_stat
+        integer :: cmd_stat
+
+        call execute_command_line(cmd, exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) exit_stat = -1
+    end subroutine run
+
+    subroutine configure_and_build(nfail)
+        integer, intent(inout) :: nfail
+        integer :: stat
+
+        call run('rm -rf '//build_dir, stat)
+        call run('cmake -S runtime -B '//build_dir// &
+                 ' > /tmp/ffc_runtime_374_cfg.log 2>&1', stat)
+        if (stat /= 0) then
+            print *, 'FAIL: runtime cmake configure failed'
+            call run('cat /tmp/ffc_runtime_374_cfg.log', stat)
+            nfail = nfail + 1
+            return
+        end if
+        call run('cmake --build '//build_dir//' -j 3'// &
+                 ' > /tmp/ffc_runtime_374_build.log 2>&1', stat)
+        if (stat /= 0) then
+            print *, 'FAIL: runtime archive build failed'
+            call run('cat /tmp/ffc_runtime_374_build.log', stat)
+            nfail = nfail + 1
+        end if
+    end subroutine configure_and_build
+
+    function archive_path(backend) result(path)
+        character(len=*), intent(in) :: backend
+        character(len=:), allocatable :: path
+
+        path = artifact_dir//'/ffc-runtime-v2-'//backend//'.lrarch'
+    end function archive_path
+
+    ! Reads the LIRIC archive header: 8-byte magic, then little-endian u32
+    ! version and u32 backend.
+    subroutine read_header(path, ok, magic, version, backend_code)
+        character(len=*), intent(in) :: path
+        logical, intent(out) :: ok
+        character(len=8), intent(out) :: magic
+        integer, intent(out) :: version
+        integer, intent(out) :: backend_code
+        integer :: unit, ios, i
+        integer :: bytes(16)
+        character(len=1) :: byte
+
+        ok = .false.
+        magic = ''
+        version = 0
+        backend_code = 0
+        open (newunit=unit, file=path, access='stream', form='unformatted', &
+              status='old', action='read', iostat=ios)
+        if (ios /= 0) return
+        do i = 1, 16
+            read (unit, iostat=ios) byte
+            if (ios /= 0) then
+                close (unit)
+                return
+            end if
+            bytes(i) = iachar(byte)
+            if (i <= 8) magic(i:i) = byte
+        end do
+        close (unit)
+        version = bytes(9) + bytes(10)*256 + bytes(11)*65536 + &
+                  bytes(12)*16777216
+        backend_code = bytes(13) + bytes(14)*256 + bytes(15)*65536 + &
+                       bytes(16)*16777216
+        ok = .true.
+    end subroutine read_header
+
+    subroutine check_archive(backend, expected_backend_code, nfail)
+        character(len=*), intent(in) :: backend
+        integer, intent(in) :: expected_backend_code
+        integer, intent(inout) :: nfail
+        character(len=:), allocatable :: path
+        character(len=8) :: magic
+        integer :: version, backend_code, unit, ios
+        integer(kind=8) :: fsize
+        logical :: ok, exists
+
+        path = archive_path(backend)
+        inquire (file=path, exist=exists)
+        if (.not. exists) then
+            print *, 'FAIL: missing archive ', path
+            nfail = nfail + 1
+            return
+        end if
+        open (newunit=unit, file=path, access='stream', form='unformatted', &
+              status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            print *, 'FAIL: cannot open archive ', path
+            nfail = nfail + 1
+            return
+        end if
+        inquire (unit=unit, size=fsize)
+        close (unit)
+        if (fsize <= 0) then
+            print *, 'FAIL: empty archive ', path
+            nfail = nfail + 1
+            return
+        end if
+
+        call read_header(path, ok, magic, version, backend_code)
+        if (.not. ok) then
+            print *, 'FAIL: cannot read header of ', path
+            nfail = nfail + 1
+            return
+        end if
+        if (magic(1:7) /= 'LRARCH1') then
+            print *, 'FAIL: bad magic in ', path, ' got ', magic(1:7)
+            nfail = nfail + 1
+        end if
+        if (version == 0) then
+            print *, 'FAIL: zero archive format version in ', path
+            nfail = nfail + 1
+        end if
+        if (backend_code /= expected_backend_code) then
+            print *, 'FAIL: ', path, ' records backend ', backend_code, &
+                ' expected ', expected_backend_code
+            nfail = nfail + 1
+        end if
+    end subroutine check_archive
+
+    ! The packaged runtime IR must define the probe entry point.
+    subroutine check_probe_symbol(nfail)
+        integer, intent(inout) :: nfail
+        integer :: stat
+
+        call run('grep -q "_ffc_runtime_probe" '// &
+                 archive_path('copy-patch'), stat)
+        if (stat /= 0) then
+            print *, 'FAIL: archive does not carry _ffc_runtime_probe'
+            nfail = nfail + 1
+        end if
+    end subroutine check_probe_symbol
+
+    ! Distinct backends must produce genuinely distinct artifacts.
+    subroutine check_backend_qualification(nfail)
+        integer, intent(inout) :: nfail
+        integer :: stat
+
+        call run('cmp -s '//archive_path('isel')//' '// &
+                 archive_path('copy-patch'), stat)
+        if (stat == 0) then
+            print *, 'FAIL: isel and copy-patch archives are identical'
+            nfail = nfail + 1
+        end if
+    end subroutine check_backend_qualification
+
+    ! A missing archive tool must fail configuration with a named dependency
+    ! diagnostic, not silently skip the artifact.
+    subroutine check_missing_tool_diagnostic(nfail)
+        integer, intent(inout) :: nfail
+        integer :: stat
+
+        call run('rm -rf /tmp/ffc_runtime_374_missing', stat)
+        call run('cmake -S runtime -B /tmp/ffc_runtime_374_missing'// &
+                 ' -DFFC_RUNTIME_ARCHIVE_TOOL=FFC_RUNTIME_ARCHIVE_TOOL-NOTFOUND'// &
+                 ' -DCMAKE_PREFIX_PATH=/nonexistent'// &
+                 ' -DLIRIC_BUILD_DIR=/nonexistent'// &
+                 ' > /tmp/ffc_runtime_374_missing.log 2>&1', stat)
+        if (stat == 0) then
+            print *, 'FAIL: missing archive tool did not fail configuration'
+            nfail = nfail + 1
+            return
+        end if
+        call run('grep -q "ffc runtime dependency missing: '// &
+                 'liric_runtime_archive" /tmp/ffc_runtime_374_missing.log', &
+                 stat)
+        if (stat /= 0) then
+            print *, 'FAIL: missing tool lacked a named dependency diagnostic'
+            nfail = nfail + 1
+        end if
+    end subroutine check_missing_tool_diagnostic
+
+end program test_runtime_archives


### PR DESCRIPTION
Closes #374.

## Summary

Produces one LIRIC runtime archive per target/backend pair with a deterministic name and a probe symbol. ffc session loading is untouched: this issue only establishes the artifact.

- NEW `runtime/ffc_runtime.c`: defines `_ffc_runtime_probe()` returning 42.
- NEW `runtime/CMakeLists.txt`: compiles the runtime to LLVM bitcode with `clang -emit-llvm -c`, then invokes `liric_runtime_archive` once per backend into a target-qualified artifact directory.
- `docs/RUNTIME_ABI.md`: new "Runtime archives" section documenting artifact names, the artifact naming version, the archive header format, the payload, and the dependency contract.

Artifacts land in `<build>/artifacts/<target>/` as `ffc-runtime-v2-isel.lrarch`, `ffc-runtime-v2-copy-patch.lrarch`, and `ffc-runtime-v2-llvm.lrarch` when LLVM is opted in.

## Invariants preserved

- **Matching runtime archives**: each archive records the LIRIC target it was built for, and the artifact directory repeats the target, so archives for different targets cannot collide. The backend enumerator is recorded inside the file, so two archives for different backends are never byte-identical - asserted directly by the test.
- **Versioned public interface**: `v2` is the artifact naming version, documented as independent of the LIRIC archive format version (currently 2) recorded inside each file. The backend codes are the frozen LIRIC session backend enumerators (isel 1, copy-patch 2, LLVM 3), which #527 just froze as public ABI.
- **Canonical ownership**: the archives are pure data artifacts. Nothing links against them and nothing loads them into a session, so no ownership or view lifetime is introduced. The `runtime/` CMake project is standalone and does not alter the fpm build of ffc itself.
- **Backend `default` aliases copy-patch** and therefore has no artifact of its own, as documented.
- No formatted I/O, no archive loading, and no GPU or accelerator targets.

## Verification

Oracle written first and recorded failing on unmodified `main` - no artifact production exists at all:

```text
$ cmake -S runtime -B /tmp/red374
CMake Error: The source directory ".../runtime" does not exist.
$ ls artifacts
ls: cannot access 'artifacts': No such file or directory
```

After the change:

```text
$ cmake -S runtime -B build && cmake --build build -j3
[ 33%] Compiling ffc runtime to LLVM bitcode
[ 66%] Packaging ffc runtime archive for backend isel
[100%] Packaging ffc runtime archive for backend copy-patch

$ ls build/artifacts/host/
ffc-runtime-v2-copy-patch.lrarch
ffc-runtime-v2-isel.lrarch

$ xxd build/artifacts/host/ffc-runtime-v2-isel.lrarch | head -2
00000000: 4c52 4152 4348 3100 0200 0000 0100 0000  LRARCH1.........
00000010: 0600 0000 2200 0000 0000 0000 4900 0000  ....".......I...
```

Magic `LRARCH1`, format version 2, backend 1 (isel); the copy-patch archive differs from it at the backend field. Both carry `_ffc_runtime_probe`.

```text
$ fo test test_runtime_archives
test_runtime_archives                      PASS       0.58s
```

Full `fo` pipeline: 284 tests run. Three fail, and all three fail identically on unmodified `main`, so the delta from this PR is zero:

- `test_fortfront_corpus_conformance` - pre-existing; verified failing at `origin/main`.
- `test_session_reject_io_01_compiler` - pre-existing; verified failing at `origin/main`.
- `test_parity_dashboard` - known to fail inside `.wt/` worktrees because the generator resolves sibling repos as `../fortfront`; passes in the primary checkout.

## Conformance gauntlet delta (lfortran suite)

| | PASS | XFAIL | XPASS | FAIL | NOREF | SKIP | TOTAL |
|---|---|---|---|---|---|---|---|
| before | 842 | 3363 | 54 | 20 | 157 | 1 | 4280 |
| after | 842 | 3362 | 55 | 20 | 157 | 1 | 4280 |

No PASS became FAIL. PASS and FAIL are both unchanged. The single XFAIL-to-XPASS move is not attributable to this PR - it changes no lowering path whatsoever - and comes from another chain's merge that landed between the baseline run and the rebase. No manifest entry is moved here for that reason.

## Fixtures added

`test/test_runtime_archives.f90` drives the runtime CMake project and checks: both archives exist and are nonempty; each carries the `LRARCH1` magic and a nonzero format version; each records its own backend enumerator; the packaged runtime carries `_ffc_runtime_probe`; the isel and copy-patch artifacts are not byte-identical; and a missing `liric_runtime_archive` fails configuration with the named `ffc runtime dependency missing: liric_runtime_archive` diagnostic rather than silently skipping the artifact.