### PR TITLE
[chardesc-03] pass character dummies and results by descriptor

### DIFF
--- a/src/session_program_lowering_character.inc
+++ b/src/session_program_lowering_character.inc
@@ -643,10 +643,11 @@
     subroutine lower_deferred_identifier_assignment(arena, value_index, context, &
                                                     symbol_index, error_msg)
         ! str = other, where str is character(len=:), allocatable and other is a
-        ! character variable (fixed or deferred). Resolve other to its
-        ! {data pointer, i32 length} and store them into str's deferred
-        ! descriptor. The source content outlives the use here (a dummy or a
-        ! local), so aliasing the pointer matches gfortran's observable output.
+        ! character variable (fixed or deferred). Fortran intrinsic assignment
+        ! gives str a value, not a view: str takes its own copy of other's
+        ! bytes at other's current length. Aliasing the source pointer would
+        ! make str observe later changes to other, and would leave str
+        ! dangling once other's storage is released.
         use, intrinsic :: iso_c_binding, only: c_int64_t
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: value_index
@@ -655,7 +656,7 @@
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: src_name
         integer :: src_index
-        type(lr_operand_desc_t) :: data_ptr, len_i32, len_i64
+        type(lr_operand_desc_t) :: data_ptr, len_i32, len_i64, buf
 
         call get_identifier_name(arena, value_index, src_name, error_msg)
         if (len_trim(error_msg) > 0) return
@@ -681,22 +682,53 @@
         if (.not. emit_liric_i32_to_i64(context%session, len_i32, len_i64, &
                 error_msg)) return
 
-        ! The destination borrows the source's storage, so it takes storage
-        ! class stack: it must never free what the source still owns. Its own
-        ! former heap block is released before the rebind.
+        ! Copy into storage the destination owns, before releasing the block it
+        ! held: the source may be a different variable that shares that block,
+        ! and the copy has to be made while it is still valid.
+        call copy_character_bytes_to_owned(context, data_ptr, len_i64, buf, &
+                                           error_msg)
+        if (len_trim(error_msg) > 0) return
         call release_owned_character_storage(context, symbol_index, error_msg)
         if (len_trim(error_msg) > 0) return
-        if (.not. emit_ptr_store(context%session, data_ptr, &
+        if (.not. emit_ptr_store(context%session, buf, &
                 context%symbols(symbol_index)%deferred_data, error_msg)) return
         if (.not. emit_i64_store(context%session, len_i64, &
                 context%symbols(symbol_index)%deferred_length, error_msg)) return
         call set_character_storage(context, symbol_index, len_i64, &
-                                   LOWERING_CHARACTER_STORAGE_STACK, error_msg)
+                                   LOWERING_CHARACTER_STORAGE_OWNED, error_msg)
         if (len_trim(error_msg) > 0) return
-        context%symbols(symbol_index)%value = data_ptr
+        context%symbols(symbol_index)%value = buf
         context%symbols(symbol_index)%has_character_value = .true.
         call set_empty(error_msg)
     end subroutine lower_deferred_identifier_assignment
+
+    subroutine copy_character_bytes_to_owned(context, src_data, len_i64, buf, &
+                                             error_msg)
+        ! Allocate len + 1 bytes the caller's descriptor will own, copy len
+        ! bytes of source text into them, and null-terminate so the print path
+        ! stops at the Fortran length. The copy is made before any release, so
+        ! it is safe even when the source aliases the storage being replaced.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: src_data
+        type(lr_operand_desc_t), intent(in) :: len_i64
+        type(lr_operand_desc_t), intent(out) :: buf
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: bytes, null_pos
+
+        if (.not. emit_i64_binary(context%session, LR_OP_ADD, len_i64, &
+                i64_immediate(context%session, 1_c_int64_t), bytes, &
+                error_msg)) return
+        if (.not. emit_malloc(context%session, bytes, buf, error_msg)) return
+        if (.not. emit_memcpy(context%session, buf, src_data, len_i64, &
+                error_msg)) return
+        if (.not. emit_i64_binary(context%session, LR_OP_ADD, buf, len_i64, &
+                null_pos, error_msg)) return
+        if (.not. emit_liric_store_char_byte(context%session, null_pos, &
+                i32_immediate(context%session, 0_c_int64_t), &
+                i32_immediate(context%session, 0_c_int64_t), error_msg)) return
+        call set_empty(error_msg)
+    end subroutine copy_character_bytes_to_owned
 
     recursive subroutine concat_character_literals(arena, node_index, &
                                                    accumulated, ok)
@@ -890,6 +922,22 @@
                 context%symbols(symbol_index)%deferred_storage, error_msg)) return
     end subroutine set_character_storage
 
+    pure function character_expression_storage_class(context) result(storage_class)
+        ! The character intrinsic helpers (trim, adjustl, adjustr, repeat, ...)
+        ! materialise their result on the heap inside an internal function, so
+        ! it can outlive the frame, and on the stack at program scope. The
+        ! descriptor that adopts such a buffer records the matching class.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(in) :: context
+        integer(c_int64_t) :: storage_class
+
+        if (context%in_internal_function) then
+            storage_class = LOWERING_CHARACTER_STORAGE_OWNED
+        else
+            storage_class = LOWERING_CHARACTER_STORAGE_STACK
+        end if
+    end function character_expression_storage_class
+
     subroutine release_owned_character_storage(context, symbol_index, error_msg)
         ! Return the descriptor's heap block to the allocator when, and only
         ! when, this descriptor owns it (storage class
@@ -897,34 +945,17 @@
         ! freed through the descriptor. The class is reset to
         ! CHARACTER_STORAGE_NULL afterwards, so a second release, or a
         ! deallocate of an already-released variable, frees nothing.
-        use, intrinsic :: iso_c_binding, only: c_int64_t
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: symbol_index
         character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: storage_class, is_owned, data_ptr, victim
 
         call set_empty(error_msg)
         if (symbol_index <= 0) return
         if (.not. context%symbols(symbol_index)%has_character_ownership) return
 
-        if (.not. emit_i32_load(context%session, &
-                context%symbols(symbol_index)%deferred_storage, storage_class, &
-                error_msg)) return
-        if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, storage_class, &
-                i32_immediate(context%session, LOWERING_CHARACTER_STORAGE_OWNED), &
-                is_owned, error_msg)) return
-        if (.not. emit_ptr_load(context%session, &
-                context%symbols(symbol_index)%deferred_data, data_ptr, &
-                error_msg)) return
-        ! free(NULL) is a no-op, so a borrowed descriptor selects the null
-        ! pointer and the call has no effect.
-        call select_value(context, is_owned, data_ptr, &
-                          null_ptr_operand(context), victim, error_msg)
-        if (len_trim(error_msg) > 0) return
-        if (.not. emit_free(context%session, victim, error_msg)) return
-        if (.not. emit_i64_store(context%session, &
-                i64_immediate(context%session, 0_c_int64_t), &
-                context%symbols(symbol_index)%deferred_storage, error_msg)) return
+        call release_character_descriptor_storage(context, &
+            context%symbols(symbol_index)%deferred_data, &
+            context%symbols(symbol_index)%deferred_storage, error_msg)
     end subroutine release_owned_character_storage
 
     subroutine bind_character_parameter_symbol(context, symbol_index, error_msg)
