### PR TITLE
[liric-abi-01] verify ffc bindings against the LIRIC ABI

### DIFF
--- a/src/liric_session_bindings.f90
+++ b/src/liric_session_bindings.f90
@@ -7,7 +7,7 @@ module liric_session_bindings
         lr_operand_desc_t, lr_inst_desc_t, &
         liric_session_t, require_open_session, &
         status_ok, liric_session_error_message, &
-        clear_liric_error, to_c_chars, set_empty
+        clear_liric_error, to_c_chars, set_empty, verify_liric_abi
     implicit none
     private
 
@@ -53,6 +53,7 @@ module liric_session_bindings
     public :: lr_session_config_t, lr_error_t, lr_operand_desc_t, &
         lr_inst_desc_t, liric_session_t
     public :: liric_session_create
+    public :: verify_liric_abi
     public :: liric_session_error_message
     public :: i32_vreg, i32_immediate, f32_vreg, f64_vreg
     public :: global_operand
@@ -259,6 +260,15 @@ contains
         type(lr_error_t) :: error
 
         call clear_liric_error(error)
+
+        ! Verify the library's published session ABI before anything is
+        ! emitted (#375). A shifted layout must stop us here, not corrupt
+        ! descriptors later.
+        if (.not. verify_liric_abi(error_msg)) then
+            session%handle = c_null_ptr
+            return
+        end if
+
         local_config = lr_session_config_t()
         if (present(config)) local_config = config
 

--- a/src/liric_session_common.f90
+++ b/src/liric_session_common.f90
@@ -12,6 +12,19 @@ module liric_session_common
         LR_OP_KIND_BLOCK
     public :: require_open_session, status_ok, liric_session_error_message, &
         clear_liric_error, to_c_chars, set_empty
+    public :: lr_session_abi_info_t, lr_session_get_abi_info
+    public :: FFC_EXPECTED_LIRIC_ABI_VERSION, FFC_EXPECTED_OPCODE_COUNT, &
+        FFC_EXPECTED_OPERAND_KIND_COUNT
+    public :: verify_liric_abi, set_liric_abi_override_for_testing, &
+        clear_liric_abi_override_for_testing
+
+    ! Published LIRIC session ABI this build of ffc mirrors (LIRIC #527).
+    ! ffc refuses to emit instructions against a library that reports anything
+    ! else, because a shifted layout would silently corrupt every descriptor
+    ! passed across the ISO_C_BINDING boundary.
+    integer(c_int), parameter :: FFC_EXPECTED_LIRIC_ABI_VERSION = 1_c_int
+    integer(c_int), parameter :: FFC_EXPECTED_OPCODE_COUNT = 47_c_int
+    integer(c_int), parameter :: FFC_EXPECTED_OPERAND_KIND_COUNT = 7_c_int
 
     integer(c_int), parameter :: LR_OK = 0_c_int
     integer(c_int), parameter :: LR_OP_RET = 0_c_int
@@ -58,6 +71,50 @@ module liric_session_common
     type, public :: liric_session_t
         type(c_ptr) :: handle = c_null_ptr
     end type liric_session_t
+
+    ! Mirror of LIRIC's lr_session_abi_info_t (liric_session.h). Field order
+    ! and types must track the C definition exactly; the verification below is
+    ! what proves they still do.
+    type, bind(c), public :: lr_session_abi_info_t
+        integer(c_int32_t) :: abi_version = 0_c_int32_t
+        integer(c_size_t) :: struct_size = 0_c_size_t
+        integer(c_size_t) :: config_size = 0_c_size_t
+        integer(c_size_t) :: error_size = 0_c_size_t
+        integer(c_size_t) :: operand_size = 0_c_size_t
+        integer(c_size_t) :: inst_size = 0_c_size_t
+        integer(c_size_t) :: config_mode_offset = 0_c_size_t
+        integer(c_size_t) :: config_target_offset = 0_c_size_t
+        integer(c_size_t) :: config_backend_offset = 0_c_size_t
+        integer(c_size_t) :: config_opt_level_offset = 0_c_size_t
+        integer(c_size_t) :: error_code_offset = 0_c_size_t
+        integer(c_size_t) :: error_msg_offset = 0_c_size_t
+        integer(c_size_t) :: error_msg_size = 0_c_size_t
+        integer(c_size_t) :: operand_kind_offset = 0_c_size_t
+        integer(c_size_t) :: operand_type_offset = 0_c_size_t
+        integer(c_size_t) :: operand_global_offset_offset = 0_c_size_t
+        integer(c_size_t) :: inst_op_offset = 0_c_size_t
+        integer(c_size_t) :: inst_type_offset = 0_c_size_t
+        integer(c_size_t) :: inst_dest_offset = 0_c_size_t
+        integer(c_size_t) :: inst_operands_offset = 0_c_size_t
+        integer(c_size_t) :: inst_num_operands_offset = 0_c_size_t
+        integer(c_int32_t) :: opcode_count = 0_c_int32_t
+        integer(c_int32_t) :: operand_kind_count = 0_c_int32_t
+    end type lr_session_abi_info_t
+
+    ! Test seam: forces the next verification to see injected metadata, so the
+    ! pre-emission refusal can be exercised without a rebuilt LIRIC.
+    logical :: abi_override_active = .false.
+    type(lr_session_abi_info_t) :: abi_override_info
+
+    interface
+        function lr_session_get_abi_info(info, info_size) result(status) &
+            bind(c, name='lr_session_get_abi_info')
+            import :: lr_session_abi_info_t, c_size_t, c_int
+            type(lr_session_abi_info_t), intent(inout) :: info
+            integer(c_size_t), value :: info_size
+            integer(c_int) :: status
+        end function lr_session_get_abi_info
+    end interface
 
 contains
 
@@ -134,5 +191,167 @@ contains
 
         allocate (character(len=0) :: value)
     end subroutine set_empty
+
+    subroutine set_liric_abi_override_for_testing(info)
+        type(lr_session_abi_info_t), intent(in) :: info
+
+        abi_override_info = info
+        abi_override_active = .true.
+    end subroutine set_liric_abi_override_for_testing
+
+    subroutine clear_liric_abi_override_for_testing()
+
+        abi_override_active = .false.
+    end subroutine clear_liric_abi_override_for_testing
+
+    function size_mismatch(label, observed, expected) result(message)
+        character(len=*), intent(in) :: label
+        integer(c_size_t), intent(in) :: observed
+        integer(c_size_t), intent(in) :: expected
+        character(len=:), allocatable :: message
+        character(len=32) :: got_text, want_text
+
+        write (got_text, '(i0)') observed
+        write (want_text, '(i0)') expected
+        message = label//': expected '//trim(want_text)// &
+            ', observed '//trim(got_text)
+    end function size_mismatch
+
+    function count_mismatch(label, observed, expected) result(message)
+        character(len=*), intent(in) :: label
+        integer(c_int32_t), intent(in) :: observed
+        integer(c_int), intent(in) :: expected
+        character(len=:), allocatable :: message
+        character(len=32) :: got_text, want_text
+
+        write (got_text, '(i0)') observed
+        write (want_text, '(i0)') expected
+        message = label//': expected '//trim(want_text)// &
+            ', observed '//trim(got_text)
+    end function count_mismatch
+
+    ! Verifies ffc's mirrored LIRIC structures and opcode constants against the
+    ! library's published session ABI. Returns .false. with a diagnostic that
+    ! names both the expected and observed value on any mismatch; the caller
+    ! must not emit a single instruction after that.
+    logical function verify_liric_abi(error_msg) result(ok)
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_session_abi_info_t) :: info
+        type(lr_session_config_t) :: config_probe
+        type(lr_error_t) :: error_probe
+        type(lr_operand_desc_t) :: operand_probe
+        type(lr_inst_desc_t) :: inst_probe
+        integer(c_int) :: status
+        character(len=32) :: got_text, want_text
+
+        ok = .false.
+        call set_empty(error_msg)
+
+        if (abi_override_active) then
+            info = abi_override_info
+            status = LR_OK
+        else
+            status = lr_session_get_abi_info(info, &
+                                             int(storage_size(info)/8, &
+                                                 c_size_t))
+        end if
+
+        if (status /= LR_OK) then
+            write (got_text, '(i0)') status
+            error_msg = 'LIRIC ABI query failed with status '//trim(got_text)// &
+                '; refusing to emit instructions'
+            return
+        end if
+
+        if (info%abi_version /= int(FFC_EXPECTED_LIRIC_ABI_VERSION, &
+                                    c_int32_t)) then
+            write (got_text, '(i0)') info%abi_version
+            write (want_text, '(i0)') FFC_EXPECTED_LIRIC_ABI_VERSION
+            error_msg = 'LIRIC session ABI version mismatch: expected '// &
+                trim(want_text)//', observed '//trim(got_text)// &
+                '; refusing to emit instructions'
+            return
+        end if
+
+        ! Every structure ffc mirrors must have the same size the library
+        ! reports, or an argument written on one side is read at the wrong
+        ! offset on the other.
+        if (info%config_size /= int(storage_size(config_probe)/8, c_size_t)) then
+            error_msg = size_mismatch('LIRIC lr_session_config_t size', &
+                                      info%config_size, &
+                                      int(storage_size(config_probe)/8, &
+                                          c_size_t))
+            return
+        end if
+        if (info%error_size /= int(storage_size(error_probe)/8, c_size_t)) then
+            error_msg = size_mismatch('LIRIC lr_error_t size', &
+                                      info%error_size, &
+                                      int(storage_size(error_probe)/8, &
+                                          c_size_t))
+            return
+        end if
+        if (info%operand_size /= int(storage_size(operand_probe)/8, &
+                                     c_size_t)) then
+            error_msg = size_mismatch('LIRIC lr_operand_desc_t size', &
+                                      info%operand_size, &
+                                      int(storage_size(operand_probe)/8, &
+                                          c_size_t))
+            return
+        end if
+        if (info%inst_size /= int(storage_size(inst_probe)/8, c_size_t)) then
+            error_msg = size_mismatch('LIRIC lr_inst_desc_t size', &
+                                      info%inst_size, &
+                                      int(storage_size(inst_probe)/8, c_size_t))
+            return
+        end if
+
+        ! Leading-field offsets must be zero on both sides, and the operand
+        ! kind discriminator must be the first field ffc writes.
+        if (info%config_mode_offset /= 0_c_size_t) then
+            error_msg = size_mismatch('LIRIC config mode offset', &
+                                      info%config_mode_offset, 0_c_size_t)
+            return
+        end if
+        if (info%error_code_offset /= 0_c_size_t) then
+            error_msg = size_mismatch('LIRIC error code offset', &
+                                      info%error_code_offset, 0_c_size_t)
+            return
+        end if
+        if (info%operand_kind_offset /= 0_c_size_t) then
+            error_msg = size_mismatch('LIRIC operand kind offset', &
+                                      info%operand_kind_offset, 0_c_size_t)
+            return
+        end if
+        if (info%inst_op_offset /= 0_c_size_t) then
+            error_msg = size_mismatch('LIRIC instruction op offset', &
+                                      info%inst_op_offset, 0_c_size_t)
+            return
+        end if
+
+        ! The opcode and operand-kind constants ffc hard-codes must still be
+        ! inside the library's published range.
+        if (info%opcode_count /= int(FFC_EXPECTED_OPCODE_COUNT, c_int32_t)) then
+            error_msg = count_mismatch('LIRIC opcode count', &
+                                       info%opcode_count, &
+                                       FFC_EXPECTED_OPCODE_COUNT)
+            return
+        end if
+        if (info%operand_kind_count /= int(FFC_EXPECTED_OPERAND_KIND_COUNT, &
+                                           c_int32_t)) then
+            error_msg = count_mismatch('LIRIC operand kind count', &
+                                       info%operand_kind_count, &
+                                       FFC_EXPECTED_OPERAND_KIND_COUNT)
+            return
+        end if
+        if (LR_OP_KIND_GLOBAL >= int(info%operand_kind_count, c_int)) then
+            error_msg = count_mismatch( &
+                'LIRIC operand kind LR_OP_KIND_GLOBAL is out of range; count', &
+                info%operand_kind_count, LR_OP_KIND_GLOBAL + 1_c_int)
+            return
+        end if
+
+        call set_empty(error_msg)
+        ok = .true.
+    end function verify_liric_abi
 
 end module liric_session_common

--- a/test/test_liric_session_bindings.f90
+++ b/test/test_liric_session_bindings.f90
@@ -9,7 +9,14 @@ program test_liric_session_bindings
         begin_liric_f64_function, emit_liric_f64_alloca, &
         emit_liric_f64_store, emit_liric_f64_load
     use liric_session_common, only: lr_operand_desc_t
-    use, intrinsic :: iso_c_binding, only: c_int64_t
+    use liric_session_common, only: lr_session_abi_info_t, &
+        lr_session_get_abi_info, verify_liric_abi, &
+        set_liric_abi_override_for_testing, &
+        clear_liric_abi_override_for_testing, &
+        FFC_EXPECTED_LIRIC_ABI_VERSION, FFC_EXPECTED_OPCODE_COUNT, &
+        FFC_EXPECTED_OPERAND_KIND_COUNT, lr_session_config_t, lr_error_t, &
+        lr_inst_desc_t, LR_OK
+    use, intrinsic :: iso_c_binding, only: c_int64_t, c_size_t
     implicit none
 
     type(liric_session_t) :: session
@@ -22,6 +29,8 @@ program test_liric_session_bindings
     type(lr_operand_desc_t) :: addr, val, src, tmp
 
     print *, '=== LIRIC session binding tests ==='
+
+    call check_liric_abi_contract()
 
     call execute_command_line('rm -f '//exe_path)
 
@@ -189,4 +198,127 @@ program test_liric_session_bindings
     call execute_command_line('rm -f '//exe_path2)
 
     print *, 'PASS: LIRIC session binding tests'
+contains
+
+    ! Issue #375: ffc's mirrored LIRIC structures and opcode constants are
+    ! verified against the library's published session ABI before any
+    ! instruction is emitted. A mismatch must stop us here, not corrupt
+    ! descriptors later.
+    subroutine check_liric_abi_contract()
+        type(lr_session_abi_info_t) :: info
+        type(lr_session_abi_info_t) :: bad
+        type(lr_session_config_t) :: config_probe
+        type(lr_error_t) :: error_probe
+        type(lr_operand_desc_t) :: operand_probe
+        type(lr_inst_desc_t) :: inst_probe
+        character(len=:), allocatable :: error_msg
+        integer :: status
+
+        ! Positive: the linked LIRIC reports exactly what ffc mirrors.
+        status = int(lr_session_get_abi_info(info, &
+                                             int(storage_size(info)/8, c_size_t)))
+        if (status /= int(LR_OK)) then
+            print *, 'FAIL: lr_session_get_abi_info returned ', status
+            stop 1
+        end if
+        if (info%abi_version /= int(FFC_EXPECTED_LIRIC_ABI_VERSION, &
+                                    kind(info%abi_version))) then
+            print *, 'FAIL: unexpected LIRIC ABI version ', info%abi_version
+            stop 1
+        end if
+        if (info%config_size /= int(storage_size(config_probe)/8, &
+                                    kind(info%config_size))) then
+            print *, 'FAIL: lr_session_config_t size differs from LIRIC'
+            stop 1
+        end if
+        if (info%error_size /= int(storage_size(error_probe)/8, &
+                                   kind(info%error_size))) then
+            print *, 'FAIL: lr_error_t size differs from LIRIC'
+            stop 1
+        end if
+        if (info%operand_size /= int(storage_size(operand_probe)/8, &
+                                     kind(info%operand_size))) then
+            print *, 'FAIL: lr_operand_desc_t size differs from LIRIC'
+            stop 1
+        end if
+        if (info%inst_size /= int(storage_size(inst_probe)/8, &
+                                  kind(info%inst_size))) then
+            print *, 'FAIL: lr_inst_desc_t size differs from LIRIC'
+            stop 1
+        end if
+        if (info%opcode_count /= int(FFC_EXPECTED_OPCODE_COUNT, &
+                                     kind(info%opcode_count))) then
+            print *, 'FAIL: opcode count differs from LIRIC'
+            stop 1
+        end if
+        if (info%operand_kind_count /= int(FFC_EXPECTED_OPERAND_KIND_COUNT, &
+                                           kind(info%operand_kind_count))) then
+            print *, 'FAIL: operand kind count differs from LIRIC'
+            stop 1
+        end if
+        if (.not. verify_liric_abi(error_msg)) then
+            print *, 'FAIL: real LIRIC rejected by ABI check: ', trim(error_msg)
+            stop 1
+        end if
+
+        ! Negative: injected metadata must be refused before emission, with a
+        ! diagnostic naming both the expected and the observed value.
+        bad = info
+        bad%abi_version = info%abi_version + 1
+        call expect_reject(bad, 'version mismatch', 'wrong ABI version')
+
+        bad = info
+        bad%operand_size = info%operand_size + 8
+        call expect_reject(bad, 'lr_operand_desc_t size', 'wrong operand size')
+
+        bad = info
+        bad%inst_size = info%inst_size - 4
+        call expect_reject(bad, 'lr_inst_desc_t size', 'wrong inst size')
+
+        bad = info
+        bad%config_size = info%config_size + 4
+        call expect_reject(bad, 'lr_session_config_t size', 'wrong config size')
+
+        bad = info
+        bad%opcode_count = info%opcode_count - 1
+        call expect_reject(bad, 'opcode count', 'wrong opcode count')
+
+        bad = info
+        bad%operand_kind_count = 1
+        call expect_reject(bad, 'operand kind count', 'wrong kind count')
+
+        bad = info
+        bad%operand_kind_offset = 8
+        call expect_reject(bad, 'operand kind offset', 'shifted kind offset')
+
+        call clear_liric_abi_override_for_testing()
+        if (.not. verify_liric_abi(error_msg)) then
+            print *, 'FAIL: ABI check did not recover after override'
+            stop 1
+        end if
+
+        print *, 'PASS: LIRIC ABI verification contract'
+    end subroutine check_liric_abi_contract
+
+    subroutine expect_reject(bad, expected_text, label)
+        type(lr_session_abi_info_t), intent(in) :: bad
+        character(len=*), intent(in) :: expected_text
+        character(len=*), intent(in) :: label
+        character(len=:), allocatable :: error_msg
+
+        call set_liric_abi_override_for_testing(bad)
+        if (verify_liric_abi(error_msg)) then
+            call clear_liric_abi_override_for_testing()
+            print *, 'FAIL: ', label, ' was accepted'
+            stop 1
+        end if
+        if (index(error_msg, expected_text) == 0) then
+            call clear_liric_abi_override_for_testing()
+            print *, 'FAIL: ', label, ' diagnostic lacks "', expected_text, &
+                '": ', trim(error_msg)
+            stop 1
+        end if
+        call clear_liric_abi_override_for_testing()
+    end subroutine expect_reject
+
 end program test_liric_session_bindings


### PR DESCRIPTION
Closes #375. Depends on krystophny/liric#527 (merged).

## Summary

ffc now verifies its mirrored LIRIC structures and opcode constants against LIRIC's published session ABI before any instruction is emitted, instead of trusting that the linked library still matches.

- `src/liric_session_common.f90`: mirrors `lr_session_abi_info_t`, binds `lr_session_get_abi_info`, and adds `verify_liric_abi`, which checks the ABI version, the sizes of all four mirrored descriptors, the leading-field offsets, and the opcode and operand-kind counts.
- `src/liric_session_bindings.f90`: `liric_session_create` runs the verification first and returns without a handle on any mismatch.
- `test/test_liric_session_bindings.f90`: positive and injected-mismatch fixtures.

## Invariants preserved

- **Verified ABI declarations**: every structure ffc mirrors across the `ISO_C_BINDING` boundary is checked against the size LIRIC reports for the same struct, using `storage_size` on ffc's own type. `lr_session_config_t`, `lr_error_t`, `lr_operand_desc_t`, and `lr_inst_desc_t` are all covered, plus the leading-field offsets that ffc's field ordering depends on.
- **Versioned public interface**: `FFC_EXPECTED_LIRIC_ABI_VERSION` records the exact published version (1) that this build of ffc mirrors. A version bump on the LIRIC side stops ffc with a named diagnostic instead of letting it emit against a shifted layout.
- **Explicit published constants**: the opcode and operand-kind counts are pinned to the values LIRIC #527 froze (47 and 7), and `LR_OP_KIND_GLOBAL` is range-checked against the reported count.
- **Fails before emission, not during**: verification runs at the top of `liric_session_create`, before the session handle exists, so a mismatched library can never receive a single instruction. Every diagnostic names both the expected and the observed value.
- No private LIRIC IR structure is exposed, no Fortran descriptor ABI changed, and no accelerator backend added.

## Verification

Unmodified `main` has no ABI verification whatsoever - the only `abi` match in `src/liric_session_common.f90` is the unrelated `call_external_abi` field, and `verify_liric_abi` does not exist:

```text
$ git show origin/main:src/liric_session_common.f90 | grep -in abi
53:        logical(c_bool) :: call_external_abi = .false.
$ git show origin/main:src/liric_session_bindings.f90 | grep -c verify_liric_abi
0
```

The check was also confirmed to be load-bearing rather than vacuous: against a LIRIC build predating #527 it fails at link with `undefined reference to lr_session_get_abi_info`, i.e. it genuinely resolves the library's published entry point.

After the change, against current LIRIC:

```text
$ fo test test_liric_session_bindings
test_liric_session_bindings                PASS       0.02s
```

Full `fo` pipeline: two tests fail, both verified pre-existing/environmental and unrelated:

- `test_fortfront_corpus_conformance` - fails identically at `origin/main`.
- `test_parity_dashboard` - known to fail inside `.wt/` worktrees because the generator resolves sibling repos as `../fortfront`; passes in the primary checkout.

## Conformance gauntlet delta (lfortran suite)

| | PASS | XFAIL | XPASS | FAIL | NOREF | SKIP | TOTAL |
|---|---|---|---|---|---|---|---|
| previous chain run | 851 | 3352 | 65 | 11 | 162 | 1 | 4280 |
| after | 850 | 3350 | 67 | 12 | 162 | 1 | 4280 |

Three cases differ, all attributable to other chains that merged to `main` between the two runs, not to this PR:

- `deallocate_01.f90` XFAIL to XPASS
- `modules_32.f90` XFAIL to XPASS
- `expr_11.f90` PASS to FAIL

`expr_11.f90` was checked directly against unmodified `origin/main` at `b198e85` and fails there too, so it is a pre-existing regression from another chain rather than something this PR introduced. This PR changes no lowering path at all; it only adds a pre-emission check that passes against the current library. No manifest entry is moved here for that reason, and the two XPASS movements belong to the chains that caused them.

## Fixtures added

`test_liric_session_bindings` now runs `check_liric_abi_contract`: the real library's reported version, all four descriptor sizes, and both counts are compared against ffc's own types and constants, and a simple instruction still emits afterwards. Seven injected-mismatch cases (version, operand size, instruction size, config size, opcode count, operand-kind count, and a shifted operand-kind offset) each have to be refused before emission with a diagnostic naming the offending field, and the check is confirmed to recover once the override is cleared.