### PR TITLE
[chardesc-04] centralize runtime-length character operations

### DIFF
--- a/src/session_program_lowering_character.inc
+++ b/src/session_program_lowering_character.inc
@@ -558,6 +558,14 @@
                         context, symbol_index, error_msg)
                     return
                 end if
+            else if (is_character_substring(arena, node%value_index, context)) &
+                then
+                ! Deferred target receives a substring view: intrinsic
+                ! assignment copies the view's bytes at the view's length, so
+                ! the target never aliases its parent's storage.
+                call lower_deferred_char_view_assignment(arena, &
+                    node%value_index, context, symbol_index, error_msg)
+                return
             else if (is_identifier(arena, node%value_index)) then
                 ! Deferred target receives another character variable: copy the
                 ! source {data, len} into the target descriptor (str = other).
@@ -591,10 +599,12 @@
             if (len_trim(error_msg) > 0) return
             call strip_literal_quotes(lit_value, literal_text)
         else if (is_identifier(arena, node%value_index) .or. &
-                 is_char_expr_call(arena, node%value_index)) then
-            ! A character variable, trim()/adjustl()/adjustr()/achar()/repeat()
-            ! result assigned to a fixed-length target: pad or truncate to the
-            ! target's declared width like gfortran's fixed-length assignment.
+                 is_char_expr_call(arena, node%value_index) .or. &
+                 is_character_substring(arena, node%value_index, context)) then
+            ! A character variable, a substring view, or a
+            ! trim()/adjustl()/adjustr()/achar()/repeat() result assigned to a
+            ! fixed-length target: pad or truncate to the target's declared
+            ! width like gfortran's fixed-length assignment.
             call lower_fixed_char_expr_assignment(arena, node%value_index, &
                 context, symbol_index, error_msg)
             return
@@ -1373,6 +1383,11 @@
             end select
             return
         end if
+        if (is_character_substring(arena, node_index, context)) then
+            call substring_operands(arena, node_index, context, data_ptr, &
+                                    length, error_msg)
+            return
+        end if
         if (is_character_array_element(arena, node_index, context)) then
             select type (n => arena%entries(node_index)%node)
             type is (call_or_subscript_node)
@@ -1433,6 +1448,276 @@
             'direct LIRIC session only supports a character variable or '// &
             'trim() here', error_msg)
     end subroutine char_expr_operands