@@ -1050,20 +1081,37 @@
         ! min(source length, target length) bytes into a blank-filled buffer
         ! of the target's declared width, matching gfortran's fixed-length
         ! assignment padding/truncation.
-        use, intrinsic :: iso_c_binding, only: c_int64_t
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: value_index
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: dest_symbol_index
         character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: src_data, src_len, dest_len_i32, cmp
-        type(lr_operand_desc_t) :: copy_len, copy_len64, buf, offset, null_ptr
-        character(len=64) :: null_name
-        integer :: dest_len
+        type(lr_operand_desc_t) :: src_data, src_len
 
         call char_expr_operands(arena, value_index, context, src_data, src_len, &
                                 error_msg)
         if (len_trim(error_msg) > 0) return
+        call store_fixed_character_value(context, dest_symbol_index, src_data, &
+                                         src_len, error_msg)
+    end subroutine lower_fixed_char_expr_assignment
+
+    subroutine store_fixed_character_value(context, dest_symbol_index, src_data, &
+                                           src_len, error_msg)
+        ! Copy a character value into a fixed-length destination: blank-fill a
+        ! buffer of the declared width, copy min(source length, declared
+        ! width) bytes, and null-terminate at the fixed end. The destination
+        ! holds a copy, never an alias of the source buffer, so a source that
+        ! is a temporary can be released straight after this call.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: dest_symbol_index
+        type(lr_operand_desc_t), intent(in) :: src_data
+        type(lr_operand_desc_t), intent(in) :: src_len
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: dest_len_i32, cmp
+        type(lr_operand_desc_t) :: copy_len, copy_len64, buf, offset, null_ptr
+        character(len=64) :: null_name
+        integer :: dest_len
 
         dest_len = context%symbols(dest_symbol_index)%character_length
         dest_len_i32 = i32_immediate(context%session, int(dest_len, c_int64_t))
@@ -1111,7 +1159,7 @@
         end if
         context%symbols(dest_symbol_index)%has_character_value = .true.
         call set_empty(error_msg)
-    end subroutine lower_fixed_char_expr_assignment
+    end subroutine store_fixed_character_value
 
     subroutine lower_runtime_fixed_char_assignment(arena, value_index, context, &
                                                     dest_symbol_index, error_msg)
@@ -1127,7 +1175,9 @@
         type(lr_operand_desc_t) :: source_data, source_len, target_len
         type(lr_operand_desc_t) :: target_len64, buffer_size, buffer, copy_len
         type(lr_operand_desc_t) :: copy_len64, source_fits, null_pos
+        integer(c_int64_t) :: buffer_storage_class
 
+        buffer_storage_class = LOWERING_CHARACTER_STORAGE_STACK
         call char_expr_operands(arena, value_index, context, source_data, &
                                 source_len, error_msg)
         if (len_trim(error_msg) > 0) return
@@ -1149,9 +1199,11 @@
         if (context%in_internal_function) then
             if (.not. emit_malloc(context%session, buffer_size, buffer, &
                     error_msg)) return
+            buffer_storage_class = LOWERING_CHARACTER_STORAGE_OWNED
         else
             if (.not. emit_alloca_bytes(context%session, buffer_size, buffer, &
                     error_msg)) return
+            buffer_storage_class = LOWERING_CHARACTER_STORAGE_STACK
         end if
         call fill_spaces(context, buffer, target_len, error_msg)
         if (len_trim(error_msg) > 0) return
@@ -1172,8 +1224,17 @@
                 i32_immediate(context%session, 0_c_int64_t), &
                 i32_immediate(context%session, 0_c_int64_t), error_msg)) return
 
+        ! The declared width is immutable here, so the freshly built buffer
+        ! replaces whatever the descriptor held. Release the former block when
+        ! this descriptor owned it, then record the new block's class so the
+        ! consumer of a returned result knows whether to free it.
+        call release_owned_character_storage(context, dest_symbol_index, error_msg)
+        if (len_trim(error_msg) > 0) return
         if (.not. emit_ptr_store(context%session, buffer, &
                 context%symbols(dest_symbol_index)%deferred_data, error_msg)) return
+        call set_character_storage(context, dest_symbol_index, target_len64, &
+                                   buffer_storage_class, error_msg)
+        if (len_trim(error_msg) > 0) return
         context%symbols(dest_symbol_index)%value = buffer
         context%symbols(dest_symbol_index)%has_character_value = .true.
         call set_empty(error_msg)
@@ -1195,9 +1256,11 @@
         if (len_trim(error_msg) > 0) return
         if (.not. emit_liric_i32_to_i64(context%session, length, length64, &
                                         error_msg)) return
