### PR TITLE
[runtime-02] select and load the matching runtime archive

### DIFF
--- a/src/liric_session_runtime_bindings.f90
+++ b/src/liric_session_runtime_bindings.f90
@@ -1,0 +1,276 @@
+! Runtime archive selection and installation (issue #376).
+!
+! Selects the LIRIC runtime archive matching the active backend and target,
+! then installs it into a session before any runtime call is lowered. The
+! archives themselves are produced by runtime/CMakeLists.txt (#374); see
+! docs/RUNTIME_ABI.md for the artifact names and the archive header format.
+!
+! Selection is opt-in: with FFC_RUNTIME_ARCHIVE_DIR unset or blank, nothing is
+! installed and the established inline-runtime lowering path is preserved
+! exactly. A configured directory is strict: a missing archive, or one built
+! for a different backend or target, is an error rather than a fallback.
+module liric_session_runtime_bindings
+    use liric_session_common, only: liric_session_t, lr_error_t, LR_OK, &
+        status_ok, require_open_session, set_empty
+    use, intrinsic :: iso_c_binding, only: c_ptr, c_int, c_size_t, c_loc, &
+        c_int8_t
+    implicit none
+    private
+
+    public :: LR_SESSION_BACKEND_DEFAULT, LR_SESSION_BACKEND_ISEL, &
+        LR_SESSION_BACKEND_COPY_PATCH, LR_SESSION_BACKEND_LLVM
+    public :: runtime_archive_backend_name, runtime_archive_name, &
+        runtime_archive_path, effective_archive_backend
+    public :: install_runtime_archive
+
+    ! Frozen LIRIC session backend enumerators (LIRIC #527 ABI freeze).
+    integer(c_int), parameter :: LR_SESSION_BACKEND_DEFAULT = 0_c_int
+    integer(c_int), parameter :: LR_SESSION_BACKEND_ISEL = 1_c_int
+    integer(c_int), parameter :: LR_SESSION_BACKEND_COPY_PATCH = 2_c_int
+    integer(c_int), parameter :: LR_SESSION_BACKEND_LLVM = 3_c_int
+
+    ! Artifact naming version; see docs/RUNTIME_ABI.md.
+    character(len=*), parameter :: ARTIFACT_VERSION = 'v2'
+    character(len=*), parameter :: ARCHIVE_MAGIC = 'LRARCH1'
+
+    interface
+        function lr_session_set_runtime_archive(handle, data, len, err) &
+            result(status) bind(c, name='lr_session_set_runtime_archive')
+            import :: c_ptr, c_int, c_size_t, lr_error_t
+            type(c_ptr), value :: handle
+            type(c_ptr), value :: data
+            integer(c_size_t), value :: len
+            type(lr_error_t), intent(inout) :: err
+            integer(c_int) :: status
+        end function lr_session_set_runtime_archive
+    end interface
+
+contains
+
+    ! Backend `default` is an alias for copy-patch and has no artifact of its
+    ! own, so it resolves to the copy-patch archive.
+    pure function effective_archive_backend(backend) result(resolved)
+        integer(c_int), intent(in) :: backend
+        integer(c_int) :: resolved
+
+        if (backend == LR_SESSION_BACKEND_DEFAULT) then
+            resolved = LR_SESSION_BACKEND_COPY_PATCH
+        else
+            resolved = backend
+        end if
+    end function effective_archive_backend
+
+    pure function runtime_archive_backend_name(backend) result(name)
+        integer(c_int), intent(in) :: backend
+        character(len=:), allocatable :: name
+        integer(c_int) :: resolved
+
+        resolved = effective_archive_backend(backend)
+        select case (resolved)
+        case (LR_SESSION_BACKEND_ISEL)
+            name = 'isel'
+        case (LR_SESSION_BACKEND_COPY_PATCH)
+            name = 'copy-patch'
+        case (LR_SESSION_BACKEND_LLVM)
+            name = 'llvm'
+        case default
+            name = ''
+        end select
+    end function runtime_archive_backend_name
+
+    pure function runtime_archive_name(backend) result(name)
+        integer(c_int), intent(in) :: backend
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: backend_name
+
+        backend_name = runtime_archive_backend_name(backend)
+        if (len(backend_name) == 0) then
+            name = ''
+        else
+            name = 'ffc-runtime-'//ARTIFACT_VERSION//'-'//backend_name// &
+                   '.lrarch'
+        end if
+    end function runtime_archive_name
+
+    ! Archives live in a target-qualified subdirectory of the configured
+    ! artifact root, matching the layout runtime/CMakeLists.txt writes.
+    pure function runtime_archive_path(directory, target, backend) result(path)
+        character(len=*), intent(in) :: directory
+        character(len=*), intent(in) :: target
+        integer(c_int), intent(in) :: backend
+        character(len=:), allocatable :: path
+        character(len=:), allocatable :: name
+
+        name = runtime_archive_name(backend)
+        if (len(name) == 0) then
+            path = ''
+        else
+            path = trim(directory)//'/'//trim(target)//'/'//name
+        end if
+    end function runtime_archive_path
+
+    subroutine read_archive_bytes(path, bytes, error_msg)
+        character(len=*), intent(in) :: path
+        integer(c_int8_t), allocatable, intent(out) :: bytes(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: unit, ios
+        integer(kind=8) :: nbytes
+        logical :: exists
+
+        call set_empty(error_msg)
+        inquire (file=path, exist=exists)
+        if (.not. exists) then
+            error_msg = 'runtime archive not found: '//path
+            return
+        end if
+        open (newunit=unit, file=path, access='stream', form='unformatted', &
+              status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            error_msg = 'cannot open runtime archive: '//path
+            return
+        end if
+        inquire (unit=unit, size=nbytes)
+        if (nbytes <= 0) then
+            close (unit)
+            error_msg = 'runtime archive is empty: '//path
+            return
+        end if
+        allocate (bytes(nbytes))
+        read (unit, iostat=ios) bytes
+        close (unit)
+        if (ios /= 0) then
+            deallocate (bytes)
+            error_msg = 'cannot read runtime archive: '//path
+        end if
+    end subroutine read_archive_bytes
+
+    ! Reads the little-endian u32 at the given 1-based byte offset.
+    pure function le_u32(bytes, offset) result(value)
+        integer(c_int8_t), intent(in) :: bytes(:)
+        integer, intent(in) :: offset
+        integer :: value
+        integer :: i, byte
+
+        value = 0
+        do i = 3, 0, -1
+            byte = int(bytes(offset + i))
+            if (byte < 0) byte = byte + 256
+            value = value*256 + byte
+        end do
+    end function le_u32
+
+    ! Rejects an archive that does not match what was asked for, rather than
+    ! accepting a mismatched fallback.
+    subroutine verify_archive(bytes, path, backend, error_msg)
+        integer(c_int8_t), intent(in) :: bytes(:)
+        character(len=*), intent(in) :: path
+        integer(c_int), intent(in) :: backend
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=len(ARCHIVE_MAGIC)) :: magic
+        integer :: i, byte, recorded
+        integer(c_int) :: wanted
+
+        call set_empty(error_msg)
+        if (size(bytes) < 16) then
+            error_msg = 'runtime archive is truncated: '//path
+            return
+        end if
+        do i = 1, len(ARCHIVE_MAGIC)
+            byte = int(bytes(i))
+            if (byte < 0) byte = byte + 256
+            magic(i:i) = achar(byte)
+        end do
+        if (magic /= ARCHIVE_MAGIC) then
+            error_msg = 'not a LIRIC runtime archive: '//path
+            return
+        end if
+        wanted = effective_archive_backend(backend)
+        recorded = le_u32(bytes, 13)
+        if (recorded /= int(wanted)) then
+            error_msg = 'runtime archive backend mismatch for '//path// &
+                ': archive records backend '// &
+                trim(backend_label(int(recorded, c_int)))// &
+                ' but the session uses backend '// &
+                trim(backend_label(wanted))
+        end if
+    end subroutine verify_archive
+
+    pure function backend_label(backend) result(label)
+        integer(c_int), intent(in) :: backend
+        character(len=:), allocatable :: label
+        character(len=:), allocatable :: name
+        character(len=16) :: number
+
+        name = runtime_archive_backend_name(backend)
+        write (number, '(i0)') backend
+        if (len(name) == 0) then
+            label = 'unknown('//trim(number)//')'
+        else
+            label = name//'('//trim(number)//')'
+        end if
+    end function backend_label
+
+    ! Installs the archive matching `backend` and `target` into `session`.
+    ! Returns .true. and leaves error_msg empty when no archive directory is
+    ! configured: that preserves the inline-runtime path unchanged.
+    logical function install_runtime_archive(session, backend, target, &
+                                             error_msg) result(ok)
+        type(liric_session_t), intent(inout) :: session
+        integer(c_int), intent(in) :: backend
+        character(len=*), intent(in) :: target
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: directory
+        character(len=:), allocatable :: path
+        integer(c_int8_t), allocatable, target :: bytes(:)
+        type(lr_error_t) :: error
+        integer(c_int) :: status
+        integer :: length, ios
+
+        ok = .false.
+        call set_empty(error_msg)
+
+        call get_environment_variable('FFC_RUNTIME_ARCHIVE_DIR', &
+                                      length=length, status=ios)
+        if (ios /= 0 .or. length <= 0) then
+            ! Unset configuration: keep the inline-runtime path.
+            ok = .true.
+            return
+        end if
+        allocate (character(len=length) :: directory)
+        call get_environment_variable('FFC_RUNTIME_ARCHIVE_DIR', directory)
+        if (len_trim(directory) == 0) then
+            ok = .true.
+            return
+        end if
+
+        if (.not. require_open_session(session, error_msg)) return
+
+        path = runtime_archive_path(directory, target, backend)
+        if (len(path) == 0) then
+            error_msg = 'no runtime archive is defined for backend '// &
+                trim(backend_label(backend))
+            return
+        end if
+
+        call read_archive_bytes(path, bytes, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        call verify_archive(bytes, path, backend, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        error%code = LR_OK
+        status = lr_session_set_runtime_archive(session%handle, &
+                                                c_loc(bytes(1)), &
+                                                int(size(bytes), c_size_t), &
+                                                error)
+        if (.not. status_ok(status, error, error_msg)) then
+            error_msg = 'failed to install runtime archive '//path//': '// &
+                error_msg
+            return
+        end if
+
+        call set_empty(error_msg)
+        ok = .true.
+    end function install_runtime_archive
+
+end module liric_session_runtime_bindings

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -53,6 +53,7 @@ module session_program_lowering
         BINDING_ASSOCIATE_NAME, &
         get_alternate_return_label, get_return_selector, &
         is_alternate_return_dummy
+    use liric_session_runtime_bindings, only: install_runtime_archive
     use liric_session_bindings, only: destroy, begin_i32_main, &
         liric_session_t, &
         begin_i32_function, begin_i64_function, begin_void_subroutine, &

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -62,6 +62,15 @@
         if (present(opt_level)) session_config%opt_level = int(opt_level, c_int)
         call liric_session_create(context%session, error_msg, session_config)
         if (len_trim(error_msg) > 0) return
+        ! Install the runtime archive matching this backend and target before
+        ! any runtime call is lowered (#376). With no archive directory
+        ! configured this is a no-op and the inline-runtime path is kept.
+        if (.not. install_runtime_archive(context%session, &
+                                          session_config%backend, &
+                                          'host', error_msg)) then
+            call destroy(context%session)
+            return
+        end if
         allocate(context%symbols(16))
         allocate(context%derived_types(8))
         allocate(context%module_exports(4))

--- a/test/test_session_runtime_archive_compiler.f90
+++ b/test/test_session_runtime_archive_compiler.f90
@@ -1,0 +1,317 @@
+! Issue #376: select and load the matching runtime archive.
+!
+! Behavioral oracle. For every backend that has an archive, this builds the
+! archives, installs the matching one into a session, emits an executable that
+! calls the packaged `_ffc_runtime_probe`, runs it, and requires exit status
+! 42. That checks the archive was really loaded and resolved, not merely that
+! a file was read.
+!
+! It also pins the selection contract: `default` selects the copy-patch
+! artifact, a missing archive and a backend-mismatched archive each report the
+! exact backend, and an unset FFC_RUNTIME_ARCHIVE_DIR preserves the inline
+! runtime path.
+program test_session_runtime_archive_compiler
+    use liric_session_bindings, only: liric_session_t, liric_session_create, &
+        destroy, lr_session_config_t, lr_operand_desc_t, emit_i32_call, &
+        emit_ret_i32_operand, begin_i32_main, finish_and_emit_exe
+    use liric_session_runtime_bindings, only: install_runtime_archive, &
+        runtime_archive_name, runtime_archive_path, &
+        effective_archive_backend, &
+        LR_SESSION_BACKEND_DEFAULT, LR_SESSION_BACKEND_ISEL, &
+        LR_SESSION_BACKEND_COPY_PATCH
+    use, intrinsic :: iso_c_binding, only: c_int, c_char
+    implicit none
+
+    interface
+        function setenv_c(name, value, overwrite) result(status) &
+            bind(c, name='setenv')
+            import :: c_char, c_int
+            character(kind=c_char), intent(in) :: name(*)
+            character(kind=c_char), intent(in) :: value(*)
+            integer(c_int), value :: overwrite
+            integer(c_int) :: status
+        end function setenv_c
+
+        function unsetenv_c(name) result(status) bind(c, name='unsetenv')
+            import :: c_char, c_int
+            character(kind=c_char), intent(in) :: name(*)
+            integer(c_int) :: status
+        end function unsetenv_c
+    end interface
+
+    character(len=*), parameter :: build_dir = '/tmp/ffc_runtime_376_build'
+    character(len=*), parameter :: artifact_root = build_dir//'/artifacts'
+    integer :: failures
+
+    failures = 0
+
+    print *, '=== runtime archive selection tests (#376) ==='
+
+    call check_names(failures)
+    call build_archives(failures)
+    if (failures == 0) then
+        call check_probe_runs(LR_SESSION_BACKEND_ISEL, 'isel', failures)
+        call check_probe_runs(LR_SESSION_BACKEND_COPY_PATCH, 'copy-patch', &
+                              failures)
+        call check_probe_runs(LR_SESSION_BACKEND_DEFAULT, 'default', failures)
+        call check_missing_archive(failures)
+        call check_backend_mismatch(failures)
+    end if
+    call check_unset_preserves_inline_path(failures)
+
+    if (failures /= 0) then
+        print *, 'FAIL: ', failures, ' runtime archive check(s) failed'
+        stop 1
+    end if
+    print *, 'PASS: runtime archive selection'
+
+contains
+
+    subroutine run(cmd, exit_stat)
+        character(len=*), intent(in) :: cmd
+        integer, intent(out) :: exit_stat
+        integer :: cmd_stat
+
+        call execute_command_line(cmd, exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) exit_stat = -1
+    end subroutine run
+
+    ! `default` must resolve to the copy-patch artifact, not one of its own.
+    subroutine check_names(nfail)
+        integer, intent(inout) :: nfail
+
+        if (runtime_archive_name(LR_SESSION_BACKEND_ISEL) /= &
+            'ffc-runtime-v2-isel.lrarch') then
+            print *, 'FAIL: wrong isel archive name'
+            nfail = nfail + 1
+        end if
+        if (runtime_archive_name(LR_SESSION_BACKEND_COPY_PATCH) /= &
+            'ffc-runtime-v2-copy-patch.lrarch') then
+            print *, 'FAIL: wrong copy-patch archive name'
+            nfail = nfail + 1
+        end if
+        if (runtime_archive_name(LR_SESSION_BACKEND_DEFAULT) /= &
+            'ffc-runtime-v2-copy-patch.lrarch') then
+            print *, 'FAIL: default backend does not alias copy-patch'
+            nfail = nfail + 1
+        end if
+        if (effective_archive_backend(LR_SESSION_BACKEND_DEFAULT) /= &
+            LR_SESSION_BACKEND_COPY_PATCH) then
+            print *, 'FAIL: default backend does not resolve to copy-patch'
+            nfail = nfail + 1
+        end if
+        if (runtime_archive_path('/root', 'host', LR_SESSION_BACKEND_ISEL) /= &
+            '/root/host/ffc-runtime-v2-isel.lrarch') then
+            print *, 'FAIL: archive path is not target-qualified'
+            nfail = nfail + 1
+        end if
+    end subroutine check_names
+
+    subroutine build_archives(nfail)
+        integer, intent(inout) :: nfail
+        integer :: stat
+
+        call run('rm -rf '//build_dir, stat)
+        call run('cmake -S runtime -B '//build_dir// &
+                 ' > /tmp/ffc_runtime_376_cfg.log 2>&1 && cmake --build '// &
+                 build_dir//' -j 3 > /tmp/ffc_runtime_376_build.log 2>&1', &
+                 stat)
+        if (stat /= 0) then
+            print *, 'FAIL: could not build runtime archives'
+            call run('cat /tmp/ffc_runtime_376_cfg.log '// &
+                     '/tmp/ffc_runtime_376_build.log', stat)
+            nfail = nfail + 1
+        end if
+    end subroutine build_archives
+
+    ! Emits `program main; return _ffc_runtime_probe(); end` through a session
+    ! with the archive installed, then requires the executable to exit 42.
+    subroutine check_probe_runs(backend, label, nfail)
+        integer(c_int), intent(in) :: backend
+        character(len=*), intent(in) :: label
+        integer, intent(inout) :: nfail
+        type(liric_session_t) :: session
+        type(lr_session_config_t) :: config
+        type(lr_operand_desc_t) :: args(0)
+        type(lr_operand_desc_t) :: probe_result
+        character(len=:), allocatable :: error_msg
+        character(len=*), parameter :: exe = '/tmp/ffc_runtime_376_probe'
+        integer :: stat
+
+        call set_archive_dir(artifact_root)
+        config = lr_session_config_t()
+        config%backend = backend
+
+        call liric_session_create(session, error_msg, config)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: ', label, ' session create: ', trim(error_msg)
+            nfail = nfail + 1
+            return
+        end if
+
+        if (.not. install_runtime_archive(session, backend, 'host', &
+                                          error_msg)) then
+            print *, 'FAIL: ', label, ' archive install: ', trim(error_msg)
+            call destroy(session)
+            nfail = nfail + 1
+            return
+        end if
+
+        if (.not. begin_i32_main(session, error_msg)) then
+            print *, 'FAIL: ', label, ' begin main: ', trim(error_msg)
+            call destroy(session)
+            nfail = nfail + 1
+            return
+        end if
+        if (.not. emit_i32_call(session, '_ffc_runtime_probe', args, &
+                                probe_result, error_msg)) then
+            print *, 'FAIL: ', label, ' probe call: ', trim(error_msg)
+            call destroy(session)
+            nfail = nfail + 1
+            return
+        end if
+        if (.not. emit_ret_i32_operand(session, probe_result, error_msg)) then
+            print *, 'FAIL: ', label, ' return: ', trim(error_msg)
+            call destroy(session)
+            nfail = nfail + 1
+            return
+        end if
+
+        call run('rm -f '//exe, stat)
+        if (.not. finish_and_emit_exe(session, exe, error_msg)) then
+            print *, 'FAIL: ', label, ' emit exe: ', trim(error_msg)
+            call destroy(session)
+            nfail = nfail + 1
+            return
+        end if
+        call destroy(session)
+
+        call run(exe, stat)
+        if (stat /= 42) then
+            print *, 'FAIL: ', label, ' probe returned ', stat, ' expected 42'
+            nfail = nfail + 1
+        end if
+        call run('rm -f '//exe, stat)
+    end subroutine check_probe_runs
+
+    ! A missing archive must name the backend it was looking for.
+    subroutine check_missing_archive(nfail)
+        integer, intent(inout) :: nfail
+        type(liric_session_t) :: session
+        type(lr_session_config_t) :: config
+        character(len=:), allocatable :: error_msg
+
+        call set_archive_dir('/tmp/ffc_runtime_376_absent')
+        config = lr_session_config_t()
+        config%backend = LR_SESSION_BACKEND_ISEL
+        call liric_session_create(session, error_msg, config)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: session create for missing-archive check'
+            nfail = nfail + 1
+            return
+        end if
+        if (install_runtime_archive(session, LR_SESSION_BACKEND_ISEL, &
+                                    'host', error_msg)) then
+            print *, 'FAIL: missing archive was accepted'
+            nfail = nfail + 1
+        else if (index(error_msg, 'ffc-runtime-v2-isel.lrarch') == 0) then
+            print *, 'FAIL: missing-archive error does not name the ', &
+                'backend artifact: ', trim(error_msg)
+            nfail = nfail + 1
+        end if
+        call destroy(session)
+    end subroutine check_missing_archive
+
+    ! A target/backend-mismatched archive must be rejected, naming both the
+    ! recorded and the requested backend, rather than silently accepted.
+    subroutine check_backend_mismatch(nfail)
+        integer, intent(inout) :: nfail
+        type(liric_session_t) :: session
+        type(lr_session_config_t) :: config
+        character(len=:), allocatable :: error_msg
+        character(len=*), parameter :: bad_root = '/tmp/ffc_runtime_376_bad'
+        integer :: stat
+
+        ! Put the copy-patch archive where the isel archive belongs.
+        call run('rm -rf '//bad_root//' && mkdir -p '//bad_root//'/host', stat)
+        call run('cp '//artifact_root//'/host/ffc-runtime-v2-copy-patch.lrarch '// &
+                 bad_root//'/host/ffc-runtime-v2-isel.lrarch', stat)
+        if (stat /= 0) then
+            print *, 'FAIL: could not stage mismatched archive'
+            nfail = nfail + 1
+            return
+        end if
+
+        call set_archive_dir(bad_root)
+        config = lr_session_config_t()
+        config%backend = LR_SESSION_BACKEND_ISEL
+        call liric_session_create(session, error_msg, config)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: session create for mismatch check'
+            nfail = nfail + 1
+            return
+        end if
+        if (install_runtime_archive(session, LR_SESSION_BACKEND_ISEL, &
+                                    'host', error_msg)) then
+            print *, 'FAIL: backend-mismatched archive was accepted'
+            nfail = nfail + 1
+        else
+            if (index(error_msg, 'copy-patch') == 0 .or. &
+                index(error_msg, 'isel') == 0) then
+                print *, 'FAIL: mismatch error does not name both backends: ', &
+                    trim(error_msg)
+                nfail = nfail + 1
+            end if
+        end if
+        call destroy(session)
+        call run('rm -rf '//bad_root, stat)
+    end subroutine check_backend_mismatch
+
+    ! With no archive directory configured, installation is a silent no-op so
+    ! the established inline-runtime lowering path is preserved.
+    subroutine check_unset_preserves_inline_path(nfail)
+        integer, intent(inout) :: nfail
+        type(liric_session_t) :: session
+        type(lr_session_config_t) :: config
+        character(len=:), allocatable :: error_msg
+        integer :: stat
+
+        call run('true', stat)
+        call unset_archive_dir()
+        config = lr_session_config_t()
+        call liric_session_create(session, error_msg, config)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: session create for unset check'
+            nfail = nfail + 1
+            return
+        end if
+        if (.not. install_runtime_archive(session, &
+                                          LR_SESSION_BACKEND_DEFAULT, &
+                                          'host', error_msg)) then
+            print *, 'FAIL: unset archive dir was treated as an error: ', &
+                trim(error_msg)
+            nfail = nfail + 1
+        else if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: unset archive dir reported ', trim(error_msg)
+            nfail = nfail + 1
+        end if
+        call destroy(session)
+    end subroutine check_unset_preserves_inline_path
+
+    subroutine set_archive_dir(value)
+        character(len=*), intent(in) :: value
+        integer(c_int) :: stat
+
+        stat = setenv_c('FFC_RUNTIME_ARCHIVE_DIR'//achar(0), &
+                        trim(value)//achar(0), 1_c_int)
+        if (stat /= 0) print *, 'WARNING: setenv failed'
+    end subroutine set_archive_dir
+
+    subroutine unset_archive_dir()
+        integer(c_int) :: stat
+
+        stat = unsetenv_c('FFC_RUNTIME_ARCHIVE_DIR'//achar(0))
+        if (stat /= 0) print *, 'WARNING: unsetenv failed'
+    end subroutine unset_archive_dir
+
+end program test_session_runtime_archive_compiler


### PR DESCRIPTION
Closes #376. Depends on #374 (merged).

## Summary

Selects the runtime archive matching the active LIRIC backend and target, then installs it into the session before any runtime call is lowered.

- NEW `src/liric_session_runtime_bindings.f90`: resolves the artifact name and target-qualified path, reads the archive, verifies it, and installs it through `lr_session_set_runtime_archive`.
- `src/session_program_lowering_top.inc` / `src/session_program_lowering.f90`: installs the archive immediately after session creation, before any runtime call is emitted.
- NEW `test/test_session_runtime_archive_compiler.f90`: executable probe per backend.

Selection is driven by `FFC_RUNTIME_ARCHIVE_DIR`, which names the artifact root; the target subdirectory and `ffc-runtime-v2-<backend>.lrarch` name follow the layout #374 produces.

## Invariants preserved

- **Matching runtime archives, no mismatched fallback**: the archive's `LRARCH1` magic and its recorded backend enumerator are checked against the session's backend before installation. A mismatch is refused with an error naming both the recorded and the requested backend, and a missing archive names the exact artifact it looked for. Nothing falls back to a different backend's archive.
- **Backend `default` aliases copy-patch**, as documented in `docs/RUNTIME_ABI.md`; asserted directly.
- **Target qualification**: the path is always `<root>/<target>/<artifact>`, so an archive built for another target is never picked up from a flat directory.
- **Canonical ownership**: installation uses the copying `lr_session_set_runtime_archive`, not the `_borrowed` variant, because the byte buffer is a local array that dies at the end of the call. The session owns its copy; no view outlives its backing storage.
- **Inline-runtime path preserved**: with `FFC_RUNTIME_ARCHIVE_DIR` unset or blank, installation is a silent no-op returning success, so existing lowering is bit-for-bit unchanged. This is what keeps the corpus delta at zero.
- **Frozen ABI values**: the backend enumerators used here are the ones LIRIC #527 froze as public ABI (isel 1, copy-patch 2, LLVM 3).
- No printf/snprintf lowering was migrated, and no GPU or accelerator archives were added.

## Verification

The oracle emits `main` returning `_ffc_runtime_probe()` through a session with the archive installed, links an executable, runs it, and requires exit status 42 - so it proves the archive was really loaded and resolved, not merely read.

Recorded failing with the installation step disabled, which is the precise "runtime archive is not loaded" state:

```text
/tmp/ffc_runtime_376_probe: symbol lookup error: undefined symbol: _ffc_runtime_probe
 FAIL: isel probe returned -1 expected 42
 FAIL: copy-patch probe returned -1 expected 42
 FAIL: default probe returned -1 expected 42
 FAIL: missing archive was accepted
 FAIL: backend-mismatched archive was accepted
 FAIL: 5 runtime archive check(s) failed
```

With the change:

```text
$ fo test test_session_runtime_archive_compiler
test_session_runtime_archive_compiler      PASS       0.38s
```

Full `fo` pipeline: 290 tests. Two fail, both verified pre-existing/environmental and unrelated to this PR:

- `test_fortfront_corpus_conformance` - fails identically at `origin/main`.
- `test_parity_dashboard` - known to fail inside `.wt/` worktrees because the generator resolves sibling repos as `../fortfront`; passes in the primary checkout.

## Conformance gauntlet delta (lfortran suite)

| | PASS | XFAIL | XPASS | FAIL | NOREF | SKIP | TOTAL |
|---|---|---|---|---|---|---|---|
| before (chain baseline) | 842 | 3363 | 54 | 20 | 157 | 1 | 4280 |
| after | 851 | 3352 | 65 | 11 | 162 | 1 | 4280 |

No PASS became FAIL. PASS rose by 9 and FAIL fell by 9; that movement comes from the array/character/polymorphism chains that merged to `main` between the baseline run and this rebase, not from this PR - with `FFC_RUNTIME_ARCHIVE_DIR` unset (as in the gauntlet) this PR is a no-op on every lowering path. No manifest entry is moved here for that reason.

## Fixtures added

`test/test_session_runtime_archive_compiler.f90`: probe returns 42 for isel, copy-patch, and `default`; artifact names and the target-qualified path are pinned; `default` resolves to copy-patch; a missing archive names the artifact; a copy-patch archive staged under the isel name is rejected naming both backends; and an unset `FFC_RUNTIME_ARCHIVE_DIR` succeeds silently.