### PR TITLE
[c-strpointer-01] lower C_F_STRPOINTER scalar character views (refs #361)

### DIFF
--- a/src/session_program_lowering_pointer.inc
+++ b/src/session_program_lowering_pointer.inc
@@ -69,6 +69,31 @@
         end if
     end subroutine define_deferred_character_pointer
 
+    subroutine scalar_character_cstring_symbol(arena, node_index, context, &
+                                               symbol_index)
+        ! Index of the symbol named by a C_F_STRPOINTER CSTRING actual when that
+        ! actual is a scalar fixed-length character variable whose bytes are
+        ! already materialised; zero otherwise (#361).
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(out) :: symbol_index
+        character(len=:), allocatable :: name, name_error
+        integer :: index
+
+        symbol_index = 0
+        if (.not. is_identifier(arena, node_index)) return
+        call get_identifier_name(arena, node_index, name, name_error)
+        if (len_trim(name_error) > 0) return
+        index = find_symbol_compat(context, name)
+        if (index <= 0) return
+        if (context%symbols(index)%value_kind /= VALUE_CHARACTER) return
+        if (context%symbols(index)%is_array) return
+        if (.not. context%symbols(index)%has_character_value) return
+        if (context%symbols(index)%character_length <= 0) return
+        symbol_index = index
+    end subroutine scalar_character_cstring_symbol
+
     subroutine lower_c_f_strpointer(arena, arg_indices, context, error_msg)
         ! c_f_strpointer(cstring, fstrptr [, nchars]): associate a
         ! deferred-length character pointer with borrowed C character storage.
@@ -80,7 +105,7 @@
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t) :: data_ptr, max_chars, length
         character(len=:), allocatable :: name
-        integer :: symbol_index
+        integer :: symbol_index, cstring_index
 
         call set_empty(error_msg)
         if (.not. allocated(arg_indices)) then
@@ -91,18 +116,28 @@
             error_msg = 'c_f_strpointer requires two or three arguments'
             return
         end if
-        if (size(arg_indices) < 3) then
+
+        ! A scalar character cstring carries its own declared length, so NCHARS
+        ! is optional there; a c_ptr cstring has no length metadata at all.
+        call scalar_character_cstring_symbol(arena, arg_indices(1), context, &
+                                             cstring_index)
+        if (cstring_index <= 0 .and. size(arg_indices) < 3) then
             error_msg = 'c_f_strpointer with a c_ptr cstring requires the '// &
                         'nchars argument'
             return
         end if
 
-        call lower_c_ptr_expression(arena, arg_indices(1), context, data_ptr, &
-                                    error_msg)
-        if (len_trim(error_msg) > 0) then
-            error_msg = 'c_f_strpointer cstring must be a c_ptr expression; '// &
-                        'character array cstrings are not yet supported'
-            return
+        if (cstring_index > 0) then
+            data_ptr = context%symbols(cstring_index)%value
+        else
+            call lower_c_ptr_expression(arena, arg_indices(1), context, data_ptr, &
+                                        error_msg)
+            if (len_trim(error_msg) > 0) then
+                error_msg = 'c_f_strpointer cstring must be a c_ptr expression '// &
+                            'or a scalar character variable; character array '// &
+                            'cstrings are not yet supported'
+                return
+            end if
         end if
 
         if (.not. is_identifier(arena, arg_indices(2))) then
@@ -122,9 +157,14 @@
             return
         end if
 
-        call lower_i64_expression(arena, arg_indices(3), context, max_chars, &
-                                  error_msg)
-        if (len_trim(error_msg) > 0) return
+        if (size(arg_indices) >= 3) then
+            call lower_i64_expression(arena, arg_indices(3), context, max_chars, &
+                                      error_msg)
+            if (len_trim(error_msg) > 0) return
+        else
+            max_chars = i64_immediate(context%session, &
+                int(context%symbols(cstring_index)%character_length, c_int64_t))
+        end if
 
         if (.not. emit_strnlen(context%session, data_ptr, max_chars, length, &
                                error_msg)) return

--- a/test/conformance/fail_owners_gfortran_dg.txt
+++ b/test/conformance/fail_owners_gfortran_dg.txt
@@ -31,10 +31,6 @@ bound_resolve_after_error_1.f90 # owner=lazy-fortran/ffc#380; reason=reject inva
 bounds_check_3.f90 # owner=lazy-fortran/ffc#337; reason=owns triplet section bounds, stride sign, omitted bounds, and zero extents
 c_f_pointer_shape_test.f90 # owner=lazy-fortran/ffc#394; reason=require SHAPE for array C_F_POINTER targets
 c_f_pointer_tests_5.f90 # owner=lazy-fortran/fortfront#2886; reason=enforce BIND(C) interoperability contracts
-c_f_strpointer-1.f90 # owner=lazy-fortran/ffc#361; reason=lower C_F_STRPOINTER character views
-c_f_strpointer-10.f90 # owner=lazy-fortran/ffc#361; reason=lower C_F_STRPOINTER character views
-c_f_strpointer-2.f90 # owner=lazy-fortran/ffc#361; reason=lower C_F_STRPOINTER character views
-c_f_strpointer-7.f90 # owner=lazy-fortran/ffc#361; reason=lower C_F_STRPOINTER character views
 c_loc_tests_17.f90 # owner=lazy-fortran/fortfront#2892; reason=reject unresolved and use-before-definition symbols
 char_array_constructor_5.f90 # owner=lazy-fortran/ffc#459; reason=owns typed CHARACTER constructors and element conversion
 char_result_18.f90 # owner=lazy-fortran/ffc#384; reason=require valid character length expressions

--- a/test/test_session_c_interop_compiler.f90
+++ b/test/test_session_c_interop_compiler.f90
@@ -82,6 +82,39 @@ program test_session_c_interop
         '           7'//new_line('a'), &
         '/tmp/ffc_session_c_strpointer_output_test')) stop 4
 
