### PR TITLE
[poly-02] track runtime type identity for class scalars (#417)

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -54,6 +54,12 @@ module session_program_lowering
         get_alternate_return_label, get_return_selector, &
         is_alternate_return_dummy
     use liric_session_runtime_bindings, only: install_runtime_archive
+    use ffc_polymorphic_descriptor, only: &
+        POLYMORPHIC_DESCRIPTOR_DATA_OFFSET, &
+        POLYMORPHIC_DESCRIPTOR_DECLARED_TYPE_OFFSET, &
+        POLYMORPHIC_DESCRIPTOR_DYNAMIC_TYPE_OFFSET, &
+        POLYMORPHIC_DESCRIPTOR_OWNERSHIP_OFFSET, &
+        POLYMORPHIC_DESCRIPTOR_SIZE, POLYMORPHIC_OWNERSHIP_BORROWED
     use liric_session_bindings, only: destroy, begin_i32_main, &
         liric_session_t, &
         begin_i32_function, begin_i64_function, begin_void_subroutine, &

--- a/src/session_program_lowering_arguments.inc
+++ b/src/session_program_lowering_arguments.inc
@@ -146,10 +146,12 @@
                                             args(i), error_msg)
                 if (len_trim(error_msg) > 0) return
             else if (actual_is_derived(arena, arg_indices(i), context)) then
-                ! A derived actual is passed by reference: the base address of
-                ! its component storage.
-                call derived_actual_address(arena, arg_indices(i), context, &
-                                             args(i), error_msg)
+                ! A derived actual reaching a class(t) dummy is passed as the
+                ! scalar class descriptor so the dummy carries the actual's
+                ! dynamic type; a type(t) dummy takes the bare base address of
+                ! the component storage.
+                call class_or_derived_actual(arena, arg_indices(i), context, &
+                                             callee_name, i, args(i), error_msg)
                 if (len_trim(error_msg) > 0) return
             else if (callee_dummy_is_class_star(arena, callee_name, i)) then
                 ! Box the actual into a {data, type_id} descriptor for a
@@ -1172,6 +1174,59 @@
         address = context%symbols(symbol_index)%allocatable_descriptor_address
         call set_empty(error_msg)
     end subroutine allocatable_array_actual_descriptor_address
