### PR TITLE
fix: classify mixed f32/f64 binary operations as f64 (#566)

### DIFF
--- a/src/session_program_lowering_expr_lowering.inc
+++ b/src/session_program_lowering_expr_lowering.inc
@@ -610,8 +610,13 @@
         if (is_binary_op(arena, node_index)) then
             call get_binary_op_info(arena, node_index, bin_op, bin_left, &
                                     bin_right, bin_line, bin_col, bin_err)
+            ! Mixed-kind arithmetic takes the widest operand kind (F2018
+            ! 10.1.5.2.1), so a binary op is f32 only when an operand is f32
+            ! and no operand is f64: "2.0*x" with x real(8) is an f64
+            ! expression, not an f32 one.
             is_f32 = is_f32_expression(arena, bin_left, context) .or. &
                      is_f32_expression(arena, bin_right, context)
+            if (is_f32) is_f32 = .not. is_f64_expression(arena, node_index, context)
             return
         end if
 

--- a/test/conformance/xfail_lfortran.txt
+++ b/test/conformance/xfail_lfortran.txt
@@ -280,7 +280,6 @@ array_shape_func_call.f90 # owner=lazy-fortran/ffc#457; reason=register resolved
 arrays_intrin_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
 arrays_intrin_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 arrays_intrin_05.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
-arrays_intrin_06.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
 arrays_intrin_07.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
 arrays_intrin_08.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
 arrays_intrin_09.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
@@ -1834,7 +1833,6 @@ intrinsics_218.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-lengt
 intrinsics_219.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
 intrinsics_21.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
 intrinsics_220.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
-intrinsics_221.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 intrinsics_222.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
 intrinsics_223.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
 intrinsics_224.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
@@ -1891,7 +1889,6 @@ intrinsics_270.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar 
 intrinsics_271.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
 intrinsics_272.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
 intrinsics_273.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
-intrinsics_274.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
 intrinsics_275.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
 intrinsics_276.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
 intrinsics_277.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
@@ -2093,7 +2090,6 @@ intrinsics_51.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrins
 intrinsics_52.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
 intrinsics_53.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 intrinsics_54.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
-intrinsics_55.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 intrinsics_56.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
 intrinsics_57.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
 intrinsics_58.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
@@ -2125,7 +2121,6 @@ intrinsics_87.f90 # owner=lazy-fortran/ffc#373; reason=reallocate allocatables f
 intrinsics_88.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 intrinsics_90.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
 intrinsics_91.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
-intrinsics_92.f90 # owner=lazy-fortran/ffc#431; reason=lower AINT and ANINT kind conversions
 intrinsics_93.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
 intrinsics_96.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
 intrinsics_97.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
@@ -2572,7 +2567,6 @@ polymorphic_arguments_02.f90 # owner=lazy-fortran/ffc#417; reason=track runtime 
 polymorphic_class_compare.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 polymorphic_select_type_01.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
 polymorphic_select_type_02.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
-precision_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 present_02.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
 present_03.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
 present_04.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once

--- a/test/test_session_mixed_kind_real_expr_compiler.f90
+++ b/test/test_session_mixed_kind_real_expr_compiler.f90
@@ -1,0 +1,40 @@
+program test_session_mixed_kind_real_expr_compiler
+    use ffc_test_support, only: expect_output
+    implicit none
+
+    ! Mixed-kind arithmetic takes the widest operand kind (F2018 10.1.5.2.1),
+    ! so a binary operation that combines a default-real (f32) literal with a
+    ! real(8) operand is an f64 expression. Nested inside a wider f64 operand
+    ! context ("2.0*x + 1"), the f32 sub-expression classification used to claim
+    ! the whole "2.0*x" product for the f32 path and the lowering rejected the
+    ! real(8) identifier inside it. Covers lfortran expr_11.f90.
+    !
+    ! Expected values were produced by gfortran on the same source.
+    character(len=*), parameter :: source = &
+        'program main'//new_line('a')// &
+        '    real*8 :: x'//new_line('a')// &
+        '    real(8) :: y'//new_line('a')// &
+        '    double precision :: z'//new_line('a')// &
+        '    x = 1.5d0'//new_line('a')// &
+        '    x = (2.0*x+1.0)/(x*(x+1))'//new_line('a')// &
+        "    print '(f0.10)', x"//new_line('a')// &
+        '    y = 3.0d0'//new_line('a')// &
+        '    y = 2.0*y+1'//new_line('a')// &
+        "    print '(f0.10)', y"//new_line('a')// &
+        '    z = 0.5d0'//new_line('a')// &
+        '    z = 1.0 + 2.0*z*3.0 - 2'//new_line('a')// &
+        "    print '(f0.10)', z"//new_line('a')// &
+        'end program main'
+
+    character(len=*), parameter :: expected = &
+        '1.0666666667'//new_line('a')// &
+        '7.0000000000'//new_line('a')// &
+        '2.0000000000'//new_line('a')
+
+    print *, '=== mixed-kind real expression compiler test ==='
+
+    if (.not. expect_output(source, expected, &
+        '/tmp/ffc_session_mixed_kind_real_expr_test')) stop 1
+
+    print *, 'PASS: mixed f32/f64 arithmetic lowers at real(8) precision'
+end program test_session_mixed_kind_real_expr_compiler


### PR DESCRIPTION
Fixes #566.

## Root cause

Not a descriptor-migration regression. `real*8` declarations work fine on their own; the `assignment target was not declared: x` diagnostic on `expr_11.f90` is a downstream artifact.

`lower_f64_operand` routes a sub-expression through the f32 path whenever `is_f32_expression` accepts it. For a binary operation that predicate returned true as soon as *either* operand was f32, so `2.0*x` with `x` real(8) was classified as an f32 expression. Nested inside a wider f64 operand context (`2.0*x + 1`, as in `x=(2.0*x+1.0)/(x*(x+1))`), the f32 lowering then reached the real(8) identifier and rejected the program.

Introducing commit: `4e1744e` "Classify real(8) contained functions when FortFront drops the return kind", which added the f32->f64 operand promotion in `lower_f64_operand`. The misclassification in `is_f32_expression` only became reachable once that promotion existed.

## Fix

Mixed-kind arithmetic takes the widest operand kind (F2018 10.1.5.2.1), so a binary operation is f32 only when an operand is f32 and no operand is f64. Corrected in the existing classifier; no parallel lowering path added.

## Coverage

`test/test_session_mixed_kind_real_expr_compiler.f90` compiles and runs mixed-kind `real*8` / `real(8)` / `double precision` arithmetic and compares printed output against values produced by gfortran on the same source.

## lfortran suite delta (full runs, own mktemp reports)

- before (`970cfbe`): PASS=850 XFAIL=3345 XPASS=72 FAIL=12
- after: PASS=851 XFAIL=3339 XPASS=78 FAIL=11

`expr_11.f90` FAIL -> PASS, plus `arrays_intrin_06`, `intrinsics_55`, `intrinsics_92`, `intrinsics_221`, `intrinsics_274`, `precision_02` XFAIL -> XPASS. All six promoted out of `xfail_lfortran.txt` and re-verified PASS. No case regressed.

`test_fortfront_corpus_conformance` and `test_parity_dashboard` fail identically on unmodified `origin/main` (verified in a detached baseline worktree) and are not affected by this change.