### PR TITLE
Fix duplicate is_dummy_argument component breaking the build on main

### DIFF
--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -231,8 +231,9 @@ module session_program_lowering_types
         type(lr_operand_desc_t) :: value
         type(lr_operand_desc_t) :: address
         logical :: is_parameter = .false.
-        ! A dummy argument of the current procedure. Its storage is borrowed
-        ! from the caller, so scope exit never finalizes it (#403).
+        ! A dummy argument of the current procedure. Its storage belongs to the
+        ! caller, so scope exit never finalizes it (#403) and a data-pointer
+        ! result may legitimately return it (#407).
         logical :: is_dummy_argument = .false.
         ! Temporary by-value override used while inlining a statement function;
         ! it is resolved by its synthetic name until the body expression is
@@ -316,9 +317,6 @@ module session_program_lowering_types
         ! address came from a data-pointer function result (#407). ASSOCIATED
         ! compares that address against null instead of folding is_associated.
         logical :: has_runtime_association = .false.
-        ! A dummy argument of the procedure being lowered. Its storage belongs
-        ! to the caller, so a data-pointer result may legitimately return it.
-        logical :: is_dummy_argument = .false.
         ! Procedure pointer (#245 B3d): `address` holds the ptr alloca slot;
         ! after assignment `value` holds the loaded callee ptr operand.
         logical :: is_proc_pointer = .false.


### PR DESCRIPTION
PRs #551 and #554 each added a `is_dummy_argument` component to `session_symbol_t` and landed independently, so `main` does not compile: "Component 'is_dummy_argument' at (1) already declared at (2)".

The two declarations mean the same thing (a dummy's storage belongs to the caller: #403 uses it to skip finalization at scope exit, #407 to allow returning it from a data-pointer result). This keeps one declaration and merges both comments. No behaviour change; both features keep the flag they were written against.

`fo build` is clean again and `fo test` is 254 passed / 2 failed, the two failures being `test_parity_dashboard` and `test_fortfront_corpus_conformance`, which fail identically on unmodified main in a worktree.