-        ! char_expr_operands has already materialised the trimmed buffer, so
-        ! the former owned block can be released before the rebind. The
-        ! trimmed buffer itself is stack storage the descriptor only borrows.
+        ! char_expr_operands has already materialised the buffer, so the
+        ! former owned block can be released before the rebind. Inside an
+        ! internal function that buffer is heap storage, because it has to
+        ! outlive the frame that produced it; at program scope it is a stack
+        ! temporary the descriptor only borrows.
         call release_owned_character_storage(context, dest_symbol_index, error_msg)
         if (len_trim(error_msg) > 0) return
         if (.not. emit_ptr_store(context%session, data_ptr, &
@@ -1205,7 +1268,8 @@
         if (.not. emit_i64_store(context%session, length64, &
             context%symbols(dest_symbol_index)%deferred_length, error_msg)) return
         call set_character_storage(context, dest_symbol_index, length64, &
-                                   LOWERING_CHARACTER_STORAGE_STACK, error_msg)
+                                   character_expression_storage_class(context), &
+                                   error_msg)
         if (len_trim(error_msg) > 0) return
         context%symbols(dest_symbol_index)%value = data_ptr
         context%symbols(dest_symbol_index)%has_character_value = .true.

--- a/src/session_program_lowering_deferred_char.inc
+++ b/src/session_program_lowering_deferred_char.inc
@@ -1,5 +1,6 @@
 integer function resolve_concat_operand(arena, node_index, context, &
-                                           out_name, operand_is_literal, error_msg) &
+                                           out_name, operand_is_literal, error_msg, &
+                                           operand_is_call) &
       result(symbol_index)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: node_index
