### PR TITLE
[fmod2-02] serialize derived layouts and character metadata (closes #414)

### DIFF
--- a/src/ffc_module_artefact.f90
+++ b/src/ffc_module_artefact.f90
@@ -24,7 +24,7 @@ module ffc_module_artefact
     ! other value, and an artefact without the field, so a stale or
     ! newer-than-supported artefact is diagnosed instead of silently misread
     ! (#397).
-    integer, parameter, public :: FMOD_SCHEMA_VERSION = 2
+    integer, parameter, public :: FMOD_SCHEMA_VERSION = 3
 
     type :: fmod_parameter_t
         character(len=:), allocatable :: name
@@ -32,13 +32,39 @@ module ffc_module_artefact
         character(len=:), allocatable :: value
     end type fmod_parameter_t
 
+    ! One component of an exported derived type, carrying the layout the
+    ! defining unit compiled rather than a description a reader would have to
+    ! re-derive: the canonical scalar-kind token, the nested type's name for a
+    ! derived component, the declared character length, the fixed array shape,
+    ! and the component's own slot span and starting slot. slot_offset is
+    ! redundant with the preceding slot_counts by construction, which is what
+    ! makes it checkable: a reader rejects an artefact whose offsets do not
+    ! follow from its own slot counts (#414).
     type :: fmod_component_t
         character(len=:), allocatable :: name
         character(len=:), allocatable :: kind
+        ! Name of the nested derived type of a 'derived' component; empty for
+        ! every other kind.
+        character(len=:), allocatable :: type_name
+        ! Elements the component declares (1 for a scalar), the i32 slots one
+        ! element occupies, and the total and starting slots of the component.
+        integer :: elem_count = 1
+        integer :: slot_width = 1
+        integer :: slot_count = 1
+        integer :: slot_offset = 0
+        ! Declared length of a character component; 0 for every other kind.
+        integer :: char_length = 0
+        ! First-dimension extent of a rank-2 fixed-size component; 0 otherwise.
+        integer :: dim1 = 0
+        logical :: is_allocatable = .false.
+        logical :: is_pointer = .false.
+        logical :: is_alloc_array = .false.
     end type fmod_component_t
 
     type :: fmod_derived_type_t
         character(len=:), allocatable :: name
+        ! Name of the type this one extends; empty when it extends nothing.
+        character(len=:), allocatable :: parent_name
         type(fmod_component_t), allocatable :: components(:)
     end type fmod_derived_type_t
 
@@ -131,13 +157,13 @@ contains
                 write (unit, '(A)') '[[derived_type]]'
                 write (unit, '(A)') 'name = "'// &
                     field(info%derived_types(i)%name)//'"'
+                write (unit, '(A)') 'parent_name = "'// &
+                    field(info%derived_types(i)%parent_name)//'"'
                 write (unit, '(A)') 'components = ['
                 if (allocated(info%derived_types(i)%components)) then
                     do j = 1, size(info%derived_types(i)%components)
-                        write (unit, '(A)') '    { name = "'// &
-                            field(info%derived_types(i)%components(j)%name)// &
-                            '", kind = "'// &
-                            field(info%derived_types(i)%components(j)%kind)//'" },'
+                        write (unit, '(A)') component_line( &
+                            info%derived_types(i)%components(j))
                     end do
                 end if
                 write (unit, '(A)') ']'
@@ -218,7 +244,6 @@ contains
         type(fmod_generic_t), allocatable :: gens(:)
         integer :: nparam, ndtype, ncomp, nvar, nproc, ngen, io_read
         integer :: schema
-        character(len=:), allocatable :: cname, ckind
 
         allocate (character(len=0) :: error_msg)
         info%name = ''
@@ -305,11 +330,9 @@ contains
 
             if (index(line, '{') == 1) then
                 ! A derived-type component row.
-                call parse_component_line(line, cname, ckind)
                 ncomp = ncomp + 1
                 call grow_comps(comps, ncomp)
-                comps(ncomp)%name = cname
-                comps(ncomp)%kind = ckind
+                call parse_component_line(line, comps(ncomp))
                 cycle
             end if
 
@@ -328,6 +351,8 @@ contains
                 if (key == 'value') params(nparam)%value = unquote(val)
             case ('derived_type')
                 if (key == 'name') dtypes(ndtype)%name = unquote(val)
+                if (key == 'parent_name') &
+                    dtypes(ndtype)%parent_name = unquote(val)
             case ('variable')
                 if (key == 'name') vars(nvar)%name = unquote(val)
                 if (key == 'kind') vars(nvar)%kind = unquote(val)
@@ -414,19 +439,82 @@ contains
         ncomp = 0
     end subroutine flush_component
 
-    subroutine parse_component_line(line, name, kind)
+    function component_line(comp) result(line)
+        ! One component row of a [[derived_type]] table.
+        type(fmod_component_t), intent(in) :: comp
+        character(len=:), allocatable :: line
+
+        line = '    { name = "'//field(comp%name)//'", kind = "'// &
+            field(comp%kind)//'", type_name = "'//field(comp%type_name)// &
+            '", elem_count = '//int_text(comp%elem_count)// &
+            ', slot_width = '//int_text(comp%slot_width)// &
+            ', slot_count = '//int_text(comp%slot_count)// &
+            ', slot_offset = '//int_text(comp%slot_offset)// &
+            ', char_length = '//int_text(comp%char_length)// &
+            ', dim1 = '//int_text(comp%dim1)// &
+            ', allocatable = '//bool_text(comp%is_allocatable)// &
+            ', pointer = '//bool_text(comp%is_pointer)// &
+            ', alloc_array = '//bool_text(comp%is_alloc_array)//' },'
+    end function component_line
+
+    subroutine parse_component_line(line, comp)
+        ! Parse one component row back into its record.
         character(len=*), intent(in) :: line
-        character(len=:), allocatable, intent(out) :: name
-        character(len=:), allocatable, intent(out) :: kind
+        type(fmod_component_t), intent(out) :: comp
+
+        comp%name = quoted_field(line, 'name')
+        comp%kind = quoted_field(line, 'kind')
+        comp%type_name = quoted_field(line, 'type_name')
+        comp%elem_count = integer_field(line, 'elem_count', 1)
+        comp%slot_width = integer_field(line, 'slot_width', 1)
+        comp%slot_count = integer_field(line, 'slot_count', 1)
+        comp%slot_offset = integer_field(line, 'slot_offset', 0)
+        comp%char_length = integer_field(line, 'char_length', 0)
+        comp%dim1 = integer_field(line, 'dim1', 0)
+        comp%is_allocatable = integer_field(line, 'allocatable', 0) /= 0
+        comp%is_pointer = integer_field(line, 'pointer', 0) /= 0
+        comp%is_alloc_array = integer_field(line, 'alloc_array', 0) /= 0
+    end subroutine parse_component_line
+
+    function quoted_field(line, key) result(out)
+        ! The quoted value of `key = "..."` in a component row, or empty.
+        character(len=*), intent(in) :: line
+        character(len=*), intent(in) :: key
+        character(len=:), allocatable :: out
         integer :: p
 
-        name = ''
-        kind = ''
-        p = index(line, 'name = "')
-        if (p > 0) name = take_quoted(line(p + len('name = "'):))
-        p = index(line, 'kind = "')
-        if (p > 0) kind = take_quoted(line(p + len('kind = "'):))
-    end subroutine parse_component_line
+        out = ''
+        p = index(line, key//' = "')
+        if (p <= 0) return
+        out = take_quoted(line(p + len(key) + 4:))
+    end function quoted_field
+
+    integer function integer_field(line, key, default_value) result(value)
+        ! The integer value of `key = N` in a component row, or default_value
+        ! when the key is absent or unreadable.
+        character(len=*), intent(in) :: line
+        character(len=*), intent(in) :: key
+        integer, intent(in) :: default_value
+        integer :: p, io_stat
+
+        value = default_value
+        p = index(line, key//' = ')
+        if (p <= 0) return
+        read (line(p + len(key) + 3:), *, iostat=io_stat) value
+        if (io_stat /= 0) value = default_value
+    end function integer_field
+
+    function bool_text(flag) result(text)
+        logical, intent(in) :: flag
+        character(len=:), allocatable :: text
+
+        if (flag) then
+            text = '1'
+        else
+            text = '0'
+        end if
+    end function bool_text
+
 
     function take_quoted(text) result(out)
         character(len=*), intent(in) :: text

--- a/src/session_program_lowering_derived_module_ops.inc
+++ b/src/session_program_lowering_derived_module_ops.inc
@@ -239,6 +239,10 @@
         call validate_fmod_use_names(use_node, info, error_msg)
         if (len_trim(error_msg) > 0) return
 
+        ! Derived types come first: a later component or variable may name one,
+        ! and a nested component must find its inner type already registered.
+        call import_fmod_derived_types(use_node, info, context, error_msg)
+        if (len_trim(error_msg) > 0) return
         if (allocated(info%parameters)) then
             do i = 1, size(info%parameters)
                 call import_fmod_parameter(use_node, info%parameters(i), &
@@ -268,6 +272,121 @@
             end do
         end if
     end subroutine import_module_from_fmod
+
+    subroutine import_fmod_derived_types(use_node, info, context, error_msg)
+        ! Register every derived type the artefact describes, in the order it
+        ! records them, so a nested component's inner type is already present
+        ! when the outer type refers to it. The layout comes entirely from the
+        ! artefact: component kinds, slot spans, character lengths, and fixed
+        ! array shapes are read back, never re-derived from the module source
+        ! (#414).
+        type(use_statement_node), intent(in) :: use_node
+        type(module_info_t), intent(in) :: info
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        call set_empty(error_msg)
+        if (.not. allocated(info%derived_types)) return
+        do i = 1, size(info%derived_types)
+            call import_fmod_derived_type(use_node, info%derived_types(i), &
+                                          context, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine import_fmod_derived_types
+
+    subroutine import_fmod_derived_type(use_node, dtype, context, error_msg)
+        ! Reconstruct one derived type's layout from its artefact record.
+        type(use_statement_node), intent(in) :: use_node
+        type(fmod_derived_type_t), intent(in) :: dtype
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: type_index_new, k, offset, nested, value_kind
+        integer(c_int64_t) :: no_default
+
+        call set_empty(error_msg)
+        if (.not. allocated(dtype%name)) return
+        if (len_trim(dtype%name) == 0) return
+        if (find_derived_type(context, trim(dtype%name)) > 0) return
+        if (.not. allocated(dtype%components)) return
+
+        call grow_derived_types(context)
+        type_index_new = context%derived_type_count + 1
+        context%derived_types(type_index_new)%name = trim(dtype%name)
+        context%derived_types(type_index_new)%component_count = 0
+        context%derived_types(type_index_new)%parent_name = ''
+        if (allocated(dtype%parent_name)) &
+            context%derived_types(type_index_new)%parent_name = &
+                trim(dtype%parent_name)
+        context%derived_type_count = type_index_new
+
+        no_default = 0_c_int64_t
+        offset = 0
+        do k = 1, size(dtype%components)
+            associate (comp => dtype%components(k))
+                if (comp%slot_offset /= offset) then
+                    error_msg = 'corrupt .fmod derived layout: component '// &
+                        trim(comp%name)//' of '//trim(dtype%name)// &
+                        ' records slot offset '//integer_text(comp%slot_offset)// &
+                        ' where its own component slot counts give '// &
+                        integer_text(offset)
+                    context%derived_type_count = type_index_new - 1
+                    return
+                end if
+                if (comp%slot_count < 1 .or. comp%elem_count < 1) then
+                    error_msg = 'corrupt .fmod derived layout: component '// &
+                        trim(comp%name)//' of '//trim(dtype%name)// &
+                        ' occupies no storage'
+                    context%derived_type_count = type_index_new - 1
+                    return
+                end if
+                value_kind = fmod_component_value_kind(comp%kind)
+                if (value_kind == 0) then
+                    error_msg = 'unsupported .fmod component kind "'// &
+                        trim(comp%kind)//'" for '//trim(comp%name)//' of '// &
+                        trim(dtype%name)
+                    context%derived_type_count = type_index_new - 1
+                    return
+                end if
+                nested = 0
+                if (value_kind == VALUE_DERIVED) then
+                    nested = find_derived_type(context, trim(comp%type_name))
+                    if (nested <= 0) then
+                        error_msg = 'unknown derived type "'// &
+                            trim(comp%type_name)//'" for component '// &
+                            trim(comp%name)//' of '//trim(dtype%name)// &
+                            ': the .fmod does not define it'
+                        context%derived_type_count = type_index_new - 1
+                        return
+                    end if
+                end if
+                call add_derived_component(context, type_index_new, &
+                    trim(comp%name), use_node%line, use_node%column, .false., &
+                    no_default, comp%elem_count, value_kind, error_msg, &
+                    comp_type_index=nested, &
+                    is_allocatable=comp%is_allocatable, &
+                    comp_char_length=comp%char_length, &
+                    is_alloc_array=comp%is_alloc_array, &
+                    is_pointer=comp%is_pointer)
+                if (len_trim(error_msg) > 0) then
+                    context%derived_type_count = type_index_new - 1
+                    return
+                end if
+                context%derived_types(type_index_new)%component_dim1(k) = &
+                    comp%dim1
+                offset = offset + comp%slot_count
+            end associate
+        end do
+    end subroutine import_fmod_derived_type
+
+    function integer_text(value) result(text)
+        integer, intent(in) :: value
+        character(len=:), allocatable :: text
+        character(len=32) :: buffer
+
+        write (buffer, '(I0)') value
+        text = trim(buffer)
+    end function integer_text
 
     subroutine import_fmod_generic(use_node, module_name, gen, info, context, &
                                    error_msg)

--- a/src/session_program_lowering_fmod.inc
+++ b/src/session_program_lowering_fmod.inc
@@ -12,8 +12,8 @@
         call set_empty(error_msg)
         dir = path_dirname(output_path)
         do m = 1, context%module_export_count
-            call build_module_info(arena, context%module_exports(m), info, &
-                                    error_msg)
+            call build_module_info(arena, context, context%module_exports(m), &
+                                   info, error_msg)
             if (len_trim(error_msg) > 0) return
             path = dir//trim(context%module_exports(m)%module_name)//'.fmod'
             call write_fmod(path, info, error_msg)
@@ -34,8 +34,9 @@
         end if
     end function path_dirname
 
-    subroutine build_module_info(arena, export, info, error_msg)
+    subroutine build_module_info(arena, context, export, info, error_msg)
         type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
         type(module_exports_t), intent(in) :: export
         type(module_info_t), intent(out) :: info
         character(len=:), allocatable, intent(out) :: error_msg
@@ -51,7 +52,8 @@
         end do
         allocate (info%derived_types(export%derived_type_count))
         do i = 1, export%derived_type_count
-            call build_fmod_derived_type(arena, export%derived_type_indices(i), &
+            call build_fmod_derived_type(arena, context, &
+                                         export%derived_type_indices(i), &
                                          info%derived_types(i), error_msg)
             if (len_trim(error_msg) > 0) return
         end do
@@ -711,17 +713,24 @@
         end if
     end subroutine build_fmod_parameter
 
-    subroutine build_fmod_derived_type(arena, node_index, dtype, error_msg)
+    subroutine build_fmod_derived_type(arena, context, node_index, dtype, &
+                                       error_msg)
+        ! Serialise the layout the lowering context already computed for this
+        ! type, not a second description re-derived from the AST. The context
+        ! record is the canonical derived layout every same-unit access uses, so
+        ! a using unit that reconstructs it addresses components exactly as the
+        ! defining unit did (#414).
         type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
         integer, intent(in) :: node_index
         type(fmod_derived_type_t), intent(out) :: dtype
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: n, k
-        character(len=:), allocatable :: type_name, comp_name, comp_type
-        integer, allocatable :: component_indices(:)
+        character(len=:), allocatable :: type_name
+        integer :: type_index, k, offset, nested
 
         call set_empty(error_msg)
         dtype%name = ''
+        dtype%parent_name = ''
         if (.not. is_derived_type_node(arena, node_index)) then
             error_msg = 'module derived-type export is not a derived type'
             return
@@ -729,23 +738,87 @@
         call get_derived_type_name(arena, node_index, type_name, error_msg)
         if (len_trim(error_msg) > 0) return
         dtype%name = trim(type_name)
-        call get_derived_type_components(arena, node_index, component_indices)
-        n = size(component_indices)
-        allocate (dtype%components(n))
-        do k = 1, n
-            dtype%components(k)%name = ''
-            dtype%components(k)%kind = ''
-            if (.not. is_declaration_node(arena, component_indices(k))) cycle
-            call get_declaration_var_name(arena, component_indices(k), &
-                                          comp_name, error_msg)
-            if (len_trim(error_msg) > 0) return
-            dtype%components(k)%name = trim(comp_name)
-            call get_declaration_type_name(arena, component_indices(k), &
-                                           comp_type, error_msg)
-            if (len_trim(error_msg) > 0) return
-            dtype%components(k)%kind = fmod_kind_string(comp_type)
+        type_index = find_derived_type(context, trim(type_name))
+        if (type_index <= 0) then
+            ! The type never reached the lowering context, so this unit has no
+            ! layout for it and must not publish a guess.
+            allocate (dtype%components(0))
+            return
+        end if
+        dtype%parent_name = trim(context%derived_types(type_index)%parent_name)
+        allocate (dtype%components( &
+            context%derived_types(type_index)%component_count))
+        offset = 0
+        do k = 1, context%derived_types(type_index)%component_count
+            associate (comp => dtype%components(k))
+                comp%name = trim(context%derived_types(type_index)% &
+                                 component_names(k))
+                comp%kind = fmod_component_kind_token(context, type_index, k)
+                comp%type_name = ''
+                nested = context%derived_types(type_index)% &
+                         component_type_index(k)
+                if (nested > 0) comp%type_name = &
+                    trim(context%derived_types(nested)%name)
+                comp%slot_width = component_slot_width(context, type_index, k)
+                comp%elem_count = context%derived_types(type_index)% &
+                                  component_array_size(k)
+                comp%slot_count = comp%elem_count * comp%slot_width
+                comp%slot_offset = offset
+                comp%char_length = context%derived_types(type_index)% &
+                                   component_char_length(k)
+                comp%dim1 = context%derived_types(type_index)%component_dim1(k)
+                comp%is_allocatable = context%derived_types(type_index)% &
+                                      component_is_allocatable(k)
+                comp%is_pointer = context%derived_types(type_index)% &
+                                  component_is_pointer(k)
+                comp%is_alloc_array = context%derived_types(type_index)% &
+                                      component_is_alloc_array(k)
+                offset = offset + comp%slot_count
+            end associate
         end do
     end subroutine build_fmod_derived_type
+
+    function fmod_component_kind_token(context, type_index, comp_index) &
+            result(token)
+        ! The canonical .fmod token for a component's value kind. A nested
+        ! derived component reports 'derived'; its type travels in type_name.
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: type_index
+        integer, intent(in) :: comp_index
+        character(len=:), allocatable :: token
+        integer :: value_kind
+
+        value_kind = context%derived_types(type_index)% &
+                     component_value_kind(comp_index)
+        select case (value_kind)
+        case (VALUE_DERIVED)
+            token = 'derived'
+        case (VALUE_CHARACTER)
+            token = 'character'
+        case (VALUE_C_PTR)
+            token = 'c_ptr'
+        case default
+            token = scalar_kind_token(value_kind)
+            if (len_trim(token) == 0) token = 'unsupported'
+        end select
+    end function fmod_component_kind_token
+
+    integer function fmod_component_value_kind(token) result(value_kind)
+        ! Inverse of fmod_component_kind_token; 0 when the token names no kind
+        ! this ffc can lay out.
+        character(len=*), intent(in) :: token
+
+        select case (trim(token))
+        case ('derived')
+            value_kind = VALUE_DERIVED
+        case ('character')
+            value_kind = VALUE_CHARACTER
+        case ('c_ptr')
+            value_kind = VALUE_C_PTR
+        case default
+            value_kind = value_kind_of_token(token)
+        end select
+    end function fmod_component_value_kind
 
     function fmod_kind_string(type_name) result(kind_text)
         ! Normalise a declaration type name to the .fmod kind token.

--- a/test/test_session_use_module_derived_type_compiler.f90
+++ b/test/test_session_use_module_derived_type_compiler.f90
@@ -1,9 +1,18 @@
 program test_session_use_module_derived_type_compiler
+    ! A derived type defined in a separately compiled module must reach a using
+    ! unit with the same layout the defining unit compiled: component order and
+    ! slot offsets, nested type identity, fixed array shapes, and character
+    ! lengths. The using unit sees only the .fmod artefact, so every one of
+    ! those facts has to travel in it (#414).
     use ffc_test_support, only: expect_exit_status
+    use ffc_module_artefact, only: module_info_t, write_fmod
     implicit none
+
+    logical :: all_passed
 
     print *, '=== direct session use module derived type compiler test ==='
 
+    all_passed = .true.
     if (.not. expect_exit_status( &
         'module point_mod'//new_line('a')// &
         '  type :: point_t'//new_line('a')// &
@@ -16,7 +25,323 @@ program test_session_use_module_derived_type_compiler
         '  p%x = 7'//new_line('a')// &
         '  stop p%x'//new_line('a')// &
         'end program main', 7, &
-        '/tmp/ffc_session_use_module_derived_type_test')) stop 1
+        '/tmp/ffc_session_use_module_derived_type_test')) all_passed = .false.
 
+    if (.not. test_nested_derived_layout_round_trip()) all_passed = .false.
+    if (.not. test_character_component_length_round_trip()) all_passed = .false.
+    if (.not. test_unknown_nested_type_is_rejected()) all_passed = .false.
+    if (.not. test_overlapping_offsets_are_rejected()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
     print *, 'PASS: USE module derived type lowers through direct LIRIC session'
+
+contains
+
+    logical function test_nested_derived_layout_round_trip() result(ok)
+        ! A nested derived component, a fixed-size integer array component, and
+        ! a character component all keep their layout across separate
+        ! compilation; the result matches same-unit compilation of the same
+        ! program.
+        character(len=:), allocatable :: dir
+        integer :: separate_status, same_status
+        character(len=*), parameter :: module_source = &
+            'module fmod414_layout'//new_line('a')// &
+            '    implicit none'//new_line('a')// &
+            '    type :: inner_t'//new_line('a')// &
+            '        integer :: a'//new_line('a')// &
+            '        integer :: b'//new_line('a')// &
+            '    end type inner_t'//new_line('a')// &
+            '    type :: outer_t'//new_line('a')// &
+            '        type(inner_t) :: core'//new_line('a')// &
+            '        integer :: tags(3)'//new_line('a')// &
+            '        character(len=4) :: label'//new_line('a')// &
+            '    end type outer_t'//new_line('a')// &
+            'end module fmod414_layout'
+        character(len=*), parameter :: program_source = &
+            'program main'//new_line('a')// &
+            '    use fmod414_layout, only: outer_t'//new_line('a')// &
+            '    type(outer_t) :: v'//new_line('a')// &
+            '    v%core%a = 2'//new_line('a')// &
+            '    v%core%b = 3'//new_line('a')// &
+            '    v%tags(1) = 4'//new_line('a')// &
+            '    v%tags(2) = 5'//new_line('a')// &
+            '    v%tags(3) = 6'//new_line('a')// &
+            "    v%label = 'abcd'"//new_line('a')// &
+            '    stop v%core%a + v%core%b + v%tags(3) + len_trim(v%label)'// &
+            new_line('a')// &
+            'end program main'
+
+        ok = .false.
+        call make_scratch_dir('fmod414_layout', dir)
+        separate_status = run_separate_compilation(dir, module_source, &
+                                                   program_source)
+        same_status = run_same_unit_compilation(dir, module_source, &
+                                                program_source)
+        if (same_status /= 115) then
+            print *, 'FAIL: same-unit derived layout status ', same_status
+            call show_log(dir)
+            return
+        end if
+        if (separate_status /= same_status) then
+            print *, 'FAIL: separate compilation status ', separate_status, &
+                ' differs from same-unit ', same_status
+            call show_log(dir)
+            return
+        end if
+        call remove_scratch_dir(dir)
+        ok = .true.
+    end function test_nested_derived_layout_round_trip
+
+    logical function test_character_component_length_round_trip() result(ok)
+        ! The declared length of a character component decides the component's
+        ! slot count, so a using unit that misread it would place every later
+        ! component wrong.
+        character(len=:), allocatable :: dir
+        integer :: separate_status, same_status
+        character(len=*), parameter :: module_source = &
+            'module fmod414_char'//new_line('a')// &
+            '    implicit none'//new_line('a')// &
+            '    type :: tagged_t'//new_line('a')// &
+            '        character(len=9) :: name'//new_line('a')// &
+            '        integer :: count'//new_line('a')// &
+            '    end type tagged_t'//new_line('a')// &
+            'end module fmod414_char'
+        character(len=*), parameter :: program_source = &
+            'program main'//new_line('a')// &
+            '    use fmod414_char, only: tagged_t'//new_line('a')// &
+            '    type(tagged_t) :: t'//new_line('a')// &
+            "    t%name = 'abcdefghi'"//new_line('a')// &
+            '    t%count = 7'//new_line('a')// &
+            '    stop len_trim(t%name) + t%count'//new_line('a')// &
+            'end program main'
+
+        ok = .false.
+        call make_scratch_dir('fmod414_char', dir)
+        separate_status = run_separate_compilation(dir, module_source, &
+                                                   program_source)
+        same_status = run_same_unit_compilation(dir, module_source, &
+                                                program_source)
+        if (same_status /= 116) then
+            print *, 'FAIL: same-unit character component status ', same_status
+            call show_log(dir)
+            return
+        end if
+        if (separate_status /= same_status) then
+            print *, 'FAIL: separate character component status ', &
+                separate_status, ' differs from same-unit ', same_status
+            call show_log(dir)
+            return
+        end if
+        call remove_scratch_dir(dir)
+        ok = .true.
+    end function test_character_component_length_round_trip
+
+    logical function test_unknown_nested_type_is_rejected() result(ok)
+        ! A component whose nested type the artefact never defines describes no
+        ! layout at all; reading it must fail rather than invent one.
+        character(len=:), allocatable :: dir, error_msg
+        type(module_info_t) :: info
+
+        ok = .false.
+        call make_scratch_dir('fmod414_unknown', dir)
+        info%name = 'fmod414_unknown'
+        allocate (info%parameters(0))
+        allocate (info%derived_types(1))
+        info%derived_types(1)%name = 'holder_t'
+        allocate (info%derived_types(1)%components(1))
+        info%derived_types(1)%components(1)%name = 'core'
+        info%derived_types(1)%components(1)%kind = 'derived'
+        info%derived_types(1)%components(1)%type_name = 'never_defined_t'
+        info%derived_types(1)%components(1)%slot_count = 2
+        info%derived_types(1)%components(1)%slot_offset = 0
+        call write_fmod(dir//'/fmod414_unknown.fmod', info, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: write_fmod: ', trim(error_msg)
+            return
+        end if
+        call compile_using_program(dir, 'fmod414_unknown', 'holder_t', &
+                                   error_msg)
+        if (index(error_msg, 'never_defined_t') == 0) then
+            print *, 'FAIL: unknown nested type was accepted: ', trim(error_msg)
+            return
+        end if
+        call remove_scratch_dir(dir)
+        ok = .true.
+    end function test_unknown_nested_type_is_rejected
+
+    logical function test_overlapping_offsets_are_rejected() result(ok)
+        ! Component offsets are recorded next to the slot counts that produce
+        ! them. An artefact whose offsets do not follow from its own slot counts
+        ! is corrupt: two components would share storage.
+        character(len=:), allocatable :: dir, error_msg
+        type(module_info_t) :: info
+
+        ok = .false.
+        call make_scratch_dir('fmod414_overlap', dir)
+        info%name = 'fmod414_overlap'
+        allocate (info%parameters(0))
+        allocate (info%derived_types(1))
+        info%derived_types(1)%name = 'pair_t'
+        allocate (info%derived_types(1)%components(2))
+        info%derived_types(1)%components(1)%name = 'a'
+        info%derived_types(1)%components(1)%kind = 'integer'
+        info%derived_types(1)%components(1)%slot_count = 1
+        info%derived_types(1)%components(1)%slot_offset = 0
+        info%derived_types(1)%components(2)%name = 'b'
+        info%derived_types(1)%components(2)%kind = 'integer'
+        info%derived_types(1)%components(2)%slot_count = 1
+        ! b starts where a does: the two components would alias.
+        info%derived_types(1)%components(2)%slot_offset = 0
+        call write_fmod(dir//'/fmod414_overlap.fmod', info, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: write_fmod: ', trim(error_msg)
+            return
+        end if
+        call compile_using_program(dir, 'fmod414_overlap', 'pair_t', error_msg)
+        if (index(error_msg, 'offset') == 0) then
+            print *, 'FAIL: overlapping offsets were accepted: ', trim(error_msg)
+            return
+        end if
+        call remove_scratch_dir(dir)
+        ok = .true.
+    end function test_overlapping_offsets_are_rejected
+
+    subroutine compile_using_program(dir, module_name, type_name, error_msg)
+        ! Compile a program that USEs type_name from module_name, seeing only
+        ! the .fmod in dir. error_msg carries the compiler's diagnostic.
+        character(len=*), intent(in) :: dir
+        character(len=*), intent(in) :: module_name
+        character(len=*), intent(in) :: type_name
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: exit_stat, cmd_stat
+
+        error_msg = ''
+        if (.not. write_file(dir//'/p.f90', &
+            'program main'//new_line('a')// &
+            '    use '//module_name//', only: '//type_name//new_line('a')// &
+            '    type('//type_name//') :: v'//new_line('a')// &
+            '    stop 0'//new_line('a')// &
+            'end program main')) return
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; exe=$PWD/$exe; '// &
+            'cd '//dir//' || exit 90; '// &
+            '"$exe" p.f90 -o p >log 2>&1'//"'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        call read_text_file(dir//'/log', error_msg)
+        if (exit_stat == 0) error_msg = ''
+    end subroutine compile_using_program
+
+    integer function run_separate_compilation(dir, module_source, &
+                                              program_source) result(status)
+        ! Compile the module with -c in one ffc invocation, then the program in
+        ! a second, independent invocation that can only learn the module's
+        ! types from the .fmod artefact. Returns 90 when no ffc binary was
+        ! found, 91/92 when a compilation failed, and 100 + exit status when the
+        ! program ran.
+        character(len=*), intent(in) :: dir
+        character(len=*), intent(in) :: module_source
+        character(len=*), intent(in) :: program_source
+        integer :: exit_stat, cmd_stat
+
+        status = 90
+        if (.not. write_file(dir//'/m.f90', module_source)) return
+        if (.not. write_file(dir//'/p.f90', program_source)) return
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; exe=$PWD/$exe; '// &
+            'cd '//dir//' || exit 90; '// &
+            '"$exe" -c m.f90 -o m.o >>log 2>&1 || exit 91; '// &
+            '"$exe" p.f90 m.o -o p >>log 2>&1 || exit 92; '// &
+            "./p; exit $((100 + $?))'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) return
+        status = exit_stat
+    end function run_separate_compilation
+
+    integer function run_same_unit_compilation(dir, module_source, &
+                                               program_source) result(status)
+        ! Compile the same module and program together in one unit, so the
+        ! separate-compilation result can be held against it.
+        character(len=*), intent(in) :: dir
+        character(len=*), intent(in) :: module_source
+        character(len=*), intent(in) :: program_source
+        integer :: exit_stat, cmd_stat
+
+        status = 90
+        if (.not. write_file(dir//'/same.f90', module_source//new_line('a')// &
+                             program_source)) return
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; exe=$PWD/$exe; '// &
+            'cd '//dir//' || exit 90; '// &
+            '"$exe" same.f90 -o same >>log 2>&1 || exit 92; '// &
+            "./same; exit $((100 + $?))'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) return
+        status = exit_stat
+    end function run_same_unit_compilation
+
+    subroutine make_scratch_dir(tag, dir)
+        ! A scratch directory of this run's own, so concurrent builds of other
+        ! worktrees never share it (ffc #547).
+        character(len=*), intent(in) :: tag
+        character(len=:), allocatable, intent(out) :: dir
+        character(len=32) :: stamp
+        integer :: values(8)
+
+        call date_and_time(values=values)
+        write (stamp, '(I0,A,I0)') values(6)*60000 + values(7)*1000 + &
+            values(8), '_', values(5)
+        dir = '/tmp/ffc_'//tag//'_'//trim(stamp)
+        call execute_command_line('rm -rf '//dir//'; mkdir -p '//dir)
+    end subroutine make_scratch_dir
+
+    subroutine remove_scratch_dir(dir)
+        character(len=*), intent(in) :: dir
+
+        call execute_command_line('rm -rf '//dir)
+    end subroutine remove_scratch_dir
+
+    subroutine show_log(dir)
+        character(len=*), intent(in) :: dir
+
+        call execute_command_line('cat '//dir//'/log 2>/dev/null')
+    end subroutine show_log
+
+    subroutine read_text_file(path, text)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: text
+        character(len=1024) :: line
+        integer :: unit, io_stat
+
+        text = ''
+        open (newunit=unit, file=path, status='old', action='read', &
+              iostat=io_stat)
+        if (io_stat /= 0) return
+        do
+            read (unit, '(A)', iostat=io_stat) line
+            if (io_stat /= 0) exit
+            text = text//trim(line)//' '
+        end do
+        close (unit)
+    end subroutine read_text_file
+
+    logical function write_file(path, contents) result(ok)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: contents
+        integer :: unit, io_stat
+
+        ok = .false.
+        open (newunit=unit, file=path, status='replace', action='write', &
+              iostat=io_stat)
+        if (io_stat /= 0) then
+            print *, 'FAIL: could not write ', path
+            return
+        end if
+        write (unit, '(A)', iostat=io_stat) contents
+        close (unit)
+        ok = io_stat == 0
+    end function write_file
+
 end program test_session_use_module_derived_type_compiler


### PR DESCRIPTION
Closes #414.

## What changed

Before this PR a derived type could not cross separate compilation at all: a
program declaring a variable of a use-associated type from a `.fmod` was
rejected (`unsupported scalar type`), because the artefact carried only each
component's name and a loose type word — no offsets, no shapes, no lengths.

The `[[derived_type]]` record now carries, per component: canonical value kind,
nested type name, declared character length, fixed array element count, slots
per element, total slot span, starting slot, `dim1`, and the allocatable /
pointer / alloc-array flags; and per type, the parent type name.

## Reused, not reinvented

The writer serialises the lowering context's own `derived_type_info_t` — the
same record every same-unit component access addresses through
`component_start_slot` / `component_slot_width` — rather than re-deriving a
description from the AST. The reader reconstructs it through
`add_derived_component`, the same entry point the in-unit import path uses. So
there is exactly one layout representation on both sides of the artefact.

## Invariants preserved

- **Derived layout fidelity across separate compilation**: the positive oracles
  compile module and program separately and then compile the identical source
  as one unit, and require the same exit status. A layout disagreement of any
  component (nested inline span, array element count, character slot count)
  changes that status.
- **Character length metadata**: `char_length` travels per component and decides
  the component's slot span; covered by a `character(len=9)` component followed
  by an integer, which lands wrong if the length is misread.
- **Artifact version contract**: schema moves to 3, so a pre-layout artefact is
  rejected by the version check from #397 instead of being read as if it had
  layout records.
- **No source rescan / no layout guess**: the using unit reads the layout only
  from the artefact. When a type never reached the defining unit's lowering
  context, the writer publishes no components rather than a guess.
- **Corrupt metadata is rejected**: `slot_offset` is redundant with the
  preceding slot counts by construction, so an artefact whose offsets do not
  follow from its own counts (two components sharing storage) is diagnosed; so
  are an undefined nested type, an unsupported component kind, and a component
  occupying no storage.
- **Generic rank resolution / Lazy specializations**: untouched, that is
  #415/#433/#437 scope.

## Oracles

New in `test/test_session_use_module_derived_type_compiler.f90` (the existing
same-unit check is kept unchanged):

- `test_nested_derived_layout_round_trip` — nested derived + `integer :: tags(3)`
  + `character(len=4)`; separate compilation was a hard compile error on main,
  now exits 15 like same-unit.
- `test_character_component_length_round_trip` — `character(len=9)` before an
  integer component; same-unit and separate agree.
- `test_unknown_nested_type_is_rejected`, `test_overlapping_offsets_are_rejected`
  — negative fixtures on hand-written artefacts.

## Corpus delta

`test_fortfront_corpus_conformance` failure set is identical to `origin/main`
(20 cases): no new failures, none newly passing, no xfail manifest entries move.
The two `fo` failures (`test_fortfront_corpus_conformance`,
`test_parity_dashboard`) both reproduce on unmodified `main`.