### PR TITLE
[arraydesc-01] define the canonical array descriptor ABI

### DIFF
--- a/docs/ARRAY_DESCRIPTOR_ABI.md
+++ b/docs/ARRAY_DESCRIPTOR_ABI.md
@@ -1,0 +1,148 @@
+# Array Descriptor ABI
+
+`array_descriptor_t` is the canonical array descriptor for new runtime
+interfaces. Existing lowering paths still use the ad hoc representations in
+`RUNTIME_ABI.md`; each migration issue moves one path onto this layout and
+removes its old representation rather than running both.
+
+## Layout
+
+The descriptor is a 200-byte, 8-byte-aligned `bind(C)` record on supported
+64-bit targets:
+
+| Offset | Size | Field | Meaning |
+|---:|---:|---|---|
+| 0 | 8 | `base` | Address of the element whose subscripts are the lower bounds |
+| 8 | 8 | `element_size` | Element storage size in bytes |
+| 16 | 4 | `element_type` | Element type code |
+| 20 | 4 | `rank` | Number of dimensions, 1 to 7 |
+| 24 | 4 | `flags` | Allocation, association, ownership, contiguity bits |
+| 28 | 4 | `reserved` | Zero; reserved for future ABI use |
+| 32 | 168 | `dim(7)` | Per-dimension metadata, seven entries of 24 bytes |
+
+Each `dim` entry is an `array_dimension_t`:
+
+| Offset in entry | Size | Field | Meaning |
+|---:|---:|---|---|
+| 0 | 8 | `lower_bound` | Fortran lower bound of the dimension |
+| 8 | 8 | `extent` | Number of elements in the dimension, `>= 0` |
+| 16 | 8 | `stride_bytes` | Signed byte distance between consecutive elements |
+
+Entry `d` is at descriptor offset `32 + 24*(d-1)`. Entries beyond `rank` are
+not part of the value; they hold the null-state defaults.
+
+The descriptor is rank-agnostic and element-kind-agnostic. All extents,
+bounds, and strides are signed 64-bit values, so a stride may be negative and
+`base` need not be the lowest address in the array.
+
+## Addressing
+
+The address of element `(i(1), ..., i(rank))` is
+
+```
+address = base + sum over d of (i(d) - lower_bound(d)) * stride_bytes(d)
+```
+
+The subscript `i(d)` is valid when
+`lower_bound(d) <= i(d) <= lower_bound(d) + extent(d) - 1`. Any other
+subscript is an `ARRAY_DESCRIPTOR_INVALID_INDEX` error from the checked
+helpers.
+
+Fortran column-major layout is a property of the strides, not of the
+addressing rule. A contiguous array has
+
+```
+stride_bytes(1) = element_size
+stride_bytes(d) = stride_bytes(d-1) * extent(d-1)   for d > 1
+```
+
+so the leftmost subscript varies fastest. `set_contiguous_array_descriptor`
+computes exactly these strides. `set_strided_array_descriptor` accepts
+arbitrary strides for view construction and sets the contiguity flag only when
+the given strides match the column-major sequence above.
+
+Bounds are carried, not normalized. A descriptor with `lower_bound = -1` and
+`extent = 2` addresses subscripts -1 and 0, and `base` is the address of
+element -1. Rebinding to a dummy with different declared bounds changes
+`lower_bound` and leaves `base`, `extent`, and `stride_bytes` untouched.
+
+## Flags
+
+| Bit | Value | Name | Meaning |
+|---:|---:|---|---|
+| 0 | 1 | `ARRAY_FLAG_ALLOCATED` | Descriptor has storage; `allocated` is true |
+| 1 | 2 | `ARRAY_FLAG_ASSOCIATED` | Descriptor designates an object; `associated` is true |
+| 2 | 4 | `ARRAY_FLAG_OWNS_DATA` | Descriptor owns the `base` allocation |
+| 3 | 8 | `ARRAY_FLAG_CONTIGUOUS` | Strides are column-major contiguous |
+
+A null descriptor has `flags == 0`, a null `base`, zero rank, zero element
+size, and element type zero. Failed initialization also leaves this state.
+
+## Element type codes
+
+| Value | Name |
+|---:|---|
+| 0 | `ARRAY_ELEMENT_NONE` |
+| 1 | `ARRAY_ELEMENT_INTEGER` |
+| 2 | `ARRAY_ELEMENT_REAL` |
+| 3 | `ARRAY_ELEMENT_LOGICAL` |
+| 4 | `ARRAY_ELEMENT_COMPLEX` |
+| 5 | `ARRAY_ELEMENT_CHARACTER` |
+| 6 | `ARRAY_ELEMENT_DERIVED` |
+
+The code names the type only. The kind lives in `element_size`, so
+`real(real64)` is code 2 with element size 8.
+
+## Ownership and lifetime
+
+Exactly one descriptor owns any given allocation. `ARRAY_FLAG_OWNS_DATA`
+marks that descriptor. `release_array_descriptor` returns the base pointer
+only for an owning descriptor and then resets every field to the null state,
+so the pointer reaches the runtime deallocator exactly once. For a borrowed
+descriptor it returns a null pointer and still resets the descriptor, so
+dropping a view never frees storage.
+
+- An allocatable array's descriptor owns its allocation. `deallocate`
+  releases the descriptor and frees the returned pointer. Finalization order
+  is unchanged: elements are finalized before the base pointer is released.
+- A pointer array's descriptor never owns storage acquired by pointer
+  assignment. Ownership stays with the target's own descriptor. A pointer
+  that acquired storage through `allocate` does own it and is the descriptor
+  that releases it.
+- A dummy argument descriptor is borrowed for the duration of the call.
+  A callee never releases a descriptor it received.
+
+## View lifetime and aliasing
+
+A section view is a descriptor whose `base` points into another descriptor's
+allocation, built through `set_strided_array_descriptor`, which never sets
+`ARRAY_FLAG_OWNS_DATA`. A view is therefore valid only while its parent
+allocation is valid, and never extends that allocation's lifetime.
+
+A view and its parent alias the same storage. Writes through either are
+immediately visible through the other, so any operation whose result depends
+on the order of overlapping element reads and writes must copy to a temporary
+first, exactly as before this ABI. Constructing a view copies metadata only
+and never moves elements.
+
+## Initialization errors
+
+| Code | Name | Condition |
+|---:|---|---|
+| 0 | `ARRAY_DESCRIPTOR_OK` | Descriptor initialized |
+| 1 | `ARRAY_DESCRIPTOR_INVALID_RANK` | `rank < 1`, `rank > 7`, or short metadata arrays |
+| 2 | `ARRAY_DESCRIPTOR_INVALID_EXTENT` | A negative extent |
+| 3 | `ARRAY_DESCRIPTOR_INVALID_ELEMENT_SIZE` | `element_size <= 0` |
+| 4 | `ARRAY_DESCRIPTOR_INVALID_ELEMENT_TYPE` | Element type outside 1 to 6 |
+| 5 | `ARRAY_DESCRIPTOR_NULL_DATA` | A null base with a positive element count |
+| 6 | `ARRAY_DESCRIPTOR_INVALID_OWNERSHIP` | Ownership requested for a null base |
+| 7 | `ARRAY_DESCRIPTOR_INVALID_INDEX` | A subscript outside its dimension's bounds |
+
+A zero-sized array is valid and may carry a null base. It is allocated and
+associated, and every subscript is out of bounds.
+
+## Scope
+
+Defining this contract changes no lowering. Automatic, assumed-shape,
+allocatable, pointer, and section paths migrate in their own issues.
+Coarray codimensions are outside this descriptor.