@@ -7,18 +8,30 @@ integer function resolve_concat_operand(arena, node_index, context, &
         character(len=:), allocatable, intent(out) :: out_name
         logical, intent(out) :: operand_is_literal
         character(len=:), allocatable, intent(out) :: error_msg
+        ! A call to a contained character-returning function is neither a
+        ! literal nor a declared symbol: the caller materialises it through
+        ! the descriptor return ABI before the concatenation reads it.
+        logical, intent(out), optional :: operand_is_call
         character(len=:), allocatable :: name
         character(len=:), allocatable :: lit_value, lit_type
         integer :: idx
 
         symbol_index = 0
         operand_is_literal = .false.
+        if (present(operand_is_call)) operand_is_call = .false.
         out_name = ''
         call set_empty(error_msg)
 
         if (.not. node_exists(arena, node_index)) then
             error_msg = 'concat operand index does not reference an AST node'
             return
+        end if
+
+        if (present(operand_is_call)) then
+            if (is_contained_char_result_call(arena, node_index, context)) then
+                operand_is_call = .true.
+                return
+            end if
         end if
 
         if (is_literal(arena, node_index)) then
@@ -81,6 +94,11 @@ integer function resolve_concat_operand(arena, node_index, context, &
         logical :: is_self_alias
         logical :: left_is_literal
         logical :: right_is_literal
+        logical :: left_is_call
+        logical :: right_is_call
+        type(lr_operand_desc_t) :: left_call_data_addr, left_call_storage_addr
+        type(lr_operand_desc_t) :: right_call_data_addr, right_call_storage_addr
+        type(lr_operand_desc_t) :: call_len_i32
         character(len=:), allocatable :: literal_text
         character(len=64) :: string_name
         character(len=:), allocatable :: combined_text
@@ -95,6 +113,8 @@ integer function resolve_concat_operand(arena, node_index, context, &
         new_storage_class = LOWERING_CHARACTER_STORAGE_STACK
         left_is_literal = .false.
         right_is_literal = .false.
+        left_is_call = .false.
+        right_is_call = .false.
         is_self_alias = .false.
 
         ! A fixed-length result (character(len=N) :: s) uses the descriptor
@@ -123,12 +143,12 @@ integer function resolve_concat_operand(arena, node_index, context, &
 
         ! Resolve left operand: get symbol index or mark as literal
         left_sym_idx = resolve_concat_operand(arena, left_idx, context, &
-            left_name, left_is_literal, error_msg)
+            left_name, left_is_literal, error_msg, left_is_call)
         if (len_trim(error_msg) > 0) return
 
         ! Resolve right operand
         right_sym_idx = resolve_concat_operand(arena, right_idx, context, &
-            right_name, right_is_literal, error_msg)
+            right_name, right_is_literal, error_msg, right_is_call)
         if (len_trim(error_msg) > 0) return
 
         ! Detect self-aliasing: dest is one of the operands
@@ -149,7 +169,15 @@ integer function resolve_concat_operand(arena, node_index, context, &
         end if
 
         ! Get left operand text/content
-        if (left_is_literal) then
+        if (left_is_call) then
+            call char_result_call_operands(arena, left_idx, context, left_data, &
+                                           call_len_i32, error_msg, &
+                                           left_call_data_addr, &
+                                           left_call_storage_addr)
+            if (len_trim(error_msg) > 0) return
+            if (.not. emit_liric_i32_to_i64(context%session, call_len_i32, &
+                    left_len, error_msg)) return
+        else if (left_is_literal) then
             call strip_literal_quotes(left_name, left_text)
             call materialize_concat_literal(context, left_text, left_data, &
                 left_len, error_msg)
@@ -171,7 +199,15 @@ integer function resolve_concat_operand(arena, node_index, context, &
         end if
 
         ! Get right operand text/content
-        if (right_is_literal) then
+        if (right_is_call) then
+            call char_result_call_operands(arena, right_idx, context, right_data, &
+                                           call_len_i32, error_msg, &
+                                           right_call_data_addr, &
+                                           right_call_storage_addr)
+            if (len_trim(error_msg) > 0) return
+            if (.not. emit_liric_i32_to_i64(context%session, call_len_i32, &
+                    right_len, error_msg)) return
+        else if (right_is_literal) then
             call strip_literal_quotes(right_name, right_text)
             call materialize_concat_literal(context, right_text, right_data, &
                 right_len, error_msg)
@@ -296,6 +332,19 @@ integer function resolve_concat_operand(arena, node_index, context, &
         call set_character_storage(context, dest_symbol_index, total_len, &
                                    new_storage_class, error_msg)
         if (len_trim(error_msg) > 0) return
+
+        ! An operand that was a function result is a temporary this statement
+        ! took ownership of; its bytes are now in the concatenated buffer.
+        if (left_is_call) then
+            call release_character_descriptor_storage(context, &
+                left_call_data_addr, left_call_storage_addr, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end if
+        if (right_is_call) then
+            call release_character_descriptor_storage(context, &
+                right_call_data_addr, right_call_storage_addr, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end if
 
         context%symbols(dest_symbol_index)%value = new_ptr
         context%symbols(dest_symbol_index)%has_character_value = .true.
@@ -457,23 +506,83 @@ integer function resolve_concat_operand(arena, node_index, context, &
 
     subroutine allocate_deferred_char_descriptor(context, descriptor_ptr, &
                                                   data_addr, len_addr, &
-                                                  error_msg)
+                                                  error_msg, capacity_addr, &
+                                                  storage_addr)
+        ! Stack-allocate a canonical 32-byte character descriptor
+        ! (docs/CHARACTER_DESCRIPTOR_ABI.md) and hand back the addresses of its
+        ! fields. Every field starts at the ABI null state, so a descriptor
+        ! that is filled in by a callee, or is only ever borrowed, still has a
+        ! well-defined storage class. The {data, length} prefix is unchanged,
+        ! so an actual-argument descriptor still matches what a
+        ! character(len=*) dummy binds against.
         use, intrinsic :: iso_c_binding, only: c_int64_t
         type(lowering_context_t), intent(inout) :: context
         type(lr_operand_desc_t), intent(out) :: descriptor_ptr
         type(lr_operand_desc_t), intent(out) :: data_addr
         type(lr_operand_desc_t), intent(out) :: len_addr
         character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t), intent(out), optional :: capacity_addr
+        type(lr_operand_desc_t), intent(out), optional :: storage_addr
+        type(lr_operand_desc_t) :: capacity_slot, storage_slot
 
         if (.not. emit_alloca_bytes(context%session, &
-            i64_immediate(context%session, 16_c_int64_t), descriptor_ptr, &
+            i64_immediate(context%session, 32_c_int64_t), descriptor_ptr, &
             error_msg)) return
         if (.not. emit_ptr_offset(context%session, descriptor_ptr, 0_c_int64_t, &
             data_addr, error_msg)) return
         if (.not. emit_ptr_offset(context%session, descriptor_ptr, 8_c_int64_t, &
             len_addr, error_msg)) return
+        if (.not. emit_ptr_offset(context%session, descriptor_ptr, 16_c_int64_t, &
+            capacity_slot, error_msg)) return
+        if (.not. emit_ptr_offset(context%session, descriptor_ptr, 24_c_int64_t, &
+            storage_slot, error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+            i64_immediate(context%session, 0_c_int64_t), data_addr, &
+            error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+            i64_immediate(context%session, 0_c_int64_t), len_addr, &
+            error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+            i64_immediate(context%session, 0_c_int64_t), capacity_slot, &
+            error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+            i64_immediate(context%session, 0_c_int64_t), storage_slot, &
+            error_msg)) return
+        if (present(capacity_addr)) capacity_addr = capacity_slot
+        if (present(storage_addr)) storage_addr = storage_slot
         call set_empty(error_msg)
     end subroutine allocate_deferred_char_descriptor
+
+    subroutine release_character_descriptor_storage(context, data_addr, &
+                                                     storage_addr, error_msg)
+        ! Release the heap block a descriptor owns, given the addresses of its
+        ! data and storage_class fields. Borrowed static and stack data is left
+        ! alone. The class is reset so a repeated release frees nothing.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: data_addr
+        type(lr_operand_desc_t), intent(in) :: storage_addr
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: storage_class, is_owned, data_ptr, victim
+
+        call set_empty(error_msg)
+        if (.not. emit_i32_load(context%session, storage_addr, storage_class, &
+                error_msg)) return
+        if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, storage_class, &
+                i32_immediate(context%session, LOWERING_CHARACTER_STORAGE_OWNED), &
+                is_owned, error_msg)) return
+        if (.not. emit_ptr_load(context%session, data_addr, data_ptr, &
+                error_msg)) return
+        ! free(NULL) is a no-op, so a borrowed descriptor selects the null
+        ! pointer and the call has no effect.
+        call select_value(context, is_owned, data_ptr, &
+                          null_ptr_operand(context), victim, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_free(context%session, victim, error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+                i64_immediate(context%session, 0_c_int64_t), storage_addr, &
+                error_msg)) return
+    end subroutine release_character_descriptor_storage
 
     subroutine prepare_deferred_char_actual(arena, node_index, context, arg, &
                                             error_msg)
@@ -607,6 +716,8 @@ integer function resolve_concat_operand(arena, node_index, context, &
         type(lr_operand_desc_t) :: descriptor_ptr
         type(lr_operand_desc_t) :: data_addr
         type(lr_operand_desc_t) :: len_addr
+        type(lr_operand_desc_t) :: capacity_addr
+        type(lr_operand_desc_t) :: storage_addr
         integer :: i
         character(len=:), allocatable :: func_name
 
@@ -625,20 +736,24 @@ integer function resolve_concat_operand(arena, node_index, context, &
 
         func_name = call_emit_name(arena, call_node%name, context)
 
-        ! The callee writes its result through a fresh {data, length} return
-        ! descriptor, so the destination stops using its own descriptor here.
-        ! Release whatever heap block that descriptor still owned first, then
-        ! drop the ownership slots: the return descriptor carries none, and the
-        ! result's storage stays owned by the callee's convention (#348).
+        ! The callee writes its result through a fresh return descriptor, so
+        ! the destination stops using its own. Release whatever heap block that
+        ! descriptor still owned first, then rebind the destination onto the
+        ! return descriptor: returning the descriptor transfers ownership, so
+        ! the destination keeps its ownership slots and a later assignment or
+        ! deallocate releases the adopted block.
         call release_owned_character_storage(context, dest_symbol_index, error_msg)
         if (len_trim(error_msg) > 0) return
-        context%symbols(dest_symbol_index)%has_character_ownership = .false.
 
         call allocate_deferred_char_descriptor(context, descriptor_ptr, &
-                                               data_addr, len_addr, error_msg)
+                                               data_addr, len_addr, error_msg, &
+                                               capacity_addr, storage_addr)
         if (len_trim(error_msg) > 0) return
         context%symbols(dest_symbol_index)%deferred_data = data_addr
         context%symbols(dest_symbol_index)%deferred_length = len_addr
+        context%symbols(dest_symbol_index)%deferred_capacity = capacity_addr
+        context%symbols(dest_symbol_index)%deferred_storage = storage_addr
+        context%symbols(dest_symbol_index)%has_character_ownership = .true.
 
         if (allocated(call_node%arg_indices)) then
             call prepare_deferred_char_call_args(arena, call_node%arg_indices, &
@@ -668,29 +783,34 @@ integer function resolve_concat_operand(arena, node_index, context, &
     end subroutine lower_deferred_char_result_call
 
     ! A fixed-length scalar destination receiving a character-returning
-    ! contained function. The callee returns its result through a {data,len}
-    ! descriptor passed as the leading sret pointer; bind the destination value
-    ! to the returned data so later reads (print) see the produced text.
+    ! contained function. The callee returns its result through the canonical
+    ! character descriptor passed as the leading sret pointer. The destination
+    ! takes a blank-padded or truncated copy at its own declared width, never
+    ! an alias of the returned buffer, so the temporary can then be released.
     subroutine lower_fixed_char_result_call(arena, node, context, &
                                             dest_symbol_index, error_msg)
-        use, intrinsic :: iso_c_binding, only: c_int64_t
         type(ast_arena_t), intent(in) :: arena
         type(assignment_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: dest_symbol_index
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t) :: data_ptr, length
+        type(lr_operand_desc_t) :: data_addr, storage_addr
 
         call char_result_call_operands(arena, node%value_index, context, &
-                                       data_ptr, length, error_msg)
+                                       data_ptr, length, error_msg, &
+                                       data_addr, storage_addr)
         if (len_trim(error_msg) > 0) return
-        context%symbols(dest_symbol_index)%value = data_ptr
-        context%symbols(dest_symbol_index)%has_character_value = .true.
-        call set_empty(error_msg)
+        call store_fixed_character_value(context, dest_symbol_index, data_ptr, &
+                                         length, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call release_character_descriptor_storage(context, data_addr, &
+                                                  storage_addr, error_msg)
     end subroutine lower_fixed_char_result_call
 
     subroutine char_result_call_operands(arena, node_index, context, data_ptr, &
-                                         length, error_msg)
+                                         length, error_msg, out_data_addr, &
+                                         out_storage_addr)
         ! Emit a call to a character-returning contained function through the
         ! deferred-character descriptor ABI (hidden first descriptor argument),
         ! then load the returned {data, len} as a scalar character expression.
@@ -705,9 +825,12 @@ integer function resolve_concat_operand(arena, node_index, context, &
         type(lr_operand_desc_t), allocatable :: user_args(:)
         type(lr_operand_desc_t), allocatable :: all_args(:)
         integer, allocatable :: copyback_indices(:)
+        type(lr_operand_desc_t), intent(out), optional :: out_data_addr
+        type(lr_operand_desc_t), intent(out), optional :: out_storage_addr
         type(lr_operand_desc_t) :: descriptor_ptr
         type(lr_operand_desc_t) :: data_addr
         type(lr_operand_desc_t) :: len_addr
+        type(lr_operand_desc_t) :: storage_addr
         integer :: i
         character(len=:), allocatable :: func_name
 
@@ -726,7 +849,8 @@ integer function resolve_concat_operand(arena, node_index, context, &
         func_name = call_emit_name(arena, call_node%name, context)
 
         call allocate_deferred_char_descriptor(context, descriptor_ptr, &
-                                               data_addr, len_addr, error_msg)
+                                               data_addr, len_addr, error_msg, &
+                                               storage_addr=storage_addr)
         if (len_trim(error_msg) > 0) return
 
         if (allocated(call_node%arg_indices)) then
@@ -754,6 +878,10 @@ integer function resolve_concat_operand(arena, node_index, context, &
                                 error_msg)) return
         if (.not. emit_i32_load(context%session, len_addr, length, &
                                 error_msg)) return
+        ! A consumer that copies the value out can release the temporary; one
+        ! that keeps the pointer alive simply does not ask for the addresses.
+        if (present(out_data_addr)) out_data_addr = data_addr
+        if (present(out_storage_addr)) out_storage_addr = storage_addr
         call set_empty(error_msg)
     end subroutine char_result_call_operands
 
@@ -769,6 +897,7 @@ integer function resolve_concat_operand(arena, node_index, context, &
         type(lr_operand_desc_t) :: descriptor_ptr
         type(lr_operand_desc_t) :: data_addr
         type(lr_operand_desc_t) :: len_addr
+        type(lr_operand_desc_t) :: storage_addr
         type(lr_operand_desc_t) :: data_value
         integer :: i
         character(len=:), allocatable :: func_name
@@ -778,7 +907,8 @@ integer function resolve_concat_operand(arena, node_index, context, &
         func_name = call_emit_name(arena, node%name, context)
 
         call allocate_deferred_char_descriptor(context, descriptor_ptr, &
-                                               data_addr, len_addr, error_msg)
+                                               data_addr, len_addr, error_msg, &
+                                               storage_addr=storage_addr)
         if (len_trim(error_msg) > 0) return
 
         if (allocated(node%arg_indices)) then
@@ -807,6 +937,12 @@ integer function resolve_concat_operand(arena, node_index, context, &
         ! The list-directed leading blank is emitted by the print loop.
         if (.not. emit_liric_print_string_operand_value(context%session, &
             context%str_print_format_id, data_value, error_msg)) return
+        ! The result has been consumed by the transfer statement, so the
+        ! caller releases the temporary it took ownership of. A borrowed
+        ! result (a static literal) is left alone.
+        call release_character_descriptor_storage(context, data_addr, &
+                                                  storage_addr, error_msg)
+        if (len_trim(error_msg) > 0) return
         call set_empty(error_msg)
     end subroutine lower_print_deferred_char_call
 

--- a/src/session_program_lowering_functions.inc
+++ b/src/session_program_lowering_functions.inc
@@ -1612,7 +1612,7 @@
         character(len=:), allocatable :: global_name
         character(kind=c_char), allocatable :: c_name(:)
         integer(c_int32_t), target :: init_i32
-        integer(c_int8_t), target :: init_i8(16)
+        integer(c_int8_t), target :: init_i8(32)
         integer(c_int64_t), target :: init_i64
         real(c_float), target :: init_f32
         real(c_double), target :: init_f64
@@ -1641,10 +1641,13 @@
             init_ptr = c_loc(init_i64)
             init_size = 8_c_size_t
         case (VALUE_CHARACTER)
+            ! A host-associated character variable or result carries the
+            ! canonical 32-byte character descriptor, so its ownership half
+            ! travels with it (docs/CHARACTER_DESCRIPTOR_ABI.md).
             global_type = lr_type_array_s(context%session%handle, &
-                lr_type_i8_s(context%session%handle), 16_c_int64_t)
+                lr_type_i8_s(context%session%handle), 32_c_int64_t)
             init_ptr = c_loc(init_i8)
-            init_size = 16_c_size_t
+            init_size = 32_c_size_t
         case (VALUE_F32)
             global_type = lr_type_f32_s(context%session%handle)
             init_ptr = c_loc(init_f32)
@@ -1845,6 +1848,13 @@
             if (.not. emit_ptr_offset(context%session, &
                 context%symbols(i)%address, 8_c_int64_t, &
                 context%symbols(i)%deferred_length, error_msg)) return
+            if (.not. emit_ptr_offset(context%session, &
+                context%symbols(i)%address, 16_c_int64_t, &
+                context%symbols(i)%deferred_capacity, error_msg)) return
+            if (.not. emit_ptr_offset(context%session, &
+                context%symbols(i)%address, 24_c_int64_t, &
+                context%symbols(i)%deferred_storage, error_msg)) return
+            context%symbols(i)%has_character_ownership = .true.
         end do
         call set_empty(error_msg)
     end subroutine materialize_host_character_globals
@@ -1856,21 +1866,44 @@
         integer, intent(in) :: symbol_index
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t) :: result_data_addr, result_length_addr
+        type(lr_operand_desc_t) :: result_capacity_addr, result_storage_addr
         type(lr_operand_desc_t) :: data_value, length_value
+        type(lr_operand_desc_t) :: capacity_value, storage_value
 
         call set_empty(error_msg)
         if (.not. emit_ptr_offset(context%session, ptr_param(context%session, 0), &
             0_c_int64_t, result_data_addr, error_msg)) return
         if (.not. emit_ptr_offset(context%session, ptr_param(context%session, 0), &
             8_c_int64_t, result_length_addr, error_msg)) return
+        if (.not. emit_ptr_offset(context%session, ptr_param(context%session, 0), &
+            16_c_int64_t, result_capacity_addr, error_msg)) return
+        if (.not. emit_ptr_offset(context%session, ptr_param(context%session, 0), &
+            24_c_int64_t, result_storage_addr, error_msg)) return
         if (.not. emit_ptr_load(context%session, &
             context%symbols(symbol_index)%deferred_data, data_value, error_msg)) return
         if (.not. emit_i64_load(context%session, &
             context%symbols(symbol_index)%deferred_length, length_value, error_msg)) return
+        if (.not. emit_i64_load(context%session, &
+            context%symbols(symbol_index)%deferred_capacity, capacity_value, &
+            error_msg)) return
+        if (.not. emit_i64_load(context%session, &
+            context%symbols(symbol_index)%deferred_storage, storage_value, &
+            error_msg)) return
         if (.not. emit_ptr_store(context%session, data_value, result_data_addr, &
             error_msg)) return
         if (.not. emit_i64_store(context%session, length_value, result_length_addr, &
             error_msg)) return
+        if (.not. emit_i64_store(context%session, capacity_value, &
+            result_capacity_addr, error_msg)) return
+        ! Returning the descriptor transfers ownership to the caller: the class
+        ! travels with the data, and the callee's own descriptor drops back to
+        ! the null class so the block is never released twice. The result
+        ! global is reused by the next call, which reinitialises it anyway.
+        if (.not. emit_i64_store(context%session, storage_value, &
+            result_storage_addr, error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+            i64_immediate(context%session, 0_c_int64_t), &
+            context%symbols(symbol_index)%deferred_storage, error_msg)) return
         if (.not. emit_ret_void(context%session, error_msg)) return
         call set_empty(error_msg)
     end subroutine emit_host_character_result_return
@@ -2687,6 +2720,21 @@
                 ptr_param(context%session, 0), 8_c_int64_t, &
                 context%symbols(context%current_function_result_index)%deferred_length, &
                 error_msg)) return
+            ! The caller's return descriptor is the canonical 32-byte record,
+            ! so the result symbol also owns its capacity and storage_class
+            ! slots. Every assignment to the result then records which storage
+            ! class the returned data belongs to, which is what lets the caller
+            ! release an owned result and leave a borrowed one alone.
+            associate (rsym => &
+                context%symbols(context%current_function_result_index))
+                if (.not. emit_ptr_offset(context%session, &
+                    ptr_param(context%session, 0), 16_c_int64_t, &
+                    rsym%deferred_capacity, error_msg)) return
+                if (.not. emit_ptr_offset(context%session, &
+                    ptr_param(context%session, 0), 24_c_int64_t, &
+                    rsym%deferred_storage, error_msg)) return
+                rsym%has_character_ownership = .true.
+            end associate
             context%symbol_count = context%current_function_result_index
         else if (value_kind == VALUE_DERIVED) then
             call grow_symbols(context)

--- a/test/test_session_character_function_result_compiler.f90
+++ b/test/test_session_character_function_result_compiler.f90
@@ -9,6 +9,7 @@ program test_session_character_function_result_compiler
         compiler_frontend_result_t, &
         compile_frontend_from_string, &
         INPUT_MODE_STANDARD
+    use ffc_test_support, only: expect_no_leaks
     implicit none
 
     logical :: all_passed
@@ -83,6 +84,144 @@ program test_session_character_function_result_compiler
         '  end function greet'//new_line('a')// &
         'end program main', &
         'len_expr_of_dummy')) all_passed = .false.
+
+    ! A runtime-length result assigned to a shorter fixed-length destination
+    ! truncates to the destination's declared width, and to a longer one pads
+    ! with blanks. The result is a value, not an alias of the callee's buffer.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  character(len=5) :: short'//new_line('a')// &
+        '  character(len=14) :: wide'//new_line('a')// &
+        '  short = greet("Ada")'//new_line('a')// &
+        '  wide = greet("Ada")'//new_line('a')// &
+        '  print *, "[", short, "]"'//new_line('a')// &
+        '  print *, "[", wide, "]"'//new_line('a')// &
+        '  print *, greet("Bob")'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function greet(name) result(s)'//new_line('a')// &
+        '    character(len=*), intent(in) :: name'//new_line('a')// &
+        '    character(len=len(name)+7) :: s'//new_line('a')// &
+        '    s = "Hello, " // name'//new_line('a')// &
+        '  end function greet'//new_line('a')// &
+        'end program main', &
+        'fixed_dest_truncates')) all_passed = .false.
+
+    ! A nested concatenating result: the inner call's result feeds the outer
+    ! concatenation, so the outer result is length 5 with the exact value.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  character(len=:), allocatable :: r'//new_line('a')// &
+        '  r = outer()'//new_line('a')// &
+        '  print *, len(r), r'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function inner() result(s)'//new_line('a')// &
+        '    character(len=:), allocatable :: s'//new_line('a')// &
+        '    s = "ab"'//new_line('a')// &
+        '  end function inner'//new_line('a')// &
+        '  function outer() result(t)'//new_line('a')// &
+        '    character(len=:), allocatable :: t'//new_line('a')// &
+        '    t = inner() // "cde"'//new_line('a')// &
+        '  end function outer'//new_line('a')// &
+        'end program main', &
+        'nested_concat_result')) all_passed = .false.
+
+    ! Reassigning a deferred destination from repeated calls transfers
+    ! ownership of each result and releases the previous one.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  character(len=:), allocatable :: r'//new_line('a')// &
+        '  r = make(4)'//new_line('a')// &
+        '  print *, len(r), r'//new_line('a')// &
+        '  r = make(2)'//new_line('a')// &
+        '  print *, len(r), r'//new_line('a')// &
+        '  deallocate(r)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function make(k) result(s)'//new_line('a')// &
+        '    integer, intent(in) :: k'//new_line('a')// &
+        '    character(len=k) :: s'//new_line('a')// &
+        '    s = repeat("Z", k)'//new_line('a')// &
+        '  end function make'//new_line('a')// &
+        'end program main', &
+        'result_reassignment')) all_passed = .false.
+
+    ! Intrinsic assignment gives the destination a value, not a view: b keeps
+    ! its own copy of a's text when a is later reassigned and its former
+    ! storage released.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  character(len=:), allocatable :: a, b'//new_line('a')// &
+        '  a = make(3)'//new_line('a')// &
+        '  b = a'//new_line('a')// &
+        '  print *, len(a), a, " ", len(b), b'//new_line('a')// &
+        '  a = make(6)'//new_line('a')// &
+        '  print *, len(a), a, " ", len(b), b'//new_line('a')// &
+        '  deallocate(a)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function make(k) result(s)'//new_line('a')// &
+        '    integer, intent(in) :: k'//new_line('a')// &
+        '    character(len=k) :: s'//new_line('a')// &
+        '    s = repeat("Q", k)'//new_line('a')// &
+        '  end function make'//new_line('a')// &
+        'end program main', &
+        'assignment_copies_not_aliases')) all_passed = .false.
+
+    ! A result used as a concatenation operand on either side.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  character(len=:), allocatable :: t'//new_line('a')// &
+        '  t = greet("Ann") // "!"'//new_line('a')// &
+        '  print *, len(t), t'//new_line('a')// &
+        '  t = "x" // greet("Bo")'//new_line('a')// &
+        '  print *, len(t), t'//new_line('a')// &
+        '  deallocate(t)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function greet(n) result(s)'//new_line('a')// &
+        '    character(len=*), intent(in) :: n'//new_line('a')// &
+        '    character(len=len(n)+3) :: s'//new_line('a')// &
+        '    s = "Hi " // n'//new_line('a')// &
+        '  end function greet'//new_line('a')// &
+        'end program main', &
+        'result_as_concat_operand')) all_passed = .false.
+
+    ! Ownership oracle: a result consumed by a fixed-length destination or by
+    ! print is a temporary the caller must release. Nothing survives the
+    ! statement, so a clean memcheck report is the whole contract.
+    if (.not. expect_no_leaks( &
+        'program main'//new_line('a')// &
+        '  character(len=5) :: f'//new_line('a')// &
+        '  f = greet("Ada")'//new_line('a')// &
+        '  print *, "[", f, "]"'//new_line('a')// &
+        '  print *, greet("Bob")'//new_line('a')// &
+        '  stop 0'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function greet(name) result(s)'//new_line('a')// &
+        '    character(len=*), intent(in) :: name'//new_line('a')// &
+        '    character(len=len(name)+7) :: s'//new_line('a')// &
+        '    s = "Hello, " // name'//new_line('a')// &
+        '  end function greet'//new_line('a')// &
+        'end program main', &
+        '/tmp/ffc_charfn_result_temp_leak')) all_passed = .false.
+
+    ! Ownership oracle: a deferred destination assumes ownership of each
+    ! result, releases the previous one, and the explicit deallocate returns
+    ! the last one.
+    if (.not. expect_no_leaks( &
+        'program main'//new_line('a')// &
+        '  character(len=:), allocatable :: r'//new_line('a')// &
+        '  r = make(4)'//new_line('a')// &
+        '  print *, len(r), r'//new_line('a')// &
+        '  r = make(2)'//new_line('a')// &
+        '  print *, len(r), r'//new_line('a')// &
+        '  deallocate(r)'//new_line('a')// &
+        '  stop 0'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function make(k) result(s)'//new_line('a')// &
+        '    integer, intent(in) :: k'//new_line('a')// &
+        '    character(len=k) :: s'//new_line('a')// &
+        '    s = repeat("Z", k)'//new_line('a')// &
+        '  end function make'//new_line('a')// &
+        'end program main', &
+        '/tmp/ffc_charfn_result_transfer_leak')) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: character function results lower through direct LIRIC session'


