### PR TITLE
[array-transform-01] accept scalar merge masks and validate spread ncopies (refs #424)

### DIFF
--- a/src/session_program_lowering_arrays.inc
+++ b/src/session_program_lowering_arrays.inc
@@ -4349,10 +4349,31 @@
         call set_empty(error_msg)
     end subroutine check_shift_shapes
 
+    ! True when merge's mask argument is a scalar logical rather than a logical
+    ! array variable. Anything that is not a declared array identifier is
+    ! treated as a scalar expression and lowered as such.
+    logical function merge_mask_is_scalar(arena, mask_index, context) &
+        result(is_scalar)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: mask_index
+        type(lowering_context_t), intent(in) :: context
+        character(len=:), allocatable :: name, err
+        integer :: sym
+
+        is_scalar = .true.
+        if (.not. is_identifier(arena, mask_index)) return
+        call get_identifier_name(arena, mask_index, name, err)
+        if (len_trim(err) > 0) return
+        sym = find_symbol_compat(context, name)
+        if (sym <= 0) return
+        if (context%symbols(sym)%is_array) is_scalar = .false.
+    end function merge_mask_is_scalar
+
     ! merge(tsource, fsource, mask) for rank-1 arrays: per element pick from
-    ! tsource where mask is .true., else from fsource. All three arrays must
-    ! share the result shape; mask is a logical array stored as i32 (nonzero
-    ! means .true.).
+    ! tsource where mask is .true., else from fsource. tsource and fsource must
+    ! share the result shape. The mask is either a conforming logical array
+    ! stored as i32 (nonzero means .true.) or a scalar logical broadcast over
+    ! every element.
     subroutine lower_merge_assignment(arena, node, symbol_index, context, &
                                       error_msg)
         type(ast_arena_t), intent(in) :: arena
@@ -4364,6 +4385,7 @@
         type(lr_operand_desc_t) :: zero
         integer :: t_index, f_index, m_index
         integer :: i, n
+        logical :: mask_is_scalar
 
         select type (rhs => arena%entries(node%value_index)%node)
         type is (call_or_subscript_node)
@@ -4377,31 +4399,55 @@
             call resolve_i32_array_argument(arena, rhs, 2, context, 'merge', &
                                             'fsource', f_index, error_msg)
             if (len_trim(error_msg) > 0) return
-            call resolve_logical_mask_argument(arena, rhs, 3, context, 'merge', &
-                                               m_index, error_msg)
-            if (len_trim(error_msg) > 0) return
+            m_index = 0
+            mask_is_scalar = merge_mask_is_scalar(arena, rhs%arg_indices(3), &
+                                                  context)
+            if (.not. mask_is_scalar) then
+                call resolve_logical_mask_argument(arena, rhs, 3, context, &
+                                                   'merge', m_index, error_msg)
+                if (len_trim(error_msg) > 0) return
+            end if
             if (context%symbols(symbol_index)%array_rank /= 1 .or. &
                 context%symbols(t_index)%array_rank /= 1 .or. &
-                context%symbols(f_index)%array_rank /= 1 .or. &
-                context%symbols(m_index)%array_rank /= 1) then
+                context%symbols(f_index)%array_rank /= 1) then
                 error_msg = 'merge supports only rank-1 arrays'
                 return
             end if
+            if (m_index > 0) then
+                if (context%symbols(m_index)%array_rank /= 1) then
+                    error_msg = 'merge supports only rank-1 arrays'
+                    return
+                end if
+            end if
             n = context%symbols(symbol_index)%array_size
             if (context%symbols(t_index)%array_size /= n .or. &
-                context%symbols(f_index)%array_size /= n .or. &
-                context%symbols(m_index)%array_size /= n) then
+                context%symbols(f_index)%array_size /= n) then
                 error_msg = 'merge operands must share the result shape'
                 return
             end if
+            if (m_index > 0) then
+                if (context%symbols(m_index)%array_size /= n) then
+                    error_msg = 'merge operands must share the result shape'
+                    return
+                end if
+            end if
             zero = i32_immediate(context%session, 0_c_int64_t)
-            do i = 0, n - 1
-                call load_array_linear_element(context, m_index, &
-                                               int(i, c_int64_t), mask_val, &
-                                               error_msg)
+            if (mask_is_scalar) then
+                call lower_logical_expression(arena, rhs%arg_indices(3), &
+                                              context, mask_val, error_msg)
                 if (len_trim(error_msg) > 0) return
                 if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, &
                         mask_val, zero, cond, error_msg)) return
+            end if
+            do i = 0, n - 1
+                if (.not. mask_is_scalar) then
+                    call load_array_linear_element(context, m_index, &
+                                                   int(i, c_int64_t), mask_val, &
+                                                   error_msg)
+                    if (len_trim(error_msg) > 0) return
+                    if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, &
+                            mask_val, zero, cond, error_msg)) return
+                end if
                 call load_array_linear_element(context, t_index, &
                                                int(i, c_int64_t), t_val, error_msg)
                 if (len_trim(error_msg) > 0) return
