### PR TITLE
Apply the lazy real-kind policy to every metadata source (fixes #571)

### DIFF
--- a/src/session_program_lowering_arguments.inc
+++ b/src/session_program_lowering_arguments.inc
@@ -311,7 +311,8 @@
         if (callee_dummy_is_array(arena, callee_name, param_pos)) return
         if (callee_dummy_is_class_star(arena, callee_name, param_pos)) return
         if (callee_dummy_is_inferred(arena, callee_name, param_pos)) return
-        dummy_kind = callee_dummy_value_kind(arena, callee_name, param_pos)
+        dummy_kind = callee_dummy_value_kind(arena, callee_name, param_pos, &
+                                             context)
         if (dummy_kind == 0) dummy_kind = external_dummy_value_kind(context, &
             callee_name, param_pos)
         if (dummy_kind == 0) return
@@ -1277,7 +1278,8 @@
         integer :: dummy_kind
 
         kind = fallback_kind
-        dummy_kind = callee_dummy_value_kind(arena, callee_name, param_pos)
+        dummy_kind = callee_dummy_value_kind(arena, callee_name, param_pos, &
+                                             context)
         if (dummy_kind == 0) then
             dummy_kind = external_dummy_value_kind(context, callee_name, &
                                                    param_pos)

--- a/src/session_program_lowering_declarations.inc
+++ b/src/session_program_lowering_declarations.inc
@@ -154,7 +154,7 @@
              binding%binding_kind /= BINDING_DECLARATION)) then
             return
         end if
-        call make_parameter_record(node, trim(node%name), binding, record)
+        call make_parameter_record(node, trim(node%name), binding, context, record)
         call store_declaration_record(context, record, error_msg)
     end subroutine collect_parameter_declaration_node
 
@@ -209,21 +209,18 @@
         record%is_array = node%is_array .or. record%rank > 0
         record%is_parameter = node%is_parameter .and. &
             binding%binding_kind == BINDING_NAMED_CONSTANT