+
+    subroutine reject_constant_substring_overrun(arena, context, symbol_index, &
+                                                 lower_index, upper_index, &
+                                                 error_msg)
+        ! Reject s(l:u) whose constant bounds fall outside a parent of known
+        ! declared width. Only a fixed-length parent has a compile-time width;
+        ! a deferred-length parent's length is a run-time value, so nothing is
+        ! decidable here and the substring is accepted. Non-constant bounds are
+        ! likewise left alone.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: symbol_index
+        integer, intent(in) :: lower_index
+        integer, intent(in) :: upper_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer(c_int64_t) :: lower_value, upper_value
+        logical :: lower_known, upper_known
+        integer :: declared_length
+
+        call set_empty(error_msg)
+        if (context%symbols(symbol_index)%is_deferred_character) return
+        declared_length = context%symbols(symbol_index)%character_length
+        if (declared_length <= 0) return
+
+        call constant_i64_value(arena, lower_index, lower_value, lower_known)
+        call constant_i64_value(arena, upper_index, upper_value, upper_known)
+
+        if (lower_known) then
+            if (lower_value < 1_c_int64_t) then
+                error_msg = 'substring start index is below the string length'
+                return
+            end if
+        end if
+        if (upper_known) then
+            if (upper_value > int(declared_length, c_int64_t)) then
+                error_msg = 'substring end index exceeds the string length'
+                return
+            end if
+        end if
+    end subroutine reject_constant_substring_overrun
+
+    subroutine constant_i64_value(arena, node_index, value, is_known)
+        ! Fold a substring bound to a compile-time integer when it is a plain
+        ! integer literal. Anything else is a run-time expression.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        integer(c_int64_t), intent(out) :: value
+        logical, intent(out) :: is_known
+        character(len=:), allocatable :: lit_value, lit_type, lit_err
+        integer :: ios
+
+        value = 0_c_int64_t
+        is_known = .false.
+        if (node_index <= 0) return
+        if (.not. node_exists(arena, node_index)) return
+        if (.not. is_literal(arena, node_index)) return
+        call get_literal_info(arena, node_index, lit_value, lit_type, lit_err)
+        if (len_trim(lit_err) > 0) return
+        if (verify(trim(adjustl(lit_value)), '0123456789') /= 0) return
+        read (lit_value, *, iostat=ios) value
+        is_known = ios == 0
+    end subroutine constant_i64_value
+
+    subroutine lower_deferred_char_view_assignment(arena, value_index, context, &
+                                                   symbol_index, error_msg)
+        ! str = other(l:u), where str is character(len=:), allocatable. The
+        ! right-hand side is a borrowed view into another variable's storage,
+        ! so the destination takes its own copy at the view's length. The copy
+        ! is made before the destination releases the block it held, which is
+        ! what keeps `s = s(2:4)` correct.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: value_index
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: data_ptr, len_i32, len_i64, buf
+
+        call substring_operands(arena, value_index, context, data_ptr, len_i32, &
+                                error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_liric_i32_to_i64(context%session, len_i32, len_i64, &
+                error_msg)) return
+
+        call copy_character_bytes_to_owned(context, data_ptr, len_i64, buf, &
+                                           error_msg)
+        if (len_trim(error_msg) > 0) return
+        call release_owned_character_storage(context, symbol_index, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_ptr_store(context%session, buf, &
+                context%symbols(symbol_index)%deferred_data, error_msg)) return
+        if (.not. emit_i64_store(context%session, len_i64, &
+                context%symbols(symbol_index)%deferred_length, error_msg)) return
+        call set_character_storage(context, symbol_index, len_i64, &
+                                   LOWERING_CHARACTER_STORAGE_OWNED, error_msg)
+        if (len_trim(error_msg) > 0) return
+        context%symbols(symbol_index)%value = buf
+        context%symbols(symbol_index)%has_character_value = .true.
+        call set_empty(error_msg)
+    end subroutine lower_deferred_char_view_assignment
+
+    subroutine materialize_character_view(context, data_ptr, length, buf, &
+                                          error_msg)
+        ! Copy a borrowed character view into a fresh null-terminated buffer of
+        ! exactly its Fortran length. A view has no terminator of its own, so
+        ! anything that reads it as a C string needs this first. The buffer
+        ! follows the same convention as the other character expression
+        ! helpers: heap inside an internal function, where it has to outlive
+        ! the frame, and stack at program scope.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: data_ptr
+        type(lr_operand_desc_t), intent(in) :: length
+        type(lr_operand_desc_t), intent(out) :: buf
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: length64, bytes, null_pos
+
+        if (.not. emit_liric_i32_to_i64(context%session, length, length64, &
+                error_msg)) return
+        if (.not. emit_i64_binary(context%session, LR_OP_ADD, length64, &
+                i64_immediate(context%session, 1_c_int64_t), bytes, &
+                error_msg)) return
+        if (context%in_internal_function) then
+            if (.not. emit_malloc(context%session, bytes, buf, error_msg)) return
+        else
+            if (.not. emit_alloca_bytes(context%session, bytes, buf, error_msg)) &
+                return
+        end if
+        if (.not. emit_memcpy(context%session, buf, data_ptr, length64, &
+                error_msg)) return
+        if (.not. emit_i64_binary(context%session, LR_OP_ADD, buf, length64, &
+                null_pos, error_msg)) return
+        if (.not. emit_liric_store_char_byte(context%session, null_pos, &
+                i32_immediate(context%session, 0_c_int64_t), &
+                i32_immediate(context%session, 0_c_int64_t), error_msg)) return
+        call set_empty(error_msg)
+    end subroutine materialize_character_view
+
+    logical function is_character_substring(arena, node_index, context) &
+            result(is_substring)
+        ! True when node is s(l:u) on a scalar character variable. The parser
+        ! produces the same array_slice_node shape as an array section, so the
+        ! base symbol's rank is what separates a substring from a section.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(in) :: context
+        character(len=:), allocatable :: base_name, name_err
+        integer :: symbol_index
+
+        is_substring = .false.
+        if (.not. node_exists(arena, node_index)) return
+        select type (n => arena%entries(node_index)%node)
+        type is (array_slice_node)
+            if (n%num_dimensions /= 1) return
+            call identifier_name(arena, n%array_index, base_name, name_err)
+            if (len_trim(name_err) > 0) return
+            symbol_index = find_symbol_compat(context, base_name)
+            if (symbol_index <= 0) return
+            if (context%symbols(symbol_index)%value_kind /= VALUE_CHARACTER) return
+            if (context%symbols(symbol_index)%is_array) return
+            is_substring = .true.
+        end select
+    end function is_character_substring
+
+    subroutine substring_operands(arena, node_index, context, data_ptr, length, &
+                                  error_msg)
+        ! s(l:u) on a scalar character: a borrowed view into s's own storage.
+        ! The view's data pointer is s's data advanced by l - 1 bytes and its
+        ! Fortran length is u - l + 1; nothing is allocated and nothing is
+        ! copied, so the view stays valid exactly as long as s's storage does.
+        ! An omitted bound defaults to 1 for the lower and len(s) for the upper.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: data_ptr
+        type(lr_operand_desc_t), intent(out) :: length
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: base_name
+        integer :: symbol_index, bounds_index, lower_index, upper_index
+        type(lr_operand_desc_t) :: base_data, base_len, lower_i32, upper_i32
+        type(lr_operand_desc_t) :: zero_based, span
+
+        call set_empty(error_msg)
+        bounds_index = 0
+        lower_index = -1
+        upper_index = -1
+        select type (n => arena%entries(node_index)%node)
+        type is (array_slice_node)
+            call identifier_name(arena, n%array_index, base_name, error_msg)
+            if (len_trim(error_msg) > 0) return
+            bounds_index = n%bounds_indices(1)
+        class default
+            error_msg = 'expected a substring reference'
+            return
+        end select
+
+        symbol_index = find_symbol_compat(context, base_name)
+        if (symbol_index <= 0) then
+            error_msg = 'substring base was not declared: '//trim(base_name)
+            return
+        end if
+        call char_length_operands(context, symbol_index, base_data, base_len, &
+                                  error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        if (.not. node_exists(arena, bounds_index)) then
+            error_msg = 'substring bounds do not reference an AST node'
+            return
+        end if
+        ! The parser produces either shape for l:u depending on context.
+        select type (b => arena%entries(bounds_index)%node)
+        type is (array_bounds_node)
+            if (b%stride_index > 0) then
+                call unsupported_feature_error('substring', 0, 0, &
+                    'a substring has no stride', error_msg)
+                return
+            end if
+            lower_index = b%lower_bound_index
+            upper_index = b%upper_bound_index
+        type is (range_expression_node)
+            if (b%stride_index > 0) then
+                call unsupported_feature_error('substring', 0, 0, &
+                    'a substring has no stride', error_msg)
+                return
+            end if
+            lower_index = b%start_index
+            upper_index = b%end_index
+        class default
+            error_msg = 'substring bounds are not a range'
+            return
+        end select
+
+        ! A fixed-length parent has a known width, so constant bounds outside
+        ! it are rejected here rather than reading past the variable, matching
+        ! gfortran's "substring end index exceeds the string length".
+        call reject_constant_substring_overrun(arena, context, symbol_index, &
+                                               lower_index, upper_index, &
+                                               error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        if (lower_index > 0) then
+            call lower_i32_expression(arena, lower_index, context, lower_i32, &
+                                      error_msg)
+            if (len_trim(error_msg) > 0) return
+        else
+            lower_i32 = i32_immediate(context%session, 1_c_int64_t)
+        end if
+        if (upper_index > 0) then
+            call lower_i32_expression(arena, upper_index, context, upper_i32, &
+                                      error_msg)
+            if (len_trim(error_msg) > 0) return
+        else
+            upper_i32 = base_len
+        end if
+
+        ! data = base + (lower - 1)
+        if (.not. emit_i32_binary(context%session, LR_OP_SUB, lower_i32, &
+                i32_immediate(context%session, 1_c_int64_t), zero_based, &
+                error_msg)) return
+        call ptr_plus_i32(context, base_data, zero_based, data_ptr, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        ! length = upper - lower + 1
+        if (.not. emit_i32_binary(context%session, LR_OP_SUB, upper_i32, &
+                zero_based, span, error_msg)) return
+        length = span
+        call set_empty(error_msg)
+    end subroutine substring_operands
 
     logical function is_character_array_element(arena, node_index, context) &
             result(is_elem)

--- a/src/session_program_lowering_deferred_char.inc
+++ b/src/session_program_lowering_deferred_char.inc
@@ -1,6 +1,6 @@
 integer function resolve_concat_operand(arena, node_index, context, &
                                            out_name, operand_is_literal, error_msg, &
-                                           operand_is_call) &
+                                           operand_is_call, operand_is_view) &
       result(symbol_index)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: node_index
@@ -12,6 +12,9 @@ integer function resolve_concat_operand(arena, node_index, context, &
         ! literal nor a declared symbol: the caller materialises it through
         ! the descriptor return ABI before the concatenation reads it.
         logical, intent(out), optional :: operand_is_call
+        ! A substring is a borrowed view: it resolves to a data pointer and a
+        ! runtime length rather than to a symbol.
+        logical, intent(out), optional :: operand_is_view
         character(len=:), allocatable :: name
         character(len=:), allocatable :: lit_value, lit_type
         integer :: idx
@@ -19,6 +22,7 @@ integer function resolve_concat_operand(arena, node_index, context, &
         symbol_index = 0
         operand_is_literal = .false.
         if (present(operand_is_call)) operand_is_call = .false.
+        if (present(operand_is_view)) operand_is_view = .false.
         out_name = ''
         call set_empty(error_msg)
 
@@ -30,6 +34,13 @@ integer function resolve_concat_operand(arena, node_index, context, &
         if (present(operand_is_call)) then
             if (is_contained_char_result_call(arena, node_index, context)) then
                 operand_is_call = .true.
+                return
+            end if
+        end if
+
+        if (present(operand_is_view)) then
+            if (is_character_substring(arena, node_index, context)) then
+                operand_is_view = .true.
                 return
             end if
         end if
@@ -96,6 +107,8 @@ integer function resolve_concat_operand(arena, node_index, context, &
         logical :: right_is_literal
         logical :: left_is_call
         logical :: right_is_call
+        logical :: left_is_view
+        logical :: right_is_view
         type(lr_operand_desc_t) :: left_call_data_addr, left_call_storage_addr
         type(lr_operand_desc_t) :: right_call_data_addr, right_call_storage_addr
         type(lr_operand_desc_t) :: call_len_i32
@@ -115,6 +128,8 @@ integer function resolve_concat_operand(arena, node_index, context, &
         right_is_literal = .false.
         left_is_call = .false.
         right_is_call = .false.
+        left_is_view = .false.
+        right_is_view = .false.
         is_self_alias = .false.
 
         ! A fixed-length result (character(len=N) :: s) uses the descriptor
@@ -143,12 +158,13 @@ integer function resolve_concat_operand(arena, node_index, context, &
 
         ! Resolve left operand: get symbol index or mark as literal
         left_sym_idx = resolve_concat_operand(arena, left_idx, context, &
-            left_name, left_is_literal, error_msg, left_is_call)
+            left_name, left_is_literal, error_msg, left_is_call, left_is_view)
         if (len_trim(error_msg) > 0) return
 
         ! Resolve right operand
         right_sym_idx = resolve_concat_operand(arena, right_idx, context, &
-            right_name, right_is_literal, error_msg, right_is_call)
+            right_name, right_is_literal, error_msg, right_is_call, &
+            right_is_view)
         if (len_trim(error_msg) > 0) return
 
         ! Detect self-aliasing: dest is one of the operands
@@ -169,7 +185,13 @@ integer function resolve_concat_operand(arena, node_index, context, &
         end if
 
         ! Get left operand text/content
-        if (left_is_call) then
+        if (left_is_view) then
+            call substring_operands(arena, left_idx, context, left_data, &
+                                    call_len_i32, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (.not. emit_liric_i32_to_i64(context%session, call_len_i32, &
+                    left_len, error_msg)) return
+        else if (left_is_call) then
             call char_result_call_operands(arena, left_idx, context, left_data, &
                                            call_len_i32, error_msg, &
                                            left_call_data_addr, &
@@ -199,7 +221,13 @@ integer function resolve_concat_operand(arena, node_index, context, &
         end if
 
         ! Get right operand text/content
-        if (right_is_call) then
+        if (right_is_view) then
+            call substring_operands(arena, right_idx, context, right_data, &
+                                    call_len_i32, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (.not. emit_liric_i32_to_i64(context%session, call_len_i32, &
+                    right_len, error_msg)) return
+        else if (right_is_call) then
             call char_result_call_operands(arena, right_idx, context, right_data, &
                                            call_len_i32, error_msg, &
                                            right_call_data_addr, &

--- a/src/session_program_lowering_print_expr.inc
+++ b/src/session_program_lowering_print_expr.inc
@@ -378,6 +378,13 @@
             ! An integer literal falls through to the integer print below.
         end if
 
+        ! s(l:u) on a scalar character prints its view's bytes at the view's
+        ! runtime length, like any other character expression.
+        if (is_character_substring(arena, node_index, context)) then
+            call lower_print_char_expr(arena, node_index, context, error_msg)
+            return
+        end if
+
         if (is_binary_op(arena, node_index)) then
             ! Character // concatenation prints as a runtime string buffer; only
             ! the // operands case is handled here (intrinsic agent, bug 2).
@@ -827,10 +834,21 @@
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t) :: data_ptr
         type(lr_operand_desc_t) :: length
+        type(lr_operand_desc_t) :: view_buf
 
         call char_expr_operands(arena, node_index, context, data_ptr, length, &
                                 error_msg)
         if (len_trim(error_msg) > 0) return
+        ! The %s conversion stops at a NUL. A borrowed view (a substring)
+        ! points into the middle of its parent's bytes and carries no
+        ! terminator of its own, so print from a terminated copy of exactly
+        ! the view's length.
+        if (is_character_substring(arena, node_index, context)) then
+            call materialize_character_view(context, data_ptr, length, view_buf, &
+                                            error_msg)
+            if (len_trim(error_msg) > 0) return
+            data_ptr = view_buf
+        end if
         if (.not. emit_liric_print_string_operand_value(context%session, &
             context%str_print_format_id, data_ptr, error_msg)) return
     end subroutine lower_print_char_expr

--- a/src/session_program_lowering_print_ops.inc
+++ b/src/session_program_lowering_print_ops.inc
@@ -33,13 +33,18 @@
         ! values, so they print concatenated.
         expr_count = size(node%expression_indices)
         if (expr_count == 1) then
-            select type (section_node => arena%entries( &
-                    node%expression_indices(1))%node)
-            type is (array_slice_node)
-                call lower_array_section_print(arena, section_node, context, &
-                                               error_msg)
-                return
-            end select
+            ! s(l:u) on a scalar character is a substring, not an array
+            ! section: it prints as one character value, not element by element.
+            if (.not. is_character_substring(arena, node%expression_indices(1), &
+                                             context)) then
+                select type (section_node => arena%entries( &
+                        node%expression_indices(1))%node)
+                type is (array_slice_node)
+                    call lower_array_section_print(arena, section_node, context, &
+                                                   error_msg)
+                    return
+                end select
+            end if
             block
                 logical :: handled
                 call emit_array_literal_print_items(arena, &
@@ -66,8 +71,11 @@
                 array_handled = .false.
                 select type (item => arena%entries(node%expression_indices(i))%node)
                 type is (array_slice_node)
-                    call emit_array_section_print_items(arena, item, context, &
-                                                        array_handled, error_msg)
+                    if (.not. is_character_substring(arena, &
+                            node%expression_indices(i), context)) then
+                        call emit_array_section_print_items(arena, item, context, &
+                                                            array_handled, error_msg)
+                    end if
                 type is (array_literal_node)
                     call emit_array_literal_print_items(arena, &
                         node%expression_indices(i), context, array_handled, &
@@ -1003,6 +1011,10 @@
             return
         end if
         if (is_character_concat(arena, node_index, context)) then
+            is_char = .true.
+            return
+        end if
+        if (is_character_substring(arena, node_index, context)) then
             is_char = .true.
             return
         end if

--- a/test/conformance/xfail_fortfront_lf.txt
+++ b/test/conformance/xfail_fortfront_lf.txt
@@ -39,7 +39,6 @@ issue_2147_mono_name_collision_wrong_types.lf # owner=lazy-fortran/ffc#437; reas
 issue_2150_reshape_variable_vs_literal_shape.lf # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
 issue_2151_array_function_broken.lf # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
 issue_2153_array_call_scalar_param.lf # owner=lazy-fortran/ffc#437; reason=emit one-unit Lazy procedure specializations
-issue_2163_character_substring_lengths.lf # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 issue_2165_undeclared_argument.lf # owner=lazy-fortran/ffc#438; reason=apply Lazy Fortran default type and intent policy
 issue_2691_implied_do_static_size_known.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 issue_2691_implied_do_static_size_unknown.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering

--- a/test/conformance/xfail_lfortran.txt
+++ b/test/conformance/xfail_lfortran.txt
@@ -502,7 +502,6 @@ call_subroutine_without_type.f90 # owner=lazy-fortran/ffc#449; reason=lower plai
 case_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 case_05.f90 # owner=lazy-fortran/ffc#455; reason=lower structured branch targets
 case_06.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
-case_08.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 c_f_proc_ptr_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 character_01.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 character_02.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
@@ -1205,7 +1204,6 @@ file_close_02.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and 
 file_open_01.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
 file_open_05.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
 file_open_07.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
-file_open_08.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 file_open_09.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
 file_open_10.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
 file_overwrite.f90 # owner=lazy-fortran/ffc#396; reason=move file-unit state behind the runtime ABI
@@ -3062,9 +3060,6 @@ string_32.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expre
 string_34.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
 string_36.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
 string_37.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
-string_38.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
-string_39.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
-string_40.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 string_42.f90 # owner=lazy-fortran/ffc#349; reason=migrate deferred scalar character storage
 string_43.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
 string_45.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
@@ -3092,7 +3087,6 @@ string_68.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expre
 string_69.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 string_71.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
 string_72.f90 # owner=lazy-fortran/ffc#337; reason=represent array sections as descriptor views
-string_73.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 string_74.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 string_75.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
 string_76.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD

--- a/test/test_session_deferred_char_compiler.f90
+++ b/test/test_session_deferred_char_compiler.f90
@@ -1,5 +1,6 @@
 program test_session_deferred_char_compiler
-    use ffc_test_support, only: expect_output, expect_exit_status, expect_no_leaks
+    use ffc_test_support, only: expect_output, expect_exit_status, &
+        expect_no_leaks, expect_error_contains
     implicit none
 
     logical :: all_passed
@@ -34,6 +35,14 @@ program test_session_deferred_char_compiler
         all_passed = .false.
     if (.not. test_repeated_deallocate_is_not_a_double_free()) &
         all_passed = .false.
+    if (.not. test_substring_of_deferred_character()) all_passed = .false.
+    if (.not. test_substring_of_fixed_character()) all_passed = .false.
+    if (.not. test_substring_with_runtime_bounds()) all_passed = .false.
+    if (.not. test_substring_assigned_and_concatenated()) all_passed = .false.
+    if (.not. test_substring_does_not_leak()) all_passed = .false.
+    if (.not. test_substring_constant_bound_past_end_is_rejected()) &
+        all_passed = .false.
+    if (.not. test_substring_with_stride_is_rejected()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: deferred-char function result ABI'
@@ -121,6 +130,146 @@ contains
         test_repeated_deallocate_is_not_a_double_free = expect_no_leaks( &
             source, '/tmp/ffc_session_deferred_double_free_test')
     end function test_repeated_deallocate_is_not_a_double_free
+
+    logical function test_substring_of_deferred_character()
+        ! A substring of a deferred-length scalar is a view of its bytes at the
+        ! requested Fortran positions: a(l:u) has length u - l + 1.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: a'//new_line('a')// &
+            '  a = "hello world"'//new_line('a')// &
+            '  print *, a(1:5)'//new_line('a')// &
+            '  print *, a(7:11)'//new_line('a')// &
+            '  print *, a(1:1)'//new_line('a')// &
+            '  print *, len(a(3:9))'//new_line('a')// &
+            '  deallocate(a)'//new_line('a')// &
+            'end program main'
+
+        test_substring_of_deferred_character = expect_output( &
+            source, &
+            ' hello'//new_line('a')// &
+            ' world'//new_line('a')// &
+            ' h'//new_line('a')// &
+            '           7'//new_line('a'), &
+            '/tmp/ffc_session_substring_deferred_test')
+    end function test_substring_of_deferred_character
+
+    logical function test_substring_of_fixed_character()
+        ! The same view over a fixed-length scalar, whose length is a declared
+        ! constant rather than descriptor metadata.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=11) :: f'//new_line('a')// &
+            '  f = "hello world"'//new_line('a')// &
+            '  print *, f(1:5)'//new_line('a')// &
+            '  print *, f(7:11)'//new_line('a')// &
+            'end program main'
+
+        test_substring_of_fixed_character = expect_output( &
+            source, &
+            ' hello'//new_line('a')// &
+            ' world'//new_line('a'), &
+            '/tmp/ffc_session_substring_fixed_test')
+    end function test_substring_of_fixed_character
+
+    logical function test_substring_with_runtime_bounds()
+        ! Substring bounds are ordinary integer expressions, evaluated at run
+        ! time; the view length follows from them.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: a'//new_line('a')// &
+            '  integer :: i, j'//new_line('a')// &
+            '  a = "hello world"'//new_line('a')// &
+            '  i = 3'//new_line('a')// &
+            '  j = 9'//new_line('a')// &
+            '  print *, a(i:j)'//new_line('a')// &
+            '  print *, len(a(i:j))'//new_line('a')// &
+            '  deallocate(a)'//new_line('a')// &
+            'end program main'
+
+        test_substring_with_runtime_bounds = expect_output( &
+            source, &
+            ' llo wor'//new_line('a')// &
+            '           7'//new_line('a'), &
+            '/tmp/ffc_session_substring_runtime_test')
+    end function test_substring_with_runtime_bounds
+
+    logical function test_substring_assigned_and_concatenated()
+        ! A substring is a character expression: it can be assigned to a
+        ! deferred or fixed destination and used as a concatenation operand,
+        ! with the usual padding and truncation on a fixed destination.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: a, b'//new_line('a')// &
+            '  character(len=8) :: f'//new_line('a')// &
+            '  a = "hello world"'//new_line('a')// &
+            '  b = a(1:5)'//new_line('a')// &
+            '  print *, len(b), b'//new_line('a')// &
+            '  f = a(7:11)'//new_line('a')// &
+            '  print *, "[", f, "]"'//new_line('a')// &
+            '  b = a(1:5) // a(7:11)'//new_line('a')// &
+            '  print *, len(b), b'//new_line('a')// &
+            '  deallocate(a)'//new_line('a')// &
+            '  deallocate(b)'//new_line('a')// &
+            'end program main'
+
+        test_substring_assigned_and_concatenated = expect_output( &
+            source, &
+            '           5 hello'//new_line('a')// &
+            ' [world   ]'//new_line('a')// &
+            '          10 helloworld'//new_line('a'), &
+            '/tmp/ffc_session_substring_expr_test')
+    end function test_substring_assigned_and_concatenated
+
+    logical function test_substring_does_not_leak()
+        ! A substring is a borrowed view into its parent's storage: taking one
+        ! allocates nothing to release, and it never frees the parent.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: a, b'//new_line('a')// &
+            '  a = "hello world"'//new_line('a')// &
+            '  b = a(1:5)'//new_line('a')// &
+            '  print *, len(b), b'//new_line('a')// &
+            '  deallocate(b)'//new_line('a')// &
+            '  deallocate(a)'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_substring_does_not_leak = expect_no_leaks( &
+            source, '/tmp/ffc_session_substring_leak_test')
+    end function test_substring_does_not_leak
+
+    logical function test_substring_constant_bound_past_end_is_rejected()
+        ! A constant upper bound beyond a fixed-length parent's declared width
+        ! is a source error, as gfortran reports it, rather than a read past
+        ! the variable.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=11) :: f'//new_line('a')// &
+            '  f = "hello world"'//new_line('a')// &
+            '  print *, f(1:20)'//new_line('a')// &
+            'end program main'
+
+        test_substring_constant_bound_past_end_is_rejected = &
+            expect_error_contains(source, &
+                'substring end index exceeds the string length', &
+                '/tmp/ffc_session_substring_overrun_test')
+    end function test_substring_constant_bound_past_end_is_rejected
+
+    logical function test_substring_with_stride_is_rejected()
+        ! A substring has no stride; s(l:u:k) is diagnosed rather than being
+        ! silently treated as a substring or an array section.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: a'//new_line('a')// &
+            '  a = "hello world"'//new_line('a')// &
+            '  print *, a(1:5:2)'//new_line('a')// &
+            'end program main'
+
+        test_substring_with_stride_is_rejected = expect_error_contains( &
+            source, 'a substring has no stride', &
+            '/tmp/ffc_session_substring_stride_test')
+    end function test_substring_with_stride_is_rejected
 
     logical function test_assumed_length_len_inside_callee()
         ! len(s) inside a callee returns the actual length of a literal actual.

--- a/test/test_session_unsupported_diagnostics.f90
+++ b/test/test_session_unsupported_diagnostics.f90
@@ -69,13 +69,17 @@ program test_session_unsupported_diagnostics
 contains
 
     logical function test_character_expression_diagnostic()
-        ! A substring target keeps the unsupported diagnostic; // concatenation
-        ! into a fixed-length scalar is now lowered (see the fixed-concat test).
+        ! An integer right-hand side keeps the unsupported diagnostic. A
+        ! substring source no longer does: s(l:u) lowers to a character view
+        ! (see the substring tests in test_session_deferred_char_compiler),
+        ! and // concatenation into a fixed-length scalar lowers too (see the
+        ! fixed-concat test). What is under test here is the diagnostic
+        ! plumbing, not which construct happens to be unsupported.
         character(len=*), parameter :: source = &
             'program main'//new_line('a')// &
             '  character(len=5) :: name'//new_line('a')// &
             '  name = "ab"'//new_line('a')// &
-            '  name = name(1:2)'//new_line('a')// &
+            '  name = 42'//new_line('a')// &
             'end program main'
 
         test_character_expression_diagnostic = expect_error_contains( &
@@ -356,13 +360,17 @@ contains
     end function test_include_statement_diagnostic
 
     logical function test_cli_character_expression_diagnostic()
-        ! A substring target keeps the unsupported diagnostic; // concatenation
-        ! into a fixed-length scalar is now lowered (see the fixed-concat test).
+        ! An integer right-hand side keeps the unsupported diagnostic. A
+        ! substring source no longer does: s(l:u) lowers to a character view
+        ! (see the substring tests in test_session_deferred_char_compiler),
+        ! and // concatenation into a fixed-length scalar lowers too (see the
+        ! fixed-concat test). What is under test here is the diagnostic
+        ! plumbing, not which construct happens to be unsupported.
         character(len=*), parameter :: source = &
             'program main'//new_line('a')// &
             '  character(len=5) :: name'//new_line('a')// &
             '  name = "ab"'//new_line('a')// &
-            '  name = name(1:2)'//new_line('a')// &
+            '  name = 42'//new_line('a')// &
             'end program main'
 
         test_cli_character_expression_diagnostic = expect_cli_error_contains( &
@@ -375,7 +383,7 @@ contains
             'program main'//new_line('a')// &
             '  character(len=5) :: name'//new_line('a')// &
             '  name = "ab"'//new_line('a')// &
-            '  name = name(1:2)'//new_line('a')// &
+            '  name = 42'//new_line('a')// &
             'end program main'
 
         test_cli_diagnostic_uses_stderr = expect_cli_error_on_stderr( &
@@ -388,7 +396,7 @@ contains
             'program main'//new_line('a')// &
             '  character(len=5) :: name'//new_line('a')// &
             '  name = "ab"'//new_line('a')// &
-            '  name = name(1:2)'//new_line('a')// &
+            '  name = 42'//new_line('a')// &
             'end program main'
 
         test_cli_json_diagnostic = expect_cli_json_error_contains( &


### PR DESCRIPTION
Closes #350.

Completes the character descriptor chunk after #349 and #348. Of the operations
this issue lists, concatenation, comparison, LEN, LEN_TRIM, TRIM, assignment and
print already went through the descriptor and already matched gfortran.
**Substring did not exist at all**: `a(1:5)` on a scalar character was lowered as
an array section and rejected with `array section requires an array`, for both
fixed- and deferred-length scalars.

Substring now lowers to a borrowed character view, and every character
expression consumer accepts one, so the whole set finally shares one primitive
set.

- `substring_operands` builds the view: `data = base + (l - 1)`,
  `length = u - l + 1`. Nothing is allocated and nothing is copied, so the view
  is valid exactly as long as its parent's storage. Omitted bounds default to 1
  and `len(parent)`. Both parser shapes for `l:u` (`array_bounds_node` and
  `range_expression_node`) are handled.
- Views are wired into `char_expr_operands`, print, deferred assignment, fixed
  assignment, and concatenation operands, so `len(a(i:j))`, `print *, a(1:5)`,
  `b = a(1:5)`, `f = a(7:11)` and `a(1:5) // a(7:11)` all work.
- `materialize_character_view` gives print a terminated copy of exactly the
  view's length. This is required, not incidental: the `%s` conversion stops at
  a NUL and a view points into the middle of its parent's bytes with no
  terminator of its own.

## Behaviour preserved

- **Character length semantics.** A substring's length is `u - l + 1`,
  independent of whether the parent is fixed, assumed or deferred length. A
  deferred parent's length is read from its descriptor at run time; a fixed
  parent's from its declared width. Nothing about the parent's own length
  changes: a substring never retargets it.
- **Blank padding and truncation on assignment.** A substring assigned to a
  fixed-length destination goes through the same `store_fixed_character_value`
  primitive as every other character expression, so it pads and truncates to
  the declared width identically — `character(len=8) :: f; f = a(7:11)` gives
  `world   `. A deferred destination takes the view's exact length.
- **Lower bounds and extents for character arrays.** Untouched. Character
  arrays keep their layout; `is_character_substring` requires a scalar parent,
  so `arr(1:3)` on a character array is still an array section and still takes
  the array path.
- **Aliasing and overlap.** A view aliases its parent by construction, which is
  what makes overlap the interesting case. Assignment from a view copies before
  the destination releases the block it held, so `s = s(2:4)` is correct:
  it produces `bcd` from `abcdef`, valgrind-clean. `name = name(1:2)` on a
  fixed-length scalar likewise copies through a blank-filled buffer rather than
  overwriting in place.
- **Allocation and finalization lifetimes.** Taking a substring allocates
  nothing, so there is nothing to release and a view never frees its parent.
  Where a copy is unavoidable (print, assignment) it follows the storage class
  convention from #349: heap inside an internal function, where it must outlive
  the frame, stack at program scope, and the destination descriptor records
  which.

## Negative fixtures

- A constant bound past a fixed-length parent's declared width is a source
  error, `substring end index exceeds the string length`, matching gfortran,
  rather than a read past the variable. A deferred parent's length is a
  run-time value, so nothing is decidable at compile time and the substring is
  accepted; ffc does not bounds-check array subscripts either, so this matches
  the established behaviour rather than inventing a new runtime check.
- `a(1:5:2)` is diagnosed with `a substring has no stride` instead of being
  silently treated as a substring or an array section.

## A test whose sample source had to change

`test_session_unsupported_diagnostics` used `name = name(1:2)` in four cases as
the *vehicle* for producing an `unsupported character assignment` diagnostic —
they assert the diagnostic plumbing (message text, CLI exit status, stderr
routing, JSON shape), not that substrings must stay unsupported; the original
comment said as much. Since that construct now lowers, the four cases use
`name = 42`, which still produces the identical diagnostic. Every assertion is
unchanged; only the still-unsupported construct that triggers it moved.

## Oracles

The five positive cases were written first and recorded failing on unmodified
main with `array section requires an array` and `unsupported character
assignment`. Expected output is taken from gfortran, and the two programs
covering the whole set were also diffed against gfortran directly — both match
byte for byte. `test_substring_does_not_leak` runs under valgrind and requires
a clean memcheck report, which is what pins "a view allocates nothing and frees
nothing".

## Not in scope

Nested runtime concatenation (`a // "-" // b`, three or more non-literal
operands) is unsupported on unmodified main and still is; it is a concat-tree
limitation independent of substrings, so the concatenation fixture here uses
two operands. Worth its own issue.

## Conformance gauntlet

Baseline is a separate worktree at the same `origin/main` commit with its own
`fo build`.

| Suite | main | branch |
|---|---|---|
| lfortran | PASS=857 XFAIL=3337 XPASS=74 FAIL=11 | PASS=863 XFAIL=3331 XPASS=74 FAIL=11 |
| fortfront-f90 | PASS=410 XFAIL=95 XPASS=2 FAIL=9 | PASS=410 XFAIL=95 XPASS=2 FAIL=9 |
| fortfront-lf | PASS=196 XFAIL=56 XPASS=0 FAIL=12 | PASS=197 XFAIL=55 XPASS=0 FAIL=12 |

Per-case: the FAIL set and the XPASS set are byte-identical to main in all three
suites, no case lost PASS, and seven cases gained it.

## Cases promoted out of the xfail manifests

Seven cases went XPASS and are now PASS with their manifest entries removed:

| Case | Suite | Manifest owner | Failed on main with |
|---|---|---|---|
| `case_08.f90` | lfortran | ffc#350 | unsupported character assignment |
| `file_open_08.f90` | lfortran | ffc#350 | unsupported character expression |
| `string_40.f90` | lfortran | ffc#350 | unsupported character assignment |
| `string_73.f90` | lfortran | ffc#350 | unsupported character expression |
| `string_38.f90` | lfortran | ffc#337 | array section requires an array |
| `string_39.f90` | lfortran | ffc#337 | array section requires an array |
| `issue_2163_character_substring_lengths.lf` | fortfront-lf | ffc#350 | unsupported character assignment |

Every one fails on unmodified main with exactly a diagnostic this change
removes, so the promotions are causal rather than coincidental. `string_38` and
`string_39` were filed against #337 (array sections) because
`array section requires an array` looked like a section problem; they are in
fact scalar substrings, which is why they fall out here.

**Flake check (ffc#599).** #599 records lfortran XPASS totals varying run to run
on unmodified main, so a single run is not evidence. Each promoted case was
compiled and run five times against its gfortran reference on this branch and
three times on a same-commit baseline build: all seven match gfortran 5/5 on the
branch and 0/3 on main. None of them is one of the cases #599 lists as flipping
(`kwargs_01`, `optional_11`, `procedure_18`, `submodule_33`, `subroutines_03`,
`derived_types_115`, `separate_compilation_46`) — that set is disjoint from this
one, and I left every one of those alone. After the promotions the suite reports
XPASS=74, the same total and the same case set as the baseline run, so the
remaining XPASS population is untouched.

`fo` is green apart from `test_parity_dashboard` and
`test_fortfront_corpus_conformance`, both of which fail identically on
unmodified `origin/main`.