+
+    subroutine class_or_derived_actual(arena, node_index, context, callee_name, &
+                                       param_pos, address, error_msg)
+        ! Route a derived actual by the dummy's spelling. class(t) takes the
+        ! canonical scalar class descriptor (#400) so declared and dynamic type
+        ! identity both reach the callee; type(t) keeps the existing bare
+        ! by-reference ABI unchanged.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: callee_name
+        integer, intent(in) :: param_pos
+        type(lr_operand_desc_t), intent(out) :: address
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: id_name
+        integer :: actual_index, declared_index, symbol_index
+
+        call class_dummy_declared_type_index(context, arena, callee_name, &
+                                             param_pos, declared_index)
+        if (declared_index <= 0) then
+            call derived_actual_address(arena, node_index, context, address, &
+                                        error_msg)
+            return
+        end if
+
+        call get_identifier_name(arena, node_index, id_name, error_msg)
+        if (len_trim(error_msg) > 0) return
+        symbol_index = resolve_symbol_at_node(context, node_index, id_name)
+        if (symbol_index <= 0) then
+            error_msg = 'derived argument was not declared: '//trim(id_name)
+            return
+        end if
+        ! Fortran 2018 7.3.2.3: the actual must be type compatible with the
+        ! class(t) dummy, i.e. its declared type is t or an extension of t.
+        actual_index = context%symbols(symbol_index)%derived_type_index
+        if (actual_index <= 0) then
+            error_msg = 'Type mismatch in argument to '//trim(callee_name)// &
+                ': actual '//trim(id_name)//' has no resolvable declared type'// &
+                ' for class('//trim(context%derived_types(declared_index)%name)// &
+                ') dummy'
+            return
+        end if
+        if (.not. derived_type_extends(context, actual_index, declared_index)) then
+            error_msg = 'Type mismatch in argument to '//trim(callee_name)// &
+                ': actual of type '// &
+                trim(context%derived_types(actual_index)%name)// &
+                ' is not type compatible with class('// &
+                trim(context%derived_types(declared_index)%name)//') dummy'
+            return
+        end if
+        call build_class_scalar_descriptor(context, symbol_index, &
+                                           declared_index, address, error_msg)
+    end subroutine class_or_derived_actual
 
     subroutine derived_actual_address(arena, node_index, context, address, &
                                       error_msg)

--- a/src/session_program_lowering_derived_module_ops.inc
+++ b/src/session_program_lowering_derived_module_ops.inc
@@ -107,6 +107,34 @@
         end if
     end subroutine extracted_derived_type_name
 
+    logical function declaration_is_class_polymorphic(node)
+        ! True when a declaration is spelled class(t) for a derived type t.
+        type(declaration_node), intent(in) :: node
+
+        declaration_is_class_polymorphic = .false.
+        if (.not. allocated(node%type_name)) return
+        ! An allocatable or pointer class entity keeps its existing
+        ! allocatable/pointer descriptor ABI until #421 gives it a dynamic
+        ! type; only a plain class(t) scalar takes the class descriptor.
+        if (node%is_allocatable) return
+        if (node%is_pointer) return
+        declaration_is_class_polymorphic = is_class_derived_type_spec(node%type_name)
+    end function declaration_is_class_polymorphic
+
+    logical function is_class_derived_type_spec(type_spec)
+        ! True for class(t) naming a derived type t, i.e. a polymorphic scalar
+        ! whose declared type is t. type(t) is monomorphic and class(*) is
+        ! unlimited polymorphic; neither matches here.
+        character(len=*), intent(in) :: type_spec
+        character(len=:), allocatable :: lowered
+
+        is_class_derived_type_spec = .false.
+        lowered = trim(lowercase_text(type_spec))
+        if (len_trim(lowered) < 6) return
+        if (lowered(1:6) /= 'class(') return
+        is_class_derived_type_spec = is_derived_type_spec(type_spec)
+    end function is_class_derived_type_spec
+
     logical function is_derived_type_spec(type_spec)
         character(len=*), intent(in) :: type_spec
         character(len=:), allocatable :: type_name

--- a/src/session_program_lowering_derived_type_ops.inc
+++ b/src/session_program_lowering_derived_type_ops.inc
@@ -841,6 +841,15 @@
                 context%symbols(index)%derived_type_index = derived_type_index
                 context%symbols(index)%array_size = &
                     total_component_slots(context, derived_type_index)
+                if (declaration_is_class_polymorphic(node)) then
+                    ! class(t) dummy: the parameter pointer is the caller's
+                    ! borrowed scalar class descriptor, not the storage. Take
+                    ! the storage from its data field and keep the address of
+                    ! its dynamic type field so the identity travels onwards.
+                    call bind_class_dummy_descriptor(context, index, &
+                                                     derived_type_index, error_msg)
+                    return
+                end if
                 context%symbols(index)%element_address = &
                     context%symbols(index)%address
                 call set_empty(error_msg)
@@ -1398,7 +1407,9 @@
         n = size(method_args)
         allocate (all_args(n + 1))
         if (position < 1 .or. position > n + 1) position = 1
-        all_args(position) = context%symbols(symbol_index)%element_address
+        call class_receiver_argument(context, arena, impl_name, position, &
+                                     symbol_index, all_args(position), error_msg)
+        if (len_trim(error_msg) > 0) return
         k = 0
         do i = 1, n + 1
             if (i == position) cycle

--- a/src/session_program_lowering_functions_tail.inc
+++ b/src/session_program_lowering_functions_tail.inc
@@ -344,6 +344,105 @@
         end do
     end function callee_dummy_is_class_star
 
+    subroutine dummy_class_declared_type(arena, body_indices, param_name, &
+                                         type_name)
+        ! Declared type name of a class(t) dummy, empty when the dummy is not
+        ! declared class(t). Mirrors dummy_is_class_star, but selects exactly
+        ! the polymorphic-derived spelling the class descriptor ABI covers.
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: param_name
+        character(len=:), allocatable, intent(out) :: type_name
+        integer :: i, k
+        logical :: matches
+
+        type_name = ''
+        if (.not. allocated(body_indices)) return
+        do i = 1, size(body_indices)
+            if (.not. node_exists(arena, body_indices(i))) cycle
+            select type (decl => arena%entries(body_indices(i))%node)
+            type is (declaration_node)
+                if (.not. allocated(decl%type_name)) cycle
+                if (.not. is_class_derived_type_spec(decl%type_name)) cycle
+                ! An allocatable or pointer class dummy aliases the caller's
+                ! own allocatable/pointer descriptor; that ABI is unchanged
+                ! here and gains its dynamic identity with #421.
+                if (decl%is_allocatable) cycle
+                if (decl%is_pointer) cycle
+                matches = .false.
+                if (allocated(decl%var_name)) then
+                    if (trim(decl%var_name) == trim(param_name)) matches = .true.
+                end if
+                if (decl%is_multi_declaration .and. allocated(decl%var_names)) then
+                    do k = 1, size(decl%var_names)
+                        if (trim(decl%var_names(k)) == trim(param_name)) &
+                            matches = .true.
+                    end do
+                end if
+                if (matches) then
+                    call extracted_derived_type_name(decl%type_name, type_name)
+                    return
+                end if
+            end select
+        end do
+    end subroutine dummy_class_declared_type
+
+    subroutine callee_dummy_class_declared_type(arena, callee_name, param_pos, &
+                                                type_name)
+        ! Declared type name of the callee's param_pos-th dummy when that dummy
+        ! is class(t); empty otherwise.
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: callee_name
+        integer, intent(in) :: param_pos
+        character(len=:), allocatable, intent(out) :: type_name
+        integer :: n
+        character(len=:), allocatable :: name, name_err
+        character(len=:), allocatable :: node_type
+        type(function_def_node), pointer :: fn_node
+        type(subroutine_def_node), pointer :: sb_node
+
+        type_name = ''
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            node_type = get_node_type_at(arena, n)
+            if (node_type == 'subroutine_def_node' .or. &
+                node_type == 'subroutine_def') then
+                sb_node => get_node_as_subroutine_def(arena, n)
+                if (.not. associated(sb_node)) cycle
+                if (allocated(sb_node%name)) then
+                    if (same_name(sb_node%name, callee_name)) then
+                        if (.not. allocated(sb_node%param_indices)) return
+                        if (param_pos < 1 .or. &
+                            param_pos > size(sb_node%param_indices)) return
+                        call parameter_name(arena, sb_node%param_indices(param_pos), &
+                                            name, name_err)
+                        if (len_trim(name_err) > 0) return
+                        call dummy_class_declared_type(arena, &
+                            sb_node%body_indices, name, type_name)
+                        return
+                    end if
+                end if
+            else if (node_type == 'function_def_node' .or. &
+                     node_type == 'function_def') then
+                fn_node => get_node_as_function_def(arena, n)
+                if (.not. associated(fn_node)) cycle
+                if (allocated(fn_node%name)) then
+                    if (same_name(fn_node%name, callee_name)) then
+                        if (.not. allocated(fn_node%param_indices)) return
+                        if (param_pos < 1 .or. &
+                            param_pos > size(fn_node%param_indices)) return
+                        call parameter_name(arena, fn_node%param_indices(param_pos), &
+                                            name, name_err)
+                        if (len_trim(name_err) > 0) return
+                        call dummy_class_declared_type(arena, &
+                            fn_node%body_indices, name, type_name)
+                        return
+                    end if
+                end if
+            end if
+        end do
+    end subroutine callee_dummy_class_declared_type
+
     logical function dummy_is_array(arena, body_indices, param_name)
         ! A dummy is an array when a body declaration names it with an array
         ! spec (is_array). Mirrors dummy_is_character for the array-argument ABI.

--- a/src/session_program_lowering_polymorphic.inc
+++ b/src/session_program_lowering_polymorphic.inc
@@ -8,6 +8,207 @@
     ! pointer class object (a runtime vtable / type-id) stays out of scope and
     ! declines gracefully.
 
+    ! Runtime type identity for class scalars (#417). A class(t) scalar dummy is
+    ! passed as the canonical scalar class descriptor of docs/RUNTIME_ABI.md
+    ! (data, declared_type, dynamic_type, ownership), built by the caller and
+    ! borrowed by the callee. The declared type is fixed by the dummy's
+    ! declaration; the dynamic type travels with the value, so re-passing a
+    ! class dummy onwards preserves the identity of the original actual instead
+    ! of collapsing it to the declared type.
+
+    recursive logical function derived_type_extends(context, type_index, &
+                                                    ancestor_index) result(yes)
+        ! True when type_index is ancestor_index or extends it, transitively.
+        ! This is the type-compatibility test of Fortran 2018 7.3.2.3: an actual
+        ! is valid for a class(t) dummy exactly when its declared type is t or
+        ! an extension of t.
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: type_index
+        integer, intent(in) :: ancestor_index
+
+        yes = .false.
+        if (type_index <= 0) return
+        if (ancestor_index <= 0) return
+        if (type_index == ancestor_index) then
+            yes = .true.
+            return
+        end if
+        if (type_index > context%derived_type_count) return
+        if (len_trim(context%derived_types(type_index)%parent_name) == 0) return
+        yes = derived_type_extends(context, &
+            find_derived_type(context, &
+                trim(context%derived_types(type_index)%parent_name)), &
+            ancestor_index)
+    end function derived_type_extends
+
+    subroutine class_dummy_declared_type_index(context, arena, callee_name, &
+                                               param_pos, type_index)
+        ! Registered index of the declared type of the callee's param_pos-th
+        ! dummy when that dummy is class(t); 0 when it is not.
+        type(lowering_context_t), intent(in) :: context
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: callee_name
+        integer, intent(in) :: param_pos
+        integer, intent(out) :: type_index
+        character(len=:), allocatable :: type_name
+
+        type_index = 0
+        call callee_dummy_class_declared_type(arena, callee_name, param_pos, &
+                                              type_name)
+        if (len_trim(type_name) == 0) return
+        type_index = find_derived_type(context, type_name)
+    end subroutine class_dummy_declared_type_index
+
+    subroutine class_actual_dynamic_type(context, symbol_index, dynamic_id, &
+                                         error_msg)
+        ! The dynamic type identity of a derived actual. A monomorphic actual's
+        ! dynamic type is its declared type, known at compile time. A class
+        ! dummy being re-passed already carries a runtime identity, which is
+        ! loaded and forwarded so the original value's identity is preserved
+        ! across any number of hand-offs.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        type(lr_operand_desc_t), intent(out) :: dynamic_id
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call set_empty(error_msg)
+        if (context%symbols(symbol_index)%is_polymorphic .and. &
+            context%symbols(symbol_index)%has_dynamic_type_address) then
+            if (.not. emit_i64_load(context%session, &
+                    context%symbols(symbol_index)%dynamic_type_address, &
+                    dynamic_id, error_msg)) return
+            return
+        end if
+        dynamic_id = i64_immediate(context%session, &
+            int(context%symbols(symbol_index)%derived_type_index, c_int64_t))
+    end subroutine class_actual_dynamic_type
+
+    subroutine build_class_scalar_descriptor(context, symbol_index, &
+                                             declared_type_index, descriptor, &
+                                             error_msg)
+        ! Borrowed class descriptor for a whole derived actual named by a symbol.
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        integer, intent(in) :: declared_type_index
+        type(lr_operand_desc_t), intent(out) :: descriptor
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: dynamic_id
+
+        call class_actual_dynamic_type(context, symbol_index, dynamic_id, &
+                                       error_msg)
+        if (len_trim(error_msg) > 0) return
+        call emit_class_scalar_descriptor(context, &
+            context%symbols(symbol_index)%element_address, declared_type_index, &
+            dynamic_id, descriptor, error_msg)
+    end subroutine build_class_scalar_descriptor
+
+    subroutine emit_class_scalar_descriptor(context, data_address, &
+                                            declared_type_index, dynamic_id, &
+                                            descriptor, error_msg)
+        ! Materialise the borrowed scalar class descriptor a class(t) dummy
+        ! receives. The descriptor is a caller-frame temporary that points at
+        ! storage the caller owns: ownership is BORROWED, so the callee never
+        ! frees the data and the data outlives the call.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: data_address
+        integer, intent(in) :: declared_type_index
+        type(lr_operand_desc_t), intent(in) :: dynamic_id
+        type(lr_operand_desc_t), intent(out) :: descriptor
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: field_addr
+
+        if (.not. emit_alloca_bytes(context%session, &
+                i64_immediate(context%session, &
+                    int(POLYMORPHIC_DESCRIPTOR_SIZE, c_int64_t)), descriptor, &
+                error_msg)) return
+        if (.not. emit_ptr_offset(context%session, descriptor, &
+                int(POLYMORPHIC_DESCRIPTOR_DATA_OFFSET, c_int64_t), field_addr, &
+                error_msg)) return
+        if (.not. emit_ptr_store(context%session, data_address, field_addr, &
+                error_msg)) return
+        if (.not. emit_ptr_offset(context%session, descriptor, &
+                int(POLYMORPHIC_DESCRIPTOR_DECLARED_TYPE_OFFSET, c_int64_t), &
+                field_addr, error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+                i64_immediate(context%session, &
+                    int(declared_type_index, c_int64_t)), field_addr, &
+                error_msg)) return
+        if (.not. emit_ptr_offset(context%session, descriptor, &
+                int(POLYMORPHIC_DESCRIPTOR_DYNAMIC_TYPE_OFFSET, c_int64_t), &
+                field_addr, error_msg)) return
+        if (.not. emit_i64_store(context%session, dynamic_id, field_addr, &
+                                 error_msg)) return
+        if (.not. emit_ptr_offset(context%session, descriptor, &
+                int(POLYMORPHIC_DESCRIPTOR_OWNERSHIP_OFFSET, c_int64_t), &
+                field_addr, error_msg)) return
+        if (.not. emit_i32_store(context%session, &
+                i32_immediate(context%session, &
+                    int(POLYMORPHIC_OWNERSHIP_BORROWED, c_int64_t)), field_addr, &
+                error_msg)) return
+        call set_empty(error_msg)
+    end subroutine emit_class_scalar_descriptor
+
+    subroutine bind_class_dummy_descriptor(context, symbol_index, declared_index, &
+                                           error_msg)
+        ! Bind a class(t) dummy to the descriptor the caller passed. The
+        ! parameter pointer is the descriptor; the value's storage is the data
+        ! field, so every component access keeps using element_address and reads
+        ! the declared-type prefix of whatever dynamic type arrived.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        integer, intent(in) :: declared_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: data_addr, data_value, dynamic_addr
+
+        if (.not. emit_ptr_offset(context%session, &
+                context%symbols(symbol_index)%address, &
+                int(POLYMORPHIC_DESCRIPTOR_DATA_OFFSET, c_int64_t), data_addr, &
+                error_msg)) return
+        if (.not. emit_ptr_load(context%session, data_addr, data_value, &
+                                error_msg)) return
+        if (.not. emit_ptr_offset(context%session, &
+                context%symbols(symbol_index)%address, &
+                int(POLYMORPHIC_DESCRIPTOR_DYNAMIC_TYPE_OFFSET, c_int64_t), &
+                dynamic_addr, error_msg)) return
+        context%symbols(symbol_index)%class_descriptor_address = &
+            context%symbols(symbol_index)%address
+        context%symbols(symbol_index)%element_address = data_value
+        context%symbols(symbol_index)%dynamic_type_address = dynamic_addr
+        context%symbols(symbol_index)%has_dynamic_type_address = .true.
+        context%symbols(symbol_index)%is_polymorphic = .true.
+        context%symbols(symbol_index)%derived_type_index = declared_index
+        call set_empty(error_msg)
+    end subroutine bind_class_dummy_descriptor
+
+    subroutine class_receiver_argument(context, arena, impl_name, position, &
+                                       symbol_index, argument, error_msg)
+        ! Argument the receiver of a type-bound call occupies. The passed-object
+        ! dummy is conventionally class(t), so it takes the same scalar class
+        ! descriptor an explicit class actual takes; a type(t) passed-object
+        ! dummy keeps the bare address.
+        type(lowering_context_t), intent(inout) :: context
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: impl_name
+        integer, intent(in) :: position
+        integer, intent(in) :: symbol_index
+        type(lr_operand_desc_t), intent(out) :: argument
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: declared_index
+
+        call class_dummy_declared_type_index(context, arena, impl_name, position, &
+                                             declared_index)
+        if (declared_index <= 0) then
+            argument = context%symbols(symbol_index)%element_address
+            call set_empty(error_msg)
+            return
+        end if
+        call build_class_scalar_descriptor(context, symbol_index, declared_index, &
+                                           argument, error_msg)
+    end subroutine class_receiver_argument
+
     logical function select_type_selector_is_monomorphic(context, sel_index)
         ! True when the selector names a plain declared-type derived object (a
         ! class(t) dummy or local lowered as type(t)): non-allocatable,

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -274,6 +274,15 @@ module session_program_lowering_types
         logical :: is_runtime_array = .false.
         logical :: is_derived = .false.
         integer :: derived_type_index = 0
+        ! Polymorphism (#417). is_polymorphic marks an entity declared class(t):
+        ! derived_type_index stays the DECLARED type, while the dynamic type is
+        ! a runtime value living in the scalar class descriptor the caller
+        ! built. dynamic_type_address is the address of that descriptor's
+        ! dynamic_type field; class_descriptor_address is the descriptor base.
+        logical :: is_polymorphic = .false.
+        logical :: has_dynamic_type_address = .false.
+        type(lr_operand_desc_t) :: dynamic_type_address
+        type(lr_operand_desc_t) :: class_descriptor_address
         type(lr_operand_desc_t) :: element_address
         ! A rank-1 array function result bound to the sret buffer (param 0). The
         ! body array declaration rebinds its shape/element kind onto this symbol's

--- a/src/session_program_lowering_where.inc
+++ b/src/session_program_lowering_where.inc
@@ -676,8 +676,38 @@
                 i32_immediate(context%session, &
                               int(linear_index, c_int64_t)*int(slots, c_int64_t)), &
                 address, error_msg)) return
+        call wrap_elemental_class_element(arena, callee_name, context, &
+            context%symbols(symbol_index)%derived_type_index, address, error_msg)
+        if (len_trim(error_msg) > 0) return
         handled = .true.
     end subroutine elementwise_derived_actual_address
+
+    subroutine wrap_elemental_class_element(arena, callee_name, context, &
+                                            actual_type_index, address, error_msg)
+        ! An elemental procedure with a class(t) scalar dummy takes the same
+        ! borrowed class descriptor a non-elemental class dummy takes, one per
+        ! element. The array is monomorphic, so every element's dynamic type is
+        ! the array's declared type. A type(t) dummy keeps the bare address.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: callee_name
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: actual_type_index
+        type(lr_operand_desc_t), intent(inout) :: address
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: descriptor
+        integer :: declared_index
+
+        call set_empty(error_msg)
+        call class_dummy_declared_type_index(context, arena, callee_name, 1, &
+                                             declared_index)
+        if (declared_index <= 0) return
+        call emit_class_scalar_descriptor(context, address, declared_index, &
+            i64_immediate(context%session, &
+                int(actual_type_index, c_int64_t)), descriptor, error_msg)
+        if (len_trim(error_msg) > 0) return
+        address = descriptor
+    end subroutine wrap_elemental_class_element
 
     ! Reject a derived actual whose declared type is neither the elemental
     ! dummy's declared type nor an extension of it (#369). Silence when the

--- a/test/test_session_class_scalar_identity_compiler.f90
+++ b/test/test_session_class_scalar_identity_compiler.f90
@@ -1,0 +1,242 @@
+program test_session_class_scalar_identity_compiler
+    use ffc_test_support, only: expect_output, expect_error_contains, &
+        expect_exe_has_symbol
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== class(t) scalar runtime type identity tests ==='
+
+    all_passed = .true.
+    if (.not. test_base_actual_through_class_dummy()) all_passed = .false.
+    if (.not. test_extension_actual_keeps_declared_prefix()) all_passed = .false.
+    if (.not. test_identity_survives_repassing()) all_passed = .false.
+    if (.not. test_type_bound_call_through_class_receiver()) all_passed = .false.
+    if (.not. test_type_info_ids_exist_for_hierarchy()) all_passed = .false.
+    if (.not. test_unrelated_actual_is_rejected()) all_passed = .false.
+    if (.not. test_parent_actual_to_extension_dummy_is_rejected()) &
+        all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: class(t) scalar runtime type identity'
+
+contains
+
+    character(len=:) function hierarchy() result(text)
+        ! A base type and one extension of it, used by every positive fixture.
+        allocatable :: text
+        text = 'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: base_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  end type base_t'//new_line('a')// &
+            '  type, extends(base_t) :: ext_t'//new_line('a')// &
+            '    integer :: y'//new_line('a')// &
+            '  end type ext_t'//new_line('a')
+    end function hierarchy
+
+    logical function test_base_actual_through_class_dummy()
+        ! A monomorphic base actual reaches a class(base_t) dummy and the dummy
+        ! reads the declared component through the descriptor's data field.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            'contains'//new_line('a')// &
+            '  subroutine show(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    print *, self%x'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(base_t) :: b'//new_line('a')// &
+            '  b%x = 7'//new_line('a')// &
+            '  call show(b)'//new_line('a')// &
+            'end program main'
+
+        test_base_actual_through_class_dummy = expect_output(source, &
+            '           7'//new_line('a'), '/tmp/ffc_class_identity_base')
+    end function test_base_actual_through_class_dummy
+
+    logical function test_extension_actual_keeps_declared_prefix()
+        ! An extension actual whose dynamic type differs from the dummy's
+        ! declared type is accepted; the callee sees the declared-type prefix
+        ! and the extension's own component is untouched by the call, so the
+        ! descriptor referenced the whole object and never copied a prefix.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            'contains'//new_line('a')// &
+            '  subroutine bump(self)'//new_line('a')// &
+            '    class(base_t), intent(inout) :: self'//new_line('a')// &
+            '    self%x = self%x + 1'//new_line('a')// &
+            '  end subroutine bump'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  e%x = 11'//new_line('a')// &
+            '  e%y = 13'//new_line('a')// &
+            '  call bump(e)'//new_line('a')// &
+            '  print *, e%x * 100 + e%y'//new_line('a')// &
+            'end program main'
+
+        ! 12 from the bumped declared prefix, 13 from the untouched extension
+        ! component: 12 * 100 + 13.
+        test_extension_actual_keeps_declared_prefix = expect_output(source, &
+            '        1213'//new_line('a'), '/tmp/ffc_class_identity_ext')
+    end function test_extension_actual_keeps_declared_prefix
+
+    logical function test_identity_survives_repassing()
+        ! A class(base_t) dummy handed on to another class(base_t) dummy keeps
+        ! referring to the caller's storage: the inner callee's write is visible
+        ! to the original object, so no copy was interposed by the descriptor.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            'contains'//new_line('a')// &
+            '  subroutine inner(self)'//new_line('a')// &
+            '    class(base_t), intent(inout) :: self'//new_line('a')// &
+            '    self%x = self%x + 5'//new_line('a')// &
+            '  end subroutine inner'//new_line('a')// &
+            '  subroutine outer(self)'//new_line('a')// &
+            '    class(base_t), intent(inout) :: self'//new_line('a')// &
+            '    call inner(self)'//new_line('a')// &
+            '  end subroutine outer'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  e%x = 2'//new_line('a')// &
+            '  e%y = 9'//new_line('a')// &
+            '  call outer(e)'//new_line('a')// &
+            '  print *, e%x * 100 + e%y'//new_line('a')// &
+            'end program main'
+
+        ! 7 = 2 + 5 written through two hand-offs, 9 untouched: 7 * 100 + 9.
+        test_identity_survives_repassing = expect_output(source, &
+            '         709'//new_line('a'), '/tmp/ffc_class_identity_repass')
+    end function test_identity_survives_repassing
+
+    logical function test_type_bound_call_through_class_receiver()
+        ! A type-bound call inserts the receiver at the passed-object position;
+        ! that dummy is class(base_t), so it takes the class descriptor too.
+        character(len=:), allocatable :: source
+
+        source = 'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: base_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: show => base_show'//new_line('a')// &
+            '  end type base_t'//new_line('a')// &
+            '  type, extends(base_t) :: ext_t'//new_line('a')// &
+            '    integer :: y'//new_line('a')// &
+            '  end type ext_t'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine base_show(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    print *, self%x'//new_line('a')// &
+            '  end subroutine base_show'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  e%x = 21'//new_line('a')// &
+            '  e%y = 22'//new_line('a')// &
+            '  call e%show()'//new_line('a')// &
+            'end program main'
+
+        test_type_bound_call_through_class_receiver = expect_output(source, &
+            '          21'//new_line('a'), '/tmp/ffc_class_identity_tbp')
+    end function test_type_bound_call_through_class_receiver
+
+    logical function test_type_info_ids_exist_for_hierarchy()
+        ! The identities stored in a class descriptor are the ids of the
+        ! per-type info constants; both the base and the extension must have a
+        ! distinct one for the two identities to be distinguishable at all.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  e%x = 1'//new_line('a')// &
+            '  e%y = 2'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_type_info_ids_exist_for_hierarchy = .true.
+        if (.not. expect_exe_has_symbol(source, &
+            '/tmp/ffc_class_identity_info_base.o', '__ffc_type_info_base_t')) &
+            test_type_info_ids_exist_for_hierarchy = .false.
+        if (.not. expect_exe_has_symbol(source, &
+            '/tmp/ffc_class_identity_info_ext.o', '__ffc_type_info_ext_t')) &
+            test_type_info_ids_exist_for_hierarchy = .false.
+    end function test_type_info_ids_exist_for_hierarchy
+
+    logical function test_unrelated_actual_is_rejected()
+        ! An actual outside the dummy's declared type hierarchy is not type
+        ! compatible (F2018 7.3.2.3) and is diagnosed, not silently accepted.
+        character(len=:), allocatable :: source
+
+        source = 'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: base_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  end type base_t'//new_line('a')// &
+            '  type :: other_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  end type other_t'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine show(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    print *, self%x'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(other_t) :: o'//new_line('a')// &
+            '  o%x = 5'//new_line('a')// &
+            '  call show(o)'//new_line('a')// &
+            'end program main'
+
+        test_unrelated_actual_is_rejected = expect_error_contains(source, &
+            'is not type compatible with class(base_t) dummy', &
+            '/tmp/ffc_class_identity_unrelated')
+    end function test_unrelated_actual_is_rejected
+
+    logical function test_parent_actual_to_extension_dummy_is_rejected()
+        ! Type compatibility is directional: a base actual is not compatible
+        ! with a class(extension) dummy, only the other way round.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            'contains'//new_line('a')// &
+            '  subroutine show(self)'//new_line('a')// &
+            '    class(ext_t), intent(in) :: self'//new_line('a')// &
+            '    print *, self%y'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(base_t) :: b'//new_line('a')// &
+            '  b%x = 3'//new_line('a')// &
+            '  call show(b)'//new_line('a')// &
+            'end program main'
+
+        test_parent_actual_to_extension_dummy_is_rejected = &
+            expect_error_contains(source, &
+            'is not type compatible with class(ext_t) dummy', &
+            '/tmp/ffc_class_identity_parent_to_ext')
+    end function test_parent_actual_to_extension_dummy_is_rejected
+
+end program test_session_class_scalar_identity_compiler


### PR DESCRIPTION
Closes #417. Follows #400, which defined the descriptor.

A `class(t)` scalar dummy no longer lowers identically to `type(t)`. It is now
passed as the canonical scalar class descriptor of `docs/RUNTIME_ABI.md`
(`data`, `declared_type`, `dynamic_type`, `ownership`), built by the caller and
borrowed by the callee, so the value's dynamic type identity reaches the callee
and survives being handed on.

## What changed

- `symbol_t` gains `is_polymorphic`, `has_dynamic_type_address`,
  `dynamic_type_address`, `class_descriptor_address`. `derived_type_index`
  keeps meaning the DECLARED type.
- `session_program_lowering_polymorphic.inc`: `derived_type_extends` (F2018
  7.3.2.3 type compatibility, walking the existing `parent_name` chain),
  `emit_class_scalar_descriptor`, `class_actual_dynamic_type`,
  `bind_class_dummy_descriptor`, `class_receiver_argument`.
- `session_program_lowering_arguments.inc`: a derived actual reaching a
  `class(t)` dummy builds the descriptor; a `type(t)` dummy keeps the bare
  by-reference ABI byte for byte.
- The two other paths that pass a receiver to a `class(t)` dummy were migrated
  with it: the type-bound call receiver
  (`lower_method_subroutine_call`) and the elemental scalar class dummy
  (`elementwise_derived_actual_address`), one descriptor per element.
- The descriptor offsets are not re-spelled here: lowering `use`s the
  `POLYMORPHIC_DESCRIPTOR_*` parameters from `ffc_polymorphic_descriptor`, the
  same constants #400 verified against real memory with `c_loc`/`c_sizeof`.

## Invariants preserved

- **Declared versus dynamic type.** The declared type is fixed by the dummy's
  declaration and is what component access uses; the dynamic type travels with
  the value. A monomorphic actual initialises both to its own type; an
  extension actual sets a dynamic type that differs from the declared one.
- **Identity is preserved, not collapsed.** Re-passing a `class(t)` dummy to
  another `class(t)` dummy loads the incoming descriptor's `dynamic_type` and
  forwards it, instead of resetting it to the declared type. Identity therefore
  survives any number of hand-offs.
- **Storage access uses the declared prefix.** Components are inherited
  parent-first, so an extension's storage starts with an exact copy of its
  parent's layout. The callee reads `data` and indexes the declared-type prefix;
  the test writes through a `class(base_t)` dummy given an `ext_t` actual and
  checks both that the write landed and that the extension's own component is
  untouched, which also proves no prefix copy was interposed.
- **Dispatch correctness.** A type-bound call inserts the receiver at the pass
  position and then takes the same descriptor, so a receiver reached through an
  inherited binding behaves identically to an explicit class actual. Overridden
  bindings still resolve statically; vtable dispatch is #420.
- **Lifetimes and ownership.** The descriptor is a caller-frame temporary with
  `ownership = BORROWED`: the callee never frees the data and the data outlives
  the call. Nothing is allocated or freed on this path, so no allocation or
  finalization lifetime changes, including on reallocation and scope exit.
- **Aliasing.** The descriptor's `data` points at the caller's storage rather
  than a copy, so `intent(inout)` writes are visible to the caller exactly as
  before. The descriptor is per call site and never aliased between calls.
- **Scope of the ABI change.** Only a plain, non-allocatable, non-pointer
  `class(t)` scalar takes the descriptor. `class(t), allocatable` and
  `class(t), pointer` keep their existing allocatable/pointer descriptor ABI
  untouched and gain a dynamic type in #421. `type(t)`, `class(*)`, and derived
  arrays are unchanged.

## Type compatibility diagnostic

Previously an actual of a completely unrelated derived type was silently
accepted for a `class(base_t)` dummy and reinterpreted through the wrong
layout. It is now diagnosed, and the check is directional: a base actual is
rejected for a `class(extension)` dummy.

## Evidence

- Before: `test_session_class_scalar_identity_compiler` fails on unmodified
  main ("unsupported source lowered without diagnostic", twice).
- After: PASS. Seven fixtures: base actual, extension actual keeping the
  declared prefix, identity across re-passing, type-bound receiver, type-info
  ids for both types in the hierarchy, and the two negative fixtures.
- Full `fo`: green except `test_fortfront_corpus_conformance` and
  `test_parity_dashboard`, both of which fail identically on unmodified main at
  the same commit (the parity snapshot refresh is owned elsewhere).
- Conformance gauntlet (`--suite lfortran`, post-#547/#562 isolation), full runs
  of main and of this branch at the same commit:
  `PASS=850 XFAIL=3345 XPASS=72 FAIL=12 NOREF=162 SKIP=1, TOTAL=4280` on both.
  A case-by-case diff of the two reports shows **zero differences**, so no
  PASS becomes FAIL and no case becomes newly passing; nothing was moved out of
  or into an xfail manifest, and no XFAIL was added.
- Two earlier runs also flagged five XFAIL->XPASS flips (`kwargs_01`,
  `optional_11`, `procedure_18`, `submodule_33`, `subroutines_03`) and one
  PASS->FAIL. Repeating the runs showed the five flip between two runs of
  *unmodified main* as well, so they are pre-existing corpus flake and were
  deliberately left in the manifest. The PASS->FAIL was
  `derived_types_16_module.f90`, a `class(t), allocatable` case; excluding
  allocatable and pointer class entities from the new ABI (they belong to #421)
  removed it, and it passes in the final runs.