-        ! Lazy Fortran default real is 8 bytes (#438). A declaration that
-        ! spells no kind selector records kind 8 so the resolved metadata and
-        ! the materialized storage agree.
-        if (context%lazy_mode .and. record%type_kind == TREAL) then
-            if (.not. node%has_kind) record%kind_value = 8
-        end if
+        call apply_lazy_real_kind(context, record%type_kind, node%has_kind, &
+                                  record%kind_value)
         record%value_kind = declaration_metadata_value_kind( &
             record%type_kind, record%kind_value, record%type_name, context, &
             node%line, node%column, node%resolved_derived_type_name)
     end subroutine make_declaration_record
 
-    subroutine make_parameter_record(node, name, binding, record)
+    subroutine make_parameter_record(node, name, binding, context, record)
         type(parameter_declaration_node), intent(in) :: node
         character(len=*), intent(in) :: name
         type(declaration_binding_t), intent(in) :: binding
+        type(lowering_context_t), intent(in) :: context
         type(declaration_record_t), intent(out) :: record
 
         record = declaration_record_t()
@@ -242,6 +239,8 @@
         ! declaration is visited; rank zero here means "unknown", not scalar.
         if (.not. node%is_array .and. record%rank == 0) record%rank = -1
         record%is_array = node%is_array .or. record%rank > 0
+        call apply_lazy_real_kind(context, record%type_kind, node%has_kind, &
+                                  record%kind_value)
         record%value_kind = declaration_metadata_value_kind( &
             record%type_kind, record%kind_value, record%type_name)
     end subroutine make_parameter_record
@@ -295,6 +294,8 @@
                     if (record%rank < 0 .and. allocated(decl%dimension_indices)) &
                         record%rank = size(decl%dimension_indices)
                     record%is_array = decl%is_array .or. record%rank > 0
+                    call apply_lazy_real_kind(context, record%type_kind, &
+                                              decl%has_kind, record%kind_value)
                     exit
                 end select
             end do
@@ -1067,6 +1068,22 @@
     ! Lazy Fortran dialect defaults apply only when the driver compiled this
     ! unit in lazy input mode (#438). Standard Fortran sources keep the
     ! processor-dependent default real kind ffc has always used.
+    ! Lazy Fortran default real is 8 bytes (#438). Every metadata source for
+    ! one symbol - specification declaration, dummy-argument entry, function
+    ! result - must record that same kind, otherwise the records collide as
+    ! conflicting declaration metadata (#571).
+    subroutine apply_lazy_real_kind(context, type_kind, has_kind, kind_value)
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: type_kind
+        logical, intent(in) :: has_kind
+        integer, intent(inout) :: kind_value
+
+        if (.not. context%lazy_mode) return
+        if (type_kind /= TREAL) return
+        if (has_kind) return
+        kind_value = 8
+    end subroutine apply_lazy_real_kind
+
     logical function lazy_defaults_active(context) result(active)
         type(lowering_context_t), intent(in), optional :: context
 

--- a/src/session_program_lowering_functions.inc
+++ b/src/session_program_lowering_functions.inc
@@ -822,6 +822,12 @@
                 ! explicit real(8)/real(real64)/double precision body declaration,
                 ! trust that over the kindless statement type.
                 value_kind = VALUE_F64
+            else if (len_trim(kind_spec) == 0 .and. &
+                     lazy_defaults_active(context)) then
+                ! Lazy Fortran default real is 8 bytes (#438): a kind-less
+                ! `real` result matches its kind-less body declaration, which
+                ! records kind 8 too (#571).
+                value_kind = VALUE_F64
             else
                 value_kind = VALUE_F32
             end if
@@ -2633,6 +2639,10 @@
             context%unit_symbol_prefix = parent_context%unit_symbol_prefix
         context%arena = arena
         context%root_index = parent_context%root_index
+        ! The dialect is a property of the translation unit, not of one
+        ! procedure: a contained procedure lowers under the same Lazy
+        ! Fortran defaults as its host (#571).
+        context%lazy_mode = parent_context%lazy_mode
         allocate(context%symbols(16))
         allocate(context%derived_types(8))
         allocate(context%module_exports(4))

--- a/src/session_program_lowering_functions_tail.inc
+++ b/src/session_program_lowering_functions_tail.inc
@@ -30,6 +30,10 @@
             context%unit_symbol_prefix = parent_context%unit_symbol_prefix
         context%arena = arena
         context%root_index = parent_context%root_index
+        ! The dialect is a property of the translation unit, not of one
+        ! procedure: a contained procedure lowers under the same Lazy
+        ! Fortran defaults as its host (#571).
+        context%lazy_mode = parent_context%lazy_mode
         allocate(context%symbols(16))
         allocate(context%derived_types(8))
         allocate(context%module_exports(4))
@@ -653,8 +657,8 @@
         is_char = dummy_is_character(arena, body_indices, name)
     end function param_at_is_character
 
-    integer function callee_dummy_value_kind(arena, callee_name, param_pos) &
-            result(value_kind)
+    integer function callee_dummy_value_kind(arena, callee_name, param_pos, &
+                                             context) result(value_kind)
         ! The scalar value kind of the param_pos-th (1-based) dummy of the
         ! contained procedure callee_name, read from its body declaration.
         ! Returns 0 when the procedure or its dummy declaration is not found, so
@@ -664,6 +668,7 @@
         type(ast_arena_t), intent(in) :: arena
         character(len=*), intent(in) :: callee_name
         integer, intent(in) :: param_pos
+        type(lowering_context_t), intent(in), optional :: context
         integer :: n
         character(len=:), allocatable :: node_type
         type(function_def_node), pointer :: fn_node
@@ -680,7 +685,7 @@
                 if (.not. allocated(sb_node%name)) cycle
                 if (.not. same_name(sb_node%name, callee_name)) cycle
                 value_kind = param_at_value_kind(arena, sb_node%param_indices, &
-                    sb_node%body_indices, param_pos)
+                    sb_node%body_indices, param_pos, context)
                 return
             else if (node_type == 'function_def_node' .or. &
                      node_type == 'function_def') then
@@ -689,7 +694,7 @@
                 if (.not. allocated(fn_node%name)) cycle
                 if (.not. same_name(fn_node%name, callee_name)) cycle
                 value_kind = param_at_value_kind(arena, fn_node%param_indices, &
-                    fn_node%body_indices, param_pos)
+                    fn_node%body_indices, param_pos, context)
                 if (value_kind == 0 .and. fn_return_type_is_i64(fn_node)) then
                     value_kind = VALUE_I64
                 end if
@@ -729,11 +734,14 @@
     end function fn_return_type_is_i64
 
     integer function param_at_value_kind(arena, param_indices, body_indices, &
-                                         param_pos) result(value_kind)
+                                         param_pos, context) result(value_kind)
         type(ast_arena_t), intent(in) :: arena
         integer, allocatable, intent(in) :: param_indices(:)
         integer, allocatable, intent(in) :: body_indices(:)
         integer, intent(in) :: param_pos
+        ! The dialect decides what a kind-less `real` dummy means, so the
+        ! caller passes its context whenever one is in scope (#571).
+        type(lowering_context_t), intent(in), optional :: context
         character(len=:), allocatable :: name, name_err, kind_err
         integer :: i, k
 
@@ -750,7 +758,8 @@
                 if (decl%is_array) cycle
                 if (allocated(decl%var_name)) then
                     if (trim(decl%var_name) == trim(name)) then
-                        call declaration_value_kind(decl, value_kind, kind_err)
+                        call declaration_value_kind(decl, value_kind, kind_err, &
+                                                    context)
                         if (len_trim(kind_err) > 0) value_kind = 0
                         return
                     end if
@@ -758,7 +767,8 @@
                 if (decl%is_multi_declaration .and. allocated(decl%var_names)) then
                     do k = 1, size(decl%var_names)
                         if (trim(decl%var_names(k)) == trim(name)) then
-                            call declaration_value_kind(decl, value_kind, kind_err)
+                            call declaration_value_kind(decl, value_kind, kind_err, &
+                                                    context)
                             if (len_trim(kind_err) > 0) value_kind = 0
                             return
                         end if
@@ -1164,7 +1174,7 @@
             value_kind = VALUE_I32
             if (present(body_indices)) then
                 value_kind = param_at_value_kind(arena, param_indices, &
-                    body_indices, i)
+                    body_indices, i, context)
                 if (value_kind == 0) then
                     ! Body declaration lacks kind spec; fall back to the
                     ! function's return type when it indicates i64.

--- a/src/session_program_lowering_inferred.inc
+++ b/src/session_program_lowering_inferred.inc
@@ -307,6 +307,10 @@
             vk = VALUE_I32
         case (TREAL)
             vk = VALUE_F32
+            ! Lazy Fortran default real is 8 bytes (#438). An inferred real
+            ! must seed the same storage the explicit kind-less declaration
+            ! records, otherwise the two collide when both are seen (#571).
+            if (lazy_defaults_active(context)) vk = VALUE_F64
         case (TDOUBLE)
             vk = VALUE_F64
         case (TLOGICAL)
@@ -326,6 +330,7 @@
                     vk = VALUE_I32
                 case (TREAL)
                     vk = VALUE_F32
+                    if (lazy_defaults_active(context)) vk = VALUE_F64
                 case (TDOUBLE)
                     vk = VALUE_F64
                 case (TLOGICAL)

--- a/test/test_session_lazy_defaults_compiler.f90
+++ b/test/test_session_lazy_defaults_compiler.f90
@@ -98,6 +98,39 @@ program test_session_lazy_defaults_compiler
         'call bump(k)'//new_line('a'), 'lf', &
         '          42', 'ffc_lf_explicit_inout')) ok = .false.
 
+    ! A kind-less `real` dummy and a kind-less `real` result must record the
+    ! same lazy default kind as the declaration itself, otherwise the two
+    ! metadata sources for the same symbol conflict (#571).
+    if (.not. runs( &
+        'program p'//new_line('a')// &
+        '    implicit none'//new_line('a')// &
+        '    real :: s'//new_line('a')// &
+        '    s = add(1.0d0/3.0d0, 0.0d0)'//new_line('a')// &
+        '    print *, s'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '    function add(a, b) result(c)'//new_line('a')// &
+        '        real, intent(in) :: a, b'//new_line('a')// &
+        '        real :: c'//new_line('a')// &
+        '        c = a + b'//new_line('a')// &
+        '    end function add'//new_line('a')// &
+        'end program p'//new_line('a'), 'lf', &
+        '  0.33333333333333331', 'ffc_lf_dummy_real_kind')) ok = .false.
+
+    ! Same invariant for a kind-less `real` dummy of a contained subroutine.
+    if (.not. runs( &
+        'program p'//new_line('a')// &
+        '    implicit none'//new_line('a')// &
+        '    real :: v'//new_line('a')// &
+        '    v = 1.0d0/3.0d0'//new_line('a')// &
+        '    call show(v)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '    subroutine show(x)'//new_line('a')// &
+        '        real, intent(in) :: x'//new_line('a')// &
+        '        print *, x'//new_line('a')// &
+        '    end subroutine show'//new_line('a')// &
+        'end program p'//new_line('a'), 'lf', &
+        '  0.33333333333333331', 'ffc_lf_dummy_real_kind_sub')) ok = .false.
+
     if (.not. ok) stop 1
     print *, 'PASS: lazy default real kind and default dummy intent apply'
 


### PR DESCRIPTION
Fixes #571.

## Preserved compiler invariant

Within one translation unit, every path that resolves the scalar kind of a
symbol must agree. A kind-less `real` is kind 8 everywhere in a `.lf` source
and the processor default everywhere in a standard source.

The Lazy Fortran default real kind (#438) was applied only where a
specification declaration built its own metadata record. Every other source of
scalar kind for the same symbol still resolved a kind-less `real` to f32:

- the dummy-argument list entry (`make_parameter_record`),
- the function result record (`make_function_result_record`, `function_value_kind`),
- FortFront's inferred type (`inferred_type_to_value_kind`),
- the callee dummy lookup used at a call site (`param_at_value_kind`,
  `callee_dummy_value_kind`, which never received a context).

Two sources disagreeing about one symbol produced
`conflicting declaration metadata`, `duplicate real declaration`, or
`mismatched scalar kind in argument`.

The root cause of the contained-procedure cases was that a child lowering
context did not inherit `lazy_mode` from its parent, so a contained function
silently lowered under standard-Fortran defaults. The dialect is a property of
the translation unit, not of one procedure.

## Red evidence

On unmodified main, all 11 `fortfront-lf` examples listed in the issue failed
to compile, e.g.

```
issue_1883_intent_result.lf:1:1: error: conflicting declaration metadata for a
```

The two new cases added to `test_session_lazy_defaults_compiler` (a kind-less
`real` dummy plus kind-less `real` result in a contained function, and a
kind-less `real` dummy of a contained subroutine) failed:

```
FAIL: ffc rejected ffc_lf_dummy_real_kind exit=1
FAIL: ffc rejected ffc_lf_dummy_real_kind_sub exit=1
```

## Green evidence

`fo test test_session_lazy_defaults_compiler` -> PASS. All 11 examples from the
issue compile and run. The `fortfront-lf` corpus goes PASS 196 -> 207,
FAIL 12 -> 1 (only `error_complete_garbage.lf`, the intended negative example).
`fortfront-f90` is unchanged apart from FAIL 9 -> 8.

Full local `fo` pipeline: build OK; the only failures are the pre-existing
`test_fortfront_corpus_conformance` (the standard-Fortran corpus failures above,
untouched by lazy mode) and the known-environmental `test_parity_dashboard`
(resolves sibling repos as `../fortfront`, fails inside worktrees).