--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -50,6 +50,10 @@ is closed with ABI documentation and executable tests.
 
 ### Allocatable array descriptor
 
+The canonical array descriptor for new runtime interfaces is specified in
+`ARRAY_DESCRIPTOR_ABI.md`. Current lowering paths use the following
+representation until their descriptor migration issues land.
+
 An `integer/real/logical, allocatable :: a(:)` declaration lowers to a 40-byte,
 8-byte-aligned descriptor on the stack, zero-initialised at declaration. The
 descriptor is element-kind-agnostic; the element kind lives on the symbol and

--- a/src/ffc_array_descriptor.f90
+++ b/src/ffc_array_descriptor.f90
@@ -1,0 +1,425 @@
+module ffc_array_descriptor
+    use, intrinsic :: iso_c_binding, only: c_associated, c_int32_t, c_int64_t, &
+        c_intptr_t, c_null_ptr, c_ptr, c_size_t
+    implicit none
+    private
+
+    public :: array_dimension_t
+    public :: array_descriptor_t
+    public :: set_array_descriptor_null
+    public :: set_contiguous_array_descriptor
+    public :: set_strided_array_descriptor
+    public :: array_descriptor_element_offset
+    public :: array_descriptor_element_address
+    public :: array_descriptor_size
+    public :: array_descriptor_extent
+    public :: array_descriptor_lower_bound
+    public :: array_descriptor_upper_bound
+    public :: array_descriptor_stride_bytes
+    public :: array_descriptor_is_allocated
+    public :: array_descriptor_is_owned
+    public :: array_descriptor_is_contiguous
+    public :: release_array_descriptor
+
+    integer, parameter, public :: ARRAY_DESCRIPTOR_MAX_RANK = 7
+
+    integer(c_intptr_t), parameter, public :: &
+        ARRAY_DESCRIPTOR_BASE_OFFSET = 0_c_intptr_t
+    integer(c_intptr_t), parameter, public :: &
+        ARRAY_DESCRIPTOR_ELEMENT_SIZE_OFFSET = 8_c_intptr_t
+    integer(c_intptr_t), parameter, public :: &
+        ARRAY_DESCRIPTOR_ELEMENT_TYPE_OFFSET = 16_c_intptr_t
+    integer(c_intptr_t), parameter, public :: &
+        ARRAY_DESCRIPTOR_RANK_OFFSET = 20_c_intptr_t
+    integer(c_intptr_t), parameter, public :: &
+        ARRAY_DESCRIPTOR_FLAGS_OFFSET = 24_c_intptr_t
+    integer(c_intptr_t), parameter, public :: &
+        ARRAY_DESCRIPTOR_RESERVED_OFFSET = 28_c_intptr_t
+    integer(c_intptr_t), parameter, public :: &
+        ARRAY_DESCRIPTOR_DIM_OFFSET = 32_c_intptr_t
+    integer(c_size_t), parameter, public :: ARRAY_DIMENSION_BYTES = 24_c_size_t
+    integer(c_size_t), parameter, public :: ARRAY_DESCRIPTOR_BYTES = 200_c_size_t
+
+    integer(c_intptr_t), parameter, public :: &
+        ARRAY_DIMENSION_LOWER_OFFSET = 0_c_intptr_t
+    integer(c_intptr_t), parameter, public :: &
+        ARRAY_DIMENSION_EXTENT_OFFSET = 8_c_intptr_t
+    integer(c_intptr_t), parameter, public :: &
+        ARRAY_DIMENSION_STRIDE_OFFSET = 16_c_intptr_t
+
+    integer(c_int32_t), parameter, public :: ARRAY_FLAG_NONE = 0_c_int32_t
+    integer(c_int32_t), parameter, public :: ARRAY_FLAG_ALLOCATED = 1_c_int32_t
+    integer(c_int32_t), parameter, public :: ARRAY_FLAG_ASSOCIATED = 2_c_int32_t
+    integer(c_int32_t), parameter, public :: ARRAY_FLAG_OWNS_DATA = 4_c_int32_t
+    integer(c_int32_t), parameter, public :: ARRAY_FLAG_CONTIGUOUS = 8_c_int32_t
+
+    integer(c_int32_t), parameter, public :: ARRAY_ELEMENT_NONE = 0_c_int32_t
+    integer(c_int32_t), parameter, public :: ARRAY_ELEMENT_INTEGER = 1_c_int32_t
+    integer(c_int32_t), parameter, public :: ARRAY_ELEMENT_REAL = 2_c_int32_t
+    integer(c_int32_t), parameter, public :: ARRAY_ELEMENT_LOGICAL = 3_c_int32_t
+    integer(c_int32_t), parameter, public :: ARRAY_ELEMENT_COMPLEX = 4_c_int32_t
+    integer(c_int32_t), parameter, public :: ARRAY_ELEMENT_CHARACTER = 5_c_int32_t
+    integer(c_int32_t), parameter, public :: ARRAY_ELEMENT_DERIVED = 6_c_int32_t
+
+    integer, parameter, public :: ARRAY_DESCRIPTOR_OK = 0
+    integer, parameter, public :: ARRAY_DESCRIPTOR_INVALID_RANK = 1
+    integer, parameter, public :: ARRAY_DESCRIPTOR_INVALID_EXTENT = 2
+    integer, parameter, public :: ARRAY_DESCRIPTOR_INVALID_ELEMENT_SIZE = 3
+    integer, parameter, public :: ARRAY_DESCRIPTOR_INVALID_ELEMENT_TYPE = 4
+    integer, parameter, public :: ARRAY_DESCRIPTOR_NULL_DATA = 5
+    integer, parameter, public :: ARRAY_DESCRIPTOR_INVALID_OWNERSHIP = 6
+    integer, parameter, public :: ARRAY_DESCRIPTOR_INVALID_INDEX = 7
+
+    type, bind(c) :: array_dimension_t
+        integer(c_int64_t) :: lower_bound = 1_c_int64_t
+        integer(c_int64_t) :: extent = 0_c_int64_t
+        integer(c_int64_t) :: stride_bytes = 0_c_int64_t
+    end type array_dimension_t
+
+    type, bind(c) :: array_descriptor_t
+        type(c_ptr) :: base = c_null_ptr
+        integer(c_int64_t) :: element_size = 0_c_int64_t
+        integer(c_int32_t) :: element_type = ARRAY_ELEMENT_NONE
+        integer(c_int32_t) :: rank = 0_c_int32_t
+        integer(c_int32_t) :: flags = ARRAY_FLAG_NONE
+        integer(c_int32_t) :: reserved = 0_c_int32_t
+        type(array_dimension_t) :: dim(ARRAY_DESCRIPTOR_MAX_RANK)
+    end type array_descriptor_t
+
+contains
+
+    subroutine set_array_descriptor_null(descriptor)
+        type(array_descriptor_t), intent(out) :: descriptor
+        integer :: dim
+
+        descriptor%base = c_null_ptr
+        descriptor%element_size = 0_c_int64_t
+        descriptor%element_type = ARRAY_ELEMENT_NONE
+        descriptor%rank = 0_c_int32_t
+        descriptor%flags = ARRAY_FLAG_NONE
+        descriptor%reserved = 0_c_int32_t
+        do dim = 1, ARRAY_DESCRIPTOR_MAX_RANK
+            descriptor%dim(dim)%lower_bound = 1_c_int64_t
+            descriptor%dim(dim)%extent = 0_c_int64_t
+            descriptor%dim(dim)%stride_bytes = 0_c_int64_t
+        end do
+    end subroutine set_array_descriptor_null
+
+    subroutine set_contiguous_array_descriptor(descriptor, base, element_type, &
+            element_size, rank, lower_bounds, extents, owns_data, status)
+        type(array_descriptor_t), intent(out) :: descriptor
+        type(c_ptr), intent(in) :: base
+        integer(c_int32_t), intent(in) :: element_type
+        integer(c_int64_t), intent(in) :: element_size
+        integer, intent(in) :: rank
+        integer(c_int64_t), intent(in) :: lower_bounds(:)
+        integer(c_int64_t), intent(in) :: extents(:)
+        logical, intent(in) :: owns_data
+        integer, intent(out) :: status
+
+        integer(c_int64_t) :: strides(ARRAY_DESCRIPTOR_MAX_RANK)
+        integer(c_int64_t) :: running
+        integer :: dim
+
+        call set_array_descriptor_null(descriptor)
+        call validate_metadata(element_type, element_size, rank, lower_bounds, &
+            extents, status)
+        if (status /= ARRAY_DESCRIPTOR_OK) return
+
+        running = element_size
+        do dim = 1, rank
+            strides(dim) = running
+            running = running*extents(dim)
+        end do
+
+        call install(descriptor, base, element_type, element_size, rank, &
+            lower_bounds, extents, strides(1:rank), owns_data, .true., status)
+    end subroutine set_contiguous_array_descriptor
+
+    subroutine set_strided_array_descriptor(descriptor, base, element_type, &
+            element_size, rank, lower_bounds, extents, strides, status)
+        type(array_descriptor_t), intent(out) :: descriptor
+        type(c_ptr), intent(in) :: base
+        integer(c_int32_t), intent(in) :: element_type
+        integer(c_int64_t), intent(in) :: element_size
+        integer, intent(in) :: rank
+        integer(c_int64_t), intent(in) :: lower_bounds(:)
+        integer(c_int64_t), intent(in) :: extents(:)
+        integer(c_int64_t), intent(in) :: strides(:)
+        integer, intent(out) :: status
+
+        logical :: contiguous
+        integer(c_int64_t) :: running
+        integer :: dim
+
+        call set_array_descriptor_null(descriptor)
+        call validate_metadata(element_type, element_size, rank, lower_bounds, &
+            extents, status)
+        if (status /= ARRAY_DESCRIPTOR_OK) return
+        if (size(strides) < rank) then
+            status = ARRAY_DESCRIPTOR_INVALID_RANK
+            return
+        end if
+
+        contiguous = .true.
+        running = element_size
+        do dim = 1, rank
+            if (strides(dim) /= running) contiguous = .false.
+            running = running*extents(dim)
+        end do
+
+        call install(descriptor, base, element_type, element_size, rank, &
+            lower_bounds, extents, strides(1:rank), .false., contiguous, status)
+    end subroutine set_strided_array_descriptor
+
+    subroutine validate_metadata(element_type, element_size, rank, lower_bounds, &
+            extents, status)
+        integer(c_int32_t), intent(in) :: element_type
+        integer(c_int64_t), intent(in) :: element_size
+        integer, intent(in) :: rank
+        integer(c_int64_t), intent(in) :: lower_bounds(:)
+        integer(c_int64_t), intent(in) :: extents(:)
+        integer, intent(out) :: status
+
+        integer :: dim
+
+        status = ARRAY_DESCRIPTOR_OK
+        if (rank < 1) then
+            status = ARRAY_DESCRIPTOR_INVALID_RANK
+            return
+        end if
+        if (rank > ARRAY_DESCRIPTOR_MAX_RANK) then
+            status = ARRAY_DESCRIPTOR_INVALID_RANK
+            return
+        end if
+        if (size(lower_bounds) < rank) then
+            status = ARRAY_DESCRIPTOR_INVALID_RANK
+            return
+        end if
+        if (size(extents) < rank) then
+            status = ARRAY_DESCRIPTOR_INVALID_RANK
+            return
+        end if
+        if (element_size <= 0_c_int64_t) then
+            status = ARRAY_DESCRIPTOR_INVALID_ELEMENT_SIZE
+            return
+        end if
+        if (element_type < ARRAY_ELEMENT_INTEGER) then
+            status = ARRAY_DESCRIPTOR_INVALID_ELEMENT_TYPE
+            return
+        end if
+        if (element_type > ARRAY_ELEMENT_DERIVED) then
+            status = ARRAY_DESCRIPTOR_INVALID_ELEMENT_TYPE
+            return
+        end if
+        do dim = 1, rank
+            if (extents(dim) < 0_c_int64_t) then
+                status = ARRAY_DESCRIPTOR_INVALID_EXTENT
+                return
+            end if
+        end do
+    end subroutine validate_metadata
+
+    subroutine install(descriptor, base, element_type, element_size, rank, &
+            lower_bounds, extents, strides, owns_data, contiguous, status)
+        type(array_descriptor_t), intent(inout) :: descriptor
+        type(c_ptr), intent(in) :: base
+        integer(c_int32_t), intent(in) :: element_type
+        integer(c_int64_t), intent(in) :: element_size
+        integer, intent(in) :: rank
+        integer(c_int64_t), intent(in) :: lower_bounds(:)
+        integer(c_int64_t), intent(in) :: extents(:)
+        integer(c_int64_t), intent(in) :: strides(:)
+        logical, intent(in) :: owns_data
+        logical, intent(in) :: contiguous
+        integer, intent(out) :: status
+
+        integer(c_int64_t) :: total
+        integer :: dim
+
+        total = 1_c_int64_t
+        do dim = 1, rank
+            total = total*extents(dim)
+        end do
+        if (total > 0_c_int64_t) then
+            if (.not. c_associated(base)) then
+                status = ARRAY_DESCRIPTOR_NULL_DATA
+                return
+            end if
+        end if
+        if (owns_data) then
+            if (.not. c_associated(base)) then
+                status = ARRAY_DESCRIPTOR_INVALID_OWNERSHIP
+                return
+            end if
+        end if
+
+        descriptor%base = base
+        descriptor%element_size = element_size
+        descriptor%element_type = element_type
+        descriptor%rank = int(rank, c_int32_t)
+        descriptor%flags = ARRAY_FLAG_ALLOCATED + ARRAY_FLAG_ASSOCIATED
+        if (owns_data) descriptor%flags = descriptor%flags + ARRAY_FLAG_OWNS_DATA
+        if (contiguous) descriptor%flags = descriptor%flags + ARRAY_FLAG_CONTIGUOUS
+        do dim = 1, rank
+            descriptor%dim(dim)%lower_bound = lower_bounds(dim)
+            descriptor%dim(dim)%extent = extents(dim)
+            descriptor%dim(dim)%stride_bytes = strides(dim)
+        end do
+        status = ARRAY_DESCRIPTOR_OK
+    end subroutine install
+
+    subroutine array_descriptor_element_offset(descriptor, indices, offset, status)
+        type(array_descriptor_t), intent(in) :: descriptor
+        integer(c_int64_t), intent(in) :: indices(:)
+        integer(c_int64_t), intent(out) :: offset
+        integer, intent(out) :: status
+
+        integer(c_int64_t) :: position
+        integer :: dim
+
+        offset = 0_c_int64_t
+        if (descriptor%rank < 1_c_int32_t) then
+            status = ARRAY_DESCRIPTOR_INVALID_RANK
+            return
+        end if
+        if (size(indices) < int(descriptor%rank)) then
+            status = ARRAY_DESCRIPTOR_INVALID_RANK
+            return
+        end if
+
+        do dim = 1, int(descriptor%rank)
+            position = indices(dim) - descriptor%dim(dim)%lower_bound
+            if (position < 0_c_int64_t) then
+                offset = 0_c_int64_t
+                status = ARRAY_DESCRIPTOR_INVALID_INDEX
+                return
+            end if
+            if (position >= descriptor%dim(dim)%extent) then
+                offset = 0_c_int64_t
+                status = ARRAY_DESCRIPTOR_INVALID_INDEX
+                return
+            end if
+            offset = offset + position*descriptor%dim(dim)%stride_bytes
+        end do
+        status = ARRAY_DESCRIPTOR_OK
+    end subroutine array_descriptor_element_offset
+
+    subroutine array_descriptor_element_address(descriptor, indices, address, &
+            status)
+        type(array_descriptor_t), intent(in) :: descriptor
+        integer(c_int64_t), intent(in) :: indices(:)
+        integer(c_intptr_t), intent(out) :: address
+        integer, intent(out) :: status
+
+        integer(c_intptr_t) :: base_address
+        integer(c_int64_t) :: offset
+
+        address = 0_c_intptr_t
+        call array_descriptor_element_offset(descriptor, indices, offset, status)
+        if (status /= ARRAY_DESCRIPTOR_OK) return
+        if (.not. c_associated(descriptor%base)) then
+            status = ARRAY_DESCRIPTOR_NULL_DATA
+            return
+        end if
+        base_address = transfer(descriptor%base, base_address)
+        address = base_address + int(offset, c_intptr_t)
+    end subroutine array_descriptor_element_address
+
+    pure function array_descriptor_size(descriptor) result(total)
+        type(array_descriptor_t), intent(in) :: descriptor
+        integer(c_int64_t) :: total
+        integer :: dim
+
+        total = 0_c_int64_t
+        if (descriptor%rank < 1_c_int32_t) return
+        total = 1_c_int64_t
+        do dim = 1, int(descriptor%rank)
+            total = total*descriptor%dim(dim)%extent
+        end do
+    end function array_descriptor_size
+
+    pure function array_descriptor_extent(descriptor, dim) result(extent)
+        type(array_descriptor_t), intent(in) :: descriptor
+        integer, intent(in) :: dim
+        integer(c_int64_t) :: extent
+
+        extent = 0_c_int64_t
+        if (dim < 1) return
+        if (dim > int(descriptor%rank)) return
+        extent = descriptor%dim(dim)%extent
+    end function array_descriptor_extent
+
+    pure function array_descriptor_lower_bound(descriptor, dim) result(lower)
+        type(array_descriptor_t), intent(in) :: descriptor
+        integer, intent(in) :: dim
+        integer(c_int64_t) :: lower
+
+        lower = 1_c_int64_t
+        if (dim < 1) return
+        if (dim > int(descriptor%rank)) return
+        lower = descriptor%dim(dim)%lower_bound
+    end function array_descriptor_lower_bound
+
+    pure function array_descriptor_upper_bound(descriptor, dim) result(upper)
+        type(array_descriptor_t), intent(in) :: descriptor
+        integer, intent(in) :: dim
+        integer(c_int64_t) :: upper
+
+        upper = 0_c_int64_t
+        if (dim < 1) return
+        if (dim > int(descriptor%rank)) return
+        upper = descriptor%dim(dim)%lower_bound + descriptor%dim(dim)%extent &
+                - 1_c_int64_t
+    end function array_descriptor_upper_bound
+
+    pure function array_descriptor_stride_bytes(descriptor, dim) result(stride)
+        type(array_descriptor_t), intent(in) :: descriptor
+        integer, intent(in) :: dim
+        integer(c_int64_t) :: stride
+
+        stride = 0_c_int64_t
+        if (dim < 1) return
+        if (dim > int(descriptor%rank)) return
+        stride = descriptor%dim(dim)%stride_bytes
+    end function array_descriptor_stride_bytes
+
+    pure function array_descriptor_is_allocated(descriptor) result(is_allocated)
+        type(array_descriptor_t), intent(in) :: descriptor
+        logical :: is_allocated
+
+        is_allocated = has_flag(descriptor%flags, ARRAY_FLAG_ALLOCATED)
+    end function array_descriptor_is_allocated
+
+    pure function array_descriptor_is_owned(descriptor) result(is_owned)
+        type(array_descriptor_t), intent(in) :: descriptor
+        logical :: is_owned
+
+        is_owned = has_flag(descriptor%flags, ARRAY_FLAG_OWNS_DATA)
+    end function array_descriptor_is_owned
+
+    pure function array_descriptor_is_contiguous(descriptor) result(is_contiguous)
+        type(array_descriptor_t), intent(in) :: descriptor
+        logical :: is_contiguous
+
+        is_contiguous = has_flag(descriptor%flags, ARRAY_FLAG_CONTIGUOUS)
+    end function array_descriptor_is_contiguous
+
+    pure function has_flag(flags, flag) result(present_flag)
+        integer(c_int32_t), intent(in) :: flags
+        integer(c_int32_t), intent(in) :: flag
+        logical :: present_flag
+
+        present_flag = iand(flags, flag) /= 0_c_int32_t
+    end function has_flag
+
+    function release_array_descriptor(descriptor) result(base)
+        type(array_descriptor_t), intent(inout) :: descriptor
+        type(c_ptr) :: base
+
+        base = c_null_ptr
+        if (array_descriptor_is_owned(descriptor)) base = descriptor%base
+        call set_array_descriptor_null(descriptor)
+    end function release_array_descriptor
+
+end module ffc_array_descriptor