### PR DESCRIPTION
Closes #348.

Follows #349. Character dummies and runtime-length character results now travel
through the canonical character descriptor of `docs/CHARACTER_DESCRIPTOR_ABI.md`
with an explicit ownership transfer at the call boundary.

- Every call-boundary descriptor — actual arguments, the hidden return
  descriptor, and host-associated character globals — is now the canonical
  32-byte record (`data`, `length`, `capacity`, `storage_class`), allocated in
  the ABI null state. The `{data, length}` prefix is byte-identical to the old
  16-byte pair, so what a `character(len=*)` dummy binds against is unchanged.
- The callee's result symbol binds the descriptor's ownership slots, so every
  assignment to the result records which storage class the returned bytes
  belong to. Returning the descriptor transfers that class to the caller and
  drops the callee's own descriptor back to the null class, so a block is never
  released twice.
- Consumers act on the class they receive. A deferred destination adopts the
  returned descriptor and owns it. A fixed-length destination takes a copy and
  then releases the temporary. `print` releases after the transfer statement. A
  concatenation operand that is a call is released once its bytes are in the
  result buffer.
- A function call is now accepted as a concatenation operand, which is what the
  nested-result fixture needs.

## Behaviour preserved

- **Character length semantics.** Assumed length (`character(len=*)`) dummies
  borrow the actual's data and length exactly as before; the prefix layout they
  bind against did not move. Fixed lengths keep their declared width. Deferred
  length still retargets to the RHS length. A runtime-length result
  (`character(len=k)`, `character(len=len(name)+7)`) still reports the length
  the callee produced.