@@ -4465,6 +4511,10 @@
             if (len_trim(error_msg) > 0) return
             if (dim_val /= 1_c_int64_t .and. dim_val /= 2_c_int64_t) then
                 error_msg = 'spread dim must be 1 or 2 for a rank-1 source'
+                return
+            end if
+            if (ncopies < 0_c_int64_t) then
+                error_msg = 'spread ncopies must be nonnegative'
                 return
             end if
             m = context%symbols(source_index)%array_size

--- a/test/test_session_array_transform_intrinsics_compiler.f90
+++ b/test/test_session_array_transform_intrinsics_compiler.f90
@@ -1,0 +1,165 @@
+program test_session_array_transform_intrinsics_compiler
+    use ffc_test_support, only: expect_output, expect_error_contains
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session array transform intrinsics compiler test ==='
+
+    all_passed = .true.
+    if (.not. test_merge_scalar_mask_true()) all_passed = .false.
+    if (.not. test_merge_scalar_mask_variable()) all_passed = .false.
+    if (.not. test_pack_unpack_roundtrip()) all_passed = .false.
+    if (.not. test_spread_real_dim1()) all_passed = .false.
+    if (.not. test_spread_invalid_dim()) all_passed = .false.
+    if (.not. test_spread_invalid_ncopies()) all_passed = .false.
+    if (.not. test_merge_nonconformable()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: array transform intrinsics lower through direct LIRIC session'
+
+contains
+
+    ! merge accepts a scalar mask: a .true. scalar selects tsource everywhere.
+    logical function test_merge_scalar_mask_true()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: t(3)'//new_line('a')// &
+            '  integer :: f(3)'//new_line('a')// &
+            '  integer :: r(3)'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  t = [1, 2, 3]'//new_line('a')// &
+            '  f = [7, 8, 9]'//new_line('a')// &
+            '  r = merge(t, f, .true.)'//new_line('a')// &
+            '  do i = 1, 3'//new_line('a')// &
+            '     print *, r(i)'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            'end program main'
+        test_merge_scalar_mask_true = expect_output( &
+            source, '           1'//new_line('a')// &
+            '           2'//new_line('a')// &
+            '           3'//new_line('a'), &
+            '/tmp/ffc_session_transform_merge_scalar_true')
+    end function test_merge_scalar_mask_true
+
+    ! A scalar logical variable mask selects fsource when it is .false.
+    logical function test_merge_scalar_mask_variable()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  real :: t(2)'//new_line('a')// &
+            '  real :: f(2)'//new_line('a')// &
+            '  real :: r(2)'//new_line('a')// &
+            '  logical :: m'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  t = [1.5, 2.5]'//new_line('a')// &
+            '  f = [3.5, 4.5]'//new_line('a')// &
+            '  m = .false.'//new_line('a')// &
+            '  r = merge(t, f, m)'//new_line('a')// &
+            '  do i = 1, 2'//new_line('a')// &
+            '     print *, r(i)'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            'end program main'
+        test_merge_scalar_mask_variable = expect_output( &
+            source, '   3.50000000    '//new_line('a')// &
+            '   4.50000000    '//new_line('a'), &
+            '/tmp/ffc_session_transform_merge_scalar_var')
+    end function test_merge_scalar_mask_variable
+
+    ! pack then unpack with the same mask restores the masked positions.
+    logical function test_pack_unpack_roundtrip()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(4)'//new_line('a')// &
+            '  integer :: p(2)'//new_line('a')// &
+            '  integer :: r(4)'//new_line('a')// &
+            '  logical :: m(4)'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  a = [1, 2, 3, 4]'//new_line('a')// &
+            '  m = [.false., .true., .false., .true.]'//new_line('a')// &
+            '  p = pack(a, m)'//new_line('a')// &
+            '  r = unpack(p, m, 0)'//new_line('a')// &
+            '  do i = 1, 4'//new_line('a')// &
+            '     print *, r(i)'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            'end program main'
+        test_pack_unpack_roundtrip = expect_output( &
+            source, '           0'//new_line('a')// &
+            '           2'//new_line('a')// &
+            '           0'//new_line('a')// &
+            '           4'//new_line('a'), &
+            '/tmp/ffc_session_transform_pack_unpack')
+    end function test_pack_unpack_roundtrip
+
+    ! spread(a, 1, n) on a real source replicates down the new leading dim.
+    logical function test_spread_real_dim1()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  real :: a(2)'//new_line('a')// &
+            '  real :: r(2, 2)'//new_line('a')// &
+            '  integer :: i, j'//new_line('a')// &
+            '  a = [1.5, 2.5]'//new_line('a')// &
+            '  r = spread(a, 1, 2)'//new_line('a')// &
+            '  do j = 1, 2'//new_line('a')// &
+            '     do i = 1, 2'//new_line('a')// &
+            '        print *, r(i, j)'//new_line('a')// &
+            '     end do'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            'end program main'
+        test_spread_real_dim1 = expect_output( &
+            source, '   1.50000000    '//new_line('a')// &
+            '   1.50000000    '//new_line('a')// &
+            '   2.50000000    '//new_line('a')// &
+            '   2.50000000    '//new_line('a'), &
+            '/tmp/ffc_session_transform_spread_real_dim1')
+    end function test_spread_real_dim1
+
+    ! A DIM outside 1..rank+1 is rejected with a diagnostic.
+    logical function test_spread_invalid_dim()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(3)'//new_line('a')// &
+            '  integer :: r(3, 2)'//new_line('a')// &
+            '  a = [1, 2, 3]'//new_line('a')// &
+            '  r = spread(a, 3, 2)'//new_line('a')// &
+            '  print *, r(1, 1)'//new_line('a')// &
+            'end program main'
+        test_spread_invalid_dim = expect_error_contains( &
+            source, 'spread dim', &
+            '/tmp/ffc_session_transform_spread_bad_dim')
+    end function test_spread_invalid_dim
+
+    ! A negative NCOPIES is rejected with a diagnostic.
+    logical function test_spread_invalid_ncopies()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(3)'//new_line('a')// &
+            '  integer :: r(3, 2)'//new_line('a')// &
+            '  a = [1, 2, 3]'//new_line('a')// &
+            '  r = spread(a, 2, -1)'//new_line('a')// &
+            '  print *, r(1, 1)'//new_line('a')// &
+            'end program main'
+        test_spread_invalid_ncopies = expect_error_contains( &
+            source, 'spread ncopies', &
+            '/tmp/ffc_session_transform_spread_bad_ncopies')
+    end function test_spread_invalid_ncopies
+
+    ! Nonconformable merge operands are rejected with a diagnostic.
+    logical function test_merge_nonconformable()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: t(3)'//new_line('a')// &
+            '  integer :: f(2)'//new_line('a')// &
+            '  logical :: m(3)'//new_line('a')// &
+            '  integer :: r(3)'//new_line('a')// &
+            '  t = [1, 2, 3]'//new_line('a')// &
+            '  f = [7, 8]'//new_line('a')// &
+            '  m = [.true., .false., .true.]'//new_line('a')// &
+            '  r = merge(t, f, m)'//new_line('a')// &
+            '  print *, r(1)'//new_line('a')// &
+            'end program main'
+        test_merge_nonconformable = expect_error_contains( &
+            source, 'merge operands must share the result shape', &
+            '/tmp/ffc_session_transform_merge_nonconformable')
+    end function test_merge_nonconformable
+
+end program test_session_array_transform_intrinsics_compiler


### PR DESCRIPTION
Closes #424.

## What changed
- `src/session_program_lowering_arrays.inc`: MERGE now accepts a **scalar logical mask** (literal or scalar variable) broadcast over every element, in addition to a conforming rank-1 logical array mask. SPREAD rejects a negative NCOPIES with a dedicated `spread ncopies must be nonnegative` diagnostic instead of the generic shape-mismatch message.
- NEW `test/test_session_array_transform_intrinsics_compiler.f90`: behavioral acceptance coverage for PACK, UNPACK, MERGE and SPREAD (values/shapes matched against gfortran output), plus negative fixtures for invalid DIM, invalid NCOPIES and nonconformable MERGE operands.

## Preserved compiler invariant
Conformability of tsource/fsource/mask and the spread result shape are still validated *before* any element is emitted: nonconformable operands fail at lowering with a diagnostic rather than silently producing wrong code. The scalar-mask path only skips the *rank/size* checks for the mask argument itself, which no longer has a shape to conform to; the comparison against zero is hoisted out of the element loop so the emitted IR is unchanged for the array-mask case.

## Red evidence (unmodified origin/main, test file copied into a throwaway worktree)
```
test_session_array_transform_intrinsics_co FAIL       0.05s
 FAIL: merge requires an identifier mask argument
 FAIL: merge requires a logical array mask: m
 FAIL: diagnostic did not contain "spread ncopies"
   actual: spread result shape does not match the target array
```

## Green evidence
```
test_session_array_transform_intrinsics_co PASS       0.06s
Summary: 1 passed, 0 failed, 0 skipped
```
Full `fo` pipeline: Build OK, Static OK (369 modules). Remaining failures are pre-existing/environmental and identical on unmodified origin/main:
- `test_parity_dashboard` — resolves sibling repos as `../fortfront`, always fails inside `.wt/` worktrees.
- `test_fortfront_corpus_conformance` — byte-identical counts on origin/main (`PASS=411 FAIL=8` / `PASS=196 FAIL=12`); failures are lazy-fortran module/type-inference fixtures unrelated to array transforms.