--- a/test/test_array_descriptor_layout.f90
+++ b/test/test_array_descriptor_layout.f90
@@ -1,0 +1,267 @@
+program test_array_descriptor_layout
+    use ffc_array_descriptor, only: array_descriptor_t, array_dimension_t, &
+        ARRAY_DESCRIPTOR_MAX_RANK, ARRAY_DESCRIPTOR_BASE_OFFSET, &
+        ARRAY_DESCRIPTOR_ELEMENT_SIZE_OFFSET, &
+        ARRAY_DESCRIPTOR_ELEMENT_TYPE_OFFSET, ARRAY_DESCRIPTOR_RANK_OFFSET, &
+        ARRAY_DESCRIPTOR_FLAGS_OFFSET, ARRAY_DESCRIPTOR_RESERVED_OFFSET, &
+        ARRAY_DESCRIPTOR_DIM_OFFSET, ARRAY_DIMENSION_BYTES, &
+        ARRAY_DESCRIPTOR_BYTES, ARRAY_DIMENSION_LOWER_OFFSET, &
+        ARRAY_DIMENSION_EXTENT_OFFSET, ARRAY_DIMENSION_STRIDE_OFFSET, &
+        ARRAY_FLAG_NONE, ARRAY_FLAG_ALLOCATED, ARRAY_FLAG_ASSOCIATED, &
+        ARRAY_FLAG_OWNS_DATA, ARRAY_FLAG_CONTIGUOUS, ARRAY_ELEMENT_NONE, &
+        ARRAY_ELEMENT_INTEGER, ARRAY_ELEMENT_DERIVED, ARRAY_DESCRIPTOR_OK, &
+        ARRAY_DESCRIPTOR_INVALID_RANK, ARRAY_DESCRIPTOR_INVALID_EXTENT, &
+        ARRAY_DESCRIPTOR_INVALID_ELEMENT_SIZE, &
+        ARRAY_DESCRIPTOR_INVALID_ELEMENT_TYPE, ARRAY_DESCRIPTOR_NULL_DATA, &
+        ARRAY_DESCRIPTOR_INVALID_OWNERSHIP, ARRAY_DESCRIPTOR_INVALID_INDEX, &
+        set_array_descriptor_null, set_contiguous_array_descriptor, &
+        set_strided_array_descriptor, array_descriptor_element_offset, &
+        array_descriptor_element_address, array_descriptor_size, &
+        array_descriptor_extent, array_descriptor_lower_bound, &
+        array_descriptor_upper_bound, array_descriptor_stride_bytes, &
+        array_descriptor_is_allocated, array_descriptor_is_owned, &
+        array_descriptor_is_contiguous, release_array_descriptor
+    use, intrinsic :: iso_c_binding, only: c_associated, c_int32_t, c_int64_t, &
+        c_intptr_t, c_loc, c_null_ptr, c_ptr, c_sizeof
+    implicit none
+
+    integer(c_int32_t), parameter :: INT32_ELEMENT_SIZE = 4_c_int32_t
+
+    type(array_descriptor_t), target :: descriptor
+    type(array_dimension_t), target :: dimension_probe
+    integer(c_int32_t), target :: storage(6)
+    type(c_ptr) :: released
+    integer(c_intptr_t) :: base_address
+    integer(c_intptr_t) :: address
+    integer(c_int64_t) :: lower_bounds(2)
+    integer(c_int64_t) :: extents(2)
+    integer(c_int64_t) :: strides(2)
+    integer(c_int64_t) :: offset
+    integer(c_int64_t) :: linear(3)
+    integer :: status
+
+    storage = 0_c_int32_t
+
+    call set_array_descriptor_null(descriptor)
+    call require_descriptor_layout(descriptor)
+    call require_dimension_layout(dimension_probe)
+    call require_null_state(descriptor, 'initial null')
+
+    lower_bounds = [1_c_int64_t, 1_c_int64_t]
+    extents = [2_c_int64_t, 3_c_int64_t]
+    call set_contiguous_array_descriptor(descriptor, c_loc(storage), &
+        ARRAY_ELEMENT_INTEGER, 4_c_int64_t, 2, lower_bounds, extents, .true., &
+        status)
+    call require(status == ARRAY_DESCRIPTOR_OK, 'contiguous status')
+    call require(descriptor%rank == 2_c_int32_t, 'rank field')
+    call require(array_descriptor_size(descriptor) == 6_c_int64_t, 'size')
+    call require(array_descriptor_extent(descriptor, 1) == 2_c_int64_t, 'extent 1')
+    call require(array_descriptor_extent(descriptor, 2) == 3_c_int64_t, 'extent 2')
+    call require(array_descriptor_upper_bound(descriptor, 2) == 3_c_int64_t, &
+        'upper bound 2')
+    call require(array_descriptor_stride_bytes(descriptor, 1) == 4_c_int64_t, &
+        'column-major stride 1')
+    call require(array_descriptor_stride_bytes(descriptor, 2) == 8_c_int64_t, &
+        'column-major stride 2')
+    call require(array_descriptor_is_allocated(descriptor), 'allocated flag')
+    call require(array_descriptor_is_owned(descriptor), 'owned flag')
+    call require(array_descriptor_is_contiguous(descriptor), 'contiguous flag')
+
+    linear(1) = element_index([1_c_int64_t, 1_c_int64_t])
+    linear(2) = element_index([2_c_int64_t, 2_c_int64_t])
+    linear(3) = element_index([2_c_int64_t, 3_c_int64_t])
+    call require(linear(1) == 1_c_int64_t, 'first element index')
+    call require(linear(2) == 4_c_int64_t, 'middle element index')
+    call require(linear(3) == 6_c_int64_t, 'last element index')
+
+    base_address = transfer(c_loc(storage), base_address)
+    call array_descriptor_element_address(descriptor, &
+        [2_c_int64_t, 3_c_int64_t], address, status)
+    call require(status == ARRAY_DESCRIPTOR_OK, 'address status')
+    call require(address - base_address == 20_c_intptr_t, 'last element address')
+
+    call array_descriptor_element_offset(descriptor, &
+        [0_c_int64_t, 1_c_int64_t], offset, status)
+    call require(status == ARRAY_DESCRIPTOR_INVALID_INDEX, 'index below lower')
+    call array_descriptor_element_offset(descriptor, &
+        [3_c_int64_t, 1_c_int64_t], offset, status)
+    call require(status == ARRAY_DESCRIPTOR_INVALID_INDEX, 'index above upper')
+
+    released = release_array_descriptor(descriptor)
+    call require(c_associated(released, c_loc(storage)), 'owned release')
+    call require_null_state(descriptor, 'owned release')
+
+    lower_bounds = [-1_c_int64_t, 2_c_int64_t]
+    extents = [2_c_int64_t, 3_c_int64_t]
+    call set_contiguous_array_descriptor(descriptor, c_loc(storage), &
+        ARRAY_ELEMENT_INTEGER, 4_c_int64_t, 2, lower_bounds, extents, .false., &
+        status)
+    call require(status == ARRAY_DESCRIPTOR_OK, 'nonunit lower status')
+    call require(array_descriptor_lower_bound(descriptor, 1) == -1_c_int64_t, &
+        'nonunit lower bound')
+    call require(array_descriptor_upper_bound(descriptor, 1) == 0_c_int64_t, &
+        'nonunit upper bound')
+    call require(element_index([-1_c_int64_t, 2_c_int64_t]) == 1_c_int64_t, &
+        'nonunit first element')
+    call require(element_index([0_c_int64_t, 4_c_int64_t]) == 6_c_int64_t, &
+        'nonunit last element')
+    released = release_array_descriptor(descriptor)
+    call require(.not. c_associated(released), 'borrowed release')
+
+    lower_bounds = [1_c_int64_t, 1_c_int64_t]
+    extents = [2_c_int64_t, 2_c_int64_t]
+    strides = [8_c_int64_t, 8_c_int64_t]
+    call set_strided_array_descriptor(descriptor, c_loc(storage), &
+        ARRAY_ELEMENT_INTEGER, 4_c_int64_t, 2, lower_bounds, extents, strides, &
+        status)
+    call require(status == ARRAY_DESCRIPTOR_OK, 'strided status')
+    call require(.not. array_descriptor_is_contiguous(descriptor), &
+        'strided view not contiguous')
+    call require(.not. array_descriptor_is_owned(descriptor), 'view never owns')
+    call require(element_index([2_c_int64_t, 2_c_int64_t]) == 5_c_int64_t, &
+        'strided last element')
+    released = release_array_descriptor(descriptor)
+    call require(.not. c_associated(released), 'view release keeps base')
+
+    call set_contiguous_array_descriptor(descriptor, c_loc(storage), &
+        ARRAY_ELEMENT_INTEGER, 4_c_int64_t, 0, lower_bounds, extents, .false., &
+        status)
+    call require(status == ARRAY_DESCRIPTOR_INVALID_RANK, 'rank zero rejected')
+    call require_null_state(descriptor, 'rank zero')
+
+    call set_contiguous_array_descriptor(descriptor, c_loc(storage), &
+        ARRAY_ELEMENT_INTEGER, 4_c_int64_t, ARRAY_DESCRIPTOR_MAX_RANK + 1, &
+        lower_bounds, extents, .false., status)
+    call require(status == ARRAY_DESCRIPTOR_INVALID_RANK, 'rank eight rejected')
+    call require_null_state(descriptor, 'rank eight')
+
+    extents = [2_c_int64_t, -1_c_int64_t]
+    call set_contiguous_array_descriptor(descriptor, c_loc(storage), &
+        ARRAY_ELEMENT_INTEGER, 4_c_int64_t, 2, lower_bounds, extents, .false., &
+        status)
+    call require(status == ARRAY_DESCRIPTOR_INVALID_EXTENT, &
+        'negative extent rejected')
+    call require_null_state(descriptor, 'negative extent')
+
+    extents = [2_c_int64_t, 3_c_int64_t]
+    call set_contiguous_array_descriptor(descriptor, c_loc(storage), &
+        ARRAY_ELEMENT_INTEGER, 0_c_int64_t, 2, lower_bounds, extents, .false., &
+        status)
+    call require(status == ARRAY_DESCRIPTOR_INVALID_ELEMENT_SIZE, &
+        'zero element size rejected')
+
+    call set_contiguous_array_descriptor(descriptor, c_loc(storage), &
+        ARRAY_ELEMENT_DERIVED + 1_c_int32_t, 4_c_int64_t, 2, lower_bounds, &
+        extents, .false., status)
+    call require(status == ARRAY_DESCRIPTOR_INVALID_ELEMENT_TYPE, &
+        'unknown element type rejected')
+
+    call set_contiguous_array_descriptor(descriptor, c_null_ptr, &
+        ARRAY_ELEMENT_INTEGER, 4_c_int64_t, 2, lower_bounds, extents, .false., &
+        status)
+    call require(status == ARRAY_DESCRIPTOR_NULL_DATA, 'null base rejected')
+
+    extents = [0_c_int64_t, 3_c_int64_t]
+    call set_contiguous_array_descriptor(descriptor, c_null_ptr, &
+        ARRAY_ELEMENT_INTEGER, 4_c_int64_t, 2, lower_bounds, extents, .true., &
+        status)
+    call require(status == ARRAY_DESCRIPTOR_INVALID_OWNERSHIP, &
+        'ownership without storage rejected')
+
+    print *, linear(1), linear(2), linear(3)
+    print *, 'PASS: array descriptor layout and addressing'
+
+contains
+
+    function element_index(indices) result(index_value)
+        integer(c_int64_t), intent(in) :: indices(:)
+        integer(c_int64_t) :: index_value
+        integer(c_int64_t) :: byte_offset
+        integer :: local_status
+
+        call array_descriptor_element_offset(descriptor, indices, byte_offset, &
+            local_status)
+        call require(local_status == ARRAY_DESCRIPTOR_OK, 'element offset status')
+        index_value = byte_offset/int(INT32_ELEMENT_SIZE, c_int64_t) + 1_c_int64_t
+    end function element_index
+
+    subroutine require_descriptor_layout(value)
+        type(array_descriptor_t), target, intent(inout) :: value
+        integer(c_intptr_t) :: origin
+        integer(c_intptr_t) :: field
+
+        origin = transfer(c_loc(value), origin)
+        field = transfer(c_loc(value%base), field)
+        call require(field - origin == ARRAY_DESCRIPTOR_BASE_OFFSET, 'base offset')
+        field = transfer(c_loc(value%element_size), field)
+        call require(field - origin == ARRAY_DESCRIPTOR_ELEMENT_SIZE_OFFSET, &
+            'element size offset')
+        field = transfer(c_loc(value%element_type), field)
+        call require(field - origin == ARRAY_DESCRIPTOR_ELEMENT_TYPE_OFFSET, &
+            'element type offset')
+        field = transfer(c_loc(value%rank), field)
+        call require(field - origin == ARRAY_DESCRIPTOR_RANK_OFFSET, 'rank offset')
+        field = transfer(c_loc(value%flags), field)
+        call require(field - origin == ARRAY_DESCRIPTOR_FLAGS_OFFSET, &
+            'flags offset')
+        field = transfer(c_loc(value%reserved), field)
+        call require(field - origin == ARRAY_DESCRIPTOR_RESERVED_OFFSET, &
+            'reserved offset')
+        field = transfer(c_loc(value%dim(1)%lower_bound), field)
+        call require(field - origin == ARRAY_DESCRIPTOR_DIM_OFFSET, 'dim offset')
+        field = transfer(c_loc(value%dim(2)%lower_bound), field)
+        call require(field - origin == ARRAY_DESCRIPTOR_DIM_OFFSET &
+            + int(ARRAY_DIMENSION_BYTES, c_intptr_t), 'dim stride')
+        field = transfer(c_loc(value%dim(ARRAY_DESCRIPTOR_MAX_RANK)%lower_bound), &
+            field)
+        call require(field - origin == ARRAY_DESCRIPTOR_DIM_OFFSET &
+            + 6_c_intptr_t*int(ARRAY_DIMENSION_BYTES, c_intptr_t), 'dim seven')
+        call require(c_sizeof(value) == ARRAY_DESCRIPTOR_BYTES, 'total size')
+    end subroutine require_descriptor_layout
+
+    subroutine require_dimension_layout(value)
+        type(array_dimension_t), target, intent(inout) :: value
+        integer(c_intptr_t) :: origin
+        integer(c_intptr_t) :: field
+
+        origin = transfer(c_loc(value), origin)
+        field = transfer(c_loc(value%lower_bound), field)
+        call require(field - origin == ARRAY_DIMENSION_LOWER_OFFSET, &
+            'dimension lower offset')
+        field = transfer(c_loc(value%extent), field)
+        call require(field - origin == ARRAY_DIMENSION_EXTENT_OFFSET, &
+            'dimension extent offset')
+        field = transfer(c_loc(value%stride_bytes), field)
+        call require(field - origin == ARRAY_DIMENSION_STRIDE_OFFSET, &
+            'dimension stride offset')
+        call require(c_sizeof(value) == ARRAY_DIMENSION_BYTES, 'dimension size')
+    end subroutine require_dimension_layout
+
+    subroutine require_null_state(value, label)
+        type(array_descriptor_t), intent(in) :: value
+        character(len=*), intent(in) :: label
+        integer :: dim
+
+        call require(.not. c_associated(value%base), label//' base')
+        call require(value%element_size == 0_c_int64_t, label//' element size')
+        call require(value%element_type == ARRAY_ELEMENT_NONE, label//' type')
+        call require(value%rank == 0_c_int32_t, label//' rank')
+        call require(value%flags == ARRAY_FLAG_NONE, label//' flags')
+        do dim = 1, ARRAY_DESCRIPTOR_MAX_RANK
+            call require(value%dim(dim)%extent == 0_c_int64_t, label//' extent')
+            call require(value%dim(dim)%stride_bytes == 0_c_int64_t, &
+                label//' stride')
+        end do
+    end subroutine require_null_state
+
+    subroutine require(condition, message)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: message
+
+        if (.not. condition) then
+            print *, 'FAIL: ', message
+            stop 1
+        end if
+    end subroutine require
+
+end program test_array_descriptor_layout


### PR DESCRIPTION
Closes #333.

Defines one canonical rank-7 array descriptor and its addressing helpers. No
lowering path changes: this issue only establishes the contract that #334-#339
migrate onto.

## What lands

- `src/ffc_array_descriptor.f90`: `array_dimension_t` (24 bytes) and
  `array_descriptor_t` (200 bytes), both `bind(C)`, with exact offset
  constants, flag bits, element type codes, error codes, contiguous and
  strided constructors, checked offset/address helpers, bound/extent/stride
  accessors, and `release_array_descriptor`.
- `docs/ARRAY_DESCRIPTOR_ABI.md`: the layout table, addressing rule,
  ownership contract, and view/aliasing rules.
- `docs/RUNTIME_ABI.md`: points the allocatable-array section at the new
  document and states the old representation stays until its migration issue.
- `test/test_array_descriptor_layout.f90`: the behavioral oracle.

## Invariants preserved and how

- **Fortran column-major layout.** Not assumed by the addressing rule; encoded
  in the strides. `set_contiguous_array_descriptor` computes
  `stride(1) = element_size`, `stride(d) = stride(d-1)*extent(d-1)`, so the
  leftmost subscript varies fastest. The test asserts strides `4, 8` for a
  `2 x 3` 4-byte array and that elements `(1,1)`, `(2,2)`, `(2,3)` land at
  linear positions `1 4 6` (byte offsets 0, 12, 20), verified against the real
  `c_loc` base address, not only against program output.
- **Lower-bound and extent semantics.** Bounds are carried, never normalized.
  Addressing is `base + sum((i-lower)*stride)`, and `base` is the address of
  the element at the lower bounds. A `lower_bound = -1` rank-2 case is
  asserted to address subscripts -1 and 0 with the same first/last linear
  positions as its unit-bound twin. Subscripts outside
  `[lower, lower+extent-1]` return `ARRAY_DESCRIPTOR_INVALID_INDEX`.
- **Overlap and aliasing.** A view shares storage with its parent; the ABI doc
  states writes through either are immediately visible through the other and
  that order-sensitive operations over overlapping storage must still copy to
  a temporary. Constructing a view copies metadata only and never moves
  elements.
- **Allocation and finalization lifetimes.** Exactly one descriptor carries
  `ARRAY_FLAG_OWNS_DATA`. `release_array_descriptor` returns the base pointer
  only for that descriptor and then resets to the null state, so the pointer
  reaches the deallocator exactly once. Ownership of a null base is rejected
  with `ARRAY_DESCRIPTOR_INVALID_OWNERSHIP`. The doc records that elements are
  finalized before the base pointer is released.
- **View lifetimes.** `set_strided_array_descriptor` never sets the ownership
  bit, so a section view cannot free or extend the lifetime of its parent
  allocation. The test asserts releasing a view returns a null pointer while
  releasing the owner returns the base.
- **No incompatible convention survives, no parallel lowering path.** Nothing
  is migrated here, so no path gains a second convention. `RUNTIME_ABI.md`
  names the legacy 40-byte allocatable descriptor as the one to be replaced,
  not run alongside.

## Verification

Oracle recorded failing on unmodified main (`Cannot open module file
'ffc_array_descriptor.mod'`), then passing with the module. `fo test
test_array_descriptor_layout` passes; the layout assertions check every field
offset via `c_loc` deltas plus `c_sizeof` totals of 24 and 200 bytes, and the
negative fixtures cover rank 0, rank 8, negative extent, zero element size,
unknown element type, null base, and ownership without storage.

Full `fo` pipeline: build, lint and format clean. The two remaining test
failures (`test_parity_dashboard`, `test_fortfront_corpus_conformance`) were
reproduced identically on a clean `origin/main` worktree and are unrelated to
this change.

## Corpus delta

lfortran gauntlet: no change. The diff adds three files and four documentation
lines and touches no lowering code. This was confirmed empirically: the cases
that differed between worktrees still differed with this branch's new sources
removed, so the difference is worktree environment (shared `/tmp` gauntlet
scratch under concurrent runs), not this change. PASS/FAIL/XFAIL/XPASS delta
is 0/0/0/0.