- **Blank padding and truncation on assignment.** Now actually correct for a
  result assigned to a fixed-length destination. That path used to alias the
  callee's buffer, so `character(len=5) :: f; f = greet("Ada")` printed
  `Hello, Ada` where gfortran prints `Hello`. The destination now takes a
  blank-padded or truncated copy at its own declared width through the same
  `store_fixed_character_value` primitive the ordinary fixed-length expression
  assignment uses, so both paths pad and truncate identically.
- **Lower bounds and extents for character arrays.** Untouched. Character
  arrays keep their current layout; this change is scalars, dummies and
  results only (#347 migrates arrays).
- **Aliasing and overlap.** A fixed-length destination no longer aliases the
  callee's returned buffer, which is what makes releasing the temporary safe.
  A deferred destination adopts the returned descriptor rather than copying, so
  no aliasing is introduced. Borrowed descriptors (static literals, stack
  temporaries) are never freed through a descriptor that only borrows them.
- **Allocation and finalization lifetimes.** A character expression temporary
  is heap storage inside an internal function, because it has to outlive the
  frame that produced it, and stack storage at program scope; the descriptor
  that adopts it records the matching class instead of guessing. A result is
  released exactly once: by the caller that copied it out, or by the
  destination that adopted it at its next assignment or its `deallocate`.

## Oracles

Behavioural, and independent of the lowering:

- `matches_gfortran` cases in
  `test/test_session_character_function_result_compiler.f90` — gfortran is the
  reference. On unmodified main `fixed_dest_truncates` fails
  (`[Hello, Ada]` / `[Hello, Ada]` against gfortran's `[Hello]` /
  `[Hello, Ada    ]`) and `nested_concat_result` fails to lower at all
  (`expected identifier or literal in concat operand`). Both pass after the
  change.
- `expect_no_leaks` runs the compiled program under valgrind and requires a
  clean memcheck report — it observes the process's actual heap behaviour. On
  unmodified main both ownership cases lose every result block (11 + 11 bytes
  for the fixed-destination and print case, 3 + 5 bytes for the
  ownership-transfer case). Both pass after the change.

## Aliasing fix found by this work

While checking overlap shapes, the ownership tracking exposed a latent aliasing
bug that only becomes observable once storage is actually released: a deferred
destination assigned from another character variable (`b = a`) was aliasing the
source pointer rather than copying it. With nothing ever freed that was
invisible; once `a` is reassigned and its former block released, `b` dangled.
Intrinsic assignment gives the destination a value, not a view, so a deferred
destination now copies the source bytes into storage it owns, and the copy is
made before any release so an aliasing source is still valid at copy time.
`assignment_copies_not_aliases` pins this against gfortran.

## Conformance gauntlet

Baseline is a separate worktree at the same `origin/main` commit with its own
`fo build`.

| Suite | main | branch |
|---|---|---|
| lfortran | PASS=850 XFAIL=3345 XPASS=72 FAIL=12 | PASS=850 XFAIL=3345 XPASS=72 FAIL=12 |
| fortfront-f90 | PASS=410 XFAIL=95 XPASS=2 FAIL=9 | PASS=410 XFAIL=95 XPASS=2 FAIL=9 |
| fortfront-lf | PASS=196 XFAIL=56 XPASS=0 FAIL=12 | PASS=196 XFAIL=56 XPASS=0 FAIL=12 |

The per-case FAIL and XPASS sets are byte-identical between main and the branch
in all three suites: no regression, and no newly-passing case to move out of an
xfail manifest.

`fo` is green apart from `test_parity_dashboard` and
`test_fortfront_corpus_conformance`, both of which fail identically on
unmodified `origin/main`.

`expr_11.f90` (#566) is not from this chain: it is `real*8 x`, with no
character construct in it, and it fails identically on unmodified `origin/main`
with `assignment target was not declared: x`.
