### PR TITLE
[test-isolation-01] isolate conformance runs from concurrent worktrees

### DIFF
--- a/scripts/conformance_check.sh
+++ b/scripts/conformance_check.sh
@@ -119,8 +119,8 @@ HAS_XPASS=0
 XPASS_FILES=""
 
 for SUITE in $SUITES; do
-    REPORT="/tmp/ffc_conformance_${SUITE}.jsonl"
-    LOG="/tmp/ffc_conformance_${SUITE}.out"
+    REPORT="${TMPDIR:-/tmp}/ffc_conformance_${SUITE}.jsonl"
+    LOG="${TMPDIR:-/tmp}/ffc_conformance_${SUITE}.out"
 
     echo "=== Running suite: $SUITE ==="
 

--- a/scripts/conformance_gauntlet.sh
+++ b/scripts/conformance_gauntlet.sh
@@ -13,7 +13,8 @@
 # Options:
 #   --suite SUITE       required
 #   --ffc PATH          path to ffc binary (auto-discovered if omitted)
-#   --report PATH       JSONL report path (default: /tmp/ffc_gauntlet_<suite>.jsonl)
+#   --report PATH       JSONL report path
+#                       (default: ${TMPDIR:-/tmp}/ffc_gauntlet_<suite>.jsonl)
 #   --file PATH         select one suite-relative file (repeatable)
 #   --files-from PATH   read suite-relative files from PATH (repeatable)
 #   --max-files N       only test the first N files (for smoke runs)
@@ -97,7 +98,7 @@ esac
 
 # Resolve report path
 if [ -z "$REPORT" ]; then
-    REPORT="/tmp/ffc_gauntlet_${SUITE}.jsonl"
+    REPORT="${TMPDIR:-/tmp}/ffc_gauntlet_${SUITE}.jsonl"
 fi
 
 # Ensure report directory exists
@@ -300,7 +301,7 @@ XFAIL_MANIFEST=$(resolve_xfail_manifest)
 SKIP_MANIFEST=$(resolve_skip_manifest)
 NOREF_MANIFEST=$(resolve_noref_manifest)
 EXT=$(file_extension)
-TMPDIR_WORK=$(mktemp -d /tmp/ffc_gauntlet_XXXXXX)
+TMPDIR_WORK=$(mktemp -d "${TMPDIR:-/tmp}/ffc_gauntlet_XXXXXX")
 trap 'rm -rf "$TMPDIR_WORK"' EXIT
 XFAIL_LOOKUP="$TMPDIR_WORK/xfail_lookup.txt"
 SKIP_LOOKUP="$TMPDIR_WORK/skip_lookup.txt"

--- a/scripts/generate_parity_dashboard.sh
+++ b/scripts/generate_parity_dashboard.sh
@@ -89,7 +89,11 @@ done
 [ -d "$MANIFEST_DIR" ] || fail "manifest directory not found: $MANIFEST_DIR"
 
 
-CORPUS_PARENT=$(dirname "$PROJECT_DIR")
+# Sibling corpora live next to the primary checkout, not next to a worktree
+# under .wt/. Resolve them from the repository's common root so a worktree
+# behaves exactly like the primary checkout.
+PRIMARY_REPO_ROOT="$(resolve_primary_checkout_root "$PROJECT_DIR")"
+CORPUS_PARENT=$(dirname "$PRIMARY_REPO_ROOT")
 FORTFRONT_DIR=${FFC_FORTFRONT_DIR:-$CORPUS_PARENT/fortfront}
 LIRIC_DIR=${FFC_LIRIC_DIR:-$CORPUS_PARENT/liric}
 pin_values=$("$SCRIPT_DIR/fetch_corpora.sh" --print-pins)

--- a/scripts/lib_conformance.sh
+++ b/scripts/lib_conformance.sh
@@ -130,31 +130,51 @@ resolve_primary_checkout_root() {
     fi
 }
 
