### PR TITLE
[fmod2-01] version scalar procedure metadata in .fmod (closes #397)

### DIFF
--- a/src/ffc_module_artefact.f90
+++ b/src/ffc_module_artefact.f90
@@ -19,6 +19,13 @@ module ffc_module_artefact
 
     character(len=*), parameter, public :: FFC_FMOD_VERSION = '0.1.0'
 
+    ! The .fmod schema this ffc writes and is able to read. Every artefact
+    ! carries it as `fmod_schema` in its [module] header. A reader rejects any
+    ! other value, and an artefact without the field, so a stale or
+    ! newer-than-supported artefact is diagnosed instead of silently misread
+    ! (#397).
+    integer, parameter, public :: FMOD_SCHEMA_VERSION = 2
+
     type :: fmod_parameter_t
         character(len=:), allocatable :: name
         character(len=:), allocatable :: kind
@@ -54,6 +61,17 @@ module ffc_module_artefact
         ! Space-joined dummy-argument names (e.g. "hi lo"), so a using unit
         ! can associate keyword actuals with this signature (#408).
         character(len=:), allocatable :: arg_names
+        ! Space-joined per-dummy INTENT tokens, one per dummy: 'in', 'out',
+        ! 'inout', or 'none' when no INTENT was declared (#397).
+        character(len=:), allocatable :: arg_intents
+        ! Space-joined per-dummy attribute flags, one '0'/'1' per dummy, for the
+        ! OPTIONAL and VALUE attributes respectively (#397).
+        character(len=:), allocatable :: arg_optionals
+        character(len=:), allocatable :: arg_values
+        ! A function's result-variable name and its scalar kind token (e.g.
+        ! 'integer'); both empty for a subroutine (#397).
+        character(len=:), allocatable :: result_name
+        character(len=:), allocatable :: result_kind
         integer :: nargs = 0
     end type fmod_procedure_t
 
@@ -95,6 +113,7 @@ contains
         write (unit, '(A)') '[module]'
         write (unit, '(A)') 'name = "'//mod_name(info)//'"'
         write (unit, '(A)') 'ffc_version = "'//FFC_FMOD_VERSION//'"'
+        write (unit, '(A,I0)') 'fmod_schema = ', FMOD_SCHEMA_VERSION
 
         if (allocated(info%parameters)) then
             do i = 1, size(info%parameters)
@@ -151,6 +170,16 @@ contains
                     field(info%procedures(i)%arg_kinds)//'"'
                 write (unit, '(A)') 'arg_names = "'// &
                     field(info%procedures(i)%arg_names)//'"'
+                write (unit, '(A)') 'arg_intents = "'// &
+                    field(info%procedures(i)%arg_intents)//'"'
+                write (unit, '(A)') 'arg_optionals = "'// &
+                    field(info%procedures(i)%arg_optionals)//'"'
+                write (unit, '(A)') 'arg_values = "'// &
+                    field(info%procedures(i)%arg_values)//'"'
+                write (unit, '(A)') 'result_name = "'// &
+                    field(info%procedures(i)%result_name)//'"'
+                write (unit, '(A)') 'result_kind = "'// &
+                    field(info%procedures(i)%result_kind)//'"'
             end do
         end if
 
@@ -188,6 +217,7 @@ contains
         type(fmod_procedure_t), allocatable :: procs(:)
         type(fmod_generic_t), allocatable :: gens(:)
         integer :: nparam, ndtype, ncomp, nvar, nproc, ngen, io_read
+        integer :: schema
         character(len=:), allocatable :: cname, ckind
 
         allocate (character(len=0) :: error_msg)
@@ -204,6 +234,7 @@ contains
         nvar = 0
         nproc = 0
         ngen = 0
+        schema = 0
         section = ''
 
         open (newunit=unit, file=path, status='old', action='read', iostat=io_stat)
@@ -246,6 +277,11 @@ contains
                 procs(nproc)%kind = ''
                 procs(nproc)%arg_kinds = ''
                 procs(nproc)%arg_names = ''
+                procs(nproc)%arg_intents = ''
+                procs(nproc)%arg_optionals = ''
+                procs(nproc)%arg_values = ''
+                procs(nproc)%result_name = ''
+                procs(nproc)%result_kind = ''
                 procs(nproc)%nargs = 0
                 cycle
             else if (line == '[[generic]]') then
@@ -282,6 +318,10 @@ contains
             select case (section)
             case ('module')
                 if (key == 'name') info%name = unquote(val)
+                if (key == 'fmod_schema') then
+                    read (val, *, iostat=io_read) schema
+                    if (io_read /= 0) schema = 0
+                end if
             case ('parameter')
                 if (key == 'name') params(nparam)%name = unquote(val)
                 if (key == 'kind') params(nparam)%kind = unquote(val)
@@ -297,6 +337,15 @@ contains
                 if (key == 'kind') procs(nproc)%kind = unquote(val)
                 if (key == 'arg_kinds') procs(nproc)%arg_kinds = unquote(val)
                 if (key == 'arg_names') procs(nproc)%arg_names = unquote(val)
+                if (key == 'arg_intents') &
+                    procs(nproc)%arg_intents = unquote(val)
+                if (key == 'arg_optionals') &
+                    procs(nproc)%arg_optionals = unquote(val)
+                if (key == 'arg_values') procs(nproc)%arg_values = unquote(val)
+                if (key == 'result_name') &
+                    procs(nproc)%result_name = unquote(val)
+                if (key == 'result_kind') &
+                    procs(nproc)%result_kind = unquote(val)
                 if (key == 'nargs') then
                     read (val, *, iostat=io_read) procs(nproc)%nargs
                     if (io_read /= 0) procs(nproc)%nargs = 0
@@ -314,9 +363,41 @@ contains
         info%variables = vars(1:nvar)
         info%procedures = procs(1:nproc)
         info%generics = gens(1:ngen)
-        if (len_trim(info%name) == 0) error_msg = 'malformed .fmod (no module name): '// &
-            trim(path)
+        if (len_trim(info%name) == 0) then
+            error_msg = 'malformed .fmod (no module name): '//trim(path)
+            return
+        end if
+        ! Reject an artefact this ffc cannot read rather than misinterpret it:
+        ! a missing field means it predates the versioned schema, any other
+        ! value means it was written by a different ffc (#397).
+        if (schema /= FMOD_SCHEMA_VERSION) then
+            error_msg = 'unsupported .fmod schema version'//schema_text(schema)// &
+                ' in '//trim(path)//' (this ffc reads schema version '// &
+                int_text(FMOD_SCHEMA_VERSION)//'): recompile the module'
+        end if
     end subroutine read_fmod
+
+    function schema_text(schema) result(text)
+        ! The schema version as it appears in a diagnostic; an artefact with no
+        ! version field reports as unversioned.
+        integer, intent(in) :: schema
+        character(len=:), allocatable :: text
+
+        if (schema <= 0) then
+            text = ' (unversioned)'
+        else
+            text = ' '//int_text(schema)
+        end if
+    end function schema_text
+
+    function int_text(value) result(text)
+        integer, intent(in) :: value
+        character(len=:), allocatable :: text
+        character(len=32) :: buffer
+
+        write (buffer, '(I0)') value
+        text = trim(buffer)
+    end function int_text
 
     subroutine flush_component(comps, ncomp, dtypes, ndtype)
         ! Attach accumulated component rows to the current derived type.

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -238,6 +238,7 @@ module session_program_lowering
         generic_interface_t, &
         operator_interface_t, &
         MAX_PROC_ARGS, &
+        ARG_INTENT_NONE, ARG_INTENT_IN, ARG_INTENT_OUT, ARG_INTENT_INOUT, &
         MAX_GENERIC_SPECIFICS, &
         MODVAR_OK, MODVAR_UNSUPPORTED, &
         common_slot_t, COMMON_MAX_SLOTS, &

--- a/src/session_program_lowering_arguments.inc
+++ b/src/session_program_lowering_arguments.inc
@@ -49,6 +49,7 @@
         integer :: hidden_count
         integer :: sp
         integer :: param_count
+        logical :: handled_by_value
         ! Actual arguments in dummy-argument order: keyword actuals are moved
         ! to the slot their dummy name selects, and a slot no actual reaches
         ! holds 0 (an omitted optional, passed as a null reference).
@@ -102,6 +103,11 @@
             call check_scalar_actual_compatibility(arena, arg_indices(i), context, &
                 callee_name, call_arg_param_pos(i, sp), error_msg)
             if (len_trim(error_msg) > 0) return
+            call check_dummy_contract_actual(arena, arg_indices(i), context, &
+                callee_name, call_arg_param_pos(i, sp), handled_by_value, &
+                args(i), error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (handled_by_value) cycle
             ! A scalar actual (literal or scalar variable, not an array element)
             ! passed where the callee declares an array dummy is a rank mismatch
             ! (F2018 15.5.2.4). callee_dummy_is_array only resolves against a
@@ -2120,3 +2126,61 @@ integer function expression_value_kind(arena, node_index, context, &
         operand%typ = lr_type_ptr_s(context%session%handle)
         operand%global_offset = 0_c_int64_t
     end function absent_optional_operand
+
+    subroutine check_dummy_contract_actual(arena, node_index, context, &
+                                           callee_name, param_pos, &
+                                           handled_by_value, arg, error_msg)
+        ! Apply the dummy's declared contract to one actual argument. A VALUE
+        ! dummy receives a copy, so the callee's assignments to it never reach
+        ! the caller's actual; handled_by_value reports that arg was filled
+        ! here. An INTENT(OUT) or INTENT(INOUT) dummy requires a definable
+        ! actual, so a literal is diagnosed instead of lowered. Both contracts
+        ! read the same way for a procedure defined in this unit and for one
+        ! imported from a .fmod artefact (#397).
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: callee_name
+        integer, intent(in) :: param_pos
+        logical, intent(out) :: handled_by_value
+        type(lr_operand_desc_t), intent(out) :: arg
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: value
+        logical :: is_optional, is_value
+        integer :: intent_code, value_kind
+
+        call set_empty(error_msg)
+        handled_by_value = .false.
+        if (param_pos < 1) return
+        call callee_dummy_contracts(arena, context, callee_name, param_pos, &
+                                    is_optional, is_value, intent_code)
+        if (intent_code == ARG_INTENT_OUT .or. intent_code == ARG_INTENT_INOUT) then
+            if (is_literal(arena, node_index)) then
+                error_msg = 'Actual argument to '//intent_text(intent_code)// &
+                    ' dummy argument of '//trim(callee_name)// &
+                    ' must be a variable'
+                return
+            end if
+        end if
+        if (.not. is_value) return
+        value_kind = arg_default_kind(arena, context, callee_name, param_pos, &
+                                      VALUE_I32)
+        call lower_expression_by_kind(arena, node_index, context, value_kind, &
+                                      value, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call make_reference_argument(context, value_kind, value, arg, error_msg)
+        if (len_trim(error_msg) > 0) return
+        handled_by_value = .true.
+    end subroutine check_dummy_contract_actual
+
+    function intent_text(intent_code) result(text)
+        ! The INTENT spelling used in a diagnostic (#397).
+        integer, intent(in) :: intent_code
+        character(len=:), allocatable :: text
+
+        if (intent_code == ARG_INTENT_OUT) then
+            text = 'INTENT(OUT)'
+        else
+            text = 'INTENT(INOUT)'
+        end if
+    end function intent_text

--- a/src/session_program_lowering_derived_module_ops.inc
+++ b/src/session_program_lowering_derived_module_ops.inc
@@ -381,6 +381,8 @@
         character(len=:), allocatable :: local_name
         integer, allocatable :: arg_kinds(:)
         character(len=64), allocatable :: arg_names(:)
+        logical, allocatable :: arg_optionals(:), arg_values(:)
+        integer, allocatable :: arg_intents(:)
         integer :: return_kind
         logical :: forced, imported
 
@@ -409,11 +411,80 @@
         call parse_fmod_arg_kinds(proc, arg_kinds, error_msg)
         if (len_trim(error_msg) > 0) return
         call parse_fmod_arg_names(proc, arg_names)
+        call parse_fmod_arg_flags(proc%arg_optionals, proc%nargs, arg_optionals)
+        call parse_fmod_arg_flags(proc%arg_values, proc%nargs, arg_values)
+        call parse_fmod_arg_intents(proc, arg_intents)
         mangled = module_procedure_mangled(module_name, trim(proc%name))
         call add_external_procedure(context, trim(local_name), mangled, &
                                     return_kind, proc%nargs, .true., arg_kinds, &
-                                    arg_names)
+                                    arg_names, arg_optionals, arg_values, &
+                                    arg_intents)
     end subroutine import_fmod_procedure
+
+    subroutine parse_fmod_arg_flags(text, nargs, flags)
+        ! Split a .fmod per-dummy '0'/'1' attribute list (OPTIONAL, VALUE) into
+        ! logicals. A shorter or absent list leaves the remaining dummies
+        ! without the attribute (#397).
+        character(len=:), allocatable, intent(in) :: text
+        integer, intent(in) :: nargs
+        logical, allocatable, intent(out) :: flags(:)
+        character(len=:), allocatable :: rest
+        integer :: n, sep
+
+        allocate (flags(max(nargs, 0)))
+        if (nargs <= 0) return
+        flags = .false.
+        if (.not. allocated(text)) return
+        rest = trim(adjustl(text))
+        n = 0
+        do while (len_trim(rest) > 0 .and. n < nargs)
+            sep = index(rest, ' ')
+            n = n + 1
+            if (sep == 0) then
+                flags(n) = trim(rest) == '1'
+                rest = ''
+            else
+                flags(n) = rest(1:sep - 1) == '1'
+                rest = adjustl(rest(sep + 1:))
+            end if
+        end do
+    end subroutine parse_fmod_arg_flags
+
+    subroutine parse_fmod_arg_intents(proc, intents)
+        ! Split the .fmod per-dummy INTENT token list into intent codes (#397).
+        type(fmod_procedure_t), intent(in) :: proc
+        integer, allocatable, intent(out) :: intents(:)
+        character(len=:), allocatable :: rest, token
+        integer :: n, sep
+
+        allocate (intents(max(proc%nargs, 0)))
+        if (proc%nargs <= 0) return
+        intents = ARG_INTENT_NONE
+        if (.not. allocated(proc%arg_intents)) return
+        rest = trim(adjustl(proc%arg_intents))
+        n = 0
+        do while (len_trim(rest) > 0 .and. n < proc%nargs)
+            sep = index(rest, ' ')
+            n = n + 1
+            if (sep == 0) then
+                token = trim(rest)
+                rest = ''
+            else
+                token = rest(1:sep - 1)
+                rest = adjustl(rest(sep + 1:))
+            end if
+            select case (trim(token))
+            case ('in')
+                intents(n) = ARG_INTENT_IN
+            case ('out')
+                intents(n) = ARG_INTENT_OUT
+            case ('inout')
+                intents(n) = ARG_INTENT_INOUT
+            case default
+                intents(n) = ARG_INTENT_NONE
+            end select
+        end do
+    end subroutine parse_fmod_arg_intents
 
     subroutine parse_fmod_arg_names(proc, arg_names)
         ! Split the .fmod arg_names token string into per-dummy names, which a

--- a/src/session_program_lowering_fmod.inc
+++ b/src/session_program_lowering_fmod.inc
@@ -262,8 +262,147 @@
             procs(count)%arg_kinds = arg_tokens
             procs(count)%arg_names = fmod_procedure_arg_names(arena, &
                                                      procedure_indices(p))
+            call fmod_procedure_dummy_attributes(arena, procedure_indices(p), &
+                                                 procs(count)%arg_intents, &
+                                                 procs(count)%arg_optionals, &
+                                                 procs(count)%arg_values)
+            call fmod_procedure_result(arena, procedure_indices(p), kind_text, &
+                                       procs(count)%result_name, &
+                                       procs(count)%result_kind)
         end do
     end subroutine build_fmod_procedures
+
+    subroutine fmod_procedure_result(arena, node_index, kind_text, result_name, &
+                                     result_kind)
+        ! The result-variable name and scalar kind token of an exported module
+        ! function, so a using unit reconstructs the same result contract the
+        ! defining unit compiled. Both empty for a subroutine (#397).
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: kind_text
+        character(len=:), allocatable, intent(out) :: result_name
+        character(len=:), allocatable, intent(out) :: result_kind
+        type(function_def_node), pointer :: fn_node
+
+        result_name = ''
+        result_kind = ''
+        if (trim(kind_text) == 'subroutine') return
+        fn_node => get_node_as_function_def(arena, node_index)
+        if (.not. associated(fn_node)) return
+        if (allocated(fn_node%result_variable)) then
+            result_name = trim(fn_node%result_variable)
+        else if (allocated(fn_node%name)) then
+            result_name = trim(fn_node%name)
+        end if
+        result_kind = trim(kind_text)
+    end subroutine fmod_procedure_result
+
+    subroutine fmod_procedure_dummy_attributes(arena, node_index, intents, &
+                                               optionals, values)
+        ! The per-dummy INTENT, OPTIONAL, and VALUE contracts of an exported
+        ! module procedure, space-joined one token per dummy. A separately
+        ! compiled caller reads them back to omit absent optionals, to pass a
+        ! VALUE dummy a copy, and to reject a non-definable actual for an
+        ! INTENT(OUT) dummy, none of which it can infer without the source
+        ! (#397).
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable, intent(out) :: intents
+        character(len=:), allocatable, intent(out) :: optionals
+        character(len=:), allocatable, intent(out) :: values
+        type(function_def_node), pointer :: fn_node
+        type(subroutine_def_node), pointer :: sb_node
+        integer, allocatable :: param_indices(:), body_indices(:)
+        character(len=:), allocatable :: intent_token
+        logical :: is_optional, is_value
+        integer :: i
+
+        intents = ''
+        optionals = ''
+        values = ''
+        fn_node => get_node_as_function_def(arena, node_index)
+        if (associated(fn_node)) then
+            if (allocated(fn_node%param_indices)) &
+                param_indices = fn_node%param_indices
+            if (allocated(fn_node%body_indices)) &
+                body_indices = fn_node%body_indices
+        else
+            sb_node => get_node_as_subroutine_def(arena, node_index)
+            if (.not. associated(sb_node)) return
+            if (allocated(sb_node%param_indices)) &
+                param_indices = sb_node%param_indices
+            if (allocated(sb_node%body_indices)) &
+                body_indices = sb_node%body_indices
+        end if
+        if (.not. allocated(param_indices)) return
+        if (.not. allocated(body_indices)) allocate (body_indices(0))
+        do i = 1, size(param_indices)
+            call param_at_attributes(arena, param_indices, body_indices, i, &
+                                     intent_token, is_optional, is_value)
+            if (i > 1) then
+                intents = intents//' '
+                optionals = optionals//' '
+                values = values//' '
+            end if
+            intents = intents//intent_token
+            optionals = optionals//flag_token(is_optional)
+            values = values//flag_token(is_value)
+        end do
+    end subroutine fmod_procedure_dummy_attributes
+
+    function flag_token(flag) result(token)
+        logical, intent(in) :: flag
+        character(len=:), allocatable :: token
+
+        if (flag) then
+            token = '1'
+        else
+            token = '0'
+        end if
+    end function flag_token
+
+    subroutine param_at_attributes(arena, param_indices, body_indices, pos, &
+                                   intent_token, is_optional, is_value)
+        ! The declared INTENT ('in', 'out', 'inout', or 'none'), OPTIONAL, and
+        ! VALUE attributes of the pos-th dummy, taken from its declaration in
+        ! the procedure body (#397).
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: param_indices(:)
+        integer, allocatable, intent(in) :: body_indices(:)
+        integer, intent(in) :: pos
+        character(len=:), allocatable, intent(out) :: intent_token
+        logical, intent(out) :: is_optional
+        logical, intent(out) :: is_value
+        character(len=:), allocatable :: name, name_err
+        integer :: i
+
+        intent_token = 'none'
+        is_optional = .false.
+        is_value = .false.
+        if (.not. allocated(param_indices)) return
+        if (pos < 1 .or. pos > size(param_indices)) return
+        call parameter_name(arena, param_indices(pos), name, name_err)
+        if (len_trim(name_err) > 0) return
+        if (.not. allocated(body_indices)) return
+        do i = 1, size(body_indices)
+            if (.not. node_exists(arena, body_indices(i))) cycle
+            select type (decl => arena%entries(body_indices(i))%node)
+            type is (declaration_node)
+                if (.not. declaration_declares_name(decl, &
+                    trim(lowercase_text(name)))) cycle
+                is_optional = decl%is_optional
+                is_value = decl%is_value
+                if (decl%has_intent) then
+                    if (allocated(decl%intent)) then
+                        intent_token = lowercase_text(trim(decl%intent))
+                        if (len_trim(intent_token) == 0) intent_token = 'none'
+                    end if
+                end if
+                return
+            end select
+        end do
+    end subroutine param_at_attributes
+
 
     function fmod_procedure_arg_names(arena, node_index) result(tokens)
         ! Space-joined dummy-argument names of an exported module procedure, so

--- a/src/session_program_lowering_functions_tail.inc
+++ b/src/session_program_lowering_functions_tail.inc
@@ -1610,3 +1610,78 @@
             count = ep%arg_count
         end associate
     end subroutine external_dummy_names
+
+    subroutine callee_dummy_contracts(arena, context, callee_name, param_pos, &
+                                      is_optional, is_value, intent_code)
+        ! The OPTIONAL, VALUE, and INTENT contracts of callee_name's param_pos-th
+        ! dummy. They come from the procedure's definition in this unit when it
+        ! has one, and otherwise from the .fmod artefact of a separately compiled
+        ! module procedure, which carries them precisely so a caller never has to
+        ! guess or rescan the defining source (#397).
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        character(len=*), intent(in) :: callee_name
+        integer, intent(in) :: param_pos
+        logical, intent(out) :: is_optional
+        logical, intent(out) :: is_value
+        integer, intent(out) :: intent_code
+        character(len=:), allocatable :: node_type, intent_token
+        type(function_def_node), pointer :: fn_node
+        type(subroutine_def_node), pointer :: sb_node
+        integer :: n, idx
+
+        is_optional = .false.
+        is_value = .false.
+        intent_code = ARG_INTENT_NONE
+        if (param_pos < 1) return
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            node_type = get_node_type_at(arena, n)
+            if (node_type == 'subroutine_def_node' .or. &
+                node_type == 'subroutine_def') then
+                sb_node => get_node_as_subroutine_def(arena, n)
+                if (.not. associated(sb_node)) cycle
+                if (.not. allocated(sb_node%name)) cycle
+                if (.not. same_name(sb_node%name, callee_name)) cycle
+                call param_at_attributes(arena, sb_node%param_indices, &
+                    sb_node%body_indices, param_pos, intent_token, is_optional, &
+                    is_value)
+                intent_code = arg_intent_code(intent_token)
+                return
+            else if (node_type == 'function_def_node' .or. &
+                     node_type == 'function_def') then
+                fn_node => get_node_as_function_def(arena, n)
+                if (.not. associated(fn_node)) cycle
+                if (.not. allocated(fn_node%name)) cycle
+                if (.not. same_name(fn_node%name, callee_name)) cycle
+                call param_at_attributes(arena, fn_node%param_indices, &
+                    fn_node%body_indices, param_pos, intent_token, is_optional, &
+                    is_value)
+                intent_code = arg_intent_code(intent_token)
+                return
+            end if
+        end do
+        idx = external_procedure_index(context, callee_name)
+        if (idx <= 0) return
+        if (.not. context%external_procedures(idx)%by_reference) return
+        if (param_pos > context%external_procedures(idx)%arg_count) return
+        is_optional = context%external_procedures(idx)%arg_is_optional(param_pos)
+        is_value = context%external_procedures(idx)%arg_is_value(param_pos)
+        intent_code = context%external_procedures(idx)%arg_intents(param_pos)
+    end subroutine callee_dummy_contracts
+
+    integer function arg_intent_code(token) result(code)
+        ! The intent code an INTENT token denotes (#397).
+        character(len=*), intent(in) :: token
+
+        select case (trim(token))
+        case ('in')
+            code = ARG_INTENT_IN
+        case ('out')
+            code = ARG_INTENT_OUT
+        case ('inout')
+            code = ARG_INTENT_INOUT
+        case default
+            code = ARG_INTENT_NONE
+        end select
+    end function arg_intent_code

--- a/src/session_program_lowering_interface.inc
+++ b/src/session_program_lowering_interface.inc
@@ -677,13 +677,17 @@
 
     subroutine add_external_procedure(context, fortran_name, c_name, &
                                       return_kind, arg_count, by_reference, &
-                                      arg_kinds, arg_names)
+                                      arg_kinds, arg_names, arg_optionals, &
+                                      arg_values, arg_intents)
         type(lowering_context_t), intent(inout) :: context
         character(len=*), intent(in) :: fortran_name, c_name
         integer, intent(in) :: return_kind, arg_count
         logical, intent(in), optional :: by_reference
         integer, intent(in), optional :: arg_kinds(:)
         character(len=*), intent(in), optional :: arg_names(:)
+        logical, intent(in), optional :: arg_optionals(:)
+        logical, intent(in), optional :: arg_values(:)
+        integer, intent(in), optional :: arg_intents(:)
         integer :: j
 
         call grow_external_procedures(context)
@@ -710,6 +714,24 @@
                     ep%arg_names(j) = trim(arg_names(j))
                 end do
             end if
+            ep%arg_is_optional = .false.
+            ep%arg_is_value = .false.
+            ep%arg_intents = ARG_INTENT_NONE
+            if (present(arg_optionals)) then
+                do j = 1, min(arg_count, size(arg_optionals))
+                    ep%arg_is_optional(j) = arg_optionals(j)
+                end do
+            end if
+            if (present(arg_values)) then
+                do j = 1, min(arg_count, size(arg_values))
+                    ep%arg_is_value(j) = arg_values(j)
+                end do
+            end if
+            if (present(arg_intents)) then
+                do j = 1, min(arg_count, size(arg_intents))
+                    ep%arg_intents(j) = arg_intents(j)
+                end do
+            end if
         end associate
     end subroutine add_external_procedure
 
@@ -726,25 +748,25 @@
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t), allocatable :: args(:)
         integer, allocatable :: copyback_indices(:)
-        integer :: n
+        integer :: empty_args(0)
 
-        n = 0
-        if (allocated(node%arg_indices)) n = size(node%arg_indices)
-        if (n /= context%external_procedures(ext_idx)%arg_count) then
-            call unsupported_feature_error('module function call', node%line, &
-                node%column, 'argument count does not match the module '// &
-                'interface for '//trim(node%name), error_msg)
-            return
-        end if
         if (allocated(node%arg_indices)) then
+            call check_module_call_arity(arena, context, ext_idx, &
+                                         trim(node%name), node%arg_indices, &
+                                         error_msg)
+            if (len_trim(error_msg) > 0) return
             call prepare_reference_args(arena, node%arg_indices, context, &
                                         VALUE_I32, trim(node%name), args, &
                                         copyback_indices, error_msg)
             if (len_trim(error_msg) > 0) return
         else
+            call check_module_call_arity(arena, context, ext_idx, &
+                                         trim(node%name), empty_args, error_msg)
+            if (len_trim(error_msg) > 0) return
             allocate (args(0))
             allocate (copyback_indices(0))
         end if
+        call pad_absent_optional_args(context, ext_idx, args, copyback_indices)
         if (.not. emit_i32_call(context%session, &
                 trim(context%external_procedures(ext_idx)%c_name), args, value, &
                 error_msg)) return
@@ -763,26 +785,91 @@
         type(lr_operand_desc_t), allocatable :: args(:)
         integer, allocatable :: copyback_indices(:)
         character(len=:), allocatable :: call_name
-        integer :: n
 
         call get_subroutine_call_arg_indices(arena, node_index, arg_indices, &
                                              error_msg)
         if (len_trim(error_msg) > 0) return
-        n = 0
-        if (allocated(arg_indices)) n = size(arg_indices)
-        if (n /= context%external_procedures(ext_idx)%arg_count) then
-            error_msg = 'argument count does not match the module interface'
-            return
-        end if
+        if (.not. allocated(arg_indices)) allocate (arg_indices(0))
         call_name = trim(context%external_procedures(ext_idx)%fortran_name)
+        call check_module_call_arity(arena, context, ext_idx, call_name, &
+                                     arg_indices, error_msg)
+        if (len_trim(error_msg) > 0) return
         call prepare_reference_args(arena, arg_indices, context, VALUE_I32, &
                                     call_name, args, copyback_indices, error_msg)
         if (len_trim(error_msg) > 0) return
+        call pad_absent_optional_args(context, ext_idx, args, copyback_indices)
         if (.not. emit_void_call(context%session, &
                 trim(context%external_procedures(ext_idx)%c_name), args, &
                 error_msg)) return
         call copy_back_reference_args(context, args, copyback_indices, error_msg)
     end subroutine lower_module_proc_void_call
+
+    subroutine check_module_call_arity(arena, context, ext_idx, callee_name, &
+                                       actual_indices, error_msg)
+        ! A call to a separately compiled module procedure is checked against
+        ! the dummy list the .fmod carries: no call may supply more actuals than
+        ! there are dummies, and every dummy the call leaves unassociated must
+        ! be OPTIONAL. Keyword actuals are placed first, so `f(b=1)` is judged
+        ! on the dummy it names rather than on its written position (#397).
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: ext_idx
+        character(len=*), intent(in) :: callee_name
+        integer, intent(in) :: actual_indices(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, allocatable :: mapped(:)
+        integer :: i, arg_count
+        logical :: supplied
+
+        call resolve_keyword_actuals(arena, context, actual_indices, &
+                                     callee_name, 0, mapped, error_msg)
+        if (len_trim(error_msg) > 0) return
+        arg_count = context%external_procedures(ext_idx)%arg_count
+        if (size(mapped) > arg_count) then
+            error_msg = 'More actual than formal arguments in call to '// &
+                trim(callee_name)
+            return
+        end if
+        do i = 1, arg_count
+            supplied = i <= size(mapped)
+            if (supplied) supplied = mapped(i) /= 0
+            if (supplied) cycle
+            if (context%external_procedures(ext_idx)%arg_is_optional(i)) cycle
+            error_msg = 'Missing actual argument for dummy argument '// &
+                trim(context%external_procedures(ext_idx)%arg_names(i))// &
+                ' in call to '//trim(callee_name)
+            return
+        end do
+    end subroutine check_module_call_arity
+
+    subroutine pad_absent_optional_args(context, ext_idx, args, copyback_indices)
+        ! Pad a call to a separately compiled module procedure up to its
+        ! declared dummy count: each dummy no actual reached is OPTIONAL (the
+        ! arity check already established that) and passes as a null reference,
+        ! the same absent-optional encoding a same-unit call uses (#397).
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: ext_idx
+        type(lr_operand_desc_t), allocatable, intent(inout) :: args(:)
+        integer, allocatable, intent(inout) :: copyback_indices(:)
+        type(lr_operand_desc_t), allocatable :: padded(:)
+        integer, allocatable :: padded_copyback(:)
+        integer :: arg_count, j
+
+        arg_count = context%external_procedures(ext_idx)%arg_count
+        if (size(args) >= arg_count) return
+        allocate (padded(arg_count))
+        allocate (padded_copyback(arg_count))
+        padded_copyback = 0
+        do j = 1, size(args)
+            padded(j) = args(j)
+            padded_copyback(j) = copyback_indices(j)
+        end do
+        do j = size(args) + 1, arg_count
+            padded(j) = absent_optional_operand(context)
+        end do
+        call move_alloc(padded, args)
+        call move_alloc(padded_copyback, copyback_indices)
+    end subroutine pad_absent_optional_args
 
     logical function has_bind_c(clause)
         character(len=:), allocatable, intent(in) :: clause

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -503,6 +503,12 @@ module session_program_lowering_types
         integer :: return_kinds(MAX_GENERIC_SPECIFICS) = VALUE_I32
     end type operator_interface_t
 
+    ! INTENT contract of a dummy argument as carried in a .fmod (#397).
+    integer, parameter, public :: ARG_INTENT_NONE = 0
+    integer, parameter, public :: ARG_INTENT_IN = 1
+    integer, parameter, public :: ARG_INTENT_OUT = 2
+    integer, parameter, public :: ARG_INTENT_INOUT = 3
+
     type, public :: external_procedure_t
         character(len=64) :: fortran_name = ''
         character(len=64) :: c_name = ''
@@ -516,6 +522,12 @@ module session_program_lowering_types
         ! compiled module procedure resolved from a .fmod passes them by
         ! reference (Fortran ABI) and targets its mangled name (#284).
         logical :: by_reference = .false.
+        ! Per-dummy contracts the .fmod carries: OPTIONAL dummies may be
+        ! omitted at a call site, a VALUE dummy receives a copy, and an
+        ! INTENT(OUT)/INTENT(INOUT) dummy requires a definable actual (#397).
+        logical :: arg_is_optional(MAX_PROC_ARGS) = .false.
+        logical :: arg_is_value(MAX_PROC_ARGS) = .false.
+        integer :: arg_intents(MAX_PROC_ARGS) = ARG_INTENT_NONE
     end type external_procedure_t
 
     integer, parameter, public :: MAX_NAMELIST_MEMBERS = 32

--- a/test/test_session_read_fmod_compiler.f90
+++ b/test/test_session_read_fmod_compiler.f90
@@ -17,6 +17,10 @@ program test_session_read_fmod_compiler
     if (.not. test_use_module_fmod_rejects_unknown_only()) all_passed = .false.
     if (.not. test_use_module_fmod_not_found_errors()) all_passed = .false.
     if (.not. test_use_module_variable_from_fmod()) all_passed = .false.
+    if (.not. test_fmod_optional_dummy_separate_compilation()) all_passed = .false.
+    if (.not. test_fmod_value_dummy_separate_compilation()) all_passed = .false.
+    if (.not. test_fmod_intent_out_rejects_literal()) all_passed = .false.
+    if (.not. test_fmod_schema_version_is_checked()) all_passed = .false.
     if (.not. test_use_repeated_rename_is_valid()) all_passed = .false.
     if (.not. test_use_repeated_rename_one_statement()) all_passed = .false.
     if (.not. test_use_two_locals_one_remote()) all_passed = .false.
@@ -449,6 +453,221 @@ contains
         end if
         ok = .true.
     end function test_same_file_conflicting_rename_rejected
+
+    integer function run_separate_compilation(dir, mod_source, prog_source, &
+                                              log_path) result(status)
+        ! Compile mod_source with -c in one ffc invocation, then prog_source in
+        ! a second, independent invocation that can only learn the module's
+        ! interface from the .fmod artefact the first invocation wrote. Returns
+        ! 0 when both compile and the program runs, 90 when no ffc binary was
+        ! found, 91 when the module compilation failed, 92 when the program
+        ! compilation failed, and 100 + exit status when the program ran.
+        ! Combined compiler output is appended to log_path.
+        character(len=*), intent(in) :: dir
+        character(len=*), intent(in) :: mod_source
+        character(len=*), intent(in) :: prog_source
+        character(len=*), intent(in) :: log_path
+        integer :: exit_stat, cmd_stat
+
+        status = 90
+        call execute_command_line('rm -rf '//dir//'; mkdir -p '//dir)
+        if (.not. write_file(dir//'/m.f90', mod_source)) return
+        if (.not. write_file(dir//'/p.f90', prog_source)) return
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; exe=$PWD/$exe; '// &
+            'cd '//dir//' || exit 90; '// &
+            '"$exe" -c m.f90 -o m.o >>'//log_path//' 2>&1 || exit 91; '// &
+            '"$exe" p.f90 m.o -o p >>'//log_path//' 2>&1 || exit 92; '// &
+            "./p; exit $((100 + $?))'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) then
+            status = 90
+            return
+        end if
+        status = exit_stat
+    end function run_separate_compilation
+
+    logical function test_fmod_optional_dummy_separate_compilation() result(ok)
+        ! A module procedure with an OPTIONAL dummy stays callable with the
+        ! optional omitted, and with it supplied by keyword, from a separately
+        ! compiled program. The using unit can only know the dummy is optional,
+        ! and what it is named, from the .fmod artefact (#397).
+        character(len=*), parameter :: dir = '/tmp/ffc_fmod397_optional'
+        character(len=*), parameter :: log_path = dir//'/log'
+        integer :: status
+
+        ok = .false.
+        status = run_separate_compilation(dir, &
+            'module fmod397_optional'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  integer function combine(a, b) result(r)'//new_line('a')// &
+            '    integer, intent(in) :: a'//new_line('a')// &
+            '    integer, intent(in), optional :: b'//new_line('a')// &
+            '    r = a'//new_line('a')// &
+            '    if (present(b)) r = r + b'//new_line('a')// &
+            '  end function combine'//new_line('a')// &
+            'end module fmod397_optional', &
+            'program main'//new_line('a')// &
+            '  use fmod397_optional, only: combine'//new_line('a')// &
+            '  stop combine(4) + 10 * combine(4, b=3)'//new_line('a')// &
+            'end program main', log_path)
+        if (status /= 174) then
+            print *, 'FAIL: optional dummy through .fmod, status ', status
+            call execute_command_line('cat '//log_path)
+            return
+        end if
+        call execute_command_line('rm -rf '//dir)
+        ok = .true.
+    end function test_fmod_optional_dummy_separate_compilation
+
+    logical function test_fmod_value_dummy_separate_compilation() result(ok)
+        ! A VALUE dummy receives a copy: the callee's assignment to it must not
+        ! reach the caller's actual. The separately compiled caller can only
+        ! learn the attribute from the .fmod artefact, and must agree with the
+        ! same-unit compilation of the same program (#397).
+        character(len=*), parameter :: dir = '/tmp/ffc_fmod397_value'
+        character(len=*), parameter :: log_path = dir//'/log'
+        character(len=*), parameter :: mod_source = &
+            'module fmod397_value'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  integer function bump(x) result(r)'//new_line('a')// &
+            '    integer, value :: x'//new_line('a')// &
+            '    x = x + 1'//new_line('a')// &
+            '    r = x'//new_line('a')// &
+            '  end function bump'//new_line('a')// &
+            'end module fmod397_value'
+        character(len=*), parameter :: prog_source = &
+            'program main'//new_line('a')// &
+            '  use fmod397_value, only: bump'//new_line('a')// &
+            '  integer :: v'//new_line('a')// &
+            '  v = 5'//new_line('a')// &
+            '  stop bump(v) + v'//new_line('a')// &
+            'end program main'
+        character(len=:), allocatable :: error_msg
+        integer :: status, exit_stat, cmd_stat
+
+        ok = .false.
+        status = run_separate_compilation(dir, mod_source, prog_source, log_path)
+        if (status /= 111) then
+            print *, 'FAIL: VALUE dummy through .fmod, status ', status
+            call execute_command_line('cat '//log_path)
+            return
+        end if
+        ! Same-unit compilation of the same module and program must agree.
+        call compile_with_include(mod_source//new_line('a')//prog_source, &
+            dir//'/same', dir, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: same-unit VALUE program rejected: ', trim(error_msg)
+            return
+        end if
+        call execute_command_line(dir//'/same', exitstat=exit_stat, &
+            cmdstat=cmd_stat)
+        if (cmd_stat /= 0 .or. exit_stat /= 11) then
+            print *, 'FAIL: same-unit VALUE program exit ', exit_stat
+            return
+        end if
+        call execute_command_line('rm -rf '//dir)
+        ok = .true.
+    end function test_fmod_value_dummy_separate_compilation
+
+    logical function test_fmod_intent_out_rejects_literal() result(ok)
+        ! A literal actual cannot be passed to an INTENT(OUT) dummy. The
+        ! separately compiled caller knows the dummy's intent only from the
+        ! .fmod artefact, so the diagnostic proves the intent round-tripped.
+        character(len=*), parameter :: dir = '/tmp/ffc_fmod397_intent'
+        character(len=*), parameter :: log_path = dir//'/log'
+        integer :: status, grep_stat, cmd_stat
+
+        ok = .false.
+        status = run_separate_compilation(dir, &
+            'module fmod397_intent'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine put(target_value)'//new_line('a')// &
+            '    integer, intent(out) :: target_value'//new_line('a')// &
+            '    target_value = 3'//new_line('a')// &
+            '  end subroutine put'//new_line('a')// &
+            'end module fmod397_intent', &
+            'program main'//new_line('a')// &
+            '  use fmod397_intent, only: put'//new_line('a')// &
+            '  call put(7)'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main', log_path)
+        if (status /= 92) then
+            print *, 'FAIL: literal to INTENT(OUT) dummy was accepted, status ', &
+                status
+            call execute_command_line('cat '//log_path)
+            return
+        end if
+        call execute_command_line('grep -qi "intent(out)" '//log_path, &
+            exitstat=grep_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0 .or. grep_stat /= 0) then
+            print *, 'FAIL: diagnostic did not mention INTENT(OUT)'
+            call execute_command_line('cat '//log_path)
+            return
+        end if
+        call execute_command_line('rm -rf '//dir)
+        ok = .true.
+    end function test_fmod_intent_out_rejects_literal
+
+    logical function test_fmod_schema_version_is_checked() result(ok)
+        ! A .fmod whose schema version this ffc does not implement is rejected
+        ! with an artefact-version diagnostic instead of being misread. An
+        ! artefact with no schema version at all (written before the field
+        ! existed) is stale and rejected the same way (#397).
+        character(len=*), parameter :: dir = '/tmp/ffc_fmod397_schema'
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  use m, only: value'//new_line('a')// &
+            '  stop value'//new_line('a')// &
+            'end program main'
+        type(module_info_t) :: info
+        character(len=:), allocatable :: error_msg
+
+        ok = .false.
+        call execute_command_line('rm -rf '//dir//'; mkdir -p '//dir)
+        info%name = 'm'
+        allocate (info%parameters(1))
+        info%parameters(1)%name = 'value'
+        info%parameters(1)%kind = 'integer'
+        info%parameters(1)%value = '37'
+        allocate (info%derived_types(0))
+        call write_fmod(dir//'/m.fmod', info, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: write_fmod: ', trim(error_msg)
+            return
+        end if
+        ! The artefact this ffc just wrote carries its own schema version and
+        ! must be accepted.
+        call compile_with_include(source, dir//'/current', dir, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: current-schema .fmod rejected: ', trim(error_msg)
+            return
+        end if
+
+        call execute_command_line("sed -i 's/^fmod_schema = .*/"// &
+            "fmod_schema = 99999/' "//dir//'/m.fmod')
+        call compile_with_include(source, dir//'/future', dir, error_msg)
+        if (index(error_msg, 'schema version') == 0) then
+            print *, 'FAIL: future .fmod schema was not rejected: ', &
+                trim(error_msg)
+            return
+        end if
+
+        call execute_command_line("sed -i '/^fmod_schema = /d' "// &
+            dir//'/m.fmod')
+        call compile_with_include(source, dir//'/stale', dir, error_msg)
+        if (index(error_msg, 'schema version') == 0) then
+            print *, 'FAIL: unversioned .fmod was not rejected: ', &
+                trim(error_msg)
+            return
+        end if
+        call execute_command_line('rm -rf '//dir)
+        ok = .true.
+    end function test_fmod_schema_version_is_checked
 
     subroutine compile_with_include(source, exe_path, include_dir, error_msg)
         character(len=*), intent(in) :: source


### PR DESCRIPTION
Closes #397.

## What changed

The `.fmod` artefact gains a schema version and carries the full scalar
signature of every exported module procedure, so a separately compiled using
unit reconstructs the contract the defining unit compiled instead of guessing.

- `[module]` records `fmod_schema`. `read_fmod` rejects any other value, and an
  artefact with no version field at all, with an artefact-version diagnostic
  naming the version read and the version this ffc implements.
- Each `[[procedure]]` record gains per-dummy INTENT, OPTIONAL, and VALUE
  contracts plus the function's result name and kind, next to the dummy names
  and kinds it already carried.
- Those facts drive lowering in the using unit: an OPTIONAL dummy may be
  omitted (positionally or by keyword) and passes as the same null reference a
  same-unit call uses; a non-OPTIONAL dummy that receives no actual is
  diagnosed by name; a VALUE dummy receives a copy so the callee's assignment
  to it no longer reaches the caller's actual; an INTENT(OUT)/INTENT(INOUT)
  dummy rejects a literal actual.

## Invariants preserved

- **Artifact version contract**: every artefact carries `fmod_schema`; the
  reader accepts exactly the version it implements and rejects newer and
  unversioned artefacts with a `schema version` diagnostic instead of
  misreading them. Asserted by a test that mutates a written artefact's version
  and one that deletes the field.
- **No source rescan**: the caller reads dummy contracts from the callee's
  definition when this unit has one, and otherwise only from the artefact
  (`callee_dummy_contracts`). No path reopens the module source, and no
  contract is inferred from a call site.
- **Same-unit / separate-compilation agreement**: the VALUE oracle compiles the
  same module and program both ways and requires the same exit status, so the
  artefact cannot encode a different ABI than same-unit lowering.
- **Derived layout, character length, generic rank**: untouched by this PR;
  derived-type and character metadata keep their current encoding (that is
  #414/#415's scope), and generic specifics keep resolving through the existing
  procedure records.

## Oracles (all recorded failing on unmodified main first)

Separate compilation, producer and consumer in independent `ffc` invocations:

- `test_fmod_optional_dummy_separate_compilation` — was `argument count does not
  match the module interface`, now exits 174.
- `test_fmod_value_dummy_separate_compilation` — was 12 (callee mutated the
  caller's actual), now 11 both separately and same-unit.
- `test_fmod_intent_out_rejects_literal` — literal to `intent(out)` was
  silently accepted, now diagnosed.
- `test_fmod_schema_version_is_checked` — a future and an unversioned artefact
  were read as if current, now both rejected.

## Corpus delta

`test_fortfront_corpus_conformance` failure set on `origin/main` and on this
branch is byte-identical (20 cases): no new failures, none newly passing, so no
xfail manifest entries move. `fo` is otherwise green; the two failures it
reports (`test_fortfront_corpus_conformance`, `test_parity_dashboard`) both
reproduce on unmodified `main`.