### PR TITLE
[fmod2-03] serialize rank-aware generic specifics (closes #415)

### DIFF
--- a/src/ffc_module_artefact.f90
+++ b/src/ffc_module_artefact.f90
@@ -24,7 +24,7 @@ module ffc_module_artefact
     ! other value, and an artefact without the field, so a stale or
     ! newer-than-supported artefact is diagnosed instead of silently misread
     ! (#397).
-    integer, parameter, public :: FMOD_SCHEMA_VERSION = 3
+    integer, parameter, public :: FMOD_SCHEMA_VERSION = 4
 
     type :: fmod_parameter_t
         character(len=:), allocatable :: name
@@ -98,6 +98,12 @@ module ffc_module_artefact
         ! 'integer'); both empty for a subroutine (#397).
         character(len=:), allocatable :: result_name
         character(len=:), allocatable :: result_kind
+        ! Space-joined per-dummy rank (0 for a scalar) and, for an
+        ! explicit-shape array dummy, its total element count. A generic
+        ! resolves an imported specific by these ranks exactly as a same-unit
+        ! call resolves one by the declared ranks (#415).
+        character(len=:), allocatable :: arg_ranks
+        character(len=:), allocatable :: arg_extents
         integer :: nargs = 0
     end type fmod_procedure_t
 
@@ -206,6 +212,10 @@ contains
                     field(info%procedures(i)%result_name)//'"'
                 write (unit, '(A)') 'result_kind = "'// &
                     field(info%procedures(i)%result_kind)//'"'
+                write (unit, '(A)') 'arg_ranks = "'// &
+                    field(info%procedures(i)%arg_ranks)//'"'
+                write (unit, '(A)') 'arg_extents = "'// &
+                    field(info%procedures(i)%arg_extents)//'"'
             end do
         end if
 
@@ -307,6 +317,8 @@ contains
                 procs(nproc)%arg_values = ''
                 procs(nproc)%result_name = ''
                 procs(nproc)%result_kind = ''
+                procs(nproc)%arg_ranks = ''
+                procs(nproc)%arg_extents = ''
                 procs(nproc)%nargs = 0
                 cycle
             else if (line == '[[generic]]') then
@@ -371,6 +383,9 @@ contains
                     procs(nproc)%result_name = unquote(val)
                 if (key == 'result_kind') &
                     procs(nproc)%result_kind = unquote(val)
+                if (key == 'arg_ranks') procs(nproc)%arg_ranks = unquote(val)
+                if (key == 'arg_extents') &
+                    procs(nproc)%arg_extents = unquote(val)
                 if (key == 'nargs') then
                     read (val, *, iostat=io_read) procs(nproc)%nargs
                     if (io_read /= 0) procs(nproc)%nargs = 0

--- a/src/session_program_lowering_arguments.inc
+++ b/src/session_program_lowering_arguments.inc
@@ -114,8 +114,8 @@
             ! procedure defined or interfaced in this unit, so external calls
             ! without an explicit interface never trip this. An assumed-rank
             ! arr(..) dummy binds to any rank, scalar included, so it is excluded.
-            if (callee_dummy_is_array(arena, callee_name, &
-                                      call_arg_param_pos(i, sp)) .and. &
+            if (callee_dummy_is_array_ctx(arena, context, callee_name, &
+                                          call_arg_param_pos(i, sp)) .and. &
                 actual_is_definite_scalar(arena, arg_indices(i), context) .and. &
                 .not. callee_dummy_is_assumed_rank(arena, callee_name, &
                                                    call_arg_param_pos(i, sp))) then
@@ -160,7 +160,8 @@
                                            args(i), error_msg)
                 if (len_trim(error_msg) > 0) return
             else if (actual_is_whole_array(arena, arg_indices(i), context) .and. &
-                     callee_dummy_is_array(arena, callee_name, i)) then
+                     callee_dummy_is_array_ctx(arena, context, callee_name, &
+                                               i)) then
                 ! Explicit-shape array actual to an array dummy: pass the
                 ! contiguous base address; the callee binds it as its dummy view.
                 call whole_array_actual_address(arena, arg_indices(i), context, &
@@ -187,8 +188,8 @@
                     context, args(i), error_msg)
                 if (len_trim(error_msg) > 0) return
             else if (actual_is_contiguous_section(arena, arg_indices(i), context) &
-                     .and. callee_dummy_is_array(arena, callee_name, &
-                                                 call_arg_param_pos(i, sp))) then
+                     .and. callee_dummy_is_array_ctx(arena, context, &
+                            callee_name, call_arg_param_pos(i, sp))) then
                 ! Contiguous rank-1 array section a(lo:hi) or whole column
                 ! a(:,j): pass the base address of the section's first element,
                 ! so the callee's rank-1 dummy views the section's storage in
@@ -2241,3 +2242,26 @@ integer function expression_value_kind(arena, node_index, context, &
             text = 'INTENT(INOUT)'
         end if
     end function intent_text
+
+    logical function callee_dummy_is_array_ctx(arena, context, callee_name, &
+                                               param_pos) result(is_array)
+        ! Whether the callee's param_pos-th dummy is an array. A procedure
+        ! defined or interfaced in this unit answers from its declaration; a
+        ! separately compiled module procedure answers from the rank the .fmod
+        ! recorded, so an array actual takes the array-argument ABI instead of
+        ! being rejected as an unsupported scalar (#415).
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        character(len=*), intent(in) :: callee_name
+        integer, intent(in) :: param_pos
+        integer :: idx
+
+        is_array = callee_dummy_is_array(arena, callee_name, param_pos)
+        if (is_array) return
+        if (param_pos < 1) return
+        idx = external_procedure_index(context, callee_name)
+        if (idx <= 0) return
+        if (.not. context%external_procedures(idx)%by_reference) return
+        if (param_pos > context%external_procedures(idx)%arg_count) return
+        is_array = context%external_procedures(idx)%arg_ranks(param_pos) > 0
+    end function callee_dummy_is_array_ctx

--- a/src/session_program_lowering_derived_module_ops.inc
+++ b/src/session_program_lowering_derived_module_ops.inc
@@ -481,7 +481,8 @@
         ! Append a specific to a generic entry, taking its signature and
         ! return kinds from an already-registered external procedure rather
         ! than from an AST node (the specific was imported from a .fmod, #284).
-        ! Ranks default to 0 (scalar) since .fmod does not yet carry rank info.
+        ! Ranks come from the artefact, so an imported generic resolves a
+        ! rank-1 or rank-2 specific exactly as a same-unit call does (#415).
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: generic_idx
         character(len=*), intent(in) :: name
@@ -505,6 +506,8 @@
             MAX_PROC_ARGS)
             context%generics(generic_idx)%specific_arg_kinds(j, sc) = &
                 context%external_procedures(ext_idx)%arg_value_kinds(j)
+            context%generics(generic_idx)%specific_arg_ranks(j, sc) = &
+                context%external_procedures(ext_idx)%arg_ranks(j)
         end do
     end subroutine add_generic_specific_from_external
 
@@ -529,7 +532,7 @@
         integer, allocatable :: arg_kinds(:)
         character(len=64), allocatable :: arg_names(:)
         logical, allocatable :: arg_optionals(:), arg_values(:)
-        integer, allocatable :: arg_intents(:)
+        integer, allocatable :: arg_intents(:), arg_ranks(:), arg_extents(:)
         integer :: return_kind
         logical :: forced, imported
 
@@ -561,11 +564,13 @@
         call parse_fmod_arg_flags(proc%arg_optionals, proc%nargs, arg_optionals)
         call parse_fmod_arg_flags(proc%arg_values, proc%nargs, arg_values)
         call parse_fmod_arg_intents(proc, arg_intents)
+        call parse_fmod_arg_integers(proc%arg_ranks, proc%nargs, arg_ranks)
+        call parse_fmod_arg_integers(proc%arg_extents, proc%nargs, arg_extents)
         mangled = module_procedure_mangled(module_name, trim(proc%name))
         call add_external_procedure(context, trim(local_name), mangled, &
                                     return_kind, proc%nargs, .true., arg_kinds, &
                                     arg_names, arg_optionals, arg_values, &
-                                    arg_intents)
+                                    arg_intents, arg_ranks, arg_extents)
     end subroutine import_fmod_procedure
 
     subroutine parse_fmod_arg_flags(text, nargs, flags)
@@ -596,6 +601,36 @@
             end if
         end do
     end subroutine parse_fmod_arg_flags
+
+    subroutine parse_fmod_arg_integers(text, nargs, values)
+        ! Split a .fmod per-dummy integer list (ranks, extents) into values. An
+        ! absent or short list leaves the remaining dummies at 0 (#415).
+        character(len=:), allocatable, intent(in) :: text
+        integer, intent(in) :: nargs
+        integer, allocatable, intent(out) :: values(:)
+        character(len=:), allocatable :: rest, token
+        integer :: n, sep, io_stat
+
+        allocate (values(max(nargs, 0)))
+        if (nargs <= 0) return
+        values = 0
+        if (.not. allocated(text)) return
+        rest = trim(adjustl(text))
+        n = 0
+        do while (len_trim(rest) > 0 .and. n < nargs)
+            sep = index(rest, ' ')
+            n = n + 1
+            if (sep == 0) then
+                token = trim(rest)
+                rest = ''
+            else
+                token = rest(1:sep - 1)
+                rest = adjustl(rest(sep + 1:))
+            end if
+            read (token, *, iostat=io_stat) values(n)
+            if (io_stat /= 0) values(n) = 0
+        end do
+    end subroutine parse_fmod_arg_integers
 
     subroutine parse_fmod_arg_intents(proc, intents)
         ! Split the .fmod per-dummy INTENT token list into intent codes (#397).

--- a/src/session_program_lowering_fmod.inc
+++ b/src/session_program_lowering_fmod.inc
@@ -68,7 +68,7 @@
         ! Public module procedures with integer-scalar signatures round-trip so
         ! a separately compiled program can call them by reference and link
         ! against the module object (#284).
-        call build_fmod_procedures(arena, trim(export%module_name), &
+        call build_fmod_procedures(arena, context, trim(export%module_name), &
                                    info%procedures, error_msg)
         if (len_trim(error_msg) > 0) return
         ! Named generic interfaces whose specifics are all exportable procedures
@@ -228,14 +228,17 @@
         call move_alloc(tmp, arr)
     end subroutine grow_fmod_generics
 
-    subroutine build_fmod_procedures(arena, module_name, procs, error_msg)
+    subroutine build_fmod_procedures(arena, context, module_name, procs, &
+                                     error_msg)
         type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
         character(len=*), intent(in) :: module_name
         type(fmod_procedure_t), allocatable, intent(out) :: procs(:)
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: module_index, p, count
         integer, allocatable :: declaration_indices(:), procedure_indices(:)
         character(len=:), allocatable :: mod_name, ff_error, kind_text, arg_tokens
+        character(len=:), allocatable :: rank_tokens, extent_tokens
         integer :: nargs
         type(module_node), pointer :: mod_node
 
@@ -252,8 +255,9 @@
         if (len_trim(ff_error) > 0) return
         count = 0
         do p = 1, size(procedure_indices)
-            call fmod_procedure_signature(arena, procedure_indices(p), mod_node, &
-                                          kind_text, nargs, arg_tokens)
+            call fmod_procedure_signature(arena, context, procedure_indices(p), &
+                                          mod_node, kind_text, nargs, &
+                                          arg_tokens, rank_tokens, extent_tokens)
             if (len_trim(kind_text) == 0) cycle
             count = count + 1
             call grow_fmod_procs(procs, count)
@@ -262,6 +266,8 @@
             procs(count)%kind = kind_text
             procs(count)%nargs = nargs
             procs(count)%arg_kinds = arg_tokens
+            procs(count)%arg_ranks = rank_tokens
+            procs(count)%arg_extents = extent_tokens
             procs(count)%arg_names = fmod_procedure_arg_names(arena, &
                                                      procedure_indices(p))
             call fmod_procedure_dummy_attributes(arena, procedure_indices(p), &
@@ -478,8 +484,9 @@
         end if
     end function procedure_fortran_name
 
-    subroutine fmod_procedure_signature(arena, node_index, mod_node, kind_text, &
-                                        nargs, arg_tokens)
+    subroutine fmod_procedure_signature(arena, context, node_index, mod_node, &
+                                        kind_text, nargs, arg_tokens, &
+                                        rank_tokens, extent_tokens)
         ! Classify a module procedure for .fmod export. kind_text is 'integer'
         ! for an integer function, 'subroutine' for a subroutine, and empty for
         ! anything not exportable (private, non-integer result, unsupported or
@@ -487,17 +494,22 @@
         ! argument count and arg_tokens the space-joined per-argument scalar-kind
         ! tokens for an exportable procedure (#284).
         type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
         integer, intent(in) :: node_index
         type(module_node), intent(in) :: mod_node
         character(len=:), allocatable, intent(out) :: kind_text
         integer, intent(out) :: nargs
         character(len=:), allocatable, intent(out) :: arg_tokens
+        character(len=:), allocatable, intent(out) :: rank_tokens
+        character(len=:), allocatable, intent(out) :: extent_tokens
         type(function_def_node), pointer :: fn_node
         type(subroutine_def_node), pointer :: sb_node
 
         kind_text = ''
         nargs = 0
         arg_tokens = ''
+        rank_tokens = ''
+        extent_tokens = ''
         if (.not. node_exists(arena, node_index)) return
         fn_node => get_node_as_function_def(arena, node_index)
         if (associated(fn_node)) then
@@ -505,8 +517,10 @@
             if (module_symbol_is_private(arena, mod_node, fn_node%name)) return
             if (procedure_has_nested_contains(arena, fn_node%body_indices)) return
             if (.not. return_type_is_integer(fn_node%return_type)) return
-            if (.not. params_all_supported_scalar(arena, fn_node%param_indices, &
-                                    fn_node%body_indices, nargs, arg_tokens)) return
+            if (.not. params_all_supported(arena, context, &
+                                    fn_node%param_indices, fn_node%body_indices, &
+                                    nargs, arg_tokens, rank_tokens, &
+                                    extent_tokens)) return
             kind_text = 'integer'
             return
         end if
@@ -515,8 +529,10 @@
             if (.not. allocated(sb_node%name)) return
             if (module_symbol_is_private(arena, mod_node, sb_node%name)) return
             if (procedure_has_nested_contains(arena, sb_node%body_indices)) return
-            if (.not. params_all_supported_scalar(arena, sb_node%param_indices, &
-                                    sb_node%body_indices, nargs, arg_tokens)) return
+            if (.not. params_all_supported(arena, context, &
+                                    sb_node%param_indices, sb_node%body_indices, &
+                                    nargs, arg_tokens, rank_tokens, &
+                                    extent_tokens)) return
             kind_text = 'subroutine'
         end if
     end subroutine fmod_procedure_signature
@@ -531,43 +547,126 @@
         return_type_is_integer = lowered == 'integer'
     end function return_type_is_integer
 
-    logical function params_all_supported_scalar(arena, param_indices, &
-                                    body_indices, nargs, arg_tokens) result(ok)
-        ! Whether every dummy of a module procedure is a scalar of a kind ffc can
-        ! pass by reference across separate compilation (integer, real, logical
-        ! of the supported kinds). arg_tokens receives the space-joined per-dummy
-        ! kind tokens. Any array, character, derived, or unsupported-kind dummy
-        ! disqualifies the procedure so a using unit never miscompiles a call
-        ! (#284).
+    logical function params_all_supported(arena, context, param_indices, &
+                                          body_indices, nargs, arg_tokens, &
+                                          rank_tokens, extent_tokens) result(ok)
+        ! Whether every dummy of a module procedure is one this ffc can pass
+        ! across separate compilation: a scalar of a supported kind, or an
+        ! explicit-shape array of such a scalar, which passes as the base
+        ! address of its contiguous storage. arg_tokens receives the per-dummy
+        ! element-kind tokens, rank_tokens the per-dummy rank (0 for a scalar),
+        ! and extent_tokens an array dummy's total element count. An assumed-
+        ! shape, assumed-rank, allocatable, character, or derived dummy still
+        ! disqualifies the procedure, so a using unit never miscompiles a call
+        ! (#284, #415).
         type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
         integer, allocatable, intent(in) :: param_indices(:)
         integer, allocatable, intent(in) :: body_indices(:)
         integer, intent(out) :: nargs
         character(len=:), allocatable, intent(out) :: arg_tokens
-        integer :: i, value_kind
+        character(len=:), allocatable, intent(out) :: rank_tokens
+        character(len=:), allocatable, intent(out) :: extent_tokens
+        integer :: i, value_kind, rank, extent
         character(len=:), allocatable :: token
 
         ok = .false.
         nargs = 0
         arg_tokens = ''
+        rank_tokens = ''
+        extent_tokens = ''
         if (.not. allocated(param_indices)) then
             ok = .true.
             return
         end if
         nargs = size(param_indices)
         do i = 1, nargs
+            rank = 0
+            extent = 0
             value_kind = param_at_value_kind(arena, param_indices, &
                                              body_indices, i)
+            if (value_kind == 0) then
+                call param_at_array_shape(arena, context, param_indices, &
+                                          body_indices, i, value_kind, rank, &
+                                          extent)
+                if (rank <= 0) return
+            end if
             token = scalar_kind_token(value_kind)
             if (len_trim(token) == 0) return
-            if (i == 1) then
-                arg_tokens = token
-            else
-                arg_tokens = arg_tokens//' '//token
+            if (i > 1) then
+                arg_tokens = arg_tokens//' '
+                rank_tokens = rank_tokens//' '
+                extent_tokens = extent_tokens//' '
             end if
+            arg_tokens = arg_tokens//token
+            rank_tokens = rank_tokens//integer_token(rank)
+            extent_tokens = extent_tokens//integer_token(extent)
         end do
         ok = .true.
-    end function params_all_supported_scalar
+    end function params_all_supported
+
+    subroutine param_at_array_shape(arena, context, param_indices, &
+                                    body_indices, pos, value_kind, rank, extent)
+        ! The element kind, rank, and total element count of an explicit-shape
+        ! array dummy. rank stays 0 when the dummy is not an array this ffc can
+        ! pass by base address (assumed shape, assumed rank, assumed size, or
+        ! allocatable), which keeps such a procedure out of the artefact (#415).
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        integer, allocatable, intent(in) :: param_indices(:)
+        integer, allocatable, intent(in) :: body_indices(:)
+        integer, intent(in) :: pos
+        integer, intent(out) :: value_kind
+        integer, intent(out) :: rank
+        integer, intent(out) :: extent
+        character(len=:), allocatable :: name, name_err, kind_err
+        integer(c_int64_t) :: element_count
+        logical :: known
+        integer :: i
+
+        value_kind = 0
+        rank = 0
+        extent = 0
+        if (.not. allocated(param_indices)) return
+        if (pos < 1 .or. pos > size(param_indices)) return
+        call parameter_name(arena, param_indices(pos), name, name_err)
+        if (len_trim(name_err) > 0) return
+        if (.not. allocated(body_indices)) return
+        do i = 1, size(body_indices)
+            if (.not. node_exists(arena, body_indices(i))) cycle
+            select type (decl => arena%entries(body_indices(i))%node)
+            type is (declaration_node)
+                if (.not. decl%is_array) cycle
+                if (decl%is_allocatable .or. decl%is_pointer) return
+                if (.not. declaration_declares_name(decl, &
+                    trim(lowercase_text(name)))) cycle
+                if (.not. allocated(decl%dimension_indices)) return
+                call declaration_value_kind(decl, value_kind, kind_err)
+                if (len_trim(kind_err) > 0) then
+                    value_kind = 0
+                    return
+                end if
+                call dummy_explicit_element_count(arena, context, body_indices, &
+                                                  name, element_count, known, &
+                                                  kind_err)
+                if (len_trim(kind_err) > 0) return
+                if (.not. known) return
+                if (element_count <= 0) return
+                rank = size(decl%dimension_indices)
+                extent = int(element_count)
+                return
+            end select
+        end do
+    end subroutine param_at_array_shape
+
+    function integer_token(value) result(token)
+        integer, intent(in) :: value
+        character(len=:), allocatable :: token
+        character(len=32) :: buffer
+
+        write (buffer, '(I0)') value
+        token = trim(buffer)
+    end function integer_token
 
     function scalar_kind_token(value_kind) result(token)
         ! The .fmod token for a by-reference scalar dummy kind, or '' when the

--- a/src/session_program_lowering_integer.inc
+++ b/src/session_program_lowering_integer.inc
@@ -253,15 +253,17 @@
        call_name = degeneric_call_name(context, node%name, &
            call_arg_count, call_arg_kinds, call_arg_ranks)
 
-      if (external_procedure_index(context, node%name) > 0) then
+      ! A use-associated generic resolves to one of its specifics first, so the
+      ! external lookup uses the resolved name (#415).
+      if (external_procedure_index(context, call_name) > 0) then
           if (context%external_procedures( &
-                  external_procedure_index(context, node%name))%by_reference) then
+                  external_procedure_index(context, call_name))%by_reference) then
               call lower_module_proc_i32_call(arena, node, &
-                  external_procedure_index(context, node%name), context, value, &
-                  error_msg)
+                  external_procedure_index(context, call_name), context, value, &
+                  error_msg, call_name)
           else
               call lower_external_i32_call(arena, node, &
-                  external_procedure_index(context, node%name), context, value, &
+                  external_procedure_index(context, call_name), context, value, &
                   error_msg)
           end if
           return

--- a/src/session_program_lowering_interface.inc
+++ b/src/session_program_lowering_interface.inc
@@ -678,7 +678,8 @@
     subroutine add_external_procedure(context, fortran_name, c_name, &
                                       return_kind, arg_count, by_reference, &
                                       arg_kinds, arg_names, arg_optionals, &
-                                      arg_values, arg_intents)
+                                      arg_values, arg_intents, arg_ranks, &
+                                      arg_extents)
         type(lowering_context_t), intent(inout) :: context
         character(len=*), intent(in) :: fortran_name, c_name
         integer, intent(in) :: return_kind, arg_count
@@ -688,6 +689,8 @@
         logical, intent(in), optional :: arg_optionals(:)
         logical, intent(in), optional :: arg_values(:)
         integer, intent(in), optional :: arg_intents(:)
+        integer, intent(in), optional :: arg_ranks(:)
+        integer, intent(in), optional :: arg_extents(:)
         integer :: j
 
         call grow_external_procedures(context)
@@ -732,11 +735,23 @@
                     ep%arg_intents(j) = arg_intents(j)
                 end do
             end if
+            ep%arg_ranks = 0
+            ep%arg_extents = 0
+            if (present(arg_ranks)) then
+                do j = 1, min(arg_count, size(arg_ranks))
+                    ep%arg_ranks(j) = arg_ranks(j)
+                end do
+            end if
+            if (present(arg_extents)) then
+                do j = 1, min(arg_count, size(arg_extents))
+                    ep%arg_extents(j) = arg_extents(j)
+                end do
+            end if
         end associate
     end subroutine add_external_procedure
 
     subroutine lower_module_proc_i32_call(arena, node, ext_idx, context, value, &
-                                          error_msg)
+                                          error_msg, callee_name)
         ! Lower a call to a separately compiled integer module function. The
         ! arguments pass by reference (Fortran ABI) and the call targets the
         ! module procedure's mangled symbol resolved from the .fmod (#284).
@@ -746,22 +761,28 @@
         type(lowering_context_t), intent(inout) :: context
         type(lr_operand_desc_t), intent(out) :: value
         character(len=:), allocatable, intent(out) :: error_msg
+        ! The name the call resolved to, which differs from the written name
+        ! when a use-associated generic selected a specific (#415).
+        character(len=*), intent(in), optional :: callee_name
         type(lr_operand_desc_t), allocatable :: args(:)
         integer, allocatable :: copyback_indices(:)
+        character(len=:), allocatable :: resolved_name
         integer :: empty_args(0)
 
+        resolved_name = trim(node%name)
+        if (present(callee_name)) resolved_name = trim(callee_name)
         if (allocated(node%arg_indices)) then
             call check_module_call_arity(arena, context, ext_idx, &
-                                         trim(node%name), node%arg_indices, &
+                                         resolved_name, node%arg_indices, &
                                          error_msg)
             if (len_trim(error_msg) > 0) return
             call prepare_reference_args(arena, node%arg_indices, context, &
-                                        VALUE_I32, trim(node%name), args, &
+                                        VALUE_I32, resolved_name, args, &
                                         copyback_indices, error_msg)
             if (len_trim(error_msg) > 0) return
         else
             call check_module_call_arity(arena, context, ext_idx, &
-                                         trim(node%name), empty_args, error_msg)
+                                         resolved_name, empty_args, error_msg)
             if (len_trim(error_msg) > 0) return
             allocate (args(0))
             allocate (copyback_indices(0))

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -537,6 +537,12 @@ module session_program_lowering_types
         logical :: arg_is_optional(MAX_PROC_ARGS) = .false.
         logical :: arg_is_value(MAX_PROC_ARGS) = .false.
         integer :: arg_intents(MAX_PROC_ARGS) = ARG_INTENT_NONE
+        ! Rank of each dummy (0 for a scalar) and, for an explicit-shape array
+        ! dummy, its total element count. A generic resolves an imported
+        ! specific by these ranks, and an array actual takes the base-address
+        ! ABI because the artefact said the dummy is an array (#415).
+        integer :: arg_ranks(MAX_PROC_ARGS) = 0
+        integer :: arg_extents(MAX_PROC_ARGS) = 0
     end type external_procedure_t
 
     integer, parameter, public :: MAX_NAMELIST_MEMBERS = 32

--- a/test/test_session_separate_generic_compiler.f90
+++ b/test/test_session_separate_generic_compiler.f90
@@ -2,11 +2,46 @@ program test_session_separate_generic_compiler
     implicit none
 
     logical :: all_passed
+    ! A generic exported by a separately compiled module must resolve in the
+    ! using unit by the same rules a same-unit call uses, including the rank of
+    ! each specific's dummies. The using unit sees only the .fmod, so the ranks
+    ! have to travel in it (#415).
+    character(len=*), parameter :: rank_module_source = &
+        'module fmod415_generic'//new_line('a')// &
+        '    implicit none'//new_line('a')// &
+        '    interface total'//new_line('a')// &
+        '        module procedure total_scalar'//new_line('a')// &
+        '        module procedure total_vec'//new_line('a')// &
+        '    end interface total'//new_line('a')// &
+        '    interface grid_total'//new_line('a')// &
+        '        module procedure grid_scalar'//new_line('a')// &
+        '        module procedure grid_mat'//new_line('a')// &
+        '    end interface grid_total'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '    integer function total_scalar(x) result(r)'//new_line('a')// &
+        '        integer, intent(in) :: x'//new_line('a')// &
+        '        r = x'//new_line('a')// &
+        '    end function total_scalar'//new_line('a')// &
+        '    integer function total_vec(x) result(r)'//new_line('a')// &
+        '        integer, intent(in) :: x(3)'//new_line('a')// &
+        '        r = x(1) + x(2) + x(3)'//new_line('a')// &
+        '    end function total_vec'//new_line('a')// &
+        '    integer function grid_scalar(y) result(r)'//new_line('a')// &
+        '        integer, intent(in) :: y'//new_line('a')// &
+        '        r = 2 * y'//new_line('a')// &
+        '    end function grid_scalar'//new_line('a')// &
+        '    integer function grid_mat(y) result(r)'//new_line('a')// &
+        '        integer, intent(in) :: y(2,2)'//new_line('a')// &
+        '        r = y(1,1) + y(2,2)'//new_line('a')// &
+        '    end function grid_mat'//new_line('a')// &
+        'end module fmod415_generic'
 
     print *, '=== separate-compilation generic interface tests ==='
 
     all_passed = .true.
     if (.not. test_use_associated_generic_resolves()) all_passed = .false.
+    if (.not. test_rank_aware_specifics_resolve()) all_passed = .false.
+    if (.not. test_no_matching_rank_is_diagnosed()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: separate-compilation generic interface'
@@ -86,6 +121,165 @@ contains
             ' /tmp/ffc_gen_mod.fmod '//main_exe//' '//out_file)
         ok = .true.
     end function test_use_associated_generic_resolves
+
+    logical function test_rank_aware_specifics_resolve() result(ok)
+        ! Scalar, rank-1, and rank-2 specifics all resolve from the artefact,
+        ! and the program's result matches same-unit compilation.
+        character(len=:), allocatable :: dir
+        integer :: separate_status, same_status
+        character(len=*), parameter :: program_source = &
+            'program main'//new_line('a')// &
+            '    use fmod415_generic, only: total, grid_total'//new_line('a')// &
+            '    integer :: v(3)'//new_line('a')// &
+            '    integer :: m(2,2)'//new_line('a')// &
+            '    v(1) = 1'//new_line('a')// &
+            '    v(2) = 2'//new_line('a')// &
+            '    v(3) = 3'//new_line('a')// &
+            '    m(1,1) = 10'//new_line('a')// &
+            '    m(2,1) = 0'//new_line('a')// &
+            '    m(1,2) = 0'//new_line('a')// &
+            '    m(2,2) = 20'//new_line('a')// &
+            '    stop total(4) + total(v) + grid_total(1) + grid_total(m)'// &
+            new_line('a')// &
+            'end program main'
+
+        ok = .false.
+        call make_scratch_dir('fmod415_resolve', dir)
+        separate_status = run_separate_compilation(dir, rank_module_source, &
+                                                   program_source)
+        same_status = run_same_unit_compilation(dir, rank_module_source, &
+                                                program_source)
+        if (same_status /= 142) then
+            print *, 'FAIL: same-unit generic resolution status ', same_status
+            call show_log(dir)
+            return
+        end if
+        if (separate_status /= same_status) then
+            print *, 'FAIL: separate generic resolution status ', &
+                separate_status, ' differs from same-unit ', same_status
+            call show_log(dir)
+            return
+        end if
+        call remove_scratch_dir(dir)
+        ok = .true.
+    end function test_rank_aware_specifics_resolve
+
+    logical function test_no_matching_rank_is_diagnosed() result(ok)
+        ! A rank-2 actual passed to a generic whose only array specific is
+        ! rank-1 matches no specific. The imported generic refuses it the same
+        ! way the same-unit generic does, rather than silently binding the
+        ! rank-1 specific and reading past the actual.
+        character(len=:), allocatable :: dir
+        integer :: separate_status, same_status
+        character(len=*), parameter :: program_source = &
+            'program main'//new_line('a')// &
+            '    use fmod415_generic, only: total'//new_line('a')// &
+            '    integer :: m(2,2)'//new_line('a')// &
+            '    m(1,1) = 1'//new_line('a')// &
+            '    m(2,1) = 1'//new_line('a')// &
+            '    m(1,2) = 1'//new_line('a')// &
+            '    m(2,2) = 1'//new_line('a')// &
+            '    stop total(m)'//new_line('a')// &
+            'end program main'
+
+        ok = .false.
+        call make_scratch_dir('fmod415_nomatch', dir)
+        separate_status = run_separate_compilation(dir, rank_module_source, &
+                                                   program_source)
+        same_status = run_same_unit_compilation(dir, rank_module_source, &
+                                                program_source)
+        if (same_status /= 92) then
+            print *, 'FAIL: same-unit rank mismatch was accepted, status ', &
+                same_status
+            call show_log(dir)
+            return
+        end if
+        if (separate_status /= 92) then
+            print *, 'FAIL: imported rank mismatch was accepted, status ', &
+                separate_status
+            call show_log(dir)
+            return
+        end if
+        call remove_scratch_dir(dir)
+        ok = .true.
+    end function test_no_matching_rank_is_diagnosed
+
+    integer function run_separate_compilation(dir, mod_source, prog_source) &
+            result(status)
+        ! Compile the module with -c in one ffc invocation, then the program in
+        ! a second, independent invocation that can only learn the generic's
+        ! specifics from the .fmod artefact. Returns 90 when no ffc binary was
+        ! found, 91/92 when a compilation failed, and 100 + exit status when the
+        ! program ran.
+        character(len=*), intent(in) :: dir
+        character(len=*), intent(in) :: mod_source
+        character(len=*), intent(in) :: prog_source
+        integer :: exit_stat, cmd_stat
+
+        status = 90
+        if (.not. write_file(dir//'/m.f90', mod_source)) return
+        if (.not. write_file(dir//'/p.f90', prog_source)) return
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; exe=$PWD/$exe; '// &
+            'cd '//dir//' || exit 90; '// &
+            '"$exe" -c m.f90 -o m.o >>log 2>&1 || exit 91; '// &
+            '"$exe" p.f90 m.o -o p >>log 2>&1 || exit 92; '// &
+            "./p; exit $((100 + $?))'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) return
+        status = exit_stat
+    end function run_separate_compilation
+
+    integer function run_same_unit_compilation(dir, mod_source, prog_source) &
+            result(status)
+        ! Compile the same module and program as one unit, so the separate
+        ! result can be held against it.
+        character(len=*), intent(in) :: dir
+        character(len=*), intent(in) :: mod_source
+        character(len=*), intent(in) :: prog_source
+        integer :: exit_stat, cmd_stat
+
+        status = 90
+        if (.not. write_file(dir//'/same.f90', mod_source//new_line('a')// &
+                             prog_source)) return
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; exe=$PWD/$exe; '// &
+            'cd '//dir//' || exit 90; '// &
+            '"$exe" same.f90 -o same >>log 2>&1 || exit 92; '// &
+            "./same; exit $((100 + $?))'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) return
+        status = exit_stat
+    end function run_same_unit_compilation
+
+    subroutine make_scratch_dir(tag, dir)
+        ! A scratch directory of this run's own, so concurrent builds of other
+        ! worktrees never share it (ffc #547).
+        character(len=*), intent(in) :: tag
+        character(len=:), allocatable, intent(out) :: dir
+        character(len=32) :: stamp
+        integer :: values(8)
+
+        call date_and_time(values=values)
+        write (stamp, '(I0,A,I0)') values(6)*60000 + values(7)*1000 + &
+            values(8), '_', values(5)
+        dir = '/tmp/ffc_'//tag//'_'//trim(stamp)
+        call execute_command_line('rm -rf '//dir//'; mkdir -p '//dir)
+    end subroutine make_scratch_dir
+
+    subroutine remove_scratch_dir(dir)
+        character(len=*), intent(in) :: dir
+
+        call execute_command_line('rm -rf '//dir)
+    end subroutine remove_scratch_dir
+
+    subroutine show_log(dir)
+        character(len=*), intent(in) :: dir
+
+        call execute_command_line('cat '//dir//'/log 2>/dev/null')
+    end subroutine show_log
 
     logical function file_contains(path, fragment) result(found)
         character(len=*), intent(in) :: path


### PR DESCRIPTION
Closes #415.

## What changed

A generic whose specifics differ by rank could not cross separate compilation
at all. The artefact only recorded procedures whose dummies were scalars, so
`total_vec(x(3))` was never exported, and dropping one specific dropped the
whole generic: the using unit was told `total` "is not exported by module".

- `[[procedure]]` gains `arg_ranks` and `arg_extents`.
- The writer now exports procedures whose dummies are scalars or
  explicit-shape arrays of a supported scalar kind (passed as the base address
  of contiguous storage). Assumed-shape, assumed-rank, assumed-size,
  allocatable, character, and derived dummies still keep a procedure out of the
  artefact rather than risking a miscompiled call.
- The reader feeds the ranks into the same generic table a same-unit interface
  block fills, so imported resolution scores by rank with the same rules
  instead of assuming rank 0 everywhere (the old code said so in a comment:
  *"Ranks default to 0 (scalar) since .fmod does not yet carry rank info"*).
- An array actual to an imported specific takes the array-argument ABI because
  the artefact says the dummy is an array.
- A use-associated generic call resolves its external through the specific it
  selected, not through the generic name — that mismatch is why the scalar
  specific linked and the array one did not.

## Invariants preserved

- **Artifact version contract**: schema moves to 4; a pre-rank artefact is
  rejected by the version check from #397 rather than read as all-scalar.
- **Generic rank resolution**: positive oracle resolves scalar, rank-1 and
  rank-2 specifics from a compiled module and requires the same exit status
  (142) as same-unit compilation of the identical source.
- **Same rules as same-unit**: the negative oracle passes a rank-2 actual to a
  generic whose only array specific is rank-1; separate and same-unit
  compilation both reject it, with the same diagnostic.
- **No source rescan / no guess**: ranks and extents come only from the
  artefact; nothing reopens the module source.
- **Derived layout and character metadata** (#414) and the scalar procedure
  contracts (#397) are unchanged and still round-trip.

## Adjacent work, not done here

ffc's source-text ambiguity pre-check treats a rank-1 and a rank-2 specific of
the same element kind as indistinguishable, so both cannot live in one generic
yet (`ambiguous interfaces total_vec and total_mat`). That is a same-unit
resolution limitation, identical before and after this PR; the fixtures use two
generics rather than weakening the check.

## Corpus delta

Measured against the recorded `origin/main` baseline: no new failures; 11 cases
that failed in the baseline now pass (several chains merged in between, so not
all are attributable here). No xfail manifest entries move. `fo`'s two failures
(`test_fortfront_corpus_conformance`, `test_parity_dashboard`) both reproduce on
unmodified `main`.