### PR TITLE
[fmod-submodule-01] export deferred module-procedure interfaces (refs #297)

### DIFF
--- a/src/ffc_module_artefact.f90
+++ b/src/ffc_module_artefact.f90
@@ -24,7 +24,7 @@ module ffc_module_artefact
     ! other value, and an artefact without the field, so a stale or
     ! newer-than-supported artefact is diagnosed instead of silently misread
     ! (#397).
-    integer, parameter, public :: FMOD_SCHEMA_VERSION = 4
+    integer, parameter, public :: FMOD_SCHEMA_VERSION = 5
 
     type :: fmod_parameter_t
         character(len=:), allocatable :: name
@@ -104,6 +104,11 @@ module ffc_module_artefact
         ! call resolves one by the declared ranks (#415).
         character(len=:), allocatable :: arg_ranks
         character(len=:), allocatable :: arg_extents
+        ! True when this module's interface declares the procedure and a
+        ! submodule supplies its body. The symbol and call contract are the
+        ! same either way; a separately compiled submodule reads the interface
+        ! it has to implement from these records (#297).
+        logical :: deferred_body = .false.
         integer :: nargs = 0
     end type fmod_procedure_t
 
@@ -216,6 +221,8 @@ contains
                     field(info%procedures(i)%arg_ranks)//'"'
                 write (unit, '(A)') 'arg_extents = "'// &
                     field(info%procedures(i)%arg_extents)//'"'
+                write (unit, '(A)') 'deferred_body = '// &
+                    bool_text(info%procedures(i)%deferred_body)
             end do
         end if
 
@@ -319,6 +326,7 @@ contains
                 procs(nproc)%result_kind = ''
                 procs(nproc)%arg_ranks = ''
                 procs(nproc)%arg_extents = ''
+                procs(nproc)%deferred_body = .false.
                 procs(nproc)%nargs = 0
                 cycle
             else if (line == '[[generic]]') then
@@ -386,6 +394,8 @@ contains
                 if (key == 'arg_ranks') procs(nproc)%arg_ranks = unquote(val)
                 if (key == 'arg_extents') &
                     procs(nproc)%arg_extents = unquote(val)
+                if (key == 'deferred_body') &
+                    procs(nproc)%deferred_body = unquote(val) == '1'
                 if (key == 'nargs') then
                     read (val, *, iostat=io_read) procs(nproc)%nargs
                     if (io_read /= 0) procs(nproc)%nargs = 0

--- a/src/session_program_lowering_fmod.inc
+++ b/src/session_program_lowering_fmod.inc
@@ -255,30 +255,125 @@
         if (len_trim(ff_error) > 0) return
         count = 0
         do p = 1, size(procedure_indices)
-            call fmod_procedure_signature(arena, context, procedure_indices(p), &
-                                          mod_node, kind_text, nargs, &
-                                          arg_tokens, rank_tokens, extent_tokens)
-            if (len_trim(kind_text) == 0) cycle
-            count = count + 1
-            call grow_fmod_procs(procs, count)
-            procs(count)%name = procedure_fortran_name(arena, &
-                                                        procedure_indices(p))
-            procs(count)%kind = kind_text
-            procs(count)%nargs = nargs
-            procs(count)%arg_kinds = arg_tokens
-            procs(count)%arg_ranks = rank_tokens
-            procs(count)%arg_extents = extent_tokens
-            procs(count)%arg_names = fmod_procedure_arg_names(arena, &
-                                                     procedure_indices(p))
-            call fmod_procedure_dummy_attributes(arena, procedure_indices(p), &
-                                                 procs(count)%arg_intents, &
-                                                 procs(count)%arg_optionals, &
-                                                 procs(count)%arg_values)
-            call fmod_procedure_result(arena, procedure_indices(p), kind_text, &
-                                       procs(count)%result_name, &
-                                       procs(count)%result_kind)
+            call record_fmod_procedure(arena, context, procedure_indices(p), &
+                                       mod_node, .false., procs, count)
+        end do
+        ! A module procedure whose interface the module declares and whose body
+        ! a submodule supplies is exported too: its symbol is mangled to this
+        ! module, so a separately compiled caller resolves and links it exactly
+        ! like a contained module procedure, and a separately compiled submodule
+        ! reads the interface it has to implement from here (#297).
+        do p = 1, size(declaration_indices)
+            call record_fmod_interface_procedures(arena, context, &
+                                                  declaration_indices(p), &
+                                                  mod_node, procs, count)
         end do
     end subroutine build_fmod_procedures
+
+    subroutine record_fmod_interface_procedures(arena, context, node_index, &
+                                                mod_node, procs, count)
+        ! Record every deferred module-procedure interface body of one interface
+        ! block. A plain interface block declares an external procedure with no
+        ! module mangling, so only bodies written `module function` /
+        ! `module subroutine` are recorded (#297).
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: node_index
+        type(module_node), intent(in) :: mod_node
+        type(fmod_procedure_t), allocatable, intent(inout) :: procs(:)
+        integer, intent(inout) :: count
+        integer :: i
+
+        if (.not. node_exists(arena, node_index)) return
+        select type (block => arena%entries(node_index)%node)
+        type is (interface_block_node)
+            if (block%is_abstract) return
+            if (.not. allocated(block%procedure_indices)) return
+            do i = 1, size(block%procedure_indices)
+                if (.not. procedure_is_deferred_module_body(arena, &
+                        block%procedure_indices(i))) cycle
+                call record_fmod_procedure(arena, context, &
+                                           block%procedure_indices(i), &
+                                           mod_node, .true., procs, count)
+            end do
+        end select
+    end subroutine record_fmod_interface_procedures
+
+    logical function procedure_is_deferred_module_body(arena, node_index) &
+            result(is_module_body)
+        ! Whether an interface body is written `module function` /
+        ! `module subroutine`, which makes it a module procedure of the
+        ! enclosing module whose body a submodule supplies (F2018 15.6.2.5).
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(function_def_node), pointer :: fn_node
+        type(subroutine_def_node), pointer :: sb_node
+
+        is_module_body = .false.
+        if (.not. node_exists(arena, node_index)) return
+        fn_node => get_node_as_function_def(arena, node_index)
+        if (associated(fn_node)) then
+            is_module_body = prefix_has_module(fn_node%prefix_keywords)
+            return
+        end if
+        sb_node => get_node_as_subroutine_def(arena, node_index)
+        if (associated(sb_node)) &
+            is_module_body = prefix_has_module(sb_node%prefix_keywords)
+    end function procedure_is_deferred_module_body
+
+    logical function prefix_has_module(prefix_keywords) result(has_module)
+        character(len=16), allocatable, intent(in) :: prefix_keywords(:)
+        integer :: i
+
+        has_module = .false.
+        if (.not. allocated(prefix_keywords)) return
+        do i = 1, size(prefix_keywords)
+            if (trim(lowercase_text(prefix_keywords(i))) == 'module') then
+                has_module = .true.
+                return
+            end if
+        end do
+    end function prefix_has_module
+
+    subroutine record_fmod_procedure(arena, context, node_index, mod_node, &
+                                     deferred_body, procs, count)
+        ! Append one exportable module procedure's signature record. The same
+        ! record describes a procedure whose body this module contains and one
+        ! whose body a submodule supplies; deferred_body only says which, since
+        ! both carry the same mangled symbol and the same call contract (#297).
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: node_index
+        type(module_node), intent(in) :: mod_node
+        logical, intent(in) :: deferred_body
+        type(fmod_procedure_t), allocatable, intent(inout) :: procs(:)
+        integer, intent(inout) :: count
+        character(len=:), allocatable :: kind_text, arg_tokens
+        character(len=:), allocatable :: rank_tokens, extent_tokens
+        integer :: nargs
+
+        call fmod_procedure_signature(arena, context, node_index, mod_node, &
+                                      kind_text, nargs, arg_tokens, &
+                                      rank_tokens, extent_tokens)
+        if (len_trim(kind_text) == 0) return
+        count = count + 1
+        call grow_fmod_procs(procs, count)
+        procs(count)%name = procedure_fortran_name(arena, node_index)
+        procs(count)%kind = kind_text
+        procs(count)%nargs = nargs
+        procs(count)%arg_kinds = arg_tokens
+        procs(count)%arg_ranks = rank_tokens
+        procs(count)%arg_extents = extent_tokens
+        procs(count)%arg_names = fmod_procedure_arg_names(arena, node_index)
+        procs(count)%deferred_body = deferred_body
+        call fmod_procedure_dummy_attributes(arena, node_index, &
+                                             procs(count)%arg_intents, &
+                                             procs(count)%arg_optionals, &
+                                             procs(count)%arg_values)
+        call fmod_procedure_result(arena, node_index, kind_text, &
+                                   procs(count)%result_name, &
+                                   procs(count)%result_kind)
+    end subroutine record_fmod_procedure
 
     subroutine fmod_procedure_result(arena, node_index, kind_text, result_name, &
                                      result_kind)
@@ -516,7 +611,7 @@
             if (.not. allocated(fn_node%name)) return
             if (module_symbol_is_private(arena, mod_node, fn_node%name)) return
             if (procedure_has_nested_contains(arena, fn_node%body_indices)) return
-            if (.not. return_type_is_integer(fn_node%return_type)) return
+            if (.not. fmod_function_result_is_integer(arena, fn_node)) return
             if (.not. params_all_supported(arena, context, &
                                     fn_node%param_indices, fn_node%body_indices, &
                                     nargs, arg_tokens, rank_tokens, &
@@ -536,6 +631,44 @@
             kind_text = 'subroutine'
         end if
     end subroutine fmod_procedure_signature
+
+    logical function fmod_function_result_is_integer(arena, fn_node) &
+            result(is_integer)
+        ! Whether a module function returns a default integer. A contained
+        ! function states its type in the header; a deferred module-procedure
+        ! interface body may instead declare its result variable in the
+        ! interface body, so that declaration is consulted too (#297).
+        type(ast_arena_t), intent(in) :: arena
+        type(function_def_node), intent(in) :: fn_node
+        character(len=:), allocatable :: result_name, kind_err
+        integer :: value_kind, i
+
+        is_integer = return_type_is_integer(fn_node%return_type)
+        if (is_integer) return
+        if (allocated(fn_node%return_type)) then
+            if (len_trim(fn_node%return_type) > 0) return
+        end if
+        result_name = ''
+        if (allocated(fn_node%result_variable)) result_name = &
+            trim(fn_node%result_variable)
+        if (len_trim(result_name) == 0 .and. allocated(fn_node%name)) &
+            result_name = trim(fn_node%name)
+        if (len_trim(result_name) == 0) return
+        if (.not. allocated(fn_node%body_indices)) return
+        do i = 1, size(fn_node%body_indices)
+            if (.not. node_exists(arena, fn_node%body_indices(i))) cycle
+            select type (decl => arena%entries(fn_node%body_indices(i))%node)
+            type is (declaration_node)
+                if (decl%is_array) cycle
+                if (.not. declaration_declares_name(decl, &
+                    trim(lowercase_text(result_name)))) cycle
+                call declaration_value_kind(decl, value_kind, kind_err)
+                if (len_trim(kind_err) > 0) return
+                is_integer = value_kind == VALUE_I32
+                return
+            end select
+        end do
+    end function fmod_function_result_is_integer
 
     logical function return_type_is_integer(return_type)
         character(len=:), allocatable, intent(in) :: return_type

--- a/test/test_session_submodule_compiler.f90
+++ b/test/test_session_submodule_compiler.f90
@@ -12,6 +12,8 @@ program test_session_submodule_compiler
     if (.not. test_separate_module_function()) all_passed = .false.
     if (.not. test_generic_interface_body_specific()) all_passed = .false.
     if (.not. test_parent_module_not_found()) all_passed = .false.
+    if (.not. test_caller_links_deferred_module_procedure()) all_passed = .false.
+    if (.not. test_plain_interface_is_not_exported()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: single-file submodules lower against the parent module'
@@ -154,5 +156,187 @@ contains
             source, 'submodule parent module not found', &
             '/tmp/ffc_session_submod_orphan_test')
     end function test_parent_module_not_found
+
+    logical function test_caller_links_deferred_module_procedure() result(ok)
+        ! A module procedure whose interface the parent declares and whose body
+        ! a submodule supplies must reach a separately compiled caller: the
+        ! caller sees only the parent's .fmod, and can resolve and link the
+        ! procedure only because the artefact carries that deferred interface
+        ! (#297).
+        character(len=:), allocatable :: dir
+        integer :: separate_status, same_status
+        character(len=*), parameter :: module_source = &
+            'module fmod297_parent'//new_line('a')// &
+            '    implicit none'//new_line('a')// &
+            '    interface'//new_line('a')// &
+            '        module function twice(x) result(r)'//new_line('a')// &
+            '            integer, intent(in) :: x'//new_line('a')// &
+            '            integer :: r'//new_line('a')// &
+            '        end function twice'//new_line('a')// &
+            '    end interface'//new_line('a')// &
+            'end module fmod297_parent'//new_line('a')// &
+            'submodule (fmod297_parent) fmod297_impl'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '    module procedure twice'//new_line('a')// &
+            '        r = 2 * x'//new_line('a')// &
+            '    end procedure twice'//new_line('a')// &
+            'end submodule fmod297_impl'
+        character(len=*), parameter :: program_source = &
+            'program main'//new_line('a')// &
+            '    use fmod297_parent, only: twice'//new_line('a')// &
+            '    stop twice(21)'//new_line('a')// &
+            'end program main'
+
+        ok = .false.
+        call make_scratch_dir('fmod297_deferred', dir)
+        separate_status = run_separate_compilation(dir, module_source, &
+                                                   program_source)
+        same_status = run_same_unit_compilation(dir, module_source, &
+                                                program_source)
+        if (same_status /= 142) then
+            print *, 'FAIL: same-unit deferred module procedure status ', &
+                same_status
+            call show_log(dir)
+            return
+        end if
+        if (separate_status /= same_status) then
+            print *, 'FAIL: separately compiled caller status ', &
+                separate_status, ' differs from same-unit ', same_status
+            call show_log(dir)
+            return
+        end if
+        call remove_scratch_dir(dir)
+        ok = .true.
+    end function test_caller_links_deferred_module_procedure
+
+    logical function test_plain_interface_is_not_exported() result(ok)
+        ! A plain interface block declares an external procedure with no module
+        ! mangling, so it must not be published as a module procedure of the
+        ! enclosing module: a caller that resolved it there would link against
+        ! a symbol the module never defines.
+        character(len=:), allocatable :: dir
+        integer :: separate_status
+        character(len=*), parameter :: module_source = &
+            'module fmod297_external'//new_line('a')// &
+            '    implicit none'//new_line('a')// &
+            '    interface'//new_line('a')// &
+            '        integer function outside(x)'//new_line('a')// &
+            '            integer, intent(in) :: x'//new_line('a')// &
+            '        end function outside'//new_line('a')// &
+            '    end interface'//new_line('a')// &
+            'end module fmod297_external'
+        character(len=*), parameter :: program_source = &
+            'program main'//new_line('a')// &
+            '    use fmod297_external, only: outside'//new_line('a')// &
+            '    stop outside(1)'//new_line('a')// &
+            'end program main'
+
+        ok = .false.
+        call make_scratch_dir('fmod297_plain', dir)
+        separate_status = run_separate_compilation(dir, module_source, &
+                                                   program_source)
+        if (separate_status /= 92) then
+            print *, 'FAIL: plain interface was exported as a module '// &
+                'procedure, status ', separate_status
+            call show_log(dir)
+            return
+        end if
+        call remove_scratch_dir(dir)
+        ok = .true.
+    end function test_plain_interface_is_not_exported
+
+    integer function run_separate_compilation(dir, mod_source, prog_source) &
+            result(status)
+        ! Compile the module (with its submodule) in one ffc invocation, then
+        ! the program in a second, independent invocation that can only learn
+        ! the module's procedures from the .fmod artefact. Returns 90 when no
+        ! ffc binary was found, 91/92 when a compilation failed, and
+        ! 100 + exit status when the program ran.
+        character(len=*), intent(in) :: dir
+        character(len=*), intent(in) :: mod_source
+        character(len=*), intent(in) :: prog_source
+        integer :: exit_stat, cmd_stat
+
+        status = 90
+        if (.not. write_source(dir//'/m.f90', mod_source)) return
+        if (.not. write_source(dir//'/p.f90', prog_source)) return
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; exe=$PWD/$exe; '// &
+            'cd '//dir//' || exit 90; '// &
+            '"$exe" -c m.f90 -o m.o >>log 2>&1 || exit 91; '// &
+            '"$exe" p.f90 m.o -o p >>log 2>&1 || exit 92; '// &
+            "./p; exit $((100 + $?))'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) return
+        status = exit_stat
+    end function run_separate_compilation
+
+    integer function run_same_unit_compilation(dir, mod_source, prog_source) &
+            result(status)
+        ! Compile the same module, submodule, and program as one unit, so the
+        ! separate result can be held against it.
+        character(len=*), intent(in) :: dir
+        character(len=*), intent(in) :: mod_source
+        character(len=*), intent(in) :: prog_source
+        integer :: exit_stat, cmd_stat
+
+        status = 90
+        if (.not. write_source(dir//'/same.f90', mod_source//new_line('a')// &
+                               prog_source)) return
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; exe=$PWD/$exe; '// &
+            'cd '//dir//' || exit 90; '// &
+            '"$exe" same.f90 -o same >>log 2>&1 || exit 92; '// &
+            "./same; exit $((100 + $?))'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) return
+        status = exit_stat
+    end function run_same_unit_compilation
+
+    subroutine make_scratch_dir(tag, dir)
+        ! A scratch directory of this run's own, so concurrent builds of other
+        ! worktrees never share it (ffc #547).
+        character(len=*), intent(in) :: tag
+        character(len=:), allocatable, intent(out) :: dir
+        character(len=32) :: stamp
+        integer :: values(8)
+
+        call date_and_time(values=values)
+        write (stamp, '(I0,A,I0)') values(6)*60000 + values(7)*1000 + &
+            values(8), '_', values(5)
+        dir = '/tmp/ffc_'//tag//'_'//trim(stamp)
+        call execute_command_line('rm -rf '//dir//'; mkdir -p '//dir)
+    end subroutine make_scratch_dir
+
+    subroutine remove_scratch_dir(dir)
+        character(len=*), intent(in) :: dir
+
+        call execute_command_line('rm -rf '//dir)
+    end subroutine remove_scratch_dir
+
+    subroutine show_log(dir)
+        character(len=*), intent(in) :: dir
+
+        call execute_command_line('cat '//dir//'/log 2>/dev/null')
+    end subroutine show_log
+
+    logical function write_source(path, contents) result(ok)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: contents
+        integer :: unit, io_stat
+
+        ok = .false.
+        open (newunit=unit, file=path, status='replace', action='write', &
+              iostat=io_stat)
+        if (io_stat /= 0) then
+            print *, 'FAIL: could not write ', path
+            return
+        end if
+        write (unit, '(A)', iostat=io_stat) contents
+        close (unit)
+        ok = io_stat == 0
+    end function write_source
 
 end program test_session_submodule_compiler


### PR DESCRIPTION
Refs #297 — first of two steps (the caller half). Does not close the issue.

## What changed

A module procedure whose interface the parent declares and whose body a
submodule supplies never reached the artefact: `build_fmod_procedures` walked
only the module's *contained* procedures. So a separately compiled caller was
told `use pm, only: twice` — *"name is not exported by module pm"* — even though
the module object defined `__pm_MOD_twice`.

The artefact now records those deferred interfaces alongside contained ones,
through a **single** record-filling entry point (`record_fmod_procedure`) that
both paths share — no second encoding and no parallel path. Only bodies written
`module function` / `module subroutine` qualify.

A deferred module-procedure interface may declare its result variable in the
interface body rather than the header, so the result kind is resolved from that
declaration when the header carries no type.

Schema moves to 5.

## Design note

Per the steer on #297: no AST synthesis, no mutable arena. The deferred
interface travels as the same `fmod_procedure_t` record every other module
procedure uses, because the call contract and the mangled symbol are identical.
`deferred_body` records only *which side supplies the body* — that is the fact a
separately compiled submodule will read in step two to learn the interface it
must implement.

## Invariants preserved

- **Artifact version contract**: schema 4 → 5; a pre-deferred artefact is
  rejected by the version check rather than read as if it had these records.
- **No source rescan**: the caller resolves and links the procedure from the
  artefact alone.
- **One convention**: contained and deferred module procedures produce byte-
  identical record shapes; the reader has one path.
- **Negative control**: a plain (non-`module`) interface block is *not*
  exported. Publishing it would point a caller at a symbol the module never
  defines. `test_plain_interface_is_not_exported` asserts the caller still
  fails to compile.
- Derived layouts (#414), generic ranks (#415) and scalar contracts (#397)
  round-trip unchanged.

## Oracles

Added to `test/test_session_submodule_compiler.f90` (all five existing tests
unchanged):

- `test_caller_links_deferred_module_procedure` — parent + submodule compiled to
  one object, caller compiled in a **separate** `ffc` invocation seeing only the
  `.fmod`; was a hard compile error on main, now exits 42, matching same-unit
  compilation of identical source.
- `test_plain_interface_is_not_exported` — negative control above.

## Corpus delta

Failure set identical to the previous measured baseline (9 cases): no new
failures, none newly passing, no xfail manifest entries move. `fo`'s two red
tests (`test_fortfront_corpus_conformance`, `test_parity_dashboard`) both
reproduce on unmodified `main`.

## Next step

`ffc -c submodule.f90` is still rejected at the driver level (*"direct LIRIC
session only lowers top-level programs"*). That is step two, landing separately
so each step is green on its own.