+    ! A scalar character cstring carries its own declared length, so nchars is
+    ! optional; an explicit nchars still caps the view (F2018 18.2.3.5, #361).
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'use, intrinsic :: iso_c_binding, only: c_f_strpointer, c_char'// &
+        new_line('a')// &
+        'character(len=12, kind=c_char), target :: s'//new_line('a')// &
+        'character(len=:), pointer :: fp, fp5'//new_line('a')// &
+        's = "hello world!"'//new_line('a')// &
+        'call c_f_strpointer(s, fp)'//new_line('a')// &
+        'call c_f_strpointer(s, fp5, 5)'//new_line('a')// &
+        'if (len(fp) /= 12) stop 100'//new_line('a')// &
+        'if (len(fp5) /= 5) stop 101'//new_line('a')// &
+        'if (fp /= "hello world!") stop 102'//new_line('a')// &
+        'if (fp5 /= "hello") stop 103'//new_line('a')// &
+        'stop 21'//new_line('a')// &
+        'end program main', 21, &
+        '/tmp/ffc_session_c_strpointer_char_status_test')) stop 6
+
+    ! The implied length of a scalar character cstring is a runtime value.
+    if (.not. expect_output( &
+        'program main'//new_line('a')// &
+        'use, intrinsic :: iso_c_binding, only: c_f_strpointer, c_char'// &
+        new_line('a')// &
+        'character(len=6, kind=c_char), target :: s'//new_line('a')// &
+        'character(len=:), pointer :: fp'//new_line('a')// &
+        's = "abcdef"'//new_line('a')// &
+        'call c_f_strpointer(s, fp)'//new_line('a')// &
+        'print *, len(fp)'//new_line('a')// &
+        'end program main', &
+        '           6'//new_line('a'), &
+        '/tmp/ffc_session_c_strpointer_char_output_test')) stop 7
+
     ! A c_ptr cstring carries no length metadata, so omitting nchars must
     ! produce a diagnostic instead of an unbounded view (#361).
     if (.not. expect_error_contains( &


### PR DESCRIPTION
Closes #361 (scalar character views).

## Change
- `src/session_program_lowering_pointer.inc`: C_F_STRPOINTER accepts a scalar fixed-length character variable as CSTRING and derives the view length from its declared length when NCHARS is omitted. Borrowed storage only.
- `test/test_session_c_interop_compiler.f90`: behavioral cases for implicit length, explicit NCHARS capping, and value comparison.
- `test/conformance/fail_owners_gfortran_dg.txt`: promoted c_f_strpointer-1/-2/-7/-10 (gauntlet PASS=4 FAIL=0).

## Preserved invariant
A c_ptr CSTRING carries no length metadata, so omitting NCHARS still diagnoses instead of forming an unbounded view.

## Evidence
- Red (origin/main + new test only): test_session_c_interop_compiler FAIL, STOP 6 at the implicit-length case.
- Green: fo test test_session_c_interop_compiler PASS; gauntlet PASS=4 on the four dg files.
- Full fo: Build OK, Static OK; only test_parity_dashboard (known .wt sibling-repo resolution) and test_fortfront_corpus_conformance (shared fortfront tree rebuilt concurrently, segfaults on .lf corpus) fail, both unrelated to this path.