-# Resolve the ffc binary. Priority: --ffc arg > FFC_BIN env > build/ tree > PATH.
+# Resolve the ffc binary. Priority: --ffc arg > FFC_BIN env > own build/ tree.
+#
+# The binary must come from the checkout that owns this script. Resolving it by
+# a relative path, or from PATH, lets a concurrently building sibling worktree
+# supply the compiler: the suite then silently measures someone else's code and
+# reports the result as this checkout's. Any candidate outside PROJECT_DIR/build
+# is therefore rejected rather than used, and the emitted path is absolute.
 find_ffc() {
+    local project_dir build_dir candidate resolved
     if [ -n "${FFC_BIN:-}" ]; then
-        echo "$FFC_BIN"
+        resolved=$(readlink -f "$FFC_BIN" 2>/dev/null) || resolved=""
+        if [ -z "$resolved" ] || [ ! -x "$resolved" ]; then
+            echo "ERROR: FFC_BIN is not an executable file: $FFC_BIN" >&2
+            return 1
+        fi
+        echo "$resolved"
         return 0
     fi
-    local candidate
-    local build_dir
-    build_dir="${PROJECT_DIR:-.}/build"
+    if [ -z "${PROJECT_DIR:-}" ]; then
+        echo "ERROR: PROJECT_DIR is unset; cannot resolve ffc from own build tree." >&2
+        return 1
+    fi
+    project_dir=$(readlink -f "$PROJECT_DIR" 2>/dev/null) || project_dir=""
+    if [ -z "$project_dir" ]; then
+        echo "ERROR: PROJECT_DIR does not exist: $PROJECT_DIR" >&2
+        return 1
+    fi
+    build_dir="$project_dir/build"
     # Pick the most recently built ffc. Several may coexist (build/fo/bin/ffc
     # from the fo backend, build/gfortran_*/app/ffc from fpm); an arbitrary
     # head -1 can return a stale one whose lowering predates recent fixes.
     candidate=$(find "$build_dir" -name ffc -type f -executable -printf '%T@ %p\n' \
         2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-) || true
     if [ -n "$candidate" ]; then
-        echo "$candidate"
-        return 0
+        resolved=$(readlink -f "$candidate" 2>/dev/null) || resolved=""
+        case "$resolved" in
+            "$build_dir"/*)
+                echo "$resolved"
+                return 0 ;;
+            *)
+                echo "ERROR: ffc candidate escapes own build tree: $candidate" >&2
+                return 1 ;;
+        esac
     fi
-    local in_path
-    in_path=$(command -v ffc 2>/dev/null) || true
-    if [ -n "$in_path" ]; then
-        echo "$in_path"
-        return 0
-    fi
-    echo "ERROR: ffc binary not found. Set FFC_BIN or run 'fpm build' first." >&2
+    echo "ERROR: no ffc binary in $build_dir. Run 'fo build' first." >&2
     return 1
 }
 

--- a/test/conformance_temp_dir.f90
+++ b/test/conformance_temp_dir.f90
@@ -1,0 +1,72 @@
+module conformance_temp_dir
+    ! Per-run scratch directories for the conformance tests.
+    !
+    ! Conformance tests used to write fixtures and reports to fixed /tmp paths.
+    ! Two concurrent runs (different worktrees, or `fo test` running tests in
+    ! parallel) then overwrote each other's fixtures, which produces spurious
+    ! failures and, worse, lets one run read another run's stale artifacts as
+    ! if they were its own.
+    !
+    ! `mktemp -d` cannot be used directly from Fortran because capturing its
+    ! stdout would itself need a uniquely named file. Instead the directory
+    ! name is drawn from the clock plus a counter and created with plain
+    ! `mkdir`, which fails when the directory already exists. That failure is
+    ! the atomic uniqueness guarantee: a name can only be claimed once.
+    implicit none
+    private
+    public :: make_temp_root, remove_temp_root
+
+contains
+
+    function make_temp_root(prefix) result(root)
+        character(len=*), intent(in) :: prefix
+        character(len=:), allocatable :: root
+        character(len=:), allocatable :: base
+        character(len=64) :: suffix
+        integer :: attempt, exit_stat, clock_count, clock_rate
+
+        base = temp_base()
+        do attempt = 1, 64
+            call system_clock(clock_count, clock_rate)
+            write (suffix, '(I0,A,I0)') abs(clock_count), '_', attempt
+            root = base//'/ffc_'//prefix//'_'//trim(suffix)
+            ! Plain mkdir (no -p): fails if the name is already taken.
+            call execute_command_line('mkdir '//quote(root)//' 2>/dev/null', &
+                exitstat=exit_stat)
+            if (exit_stat == 0) return
+        end do
+        error stop 'make_temp_root: could not create a unique temporary directory'
+    end function make_temp_root
+
+    subroutine remove_temp_root(root)
+        character(len=*), intent(in) :: root
+
+        if (len_trim(root) == 0) return
+        call execute_command_line('rm -rf '//quote(trim(root)))
+    end subroutine remove_temp_root
+
+    function temp_base() result(base)
+        character(len=:), allocatable :: base
+        character(len=4096) :: buffer
+        integer :: length, status
+
+        call get_environment_variable('TMPDIR', buffer, length, status)
+        if (status == 0 .and. length > 0) then
+            base = buffer(1:length)
+            do while (len(base) > 1)
+                if (base(len(base):len(base)) /= '/') exit
+                base = base(1:len(base) - 1)
+            end do
+        else
+            base = '/tmp'
+        end if
+    end function temp_base
+
+    function quote(text) result(quoted)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: quoted
+
+        quoted = "'"//text//"'"
+    end function quote
+
+end module conformance_temp_dir

--- a/test/test_conformance_gauntlet_smoke.f90
+++ b/test/test_conformance_gauntlet_smoke.f90
@@ -1,55 +1,60 @@
 program test_conformance_gauntlet_smoke
+    use conformance_temp_dir, only: make_temp_root, remove_temp_root
     implicit none
 
     integer, parameter :: RUN_TIMEOUT_SECONDS = 120
     character(len=*), parameter :: SCRIPT = &
         'scripts/conformance_gauntlet.sh'
-    character(len=*), parameter :: ROOT_REPORT = &
-        '/tmp/ffc_gauntlet_smoke_root.jsonl'
-    character(len=*), parameter :: TMP_CWD_REPORT = &
-        '/tmp/ffc_gauntlet_smoke_tmpcwd.jsonl'
-    character(len=*), parameter :: NAMED_REPORT = &
-        '/tmp/ffc_gauntlet_smoke_named.jsonl'
-    character(len=*), parameter :: LIST_REPORT = &
-        '/tmp/ffc_gauntlet_smoke_list.jsonl'
-    character(len=*), parameter :: LIMITED_REPORT = &
-        '/tmp/ffc_gauntlet_smoke_limited.jsonl'
-    character(len=*), parameter :: FORWARDED_REPORT = &
-        '/tmp/ffc_conformance_fortfront-f90.jsonl'
-    character(len=*), parameter :: SELECTION_LIST = &
-        '/tmp/ffc_gauntlet_smoke_files.txt'
-    character(len=*), parameter :: FORWARD_SELECTION_LIST = &
-        '/tmp/ffc_gauntlet_smoke_forward_files.txt'
-    character(len=*), parameter :: FAILURE_LOG = &
-        '/tmp/ffc_gauntlet_smoke_failure.log'
-    character(len=*), parameter :: DG_FIXTURE_DIR = &
-        '/tmp/ffc_gauntlet_dg_fixtures'
-    character(len=*), parameter :: DG_REPORT = &
-        '/tmp/ffc_gauntlet_dg_warning.jsonl'
-    character(len=*), parameter :: DG_NEGATIVE_REPORT = &
-        '/tmp/ffc_gauntlet_dg_negative.jsonl'
-    character(len=*), parameter :: UNDEFINED_REPORT = &
-        '/tmp/ffc_gauntlet_undefined_output.jsonl'
-    character(len=*), parameter :: UNDEFINED_NEGATIVE_REPORT = &
-        '/tmp/ffc_gauntlet_undefined_negative.jsonl'
-    character(len=*), parameter :: UNDEFINED_FIXTURE_ROOT = &
-        '/tmp/ffc_gauntlet_undefined_fortfront'
-    character(len=*), parameter :: UNDEFINED_MANIFEST = &
-        '/tmp/ffc_gauntlet_undefined_manifest.txt'
-    character(len=*), parameter :: UNLINKED_REPORT = &
-        '/tmp/ffc_gauntlet_unlinked.jsonl'
-    character(len=*), parameter :: NOREF_NEGATIVE_REPORT = &
-        '/tmp/ffc_gauntlet_noref_negative.jsonl'
+    ! Per-run scratch directory: concurrent runs must not share fixtures.
+    character(len=:), allocatable :: ROOT
+    character(len=:), allocatable :: ROOT_REPORT
+    character(len=:), allocatable :: TMP_CWD_REPORT
+    character(len=:), allocatable :: NAMED_REPORT
+    character(len=:), allocatable :: LIST_REPORT
+    character(len=:), allocatable :: LIMITED_REPORT
+    character(len=:), allocatable :: FORWARDED_REPORT
+    character(len=:), allocatable :: SELECTION_LIST
+    character(len=:), allocatable :: FORWARD_SELECTION_LIST
+    character(len=:), allocatable :: FAILURE_LOG
+    character(len=:), allocatable :: DG_FIXTURE_DIR
+    character(len=:), allocatable :: DG_REPORT
+    character(len=:), allocatable :: DG_NEGATIVE_REPORT
+    character(len=:), allocatable :: UNDEFINED_REPORT
+    character(len=:), allocatable :: UNDEFINED_NEGATIVE_REPORT
+    character(len=:), allocatable :: UNDEFINED_FIXTURE_ROOT
+    character(len=:), allocatable :: UNDEFINED_MANIFEST
+    character(len=:), allocatable :: UNLINKED_REPORT
+    character(len=:), allocatable :: NOREF_NEGATIVE_REPORT
 
     logical :: all_passed
 
     print *, '=== conformance gauntlet smoke test ==='
 
+    ROOT = make_temp_root('gauntlet_smoke')
+    ROOT_REPORT = ROOT//'/ffc_gauntlet_smoke_root.jsonl'
+    TMP_CWD_REPORT = ROOT//'/ffc_gauntlet_smoke_tmpcwd.jsonl'
+    NAMED_REPORT = ROOT//'/ffc_gauntlet_smoke_named.jsonl'
+    LIST_REPORT = ROOT//'/ffc_gauntlet_smoke_list.jsonl'
+    LIMITED_REPORT = ROOT//'/ffc_gauntlet_smoke_limited.jsonl'
+    FORWARDED_REPORT = ROOT//'/ffc_conformance_fortfront-f90.jsonl'
+    SELECTION_LIST = ROOT//'/ffc_gauntlet_smoke_files.txt'
+    FORWARD_SELECTION_LIST = ROOT//'/ffc_gauntlet_smoke_forward_files.txt'
+    FAILURE_LOG = ROOT//'/ffc_gauntlet_smoke_failure.log'
+    DG_FIXTURE_DIR = ROOT//'/ffc_gauntlet_dg_fixtures'
+    DG_REPORT = ROOT//'/ffc_gauntlet_dg_warning.jsonl'
+    DG_NEGATIVE_REPORT = ROOT//'/ffc_gauntlet_dg_negative.jsonl'
+    UNDEFINED_REPORT = ROOT//'/ffc_gauntlet_undefined_output.jsonl'
+    UNDEFINED_NEGATIVE_REPORT = ROOT//'/ffc_gauntlet_undefined_negative.jsonl'
+    UNDEFINED_FIXTURE_ROOT = ROOT//'/ffc_gauntlet_undefined_fortfront'
+    UNDEFINED_MANIFEST = ROOT//'/ffc_gauntlet_undefined_manifest.txt'
+    UNLINKED_REPORT = ROOT//'/ffc_gauntlet_unlinked.jsonl'
+    NOREF_NEGATIVE_REPORT = ROOT//'/ffc_gauntlet_noref_negative.jsonl'
+
     all_passed = .true.
     if (.not. run_smoke('timeout 120 bash '//SCRIPT// &
         ' --suite fortfront-f90 --max-files 20 --report '// &
         ROOT_REPORT, ROOT_REPORT, 20)) all_passed = .false.
-    if (.not. run_smoke('repo="$PWD"; cd /tmp && timeout 120 bash '// &
+    if (.not. run_smoke('repo="$PWD"; cd '//ROOT//' && timeout 120 bash '// &
         '"$repo/'//SCRIPT//'" --suite fortfront-f90 --max-files 20 '// &
         '--report '//TMP_CWD_REPORT, &
         TMP_CWD_REPORT, 20)) all_passed = .false.
@@ -75,7 +80,10 @@ program test_conformance_gauntlet_smoke
     if (.not. file_contains(LIMITED_REPORT, &
         '"file":"ast_coverage_control_flow.f90"')) all_passed = .false.
 
-    if (.not. run_smoke('repo="$PWD"; cd /tmp && timeout 120 bash'// &
+    ! conformance_check.sh writes its default report under TMPDIR, so the
+    ! forwarded run stays inside this run's scratch directory.
+    if (.not. run_smoke('repo="$PWD"; cd '//ROOT//' && TMPDIR='//ROOT// &
+        ' timeout 120 bash'// &
         ' "$repo/scripts/conformance_check.sh"'// &
         ' --no-build --suite fortfront-f90'// &
         ' --file ast_coverage_control_flow.f90'// &
@@ -109,7 +117,9 @@ program test_conformance_gauntlet_smoke
     call run_dg_directive_smoke(all_passed)
     call run_noref_smoke(all_passed)
 
+    ! Keep the scratch directory when something failed: it holds the logs.
     if (.not. all_passed) stop 1
+    call remove_temp_root(ROOT)
     print *, 'PASS: gauntlet smoke test completed with zero FAIL records'
 
 contains

--- a/test/test_conformance_isolation.f90
+++ b/test/test_conformance_isolation.f90
@@ -1,0 +1,229 @@
+program test_conformance_isolation
+    ! Regression test for lazy-fortran/ffc#547.
+    !
+    ! Concurrent conformance runs (parallel `fo test`, several worktrees) must
+    ! not be able to observe each other's artifacts, and must never measure
+    ! another checkout's compiler.
+    use conformance_temp_dir, only: make_temp_root, remove_temp_root
+    implicit none
+
+    character(len=:), allocatable :: root
+    logical :: passed
+
+    print *, '=== conformance isolation test ==='
+
+    root = make_temp_root('conformance_isolation')
+    passed = .true.
+
+    if (.not. temp_roots_are_disjoint()) passed = .false.
+    if (.not. ffc_resolves_inside_own_build_tree()) passed = .false.
+    if (.not. ffc_resolution_refuses_foreign_binaries()) passed = .false.
+    if (.not. concurrent_runs_do_not_share_reports()) passed = .false.
+
+    ! Keep the scratch directory when something failed: it holds the logs.
+    if (.not. passed) stop 1
+    call remove_temp_root(root)
+    print *, 'PASS: concurrent conformance runs are isolated'
+
+contains
+
+    logical function temp_roots_are_disjoint() result(ok)
+        character(len=:), allocatable :: left, right
+
+        left = make_temp_root('isolation_probe')
+        right = make_temp_root('isolation_probe')
+        ok = left /= right
+        if (.not. ok) then
+            print *, 'FAIL: two scratch roots collided: '//left
+        else
+            call execute_command_line('printf left > '//left//'/marker')
+            call execute_command_line('printf right > '//right//'/marker')
+            ok = file_content_is(left//'/marker', 'left') .and. &
+                file_content_is(right//'/marker', 'right')
+            if (.not. ok) print *, 'FAIL: scratch roots observed each other'
+        end if
+        call remove_temp_root(left)
+        call remove_temp_root(right)
+    end function temp_roots_are_disjoint
+
+    logical function ffc_resolves_inside_own_build_tree() result(ok)
+        character(len=:), allocatable :: log_path
+        character(len=4096) :: resolved
+        integer :: exit_stat
+
+        log_path = root//'/find_ffc_own.log'
+        ! A relative PROJECT_DIR must still resolve to an absolute path
+        ! inside this checkout's own build tree.
+        call execute_command_line('bash -c ''unset FFC_BIN; PROJECT_DIR=.; '// &
+            'source scripts/lib_conformance.sh; find_ffc'' > '// &
+            log_path//' 2>&1', exitstat=exit_stat)
+        ok = exit_stat == 0
+        if (.not. ok) then
+            print *, 'FAIL: find_ffc did not resolve a binary'
+            call execute_command_line('cat '//log_path)
+            return
+        end if
+        call read_first_line(log_path, resolved)
+        ok = starts_with(trim(resolved), current_directory()//'/build/')
+        if (.not. ok) then
+            print *, 'FAIL: find_ffc left this checkout: '//trim(resolved)
+            return
+        end if
+        ok = index(trim(resolved), '..') == 0
+        if (.not. ok) print *, 'FAIL: find_ffc returned a traversing path'
+    end function ffc_resolves_inside_own_build_tree
+
+    logical function ffc_resolution_refuses_foreign_binaries() result(ok)
+        character(len=:), allocatable :: sibling, decoy_dir, log_path
+        integer :: exit_stat
+
+        ! A sibling worktree with its own freshly built compiler, plus an ffc
+        ! on PATH. Neither may be adopted by a checkout that has no build.
+        sibling = root//'/sibling-worktree'
+        decoy_dir = root//'/decoy-bin'
+        log_path = root//'/find_ffc_foreign.log'
+        call execute_command_line('mkdir -p '//sibling//'/build/fo/app '// &
+            decoy_dir//' '//root//'/empty-checkout')
+        call write_stub(sibling//'/build/fo/app/ffc')
+        call write_stub(decoy_dir//'/ffc')
+
+        call execute_command_line('PATH='//decoy_dir//':"$PATH" bash -c '// &
+            '''unset FFC_BIN; PROJECT_DIR='//root//'/empty-checkout; '// &
+            'source scripts/lib_conformance.sh; find_ffc'' > '// &
+            log_path//' 2>&1', exitstat=exit_stat)
+        ok = exit_stat /= 0
+        if (.not. ok) then
+            print *, 'FAIL: find_ffc accepted a foreign ffc binary'
+            call execute_command_line('cat '//log_path)
+            return
+        end if
+        ok = .not. file_contains(log_path, sibling) .and. &
+            .not. file_contains(log_path, decoy_dir//'/ffc')
+        if (.not. ok) print *, 'FAIL: find_ffc offered a foreign ffc path'
+    end function ffc_resolution_refuses_foreign_binaries
+
+    logical function concurrent_runs_do_not_share_reports() result(ok)
+        character(len=:), allocatable :: left, right
+
+        ! Two gauntlet runs started at the same time, each with its own scratch
+        ! directory and no explicit --report. Their default report paths must
+        ! stay inside their own scratch directory and describe only their own
+        ! selection.
+        left = root//'/run-left'
+        right = root//'/run-right'
+        call execute_command_line('mkdir -p '//left//' '//right)
+        call execute_command_line( &
+            'TMPDIR='//left//' timeout 180 bash scripts/conformance_gauntlet.sh'// &
+            ' --suite fortfront-f90 --file ast_coverage_control_flow.f90'// &
+            ' > '//left//'/run.log 2>&1 & '// &
+            'TMPDIR='//right//' timeout 180 bash scripts/conformance_gauntlet.sh'// &
+            ' --suite fortfront-f90 --file ast_coverage_io_statements.f90'// &
+            ' > '//right//'/run.log 2>&1 & '//'wait')
+
+        ok = .true.
+        call require_own_report(left, 'ast_coverage_control_flow.f90', &
+            'ast_coverage_io_statements.f90', ok)
+        call require_own_report(right, 'ast_coverage_io_statements.f90', &
+            'ast_coverage_control_flow.f90', ok)
+        if (.not. ok) print *, 'FAIL: concurrent runs shared report artifacts'
+    end function concurrent_runs_do_not_share_reports
+
+    subroutine require_own_report(run_root, own_file, foreign_file, ok)
+        character(len=*), intent(in) :: run_root, own_file, foreign_file
+        logical, intent(inout) :: ok
+        character(len=:), allocatable :: report
+        logical :: exists
+
+        report = run_root//'/ffc_gauntlet_fortfront-f90.jsonl'
+        inquire (file=report, exist=exists)
+        if (.not. exists) then
+            print *, 'FAIL: no report inside own scratch directory: '//report
+            ok = .false.
+            return
+        end if
+        if (.not. file_contains(report, '"file":"'//own_file//'"')) then
+            print *, 'FAIL: report is missing its own case: '//own_file
+            ok = .false.
+        end if
+        if (file_contains(report, '"file":"'//foreign_file//'"')) then
+            print *, 'FAIL: report contains the other run''s case: '//foreign_file
+            ok = .false.
+        end if
+    end subroutine require_own_report
+
+    subroutine write_stub(path)
+        character(len=*), intent(in) :: path
+        integer :: unit
+
+        open (newunit=unit, file=path, status='replace', action='write')
+        write (unit, '(A)') '#!/bin/sh'
+        write (unit, '(A)') 'exit 0'
+        close (unit)
+        call execute_command_line('chmod +x '//path)
+        call execute_command_line('touch '//path)
+    end subroutine write_stub
+
+    function current_directory() result(directory)
+        character(len=:), allocatable :: directory
+        character(len=4096) :: buffer
+
+        call getcwd_text(buffer)
+        directory = trim(buffer)
+    end function current_directory
+
+    subroutine getcwd_text(buffer)
+        character(len=*), intent(out) :: buffer
+        character(len=:), allocatable :: path
+
+        path = root//'/cwd.txt'
+        call execute_command_line('pwd -P > '//path)
+        call read_first_line(path, buffer)
+    end subroutine getcwd_text
+
+    subroutine read_first_line(path, line)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(out) :: line
+        integer :: unit, io_stat
+
+        line = ''
+        open (newunit=unit, file=path, status='old', action='read', &
+            iostat=io_stat)
+        if (io_stat /= 0) return
+        read (unit, '(A)', iostat=io_stat) line
+        close (unit)
+    end subroutine read_first_line
+
+    logical function starts_with(text, prefix) result(match)
+        character(len=*), intent(in) :: text, prefix
+
+        match = .false.
+        if (len(text) < len(prefix)) return
+        match = text(1:len(prefix)) == prefix
+    end function starts_with
+
+    logical function file_content_is(path, expected) result(match)
+        character(len=*), intent(in) :: path, expected
+        character(len=4096) :: line
+
+        call read_first_line(path, line)
+        match = trim(line) == expected
+    end function file_content_is
+
+    logical function file_contains(path, needle) result(found)
+        character(len=*), intent(in) :: path, needle
+        character(len=4096) :: line
+        integer :: unit, io_stat
+
+        found = .false.
+        open (newunit=unit, file=path, status='old', action='read', &
+            iostat=io_stat)
+        if (io_stat /= 0) return
+        do
+            read (unit, '(A)', iostat=io_stat) line
+            if (io_stat /= 0) exit
+            if (index(line, needle) > 0) found = .true.
+        end do
+        close (unit)
+    end function file_contains
+
+end program test_conformance_isolation

--- a/test/test_fortfront_corpus_conformance.f90
+++ b/test/test_fortfront_corpus_conformance.f90
@@ -1,30 +1,38 @@
 program test_fortfront_corpus_conformance
+    use conformance_temp_dir, only: make_temp_root, remove_temp_root
     implicit none
 
     integer, parameter :: RUN_TIMEOUT_SECONDS = 180
     character(len=*), parameter :: SCRIPT = &
         'scripts/conformance_gauntlet.sh'
-    character(len=*), parameter :: F90_REPORT = &
-        '/tmp/ffc_fortfront_f90_corpus.jsonl'
-    character(len=*), parameter :: LF_REPORT = &
-        '/tmp/ffc_fortfront_lf_corpus.jsonl'
-    character(len=*), parameter :: F90_LOG = &
-        '/tmp/ffc_fortfront_f90_corpus.out'
-    character(len=*), parameter :: LF_LOG = &
-        '/tmp/ffc_fortfront_lf_corpus.out'
-    character(len=*), parameter :: SYNTHETIC_XPASS_REPORT = &
-        '/tmp/ffc_fortfront_synthetic_xpass.jsonl'
+    ! Per-run scratch directory: concurrent runs must not share report paths.
+    character(len=:), allocatable :: ROOT
+    character(len=:), allocatable :: F90_REPORT
+    character(len=:), allocatable :: LF_REPORT
+    character(len=:), allocatable :: F90_LOG
+    character(len=:), allocatable :: LF_LOG
+    character(len=:), allocatable :: SYNTHETIC_XPASS_REPORT
 
     integer :: failed
 
     print *, '=== fortfront corpus conformance test ==='
+
+    ROOT = make_temp_root('fortfront_corpus')
+    F90_REPORT = ROOT//'/fortfront_f90_corpus.jsonl'
+    LF_REPORT = ROOT//'/fortfront_lf_corpus.jsonl'
+    F90_LOG = ROOT//'/fortfront_f90_corpus.out'
+    LF_LOG = ROOT//'/fortfront_lf_corpus.out'
+    SYNTHETIC_XPASS_REPORT = ROOT//'/fortfront_synthetic_xpass.jsonl'
 
     failed = 0
     call verify_xpass_rejection(failed)
     call run_suite('fortfront-f90', F90_REPORT, F90_LOG, 442, failed)
     call run_suite('fortfront-lf', LF_REPORT, LF_LOG, 264, failed)
 
+    ! Keep the scratch directory when something failed: it holds the logs.
     if (failed > 0) stop 1
+    call remove_temp_root(ROOT)
+
     print *, 'PASS: full fortfront corpus conforms to ffc xfail manifests'
 
 contains
@@ -43,7 +51,7 @@ contains
         call execute_command_line('rm -f '//report//' '//log_path)
         ! Generous per-file timeout so a single slow compile under full-suite
         ! load is not a false failure (idle compiles are well under a second).
-        cmd = 'timeout '//trim(timeout_text)//' bash '//SCRIPT// &
+        cmd = 'TMPDIR='//ROOT//' timeout '//trim(timeout_text)//' bash '//SCRIPT// &
             ' --suite '//suite//' --report '//report// &
             ' --timeout 30 > '//log_path//' 2>&1'
         call execute_command_line(cmd, exitstat=exit_stat)

--- a/test/test_parity_dashboard.f90
+++ b/test/test_parity_dashboard.f90
@@ -1,17 +1,26 @@
 program test_parity_dashboard
+    use conformance_temp_dir, only: make_temp_root, remove_temp_root
     implicit none
 
-    character(len=*), parameter :: ROOT = '/tmp/ffc_parity_dashboard_test'
-    character(len=*), parameter :: REPORT_DIR = ROOT//'/reports'
-    character(len=*), parameter :: MANIFEST_DIR = ROOT//'/manifests'
-    character(len=*), parameter :: OUTPUT_ONE = ROOT//'/one.md'
-    character(len=*), parameter :: OUTPUT_TWO = ROOT//'/two.md'
-    character(len=*), parameter :: LOG_PATH = ROOT//'/failure.log'
+    ! Per-run scratch directory: concurrent runs must not share fixture paths.
+    character(len=:), allocatable :: ROOT
+    character(len=:), allocatable :: REPORT_DIR
+    character(len=:), allocatable :: MANIFEST_DIR
+    character(len=:), allocatable :: OUTPUT_ONE
+    character(len=:), allocatable :: OUTPUT_TWO
+    character(len=:), allocatable :: LOG_PATH
     character(len=64) :: fixture_source_digest
     character(len=64) :: fixture_binary_digest
     character(len=40) :: fixture_ffc_revision
     character(len=1024) :: fixture_binary_path
     logical :: passed
+
+    ROOT = make_temp_root('parity_dashboard')
+    REPORT_DIR = ROOT//'/reports'
+    MANIFEST_DIR = ROOT//'/manifests'
+    OUTPUT_ONE = ROOT//'/one.md'
+    OUTPUT_TWO = ROOT//'/two.md'
+    LOG_PATH = ROOT//'/failure.log'
 
     passed = .true.
     call write_valid_inputs()
@@ -26,13 +35,15 @@ program test_parity_dashboard
     if (.not. snapshot_negative_cases_fail()) passed = .false.
     if (.not. negative_cases_fail()) passed = .false.
 
+    ! Keep the scratch directory when something failed: it holds the logs.
     if (.not. passed) stop 1
+    call remove_temp_root(ROOT)
     print *, 'PASS: parity dashboard generation'
 
 contains
 
     subroutine write_valid_inputs()
-        call execute_command_line('rm -rf '//ROOT)
+        call execute_command_line('rm -rf '//REPORT_DIR//' '//MANIFEST_DIR)
         call execute_command_line('mkdir -p '//REPORT_DIR//' '//MANIFEST_DIR)
         call read_fixture_digests()
         call write_fortfront_f90_report(.false., fixture_ffc_revision)
@@ -366,8 +377,9 @@ contains
             ROOT//'/stale-ffc')
         call execute_command_line('touch -d 2000-01-01 '//ROOT//'/stale-ffc')
         call execute_command_line("bash -c 'source scripts/lib_conformance.sh; "// &
+            'parent=$(dirname "$(resolve_primary_checkout_root "$PWD")"); '// &
             'require_compiler_inputs_older_than_binary '//ROOT// &
-            "/stale-ffc . ../fortfront ../liric' > "// &
+            '/stale-ffc . "$parent/fortfront" "$parent/liric"'''//' > '// &
             LOG_PATH//' 2>&1', exitstat=exit_stat)
         ok = exit_stat /= 0 .and. &
             file_contains(LOG_PATH, 'compiler binary predates')


### PR DESCRIPTION
Fixes #547.

Conformance tests could silently measure another worktree's build and overwrite each other's fixtures.

- `find_ffc` now resolves only from `PROJECT_DIR/build`, canonicalizes to an absolute path, and refuses any candidate outside that tree. The PATH fallback is gone: it was the route by which a sibling checkout's compiler could be adopted.
- Default report paths in `conformance_gauntlet.sh` and `conformance_check.sh` honor `TMPDIR`; every conformance test (`test_parity_dashboard`, `test_conformance_gauntlet_smoke`, `test_fortfront_corpus_conformance`) now allocates a per-run scratch directory instead of writing to fixed `/tmp` paths, and passes it to child processes.
- `generate_parity_dashboard.sh` resolves sibling repositories from the primary checkout root (`resolve_primary_checkout_root`) instead of `dirname $PROJECT_DIR`, so a worktree under `.wt/` sees `../fortfront` exactly like the primary checkout does.
- New `test_conformance_isolation` runs two gauntlet invocations concurrently with separate scratch directories and asserts each observes only its own report; it also asserts `find_ffc` stays inside its own build tree and refuses a sibling worktree's or a PATH-supplied `ffc`. Reverting the default-report change makes it fail.

Pre-existing red on main, not addressed here: `test_parity_dashboard` (stale snapshot digest) and `test_fortfront_corpus_conformance` (the FortFront corpus grew from 442 to 516 files). Both belong to the parity snapshot refresh (#531/#532/#540).