### PR TITLE
[chardesc-02] migrate deferred scalar character storage to the canonical descriptor

### DIFF
--- a/src/ffc_test_support.f90
+++ b/src/ffc_test_support.f90
@@ -24,8 +24,58 @@ module ffc_test_support
     public :: expect_output_with_stdin
     public :: expect_stderr_and_exit
     public :: expect_eof_stderr_and_exit
+    public :: expect_no_leaks
 
 contains
+
+    logical function expect_no_leaks(source, exe_path) result(ok)
+        ! Compiles source and runs the executable under valgrind, requiring a
+        ! clean memcheck report: no definitely/indirectly lost blocks, no
+        ! invalid free, no invalid read or write. This is an ownership oracle
+        ! independent of the lowering: it observes the process's actual heap
+        ! behaviour rather than the emitted IR. When valgrind is not installed
+        ! the check reports success so the suite still runs.
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: exe_path
+        character(len=:), allocatable :: error_msg, out_path
+        integer :: cmd_stat, exit_stat, probe_stat
+
+        ok = .false.
+        call execute_command_line('command -v valgrind > /dev/null 2>&1', &
+            exitstat=probe_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0 .or. probe_stat /= 0) then
+            print *, 'SKIP: valgrind not available for leak check ', exe_path
+            ok = .true.
+            return
+        end if
+
+        call compile_to_exe(source, exe_path, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: ', trim(error_msg)
+            call execute_command_line('rm -f '//exe_path)
+            return
+        end if
+
+        out_path = exe_path//'.vg'
+        call execute_command_line('valgrind -q --leak-check=full '// &
+            '--errors-for-leak-kinds=definite,indirect --error-exitcode=97 '// &
+            exe_path//' > '//out_path//' 2>&1', &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) then
+            print *, 'FAIL: emitted executable did not run under valgrind: ', &
+                exe_path
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+        if (exit_stat == 97) then
+            print *, 'FAIL: valgrind reported a memory error for ', exe_path
+            call execute_command_line('cat '//out_path)
+            call execute_command_line('rm -f '//exe_path//' '//out_path)
+            return
+        end if
+        call execute_command_line('rm -f '//exe_path//' '//out_path)
+        ok = .true.
+    end function expect_no_leaks
 
     logical function expect_stderr_and_exit(source, expected, expected_exit, &
             exe_path) result(ok)

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -308,10 +308,23 @@ module session_program_lowering
         fmod_component_t, fmod_derived_type_t, &
         fmod_variable_t, fmod_procedure_t, fmod_generic_t, &
         write_fmod, read_fmod
+    use ffc_character_descriptor, only: CHARACTER_STORAGE_STATIC, &
+        CHARACTER_STORAGE_STACK, CHARACTER_STORAGE_OWNED
     implicit none
     private
     public :: lower_program_to_liric_exe
     public :: lower_program_to_liric_object
+
+    ! Storage classes of the canonical character descriptor, widened to the
+    ! i64 immediate width the lowering emits with. They are derived from
+    ! ffc_character_descriptor so the emitted descriptors and the host-side
+    ! descriptor helpers cannot drift apart.
+    integer(c_int64_t), parameter :: LOWERING_CHARACTER_STORAGE_STATIC = &
+        int(CHARACTER_STORAGE_STATIC, c_int64_t)
+    integer(c_int64_t), parameter :: LOWERING_CHARACTER_STORAGE_STACK = &
+        int(CHARACTER_STORAGE_STACK, c_int64_t)
+    integer(c_int64_t), parameter :: LOWERING_CHARACTER_STORAGE_OWNED = &
+        int(CHARACTER_STORAGE_OWNED, c_int64_t)
 
     ! Reduction kinds for dim-wise whole-array reductions (sum/product/count/
     ! any/all along one dimension). See lower_dim_reduction_assignment.

--- a/src/session_program_lowering_allocatable.inc
+++ b/src/session_program_lowering_allocatable.inc
@@ -555,6 +555,12 @@
         if (.not. emit_i64_binary(context%session, LR_OP_ADD, len_i64, &
                 i64_immediate(context%session, 1_c_int64_t), bytes_i64, &
                 error_msg)) return
+        ! An explicit allocate over an already-allocated deferred character is
+        ! an error in standard Fortran; releasing first keeps the descriptor
+        ! from silently leaking its former owned block if it happens anyway.
+        call release_owned_character_storage(context, symbol_index, error_msg)
+        if (len_trim(error_msg) > 0) return
+
         if (.not. emit_malloc(context%session, bytes_i64, data_ptr, error_msg)) &
             return
 
@@ -562,6 +568,11 @@
                 context%symbols(symbol_index)%deferred_data, error_msg)) return
         if (.not. emit_i64_store(context%session, len_i64, &
                 context%symbols(symbol_index)%deferred_length, error_msg)) return
+        ! capacity is the requested length: the extra byte is the trailing NUL
+        ! the printers rely on, not usable character storage.
+        call set_character_storage(context, symbol_index, len_i64, &
+                                   LOWERING_CHARACTER_STORAGE_OWNED, error_msg)
+        if (len_trim(error_msg) > 0) return
         context%symbols(symbol_index)%value = data_ptr
         context%symbols(symbol_index)%has_character_value = .true.
         call set_empty(error_msg)
@@ -1370,15 +1381,25 @@
     end subroutine lower_one_deallocate_var
 
     subroutine lower_deallocate_deferred_char(symbol_index, context, error_msg)
-        ! deallocate(str) for a character(len=:), allocatable scalar. Mark the
-        ! descriptor unallocated by zeroing its data pointer and length. The data
-        ! slot may currently hold a static string pointer (after str = literal),
-        ! so it is not free()d here; the descriptor reset is what later reads see.
+        ! deallocate(str) for a character(len=:), allocatable scalar. Release
+        ! the storage first: the data slot may hold a static string pointer
+        ! (after str = literal) or a stack buffer, which the storage class
+        ! distinguishes from heap storage this descriptor owns, so only owned
+        ! storage is returned and it is returned exactly once. Then reset the
+        ! descriptor to the ABI null state, which is what later reads see.
         use, intrinsic :: iso_c_binding, only: c_int64_t
         integer, intent(in) :: symbol_index
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
 
+        call release_owned_character_storage(context, symbol_index, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (context%symbols(symbol_index)%has_character_ownership) then
+            if (.not. emit_i64_store(context%session, &
+                    i64_immediate(context%session, 0_c_int64_t), &
+                    context%symbols(symbol_index)%deferred_capacity, &
+                    error_msg)) return
+        end if
         if (.not. emit_i64_store(context%session, &
                 i64_immediate(context%session, 0_c_int64_t), &
                 context%symbols(symbol_index)%deferred_data, error_msg)) return

--- a/src/session_program_lowering_character.inc
+++ b/src/session_program_lowering_character.inc
@@ -668,16 +668,31 @@
             return
         end if
 
+        if (src_index == symbol_index) then
+            ! str = str keeps the descriptor exactly as it is. Releasing and
+            ! reinstalling the same pointer would be a use after free.
+            call set_empty(error_msg)
+            return
+        end if
+
         call char_length_operands(context, src_index, data_ptr, len_i32, &
                                   error_msg)
         if (len_trim(error_msg) > 0) return
         if (.not. emit_liric_i32_to_i64(context%session, len_i32, len_i64, &
                 error_msg)) return
 
+        ! The destination borrows the source's storage, so it takes storage
+        ! class stack: it must never free what the source still owns. Its own
+        ! former heap block is released before the rebind.
+        call release_owned_character_storage(context, symbol_index, error_msg)
+        if (len_trim(error_msg) > 0) return
         if (.not. emit_ptr_store(context%session, data_ptr, &
                 context%symbols(symbol_index)%deferred_data, error_msg)) return
         if (.not. emit_i64_store(context%session, len_i64, &
                 context%symbols(symbol_index)%deferred_length, error_msg)) return
+        call set_character_storage(context, symbol_index, len_i64, &
+                                   LOWERING_CHARACTER_STORAGE_STACK, error_msg)
+        if (len_trim(error_msg) > 0) return
         context%symbols(symbol_index)%value = data_ptr
         context%symbols(symbol_index)%has_character_value = .true.
         call set_empty(error_msg)
@@ -794,6 +809,8 @@
         type(lr_operand_desc_t) :: descriptor
         type(lr_operand_desc_t) :: data_addr
         type(lr_operand_desc_t) :: len_addr
+        type(lr_operand_desc_t) :: capacity_addr
+        type(lr_operand_desc_t) :: storage_addr
 
         if (find_symbol_compat(context, name) > 0) then
             error_msg = 'duplicate character declaration: '//trim(name)
@@ -807,30 +824,108 @@
         context%symbols(index)%is_deferred_character = .true.
         context%symbols(index)%has_character_value = .false.
 
-        ! One contiguous 16-byte descriptor {i8* data; i64 length}, so the
-        ! data slot is at offset 0 and the length at offset 8. This matches the
-        ! parameter ABI (bind_character_parameter_symbol), so the descriptor's
-        ! address can be passed for an intent(out)/(inout) dummy. Both fields
-        ! start zeroed for a well-defined unallocated state.
+        ! One contiguous 32-byte canonical character descriptor
+        ! {i8* data; i64 length; i64 capacity; i32 storage_class}, laid out as
+        ! docs/CHARACTER_DESCRIPTOR_ABI.md specifies. The {data, length} prefix
+        ! is unchanged, so the descriptor's address is still what a
+        ! character(len=*) dummy binds against (bind_character_parameter_symbol)
+        ! for an intent(out)/(inout) actual. Every field starts zeroed, which is
+        ! the ABI's null state: no data, zero length, zero capacity, storage
+        ! class CHARACTER_STORAGE_NULL.
         if (.not. emit_alloca_bytes(context%session, &
-                i64_immediate(context%session, 16_c_int64_t), descriptor, &
+                i64_immediate(context%session, 32_c_int64_t), descriptor, &
                 error_msg)) return
         if (.not. emit_ptr_offset(context%session, descriptor, 0_c_int64_t, &
                                   data_addr, error_msg)) return
         if (.not. emit_ptr_offset(context%session, descriptor, 8_c_int64_t, &
                                   len_addr, error_msg)) return
+        if (.not. emit_ptr_offset(context%session, descriptor, 16_c_int64_t, &
+                                  capacity_addr, error_msg)) return
+        if (.not. emit_ptr_offset(context%session, descriptor, 24_c_int64_t, &
+                                  storage_addr, error_msg)) return
         if (.not. emit_i64_store(context%session, &
                                  i64_immediate(context%session, 0_c_int64_t), &
                                  data_addr, error_msg)) return
         if (.not. emit_i64_store(context%session, &
                                  i64_immediate(context%session, 0_c_int64_t), &
                                  len_addr, error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+                                 i64_immediate(context%session, 0_c_int64_t), &
+                                 capacity_addr, error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+                                 i64_immediate(context%session, 0_c_int64_t), &
+                                 storage_addr, error_msg)) return
 
         context%symbols(index)%deferred_data = data_addr
         context%symbols(index)%deferred_length = len_addr
+        context%symbols(index)%deferred_capacity = capacity_addr
+        context%symbols(index)%deferred_storage = storage_addr
+        context%symbols(index)%has_character_ownership = .true.
         context%symbol_count = index
         call set_empty(error_msg)
     end subroutine define_deferred_character_symbol
+
+    subroutine set_character_storage(context, symbol_index, capacity, &
+                                     storage_class, error_msg)
+        ! Record the ownership half of the canonical character descriptor:
+        ! how many bytes are usable at data without reallocating, and which
+        ! storage class owns them (docs/CHARACTER_DESCRIPTOR_ABI.md). Symbols
+        ! whose descriptor is only the 16-byte {data, length} prefix (dummies,
+        ! runtime-fixed automatics) carry no ownership slots and are skipped.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        type(lr_operand_desc_t), intent(in) :: capacity
+        integer(c_int64_t), intent(in) :: storage_class
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call set_empty(error_msg)
+        if (symbol_index <= 0) return
+        if (.not. context%symbols(symbol_index)%has_character_ownership) return
+
+        if (.not. emit_i64_store(context%session, capacity, &
+                context%symbols(symbol_index)%deferred_capacity, error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+                i64_immediate(context%session, storage_class), &
+                context%symbols(symbol_index)%deferred_storage, error_msg)) return
+    end subroutine set_character_storage
+
+    subroutine release_owned_character_storage(context, symbol_index, error_msg)
+        ! Return the descriptor's heap block to the allocator when, and only
+        ! when, this descriptor owns it (storage class
+        ! CHARACTER_STORAGE_OWNED). Borrowed static and stack data is never
+        ! freed through the descriptor. The class is reset to
+        ! CHARACTER_STORAGE_NULL afterwards, so a second release, or a
+        ! deallocate of an already-released variable, frees nothing.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: storage_class, is_owned, data_ptr, victim
+
+        call set_empty(error_msg)
+        if (symbol_index <= 0) return
+        if (.not. context%symbols(symbol_index)%has_character_ownership) return
+
+        if (.not. emit_i32_load(context%session, &
+                context%symbols(symbol_index)%deferred_storage, storage_class, &
+                error_msg)) return
+        if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, storage_class, &
+                i32_immediate(context%session, LOWERING_CHARACTER_STORAGE_OWNED), &
+                is_owned, error_msg)) return
+        if (.not. emit_ptr_load(context%session, &
+                context%symbols(symbol_index)%deferred_data, data_ptr, &
+                error_msg)) return
+        ! free(NULL) is a no-op, so a borrowed descriptor selects the null
+        ! pointer and the call has no effect.
+        call select_value(context, is_owned, data_ptr, &
+                          null_ptr_operand(context), victim, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_free(context%session, victim, error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+                i64_immediate(context%session, 0_c_int64_t), &
+                context%symbols(symbol_index)%deferred_storage, error_msg)) return
+    end subroutine release_owned_character_storage
 
     subroutine bind_character_parameter_symbol(context, symbol_index, error_msg)
         type(lowering_context_t), intent(inout) :: context
@@ -1100,10 +1195,18 @@
         if (len_trim(error_msg) > 0) return
         if (.not. emit_liric_i32_to_i64(context%session, length, length64, &
                                         error_msg)) return
+        ! char_expr_operands has already materialised the trimmed buffer, so
+        ! the former owned block can be released before the rebind. The
+        ! trimmed buffer itself is stack storage the descriptor only borrows.
+        call release_owned_character_storage(context, dest_symbol_index, error_msg)
+        if (len_trim(error_msg) > 0) return
         if (.not. emit_ptr_store(context%session, data_ptr, &
             context%symbols(dest_symbol_index)%deferred_data, error_msg)) return
         if (.not. emit_i64_store(context%session, length64, &
             context%symbols(dest_symbol_index)%deferred_length, error_msg)) return
+        call set_character_storage(context, dest_symbol_index, length64, &
+                                   LOWERING_CHARACTER_STORAGE_STACK, error_msg)
+        if (len_trim(error_msg) > 0) return
         context%symbols(dest_symbol_index)%value = data_ptr
         context%symbols(dest_symbol_index)%has_character_value = .true.
         call set_empty(error_msg)

--- a/src/session_program_lowering_control.inc
+++ b/src/session_program_lowering_control.inc
@@ -288,6 +288,12 @@
                 then_result%symbols(index)%deferred_data
             context%symbols(index)%deferred_length = &
                 then_result%symbols(index)%deferred_length
+            context%symbols(index)%has_character_ownership = &
+                then_result%symbols(index)%has_character_ownership
+            context%symbols(index)%deferred_capacity = &
+                then_result%symbols(index)%deferred_capacity
+            context%symbols(index)%deferred_storage = &
+                then_result%symbols(index)%deferred_storage
             context%symbols(index)%character_length = &
                 then_result%symbols(index)%character_length
             context%symbols(index)%has_character_value = &

--- a/src/session_program_lowering_deferred_char.inc
+++ b/src/session_program_lowering_deferred_char.inc
@@ -89,8 +89,10 @@ integer function resolve_concat_operand(arena, node_index, context, &
         type(lr_operand_desc_t) :: null_byte_ptr
         type(lr_operand_desc_t) :: null_dest
         character(len=64) :: null_name
+        integer(c_int64_t) :: new_storage_class
 
         call set_empty(error_msg)
+        new_storage_class = LOWERING_CHARACTER_STORAGE_STACK
         left_is_literal = .false.
         right_is_literal = .false.
         is_self_alias = .false.
@@ -215,13 +217,21 @@ integer function resolve_concat_operand(arena, node_index, context, &
                                           combined_text, new_ptr, error_msg)
             if (len_trim(error_msg) > 0) return
 
-            ! Store pointer and length in descriptor
+            ! Store pointer and length in descriptor. The folded literal is a
+            ! global, so this is a borrow; release any owned block first.
+            call release_owned_character_storage(context, dest_symbol_index, &
+                                                 error_msg)
+            if (len_trim(error_msg) > 0) return
             if (.not. emit_ptr_store(context%session,  &
                 new_ptr, &
                 context%symbols(dest_symbol_index)%deferred_data, error_msg)) return
             if (.not. emit_i64_store(context%session,  &
                 i64_immediate(context%session, combined_len), &
                 context%symbols(dest_symbol_index)%deferred_length, error_msg)) return
+            call set_character_storage(context, dest_symbol_index, &
+                i64_immediate(context%session, combined_len), &
+                LOWERING_CHARACTER_STORAGE_STATIC, error_msg)
+            if (len_trim(error_msg) > 0) return
 
             context%symbols(dest_symbol_index)%value = new_ptr
             context%symbols(dest_symbol_index)%has_character_value = .true.
@@ -240,9 +250,11 @@ integer function resolve_concat_operand(arena, node_index, context, &
             dest_symbol_index == context%current_function_result_index) then
             if (.not. emit_malloc(context%session, alloca_size, new_ptr, &
                 error_msg)) return
+            new_storage_class = LOWERING_CHARACTER_STORAGE_OWNED
         else
             if (.not. emit_alloca_bytes(context%session, alloca_size, new_ptr, &
                 error_msg)) return
+            new_storage_class = LOWERING_CHARACTER_STORAGE_STACK
         end if
 
         if (.not. emit_memcpy(context%session,  &
@@ -269,6 +281,11 @@ integer function resolve_concat_operand(arena, node_index, context, &
             null_dest, null_byte_ptr, &
             i64_immediate(context%session, 1_c_int64_t), error_msg)) return
 
+        ! Both operands have been copied out by now, so releasing the former
+        ! owned block here is safe even when the destination is also an operand
+        ! (s = s // suffix).
+        call release_owned_character_storage(context, dest_symbol_index, error_msg)
+        if (len_trim(error_msg) > 0) return
         if (.not. emit_ptr_store(context%session,  &
             new_ptr, context%symbols(dest_symbol_index)%deferred_data, &
             error_msg)) return
@@ -276,6 +293,9 @@ integer function resolve_concat_operand(arena, node_index, context, &
         if (.not. emit_i64_store(context%session,  &
             total_len, context%symbols(dest_symbol_index)%deferred_length, &
             error_msg)) return
+        call set_character_storage(context, dest_symbol_index, total_len, &
+                                   new_storage_class, error_msg)
+        if (len_trim(error_msg) > 0) return
 
         context%symbols(dest_symbol_index)%value = new_ptr
         context%symbols(dest_symbol_index)%has_character_value = .true.
@@ -418,10 +438,17 @@ integer function resolve_concat_operand(arena, node_index, context, &
         end if
         if (len_trim(error_msg) > 0) return
 
+        ! The literal lives in a global, so the descriptor borrows it. Any heap
+        ! block the descriptor still owned is released before it is overwritten.
+        call release_owned_character_storage(context, dest_symbol_index, error_msg)
+        if (len_trim(error_msg) > 0) return
         if (.not. emit_ptr_store(context%session, data_op, &
             context%symbols(dest_symbol_index)%deferred_data, error_msg)) return
         if (.not. emit_i64_store(context%session, len_op, &
             context%symbols(dest_symbol_index)%deferred_length, error_msg)) return
+        call set_character_storage(context, dest_symbol_index, len_op, &
+                                   LOWERING_CHARACTER_STORAGE_STATIC, error_msg)
+        if (len_trim(error_msg) > 0) return
 
         context%symbols(dest_symbol_index)%value = data_op
         context%symbols(dest_symbol_index)%has_character_value = .true.
@@ -597,6 +624,15 @@ integer function resolve_concat_operand(arena, node_index, context, &
         end select
 
         func_name = call_emit_name(arena, call_node%name, context)
+
+        ! The callee writes its result through a fresh {data, length} return
+        ! descriptor, so the destination stops using its own descriptor here.
+        ! Release whatever heap block that descriptor still owned first, then
+        ! drop the ownership slots: the return descriptor carries none, and the
+        ! result's storage stays owned by the callee's convention (#348).
+        call release_owned_character_storage(context, dest_symbol_index, error_msg)
+        if (len_trim(error_msg) > 0) return
+        context%symbols(dest_symbol_index)%has_character_ownership = .false.
 
         call allocate_deferred_char_descriptor(context, descriptor_ptr, &
                                                data_addr, len_addr, error_msg)

--- a/src/session_program_lowering_select.inc
+++ b/src/session_program_lowering_select.inc
@@ -325,6 +325,12 @@
                     results(1)%symbols(index)%deferred_data
                 context%symbols(index)%deferred_length = &
                     results(1)%symbols(index)%deferred_length
+                context%symbols(index)%has_character_ownership = &
+                    results(1)%symbols(index)%has_character_ownership
+                context%symbols(index)%deferred_capacity = &
+                    results(1)%symbols(index)%deferred_capacity
+                context%symbols(index)%deferred_storage = &
+                    results(1)%symbols(index)%deferred_storage
                 context%symbols(index)%character_length = &
                     results(1)%symbols(index)%character_length
                 context%symbols(index)%has_character_value = &

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -290,6 +290,15 @@ module session_program_lowering_types
         logical :: is_runtime_fixed_character = .false.
         type(lr_operand_desc_t) :: deferred_data
         type(lr_operand_desc_t) :: deferred_length
+        ! Canonical character descriptor ownership slots, see
+        ! docs/CHARACTER_DESCRIPTOR_ABI.md: capacity at offset 16 and
+        ! storage_class at offset 24. Only a local deferred-length allocatable
+        ! scalar owns the full 32-byte record; a dummy descriptor keeps the
+        ! 16-byte {data, length} prefix, which the 32-byte record extends
+        ! compatibly, so passing it to a character(len=*) dummy is unchanged.
+        logical :: has_character_ownership = .false.
+        type(lr_operand_desc_t) :: deferred_capacity
+        type(lr_operand_desc_t) :: deferred_storage
         logical :: is_allocatable = .false.
         type(lr_operand_desc_t) :: allocatable_descriptor_address
         ! Compile-time element count of a rank-1 allocatable when the most

--- a/test/test_session_deferred_char_compiler.f90
+++ b/test/test_session_deferred_char_compiler.f90
@@ -1,5 +1,5 @@
 program test_session_deferred_char_compiler
-    use ffc_test_support, only: expect_output, expect_exit_status
+    use ffc_test_support, only: expect_output, expect_exit_status, expect_no_leaks
     implicit none
 
     logical :: all_passed
@@ -26,11 +26,101 @@ program test_session_deferred_char_compiler
     if (.not. test_pass_literal_to_assumed_length_dummy()) all_passed = .false.
     if (.not. test_assumed_length_len_inside_callee()) all_passed = .false.
     if (.not. test_assumed_length_len_trim()) all_passed = .false.
+    if (.not. test_repeated_length_changes_report_each_length()) &
+        all_passed = .false.
+    if (.not. test_explicit_allocation_is_released_on_deallocate()) &
+        all_passed = .false.
+    if (.not. test_reassignment_releases_the_previous_allocation()) &
+        all_passed = .false.
+    if (.not. test_repeated_deallocate_is_not_a_double_free()) &
+        all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: deferred-char function result ABI'
 
 contains
+
+    function repeated_length_source() result(text)
+        ! Shared source for the repeated-length-change cases: assignments of
+        ! length 2, 8 and 1, then an explicit allocation reused by an
+        ! assignment of exactly the allocated length.
+        character(len=:), allocatable :: text
+        character(len=*), parameter :: body = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: s'//new_line('a')// &
+            '  s = "ab"'//new_line('a')// &
+            '  print *, len(s), s'//new_line('a')// &
+            '  s = "abcdefgh"'//new_line('a')// &
+            '  print *, len(s), s'//new_line('a')// &
+            '  s = "z"'//new_line('a')// &
+            '  print *, len(s), s'//new_line('a')// &
+            '  deallocate(s)'//new_line('a')// &
+            '  allocate(character(len=3) :: s)'//new_line('a')// &
+            '  s = "xyz"'//new_line('a')// &
+            '  print *, len(s), s'//new_line('a')// &
+            '  deallocate(s)'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        text = body
+    end function repeated_length_source
+
+    logical function test_repeated_length_changes_report_each_length()
+        ! Each assignment retargets the descriptor length to the RHS length,
+        ! and the explicit allocate(character(len=3)) fixes length 3.
+        test_repeated_length_changes_report_each_length = expect_output( &
+            repeated_length_source(), &
+            '           2 ab'//new_line('a')// &
+            '           8 abcdefgh'//new_line('a')// &
+            '           1 z'//new_line('a')// &
+            '           3 xyz'//new_line('a'), &
+            '/tmp/ffc_session_deferred_relength_test')
+    end function test_repeated_length_changes_report_each_length
+
+    logical function test_explicit_allocation_is_released_on_deallocate()
+        ! allocate(character(len=n) :: s) owns heap storage; the descriptor
+        ! must release it exactly once, and only once, at deallocate.
+        test_explicit_allocation_is_released_on_deallocate = expect_no_leaks( &
+            repeated_length_source(), &
+            '/tmp/ffc_session_deferred_relength_leak_test')
+    end function test_explicit_allocation_is_released_on_deallocate
+
+    logical function test_reassignment_releases_the_previous_allocation()
+        ! Assigning over an owned descriptor releases the former storage
+        ! before installing the replacement.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: s'//new_line('a')// &
+            '  integer :: n'//new_line('a')// &
+            '  n = 5'//new_line('a')// &
+            '  allocate(character(len=n) :: s)'//new_line('a')// &
+            '  s = "hello"'//new_line('a')// &
+            '  s = "world!!"'//new_line('a')// &
+            '  print *, len(s), s'//new_line('a')// &
+            '  deallocate(s)'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_reassignment_releases_the_previous_allocation = expect_no_leaks( &
+            source, '/tmp/ffc_session_deferred_reassign_leak_test')
+    end function test_reassignment_releases_the_previous_allocation
+
+    logical function test_repeated_deallocate_is_not_a_double_free()
+        ! Deallocating an already-released descriptor sees the null state and
+        ! must not free the former pointer a second time.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: s'//new_line('a')// &
+            '  allocate(character(len=4) :: s)'//new_line('a')// &
+            '  s = "abcd"'//new_line('a')// &
+            '  deallocate(s)'//new_line('a')// &
+            '  deallocate(s)'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_repeated_deallocate_is_not_a_double_free = expect_no_leaks( &
+            source, '/tmp/ffc_session_deferred_double_free_test')
+    end function test_repeated_deallocate_is_not_a_double_free
 
     logical function test_assumed_length_len_inside_callee()
         ! len(s) inside a callee returns the actual length of a literal actual.


### PR DESCRIPTION
Closes #349.

Migrates the deferred-length allocatable character scalar from the ad-hoc
16-byte `{data, length}` pair to the canonical 32-byte character descriptor
of `docs/CHARACTER_DESCRIPTOR_ABI.md`: `data` at 0, `length` at 8, `capacity`
at 16, `storage_class` at 24. The storage-class values are derived from
`ffc_character_descriptor` so the emitted descriptors and the host-side
descriptor helpers cannot drift apart, and no competing descriptor
convention is introduced.

Two shared primitives now carry the ownership half of every deferred scalar
path: `set_character_storage` records capacity and class at each install
site, and `release_owned_character_storage` returns the heap block to the
allocator when, and only when, the descriptor owns it, resetting the class so
a second release frees nothing.

## Behaviour preserved

- **Character length semantics.** Fixed lengths are untouched: a
  `character(len=N)` destination still pads or truncates to N, and the
  runtime-fixed automatic (`character(len=len(dummy))`) keeps its immutable
  declared width. Assumed length (`character(len=*)`) dummies still bind
  against the descriptor's `{data, length}` prefix, which the 32-byte record
  extends compatibly, so no dummy or result ABI changes here (that is #348).
  Deferred length still retargets to the RHS length on every assignment, and
  `allocate(character(len=n) :: x)` still fixes length `n`.
- **Blank padding and truncation on assignment.** Untouched. No padding or
  truncation path was rerouted; only the ownership slots were added around
  the existing data/length stores.
- **Lower bounds and extents for character arrays.** Untouched. Character
  arrays keep their current layout entirely; this change is scalar-only
  (#347 migrates arrays).
- **Aliasing and overlap.** `str = str` is now an explicit no-op rather than
  a release-and-reinstall of the same pointer. `str = str // suffix` releases
  the former block only after both operands have been copied into the new
  buffer. A destination that borrows another variable's storage
  (`dst = src`) takes storage class stack, so it never frees what the source
  still owns.
- **Allocation and finalization lifetimes.** Static literal data takes class
  1, stack buffers class 2, heap blocks from `allocate` or from an internal
  function's result concatenation take class 3. `deallocate` releases only
  class 3 and releases it exactly once; deallocating an unallocated or
  already-released descriptor sees the null state and frees nothing. The
  descriptor is reset to the ABI null state (null data, zero length, zero
  capacity, class 0) afterwards.

## Oracle

`expect_no_leaks` in `src/ffc_test_support.f90` runs the compiled program
under valgrind and requires a clean memcheck report. It observes the
process's actual heap behaviour, so it is independent of the lowering it
checks; it reports success when valgrind is not installed.

On unmodified main the three new ownership cases fail with definitely-lost
blocks (4, 6 and 5 bytes): `deallocate` deliberately never freed, so every
`allocate(character(len=n) :: x)` leaked. They pass after the change. The
repeated-length-change output case (lengths 2, 8, 1, then an explicit
`allocate(character(len=3))`) passes before and after and pins the length
semantics against the migration.

## Conformance gauntlet

Baseline is a separate worktree at `origin/main` with its own `fo build`
(the default installed `ffc` on `PATH` gives a misleading baseline).

| Suite | main | branch |
|---|---|---|
| lfortran | PASS=841 XFAIL=3363 XPASS=54 FAIL=21 | PASS=841 XFAIL=3363 XPASS=54 FAIL=21 |
| fortfront-f90 | PASS=407 XFAIL=99 XPASS=0 FAIL=10 | PASS=407 XFAIL=99 XPASS=0 FAIL=10 |
| fortfront-lf | PASS=205 XFAIL=58 XPASS=0 FAIL=1 | PASS=205 XFAIL=58 XPASS=0 FAIL=1 |

The per-case FAIL and XPASS sets are byte-identical between main and the
branch in all three suites: no regression, and no newly-passing case to move
out of an xfail manifest.

`fo` is green apart from `test_parity_dashboard` and
`test_fortfront_corpus_conformance`, both of which fail identically on
unmodified `origin/main` in a worktree (the dashboard resolves sibling repos
as `../fortfront`, which does not exist under `.wt/`).
