### PR TITLE
[runtime-06] link the ffc runtime into every emitted executable (closes #565)

### DIFF
--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -493,15 +493,57 @@ components = [
   `use, only:` names and rename targets are validated against the records; a
   local rename keeps the recorded remote name for storage and linkage.
 
-## Runtime archives
+## Runtime delivery
 
-`ffc` packages its runtime support code into LIRIC runtime archives, one per
-target/backend pair. The archives are data artifacts: nothing links against
-them, and this slice does not load them into an ffc session.
+`runtime/ffc_runtime.c` is the single source of truth for the ffc runtime.
+Every entry point defined there is listed in `ffc_runtime_link`'s
+`FFC_RUNTIME_SYMBOLS` and documented under [Runtime entry points](#runtime-entry-points)
+below. Two independent consumers read that file.
 
-The standalone CMake project in `runtime/` builds them. `runtime/ffc_runtime.c`
-is compiled to LLVM bitcode with `clang -emit-llvm -c`, and
-`liric_runtime_archive` packages that bitcode once per backend.
+### Linked into every emitted executable
+
+This is how a compiled program gets its runtime, and the only mechanism the
+lowerer may rely on.
+
+`src/ffc_runtime_source.f90` embeds `runtime/ffc_runtime.c` verbatim in the
+compiler binary; regenerate it with `scripts/generate_runtime_source.sh` after
+every edit to the C file. At link time `ffc_runtime_link` materialises the
+embedded source into a content-addressed file under `TMPDIR` and passes it to
+`lr_session_emit_exe_objects`, which hands it to the same system C compiler
+that already performs the link. Every executable `ffc` emits therefore carries
+a definition of every runtime entry point.
+
+The contract this fixes (issue #565):
+
+- **Unconditional.** There is no environment variable, no artifact to install,
+  and no discovery step. An executable is never emitted without its runtime.
+- **No inline fallback.** The lowerer emits calls to runtime symbols and
+  nothing else. The parallel path that synthesised the same entry points
+  inline is retired; ROADMAP Chunk 3 forbids reintroducing it.
+- **Mismatch is impossible by construction.** The runtime that gets linked is
+  the one compiled into the running compiler, so a compiler and its runtime
+  cannot drift apart, and there is no stale installed copy to pick up.
+- **Failure is loud.** When the runtime cannot be materialised, lowering fails
+  with a named error and emits nothing. It never silently produces a binary
+  that dies with `undefined symbol` at run time.
+- **Object output is unaffected.** `ffc -c` leaves runtime symbols undefined
+  in the object, to be resolved by the link that consumes it.
+
+`test_runtime_link_compiler` is the oracle: it checks that a normally compiled
+program's symbol table defines the runtime entry points, that the linked
+runtime is callable, that every declared symbol is really defined by the
+embedded source, and that the embedded source is byte-identical to
+`runtime/ffc_runtime.c`.
+
+### Packaged into LIRIC runtime archives
+
+The standalone CMake project in `runtime/` also packages the same file for
+sessions that resolve runtime calls without a system linker.
+`runtime/ffc_runtime.c` is compiled to LLVM bitcode with `clang -emit-llvm -c`,
+and `liric_runtime_archive` packages that bitcode once per backend.
+`install_runtime_archive` reads and installs one; the artifact directory is an
+explicit argument, and a missing, unreadable, or backend-mismatched archive is
+an error. It is not on the executable-emission path.
 
 ### Artifact names
 
@@ -539,14 +581,21 @@ byte-identical.
 
 ### Payload
 
-The archive carries the runtime's LIRIC IR text plus a compiled blob package.
-This slice defines exactly one entry point:
+The archive carries the runtime's LIRIC IR text plus a compiled blob package,
+built from the same `runtime/ffc_runtime.c` that is linked into executables.
 
-- `int _ffc_runtime_probe(void)` returns 42. It exists so a consumer can
-  confirm end to end that the archive it selected actually resolves.
+### Runtime entry points
+
+The complete runtime ABI. Adding an entry point means editing
+`runtime/ffc_runtime.c`, regenerating the embedding, adding the symbol to
+`FFC_RUNTIME_SYMBOLS`, and adding it here in the same change.
+
+| Symbol | Signature | Contract |
+|---|---|---|
+| `_ffc_runtime_probe` | `int _ffc_runtime_probe(void)` | Returns 42. Lets a consumer confirm end to end that the runtime it linked or loaded really resolves. |
 
 Runtime entry points for file units, formatted output, IOSTAT/IOMSG, and
-descriptor allocation are added by their own issues.
+descriptor allocation are added by their own issues (#396, #423, #427, #428).
 
 ### Dependencies
 

--- a/runtime/ffc_runtime.c
+++ b/runtime/ffc_runtime.c
@@ -1,17 +1,27 @@
 /* ffc runtime support library.
  *
- * This translation unit is compiled to LLVM bitcode and packaged into one
- * backend-qualified LIRIC runtime archive per target/backend pair
- * (see runtime/CMakeLists.txt and docs/RUNTIME_ABI.md).
+ * Single source of truth for the ffc runtime. Two consumers
+ * read this file:
  *
- * It currently carries only the probe symbol that lets a consumer confirm it
- * loaded a real archive. Runtime entry points for file units, formatted
- * output, IOSTAT/IOMSG, and descriptor allocation are added by their own
- * issues; this issue only establishes the artifact.
+ *   - src/ffc_runtime_source.f90 embeds it verbatim in the
+ *     compiler, and ffc links it into every executable it
+ *     emits (issue #565). Regenerate that module with
+ *     scripts/generate_runtime_source.sh after every edit;
+ *     test_runtime_link_compiler checks the two agree.
+ *   - runtime/CMakeLists.txt packages it into the
+ *     backend-qualified LIRIC runtime archives (#374), used
+ *     by sessions that resolve runtime calls without a
+ *     system linker.
+ *
+ * Every entry point defined here must also be listed in
+ * ffc_runtime_link's FFC_RUNTIME_SYMBOLS, and documented in
+ * docs/RUNTIME_ABI.md. Lines stay at or below 66 columns so
+ * the generated Fortran embedding fits in 88.
  */
 
-/* Returns 42. The sole purpose is to give a loader a cheap, unambiguous
- * end-to-end check that the archive it selected actually resolves. */
+/* Returns 42. The sole purpose is to give a consumer a
+ * cheap, unambiguous end-to-end check that the runtime it
+ * linked is really present and callable. */
 int _ffc_runtime_probe(void) {
     return 42;
 }

--- a/scripts/generate_runtime_source.sh
+++ b/scripts/generate_runtime_source.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Regenerate src/ffc_runtime_source.f90 from runtime/ffc_runtime.c.
+#
+# ffc links its runtime into every executable it emits, so the runtime
+# source travels inside the compiler binary rather than being looked up on
+# disk: a compiler and its runtime can then never be mismatched (issue #565).
+# runtime/ffc_runtime.c stays the single source of truth; this script embeds
+# it, and test_runtime_link_compiler fails if the two drift apart.
+#
+# Usage: scripts/generate_runtime_source.sh [output-path]
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+src="$root/runtime/ffc_runtime.c"
+out="${1:-$root/src/ffc_runtime_source.f90}"
+
+if [ ! -f "$src" ]; then
+    echo "generate_runtime_source: missing $src" >&2
+    exit 1
+fi
+
+long=$(awk 'length($0) > 66 { print NR": "length($0) }' "$src")
+if [ -n "$long" ]; then
+    echo "generate_runtime_source: runtime/ffc_runtime.c has lines over 66" >&2
+    echo "columns, which do not fit the generated 88-column Fortran:" >&2
+    echo "$long" >&2
+    exit 1
+fi
+
+{
+    cat <<'HEADER'
+! GENERATED FILE - DO NOT EDIT.
+!
+! Regenerate with scripts/generate_runtime_source.sh after editing
+! runtime/ffc_runtime.c, which is the single source of truth for the ffc
+! runtime. test_runtime_link_compiler fails when this copy drifts.
+!
+! ffc links its runtime into every executable it emits (issue #565), so the
+! runtime source ships inside the compiler binary. That makes a
+! compiler/runtime version mismatch impossible by construction: there is no
+! separately installed artifact to go missing or go stale.
+module ffc_runtime_source
+    implicit none
+    private
+
+    public :: ffc_runtime_source_text
+
+contains
+
+    ! The verbatim contents of runtime/ffc_runtime.c, newline-terminated.
+    subroutine ffc_runtime_source_text(text)
+        character(len=:), allocatable, intent(out) :: text
+        character(len=1), parameter :: NL = new_line('a')
+
+        text = ''
+HEADER
+    while IFS= read -r line || [ -n "$line" ]; do
+        escaped=${line//\'/\'\'}
+        if [ -z "$escaped" ]; then
+            printf "        text = text//NL\n"
+        else
+            printf "        text = text// &\n            '%s'//NL\n" "$escaped"
+        fi
+    done < "$src"
+    cat <<'FOOTER'
+    end subroutine ffc_runtime_source_text
+
+end module ffc_runtime_source
+FOOTER
+} > "$out"
+
+echo "generate_runtime_source: wrote $out"

--- a/src/ffc_runtime_link.f90
+++ b/src/ffc_runtime_link.f90
@@ -1,0 +1,209 @@
+! Runtime delivery for emitted executables (issue #565).
+!
+! ffc lowers runtime entry points as calls to external symbols, so every
+! executable it emits must carry a definition of those symbols. This module
+! provides that definition as a link input.
+!
+! The runtime source is embedded in the compiler binary (ffc_runtime_source,
+! generated from runtime/ffc_runtime.c). It is materialised into a
+! content-addressed file under the temporary directory and handed to
+! lr_session_emit_exe_objects, which passes it to the system C compiler that
+! already performs the link. Consequences, all deliberate:
+!
+!   - There is no installed runtime artifact to discover, so there is no
+!     environment variable to set and no opt-in path. Every executable ffc
+!     emits is linked against the runtime, unconditionally.
+!   - A compiler/runtime version mismatch is impossible by construction: the
+!     runtime that gets linked is the one compiled into this binary.
+!   - When the runtime cannot be materialised, lowering fails with a named
+!     error. It never silently falls back to synthesising the entry points
+!     inline; that parallel lowering path is retired (ROADMAP Chunk 3).
+!
+! FFC_RUNTIME_SYMBOLS is the authoritative list of entry points the lowerer
+! may call. test_runtime_link_compiler compiles the embedded source and fails
+! unless every listed symbol is defined by it, so emitting a call to a symbol
+! the runtime does not define is caught at test time rather than becoming an
+! executable that dies with "undefined symbol" at run time.
+module ffc_runtime_link
+    use ffc_runtime_source, only: ffc_runtime_source_text
+    use, intrinsic :: iso_c_binding, only: c_int, c_char, c_null_char
+    implicit none
+    private
+
+    public :: FFC_RUNTIME_SYMBOLS, ffc_runtime_link_input
+
+    interface
+        function c_getpid() result(pid) bind(c, name='getpid')
+            import :: c_int
+            integer(c_int) :: pid
+        end function c_getpid
+
+        function c_rename(old_path, new_path) result(status) &
+            bind(c, name='rename')
+            import :: c_char, c_int
+            character(kind=c_char), intent(in) :: old_path(*)
+            character(kind=c_char), intent(in) :: new_path(*)
+            integer(c_int) :: status
+        end function c_rename
+    end interface
+
+    ! Every runtime entry point the lowerer is allowed to call. Each issue
+    ! that moves compiler-emitted code behind the runtime ABI adds its symbols
+    ! here and to docs/RUNTIME_ABI.md.
+    character(len=*), parameter :: FFC_RUNTIME_SYMBOLS(1) = &
+        [character(len=32) :: '_ffc_runtime_probe']
+
+contains
+
+    ! Returns the path of a C source file holding the embedded runtime, ready
+    ! to be passed to lr_session_emit_exe_objects as a link input. The name is
+    ! derived from the runtime contents, so concurrent compilations share one
+    ! file and a stale file from an older compiler is never picked up.
+    subroutine ffc_runtime_link_input(path, error_msg)
+        character(len=:), allocatable, intent(out) :: path
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: text
+
+        error_msg = ''
+        call ffc_runtime_source_text(text)
+        if (len(text) == 0) then
+            error_msg = 'ffc runtime source is empty: the compiler was '// &
+                'built without a usable runtime'
+            path = ''
+            return
+        end if
+        path = runtime_link_path(text)
+        call materialise(path, text, error_msg)
+        if (len_trim(error_msg) > 0) path = ''
+    end subroutine ffc_runtime_link_input
+
+    function runtime_link_path(text) result(path)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: path
+        character(len=16) :: digest
+
+        write (digest, '(z16.16)') fnv1a(text)
+        path = temp_directory()//'/ffc-runtime-'//trim(digest)//'.c'
+    end function runtime_link_path
+
+    ! FNV-1a over the runtime text. Only used to name the file; correctness
+    ! does not rest on it, because the contents are verified before reuse.
+    function fnv1a(text) result(hash)
+        character(len=*), intent(in) :: text
+        integer(kind=8) :: hash
+        integer(kind=8), parameter :: PRIME = 1099511628211_8
+        integer :: i
+
+        hash = -3750763034362895579_8
+        do i = 1, len(text)
+            hash = ieor(hash, int(iachar(text(i:i)), kind=8))
+            hash = hash*PRIME
+        end do
+    end function fnv1a
+
+    function temp_directory() result(directory)
+        character(len=:), allocatable :: directory
+        integer :: length, status
+
+        call get_environment_variable('TMPDIR', length=length, status=status)
+        if (status /= 0 .or. length <= 0) then
+            directory = '/tmp'
+            return
+        end if
+        allocate (character(len=length) :: directory)
+        call get_environment_variable('TMPDIR', directory)
+        if (len_trim(directory) == 0) then
+            directory = '/tmp'
+        else
+            directory = trim(directory)
+        end if
+    end function temp_directory
+
+    ! Writes text to path unless a file with exactly that content is already
+    ! there. The write goes to a private temporary and is renamed into place,
+    ! so parallel compilations never observe a partial file.
+    subroutine materialise(path, text, error_msg)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: staging
+        character(len=32) :: pid_text
+        integer :: unit, ios
+
+        error_msg = ''
+        if (file_matches(path, text)) return
+
+        write (pid_text, '(i0)') getpid()
+        staging = path//'.'//trim(pid_text)//'.tmp'
+        open (newunit=unit, file=staging, access='stream', &
+              form='unformatted', status='replace', action='write', &
+              iostat=ios)
+        if (ios /= 0) then
+            error_msg = 'cannot write the ffc runtime to '//staging
+            return
+        end if
+        write (unit, iostat=ios) text
+        close (unit, iostat=ios)
+        if (ios /= 0) then
+            error_msg = 'cannot write the ffc runtime to '//staging
+            return
+        end if
+        call rename_into_place(staging, path, error_msg)
+    end subroutine materialise
+
+    logical function file_matches(path, text) result(matches)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: existing
+        integer :: unit, ios
+        integer(kind=8) :: nbytes
+        logical :: exists
+
+        matches = .false.
+        inquire (file=path, exist=exists)
+        if (.not. exists) return
+        open (newunit=unit, file=path, access='stream', form='unformatted', &
+              status='old', action='read', iostat=ios)
+        if (ios /= 0) return
+        inquire (unit=unit, size=nbytes)
+        if (nbytes /= len(text)) then
+            close (unit)
+            return
+        end if
+        allocate (character(len=len(text)) :: existing)
+        read (unit, iostat=ios) existing
+        close (unit)
+        if (ios == 0) matches = existing == text
+    end function file_matches
+
+    subroutine rename_into_place(staging, path, error_msg)
+        character(len=*), intent(in) :: staging
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(kind=c_char), allocatable, target :: c_from(:), c_to(:)
+
+        error_msg = ''
+        call to_c_string(staging, c_from)
+        call to_c_string(path, c_to)
+        if (c_rename(c_from, c_to) /= 0_c_int) then
+            error_msg = 'cannot install the ffc runtime at '//path
+        end if
+    end subroutine rename_into_place
+
+    subroutine to_c_string(text, buffer)
+        character(len=*), intent(in) :: text
+        character(kind=c_char), allocatable, intent(out) :: buffer(:)
+        integer :: i
+
+        allocate (buffer(len(text) + 1))
+        do i = 1, len(text)
+            buffer(i) = text(i:i)
+        end do
+        buffer(len(text) + 1) = c_null_char
+    end subroutine to_c_string
+
+    integer function getpid()
+        getpid = int(c_getpid())
+    end function getpid
+
+end module ffc_runtime_link

--- a/src/ffc_runtime_source.f90
+++ b/src/ffc_runtime_source.f90
@@ -1,0 +1,80 @@
+! GENERATED FILE - DO NOT EDIT.
+!
+! Regenerate with scripts/generate_runtime_source.sh after editing
+! runtime/ffc_runtime.c, which is the single source of truth for the ffc
+! runtime. test_runtime_link_compiler fails when this copy drifts.
+!
+! ffc links its runtime into every executable it emits (issue #565), so the
+! runtime source ships inside the compiler binary. That makes a
+! compiler/runtime version mismatch impossible by construction: there is no
+! separately installed artifact to go missing or go stale.
+module ffc_runtime_source
+    implicit none
+    private
+
+    public :: ffc_runtime_source_text
+
+contains
+
+    ! The verbatim contents of runtime/ffc_runtime.c, newline-terminated.
+    subroutine ffc_runtime_source_text(text)
+        character(len=:), allocatable, intent(out) :: text
+        character(len=1), parameter :: NL = new_line('a')
+
+        text = ''
+        text = text// &
+            '/* ffc runtime support library.'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' * Single source of truth for the ffc runtime. Two consumers'//NL
+        text = text// &
+            ' * read this file:'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' *   - src/ffc_runtime_source.f90 embeds it verbatim in the'//NL
+        text = text// &
+            ' *     compiler, and ffc links it into every executable it'//NL
+        text = text// &
+            ' *     emits (issue #565). Regenerate that module with'//NL
+        text = text// &
+            ' *     scripts/generate_runtime_source.sh after every edit;'//NL
+        text = text// &
+            ' *     test_runtime_link_compiler checks the two agree.'//NL
+        text = text// &
+            ' *   - runtime/CMakeLists.txt packages it into the'//NL
+        text = text// &
+            ' *     backend-qualified LIRIC runtime archives (#374), used'//NL
+        text = text// &
+            ' *     by sessions that resolve runtime calls without a'//NL
+        text = text// &
+            ' *     system linker.'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' * Every entry point defined here must also be listed in'//NL
+        text = text// &
+            ' * ffc_runtime_link''s FFC_RUNTIME_SYMBOLS, and documented in'//NL
+        text = text// &
+            ' * docs/RUNTIME_ABI.md. Lines stay at or below 66 columns so'//NL
+        text = text// &
+            ' * the generated Fortran embedding fits in 88.'//NL
+        text = text// &
+            ' */'//NL
+        text = text//NL
+        text = text// &
+            '/* Returns 42. The sole purpose is to give a consumer a'//NL
+        text = text// &
+            ' * cheap, unambiguous end-to-end check that the runtime it'//NL
+        text = text// &
+            ' * linked is really present and callable. */'//NL
+        text = text// &
+            'int _ffc_runtime_probe(void) {'//NL
+        text = text// &
+            '    return 42;'//NL
+        text = text// &
+            '}'//NL
+    end subroutine ffc_runtime_source_text
+
+end module ffc_runtime_source

--- a/src/ffc_test_support.f90
+++ b/src/ffc_test_support.f90
@@ -25,6 +25,8 @@ module ffc_test_support
     public :: expect_stderr_and_exit
     public :: expect_eof_stderr_and_exit
     public :: expect_no_leaks
+    ! Lets a test keep the emitted executable and inspect it (#565).
+    public :: compile_to_exe
 
 contains
 

--- a/src/liric_session_runtime_bindings.f90
+++ b/src/liric_session_runtime_bindings.f90
@@ -5,10 +5,13 @@
 ! archives themselves are produced by runtime/CMakeLists.txt (#374); see
 ! docs/RUNTIME_ABI.md for the artifact names and the archive header format.
 !
-! Selection is opt-in: with FFC_RUNTIME_ARCHIVE_DIR unset or blank, nothing is
-! installed and the established inline-runtime lowering path is preserved
-! exactly. A configured directory is strict: a missing archive, or one built
-! for a different backend or target, is an error rather than a fallback.
+! Selection is strict and unconditional: the caller names the artifact
+! directory, and a missing archive, or one built for a different backend or
+! target, is an error rather than a fallback. #565 removed the environment
+! variable that used to make this opt-in, along with the inline-runtime path
+! it fell back to; ffc now links its runtime into every executable it emits
+! (see ffc_runtime_link), and this facility serves sessions that must resolve
+! runtime calls without a system linker.
 module liric_session_runtime_bindings
     use liric_session_common, only: liric_session_t, lr_error_t, LR_OK, &
         status_ok, require_open_session, set_empty
@@ -210,36 +213,33 @@ contains
         end if
     end function backend_label
 
-    ! Installs the archive matching `backend` and `target` into `session`.
-    ! Returns .true. and leaves error_msg empty when no archive directory is
-    ! configured: that preserves the inline-runtime path unchanged.
-    logical function install_runtime_archive(session, backend, target, &
-                                             error_msg) result(ok)
+    ! Installs the archive matching `backend` and `target` into `session`,
+    ! reading it from `directory`.
+    !
+    ! The directory is an explicit argument, with no environment variable
+    ! behind it. #565 retired the opt-in form of this call: a caller either
+    ! installs an archive or it does not, and every failure to install a
+    ! requested archive is an error. Nothing falls back to synthesising the
+    ! runtime entry points inline. Executables emitted by ffc get their
+    ! runtime by static link instead (see ffc_runtime_link); this facility
+    ! remains for sessions that resolve runtime calls without a system linker.
+    logical function install_runtime_archive(session, directory, backend, &
+                                             target, error_msg) result(ok)
         type(liric_session_t), intent(inout) :: session
+        character(len=*), intent(in) :: directory
         integer(c_int), intent(in) :: backend
         character(len=*), intent(in) :: target
         character(len=:), allocatable, intent(out) :: error_msg
-        character(len=:), allocatable :: directory
         character(len=:), allocatable :: path
         integer(c_int8_t), allocatable, target :: bytes(:)
         type(lr_error_t) :: error
         integer(c_int) :: status
-        integer :: length, ios
 
         ok = .false.
         call set_empty(error_msg)
 
-        call get_environment_variable('FFC_RUNTIME_ARCHIVE_DIR', &
-                                      length=length, status=ios)
-        if (ios /= 0 .or. length <= 0) then
-            ! Unset configuration: keep the inline-runtime path.
-            ok = .true.
-            return
-        end if
-        allocate (character(len=length) :: directory)
-        call get_environment_variable('FFC_RUNTIME_ARCHIVE_DIR', directory)
         if (len_trim(directory) == 0) then
-            ok = .true.
+            error_msg = 'no runtime archive directory was given'
             return
         end if
 

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -53,7 +53,7 @@ module session_program_lowering
         BINDING_ASSOCIATE_NAME, &
         get_alternate_return_label, get_return_selector, &
         is_alternate_return_dummy
-    use liric_session_runtime_bindings, only: install_runtime_archive
+    use ffc_runtime_link, only: ffc_runtime_link_input
     use ffc_polymorphic_descriptor, only: &
         POLYMORPHIC_DESCRIPTOR_DATA_OFFSET, &
         POLYMORPHIC_DESCRIPTOR_DECLARED_TYPE_OFFSET, &

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -67,15 +67,11 @@
         if (present(opt_level)) session_config%opt_level = int(opt_level, c_int)
         call liric_session_create(context%session, error_msg, session_config)
         if (len_trim(error_msg) > 0) return
-        ! Install the runtime archive matching this backend and target before
-        ! any runtime call is lowered (#376). With no archive directory
-        ! configured this is a no-op and the inline-runtime path is kept.
-        if (.not. install_runtime_archive(context%session, &
-                                          session_config%backend, &
-                                          'host', error_msg)) then
-            call destroy(context%session)
-            return
-        end if
+        ! The runtime reaches an emitted executable by being linked into it
+        ! (see emit_executable_output and ffc_runtime_link, #565), not by
+        ! installing a separately built archive into the session. Nothing is
+        ! configured here, so there is no unset-configuration case and no
+        ! inline-runtime fallback to fall into.
         allocate(context%symbols(16))
         allocate(context%derived_types(8))
         allocate(context%module_exports(4))
@@ -548,15 +544,34 @@
         character(len=*), intent(in) :: output_path
         character(len=*), intent(in), optional :: link_objects(:)
         character(len=:), allocatable, intent(out) :: error_msg
+        integer, parameter :: PATH_BUFFER_LEN = 4096
+        character(len=:), allocatable :: runtime_input
+        character(len=PATH_BUFFER_LEN), allocatable :: inputs(:)
+        integer :: n, i
 
-        if (present(link_objects)) then
-            if (size(link_objects) > 0) then
-                ok = finish_and_emit_exe_objects(session, output_path, &
-                                                 link_objects, error_msg)
-                return
-            end if
+        ok = .false.
+        ! Every emitted executable is linked against the ffc runtime, so a
+        ! lowered runtime call always resolves. There is no unlinked variant
+        ! and no inline fallback: when the runtime cannot be provided, this
+        ! fails by name (#565).
+        call ffc_runtime_link_input(runtime_input, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (len_trim(runtime_input) > PATH_BUFFER_LEN) then
+            error_msg = 'ffc runtime link input path is too long: '// &
+                runtime_input
+            return
         end if
-        ok = finish_and_emit_exe(session, output_path, error_msg)
+
+        n = 0
+        if (present(link_objects)) n = size(link_objects)
+        allocate (inputs(n + 1))
+        do i = 1, n
+            inputs(i) = link_objects(i)
+        end do
+        inputs(n + 1) = runtime_input
+
+        ok = finish_and_emit_exe_objects(session, output_path, inputs, &
+                                         error_msg)
     end function emit_executable_output
     subroutine validate_program(arena, root_index, error_msg)
         type(ast_arena_t), intent(in) :: arena

--- a/test/conformance/xfail_lfortran.txt
+++ b/test/conformance/xfail_lfortran.txt
@@ -481,7 +481,6 @@ block_08.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations
 block_10.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 block_11.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
 block_12.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
-block_13.f90 # owner=lazy-fortran/ffc#402; reason=lower allocatable character components
 block_14.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
 block_15.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
 block_17.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards

--- a/test/test_runtime_link_compiler.f90
+++ b/test/test_runtime_link_compiler.f90
@@ -1,0 +1,311 @@
+! Issue #565: ffc links its runtime into every executable it emits.
+!
+! Behavioral oracle for the delivery decision. The four issues that move
+! compiler-emitted code behind the runtime ABI (#396, #423, #427, #428) all
+! depend on an emitted call to a runtime symbol resolving in the produced
+! binary, with no environment variable set and no inline fallback.
+!
+! What is checked, and why each check is here:
+!
+!   1. Every executable the real lowering path emits defines the runtime
+!      entry points. Proved by compiling an ordinary Fortran program through
+!      lower_program_to_liric_exe and reading the runtime symbols out of the
+!      resulting binary's symbol table. This fails on the pre-#565 compiler,
+!      which linked no runtime unless FFC_RUNTIME_ARCHIVE_DIR was set.
+!   2. The linked runtime is callable, not merely present: a session that
+!      calls `_ffc_runtime_probe` and links the same runtime input runs and
+!      exits 42.
+!   3. Without that link input the same session produces a binary that dies
+!      with an undefined symbol. This is the silent failure mode the design
+!      exists to remove, and pinning it keeps check 2 honest.
+!   4. Every symbol in FFC_RUNTIME_SYMBOLS is really defined by the embedded
+!      runtime source. A lowering that emits a call to a symbol the runtime
+!      does not define would otherwise produce a binary that links cleanly
+!      and then dies at run time.
+!   5. The embedded runtime source is byte-identical to runtime/ffc_runtime.c,
+!      so the compiler and the CMake-packaged archives cannot drift apart.
+program test_runtime_link_compiler
+    use ffc_runtime_link, only: ffc_runtime_link_input, FFC_RUNTIME_SYMBOLS
+    use ffc_runtime_source, only: ffc_runtime_source_text
+    use liric_session_bindings, only: liric_session_t, liric_session_create, &
+        destroy, lr_session_config_t, lr_operand_desc_t, emit_i32_call, &
+        emit_ret_i32_operand, begin_i32_main, finish_and_emit_exe, &
+        finish_and_emit_exe_objects
+    use ffc_test_support, only: compile_to_exe
+    implicit none
+
+    character(len=*), parameter :: WORK = '/tmp/ffc_runtime_link_565'
+    integer :: failures
+
+    failures = 0
+    call run_quiet('rm -rf '//WORK//' && mkdir -p '//WORK)
+
+    print *, '=== runtime link tests (#565) ==='
+
+    call check_embedded_source_matches_file(failures)
+    call check_declared_symbols_are_defined(failures)
+    call check_probe_runs_with_runtime(failures)
+    call check_probe_fails_without_runtime(failures)
+    call check_emitted_executable_carries_runtime(failures)
+
+    if (failures /= 0) then
+        print *, 'FAIL: ', failures, ' runtime link check(s) failed'
+        stop 1
+    end if
+    print *, 'PASS: runtime link'
+
+contains
+
+    subroutine run_quiet(command)
+        character(len=*), intent(in) :: command
+        integer :: exit_stat, cmd_stat
+
+        call execute_command_line(command, exitstat=exit_stat, &
+                                  cmdstat=cmd_stat)
+    end subroutine run_quiet
+
+    ! Runs a command and returns its exit status without aborting the test
+    ! when the command fails.
+    integer function status_of(command) result(status)
+        character(len=*), intent(in) :: command
+        character(len=*), parameter :: rc_file = WORK//'/rc'
+        integer :: unit, ios, exit_stat, cmd_stat
+
+        status = -1
+        call execute_command_line('{ '//command//' ; } > /dev/null 2>&1; '// &
+                                  'echo $? > '//rc_file, exitstat=exit_stat, &
+                                  cmdstat=cmd_stat)
+        if (cmd_stat /= 0) return
+        open (newunit=unit, file=rc_file, status='old', iostat=ios)
+        if (ios /= 0) return
+        read (unit, *, iostat=ios) status
+        close (unit)
+        if (ios /= 0) status = -1
+    end function status_of
+
+    subroutine read_text_file(path, text, ok)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: text
+        logical, intent(out) :: ok
+        integer :: unit, ios
+        integer(kind=8) :: nbytes
+
+        ok = .false.
+        open (newunit=unit, file=path, access='stream', form='unformatted', &
+              status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            text = ''
+            return
+        end if
+        inquire (unit=unit, size=nbytes)
+        if (nbytes <= 0) then
+            close (unit)
+            text = ''
+            return
+        end if
+        allocate (character(len=nbytes) :: text)
+        read (unit, iostat=ios) text
+        close (unit)
+        ok = ios == 0
+    end subroutine read_text_file
+
+    ! The generated embedding must reproduce runtime/ffc_runtime.c exactly,
+    ! so the linked runtime and the archived runtime are the same code.
+    subroutine check_embedded_source_matches_file(nfail)
+        integer, intent(inout) :: nfail
+        character(len=:), allocatable :: embedded, on_disk
+        logical :: ok
+
+        call ffc_runtime_source_text(embedded)
+        call read_text_file('runtime/ffc_runtime.c', on_disk, ok)
+        if (.not. ok) then
+            print *, 'FAIL: cannot read runtime/ffc_runtime.c'
+            nfail = nfail + 1
+            return
+        end if
+        if (embedded /= on_disk) then
+            print *, 'FAIL: the embedded runtime source has drifted from ', &
+                'runtime/ffc_runtime.c; run scripts/generate_runtime_source.sh'
+            nfail = nfail + 1
+        end if
+    end subroutine check_embedded_source_matches_file
+
+    ! Guards the lowerer: a symbol it is allowed to call must exist.
+    subroutine check_declared_symbols_are_defined(nfail)
+        integer, intent(inout) :: nfail
+        character(len=:), allocatable :: link_input, error_msg, symbols
+        character(len=*), parameter :: obj = WORK//'/runtime.o'
+        character(len=*), parameter :: nm_out = WORK//'/runtime.nm'
+        logical :: ok
+        integer :: i, status
+
+        call ffc_runtime_link_input(link_input, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: runtime link input: ', trim(error_msg)
+            nfail = nfail + 1
+            return
+        end if
+
+        status = status_of('cc -c -o '//obj//' '//link_input)
+        if (status /= 0) then
+            print *, 'FAIL: the embedded runtime source does not compile'
+            nfail = nfail + 1
+            return
+        end if
+        status = status_of('nm --defined-only -g '//obj//' > '//nm_out)
+        if (status /= 0) then
+            print *, 'FAIL: cannot list the runtime object symbols'
+            nfail = nfail + 1
+            return
+        end if
+        call read_text_file(nm_out, symbols, ok)
+        if (.not. ok) then
+            print *, 'FAIL: cannot read the runtime object symbol list'
+            nfail = nfail + 1
+            return
+        end if
+        do i = 1, size(FFC_RUNTIME_SYMBOLS)
+            if (index(symbols, ' '//trim(FFC_RUNTIME_SYMBOLS(i))// &
+                      new_line('a')) == 0) then
+                print *, 'FAIL: the runtime does not define declared ', &
+                    'symbol ', trim(FFC_RUNTIME_SYMBOLS(i))
+                nfail = nfail + 1
+            end if
+        end do
+    end subroutine check_declared_symbols_are_defined
+
+    ! Emits a session that calls the runtime probe. `with_runtime` selects
+    ! whether the runtime link input is supplied, which is the only
+    ! difference between the two binaries.
+    subroutine emit_probe_exe(with_runtime, exe, emitted)
+        logical, intent(in) :: with_runtime
+        character(len=*), intent(in) :: exe
+        logical, intent(out) :: emitted
+        type(liric_session_t) :: session
+        type(lr_session_config_t) :: config
+        type(lr_operand_desc_t) :: args(0)
+        type(lr_operand_desc_t) :: probe_result
+        character(len=:), allocatable :: error_msg, link_input
+        character(len=4096) :: inputs(1)
+
+        emitted = .false.
+        config = lr_session_config_t()
+        call liric_session_create(session, error_msg, config)
+        if (len_trim(error_msg) > 0) return
+        if (.not. begin_i32_main(session, error_msg)) then
+            call destroy(session)
+            return
+        end if
+        if (.not. emit_i32_call(session, '_ffc_runtime_probe', args, &
+                                probe_result, error_msg)) then
+            call destroy(session)
+            return
+        end if
+        if (.not. emit_ret_i32_operand(session, probe_result, error_msg)) then
+            call destroy(session)
+            return
+        end if
+        if (with_runtime) then
+            call ffc_runtime_link_input(link_input, error_msg)
+            if (len_trim(error_msg) > 0) then
+                call destroy(session)
+                return
+            end if
+            inputs(1) = link_input
+            emitted = finish_and_emit_exe_objects(session, exe, inputs, &
+                                                  error_msg)
+        else
+            emitted = finish_and_emit_exe(session, exe, error_msg)
+        end if
+        call destroy(session)
+    end subroutine emit_probe_exe
+
+    subroutine check_probe_runs_with_runtime(nfail)
+        integer, intent(inout) :: nfail
+        character(len=*), parameter :: exe = WORK//'/probe_linked'
+        logical :: emitted
+        integer :: status
+
+        call emit_probe_exe(.true., exe, emitted)
+        if (.not. emitted) then
+            print *, 'FAIL: could not emit the probe executable'
+            nfail = nfail + 1
+            return
+        end if
+        status = status_of(exe)
+        if (status /= 42) then
+            print *, 'FAIL: linked runtime probe returned ', status, &
+                ' instead of 42'
+            nfail = nfail + 1
+        end if
+    end subroutine check_probe_runs_with_runtime
+
+    ! Pins the failure mode the linked runtime removes: without it the call
+    ! still links, and the binary dies at run time instead.
+    subroutine check_probe_fails_without_runtime(nfail)
+        integer, intent(inout) :: nfail
+        character(len=*), parameter :: exe = WORK//'/probe_unlinked'
+        logical :: emitted
+        integer :: status
+
+        call emit_probe_exe(.false., exe, emitted)
+        if (.not. emitted) return
+        status = status_of(exe)
+        if (status == 42) then
+            print *, 'FAIL: the probe resolved without linking the runtime, ', &
+                'so this test cannot tell the two apart'
+            nfail = nfail + 1
+        end if
+    end subroutine check_probe_fails_without_runtime
+
+    ! The end-to-end guarantee: an ordinary compile links the runtime.
+    subroutine check_emitted_executable_carries_runtime(nfail)
+        integer, intent(inout) :: nfail
+        character(len=*), parameter :: exe = WORK//'/hello'
+        character(len=*), parameter :: nm_out = WORK//'/hello.nm'
+        character(len=:), allocatable :: error_msg, symbols
+        logical :: ok
+        integer :: i, status
+
+        call compile_to_exe( &
+            'program main'//new_line('a')// &
+            '    integer :: value'//new_line('a')// &
+            '    value = 7'//new_line('a')// &
+            '    stop value'//new_line('a')// &
+            'end program main'//new_line('a'), exe, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: compiling a program failed: ', trim(error_msg)
+            nfail = nfail + 1
+            return
+        end if
+
+        status = status_of(exe)
+        if (status /= 7) then
+            print *, 'FAIL: the compiled program exited ', status, &
+                ' instead of 7'
+            nfail = nfail + 1
+        end if
+
+        status = status_of('nm --defined-only '//exe//' > '//nm_out)
+        if (status /= 0) then
+            print *, 'FAIL: cannot list the emitted executable symbols'
+            nfail = nfail + 1
+            return
+        end if
+        call read_text_file(nm_out, symbols, ok)
+        if (.not. ok) then
+            print *, 'FAIL: cannot read the emitted executable symbol list'
+            nfail = nfail + 1
+            return
+        end if
+        do i = 1, size(FFC_RUNTIME_SYMBOLS)
+            if (index(symbols, ' '//trim(FFC_RUNTIME_SYMBOLS(i))// &
+                      new_line('a')) == 0) then
+                print *, 'FAIL: the emitted executable does not carry ', &
+                    'runtime symbol ', trim(FFC_RUNTIME_SYMBOLS(i))
+                nfail = nfail + 1
+            end if
+        end do
+    end subroutine check_emitted_executable_carries_runtime
+
+end program test_runtime_link_compiler

--- a/test/test_session_runtime_archive_compiler.f90
+++ b/test/test_session_runtime_archive_compiler.f90
@@ -8,8 +8,11 @@
 !
 ! It also pins the selection contract: `default` selects the copy-patch
 ! artifact, a missing archive and a backend-mismatched archive each report the
-! exact backend, and an unset FFC_RUNTIME_ARCHIVE_DIR preserves the inline
-! runtime path.
+! exact backend, and a blank artifact directory is an error.
+!
+! #565 removed the FFC_RUNTIME_ARCHIVE_DIR opt-in and the inline-runtime path
+! it used to fall back to, so the directory is now an explicit argument and
+! every failure to install a requested archive is loud.
 program test_session_runtime_archive_compiler
     use liric_session_bindings, only: liric_session_t, liric_session_create, &
         destroy, lr_session_config_t, lr_operand_desc_t, emit_i32_call, &
@@ -19,25 +22,8 @@ program test_session_runtime_archive_compiler
         effective_archive_backend, &
         LR_SESSION_BACKEND_DEFAULT, LR_SESSION_BACKEND_ISEL, &
         LR_SESSION_BACKEND_COPY_PATCH
-    use, intrinsic :: iso_c_binding, only: c_int, c_char
+    use, intrinsic :: iso_c_binding, only: c_int
     implicit none
-
-    interface
-        function setenv_c(name, value, overwrite) result(status) &
-            bind(c, name='setenv')
-            import :: c_char, c_int
-            character(kind=c_char), intent(in) :: name(*)
-            character(kind=c_char), intent(in) :: value(*)
-            integer(c_int), value :: overwrite
-            integer(c_int) :: status
-        end function setenv_c
-
-        function unsetenv_c(name) result(status) bind(c, name='unsetenv')
-            import :: c_char, c_int
-            character(kind=c_char), intent(in) :: name(*)
-            integer(c_int) :: status
-        end function unsetenv_c
-    end interface
 
     character(len=*), parameter :: build_dir = '/tmp/ffc_runtime_376_build'
     character(len=*), parameter :: artifact_root = build_dir//'/artifacts'
@@ -57,7 +43,7 @@ program test_session_runtime_archive_compiler
         call check_missing_archive(failures)
         call check_backend_mismatch(failures)
     end if
-    call check_unset_preserves_inline_path(failures)
+    call check_blank_directory_is_an_error(failures)
 
     if (failures /= 0) then
         print *, 'FAIL: ', failures, ' runtime archive check(s) failed'
@@ -138,7 +124,6 @@ contains
         character(len=*), parameter :: exe = '/tmp/ffc_runtime_376_probe'
         integer :: stat
 
-        call set_archive_dir(artifact_root)
         config = lr_session_config_t()
         config%backend = backend
 
@@ -149,8 +134,8 @@ contains
             return
         end if
 
-        if (.not. install_runtime_archive(session, backend, 'host', &
-                                          error_msg)) then
+        if (.not. install_runtime_archive(session, artifact_root, backend, &
+                                          'host', error_msg)) then
             print *, 'FAIL: ', label, ' archive install: ', trim(error_msg)
             call destroy(session)
             nfail = nfail + 1
@@ -201,7 +186,6 @@ contains
         type(lr_session_config_t) :: config
         character(len=:), allocatable :: error_msg
 
-        call set_archive_dir('/tmp/ffc_runtime_376_absent')
         config = lr_session_config_t()
         config%backend = LR_SESSION_BACKEND_ISEL
         call liric_session_create(session, error_msg, config)
@@ -210,8 +194,9 @@ contains
             nfail = nfail + 1
             return
         end if
-        if (install_runtime_archive(session, LR_SESSION_BACKEND_ISEL, &
-                                    'host', error_msg)) then
+        if (install_runtime_archive(session, '/tmp/ffc_runtime_376_absent', &
+                                    LR_SESSION_BACKEND_ISEL, 'host', &
+                                    error_msg)) then
             print *, 'FAIL: missing archive was accepted'
             nfail = nfail + 1
         else if (index(error_msg, 'ffc-runtime-v2-isel.lrarch') == 0) then
@@ -242,7 +227,6 @@ contains
             return
         end if
 
-        call set_archive_dir(bad_root)
         config = lr_session_config_t()
         config%backend = LR_SESSION_BACKEND_ISEL
         call liric_session_create(session, error_msg, config)
@@ -251,8 +235,9 @@ contains
             nfail = nfail + 1
             return
         end if
-        if (install_runtime_archive(session, LR_SESSION_BACKEND_ISEL, &
-                                    'host', error_msg)) then
+        if (install_runtime_archive(session, bad_root, &
+                                    LR_SESSION_BACKEND_ISEL, 'host', &
+                                    error_msg)) then
             print *, 'FAIL: backend-mismatched archive was accepted'
             nfail = nfail + 1
         else
@@ -267,51 +252,31 @@ contains
         call run('rm -rf '//bad_root, stat)
     end subroutine check_backend_mismatch
 
-    ! With no archive directory configured, installation is a silent no-op so
-    ! the established inline-runtime lowering path is preserved.
-    subroutine check_unset_preserves_inline_path(nfail)
+    ! A blank artifact directory is a caller error, not a licence to skip
+    ! installation. The opt-out that used to live here is gone (#565).
+    subroutine check_blank_directory_is_an_error(nfail)
         integer, intent(inout) :: nfail
         type(liric_session_t) :: session
         type(lr_session_config_t) :: config
         character(len=:), allocatable :: error_msg
-        integer :: stat
 
-        call run('true', stat)
-        call unset_archive_dir()
         config = lr_session_config_t()
         call liric_session_create(session, error_msg, config)
         if (len_trim(error_msg) > 0) then
-            print *, 'FAIL: session create for unset check'
+            print *, 'FAIL: session create for blank-directory check'
             nfail = nfail + 1
             return
         end if
-        if (.not. install_runtime_archive(session, &
-                                          LR_SESSION_BACKEND_DEFAULT, &
-                                          'host', error_msg)) then
-            print *, 'FAIL: unset archive dir was treated as an error: ', &
-                trim(error_msg)
+        if (install_runtime_archive(session, '   ', &
+                                    LR_SESSION_BACKEND_DEFAULT, 'host', &
+                                    error_msg)) then
+            print *, 'FAIL: a blank archive directory was accepted'
             nfail = nfail + 1
-        else if (len_trim(error_msg) > 0) then
-            print *, 'FAIL: unset archive dir reported ', trim(error_msg)
+        else if (len_trim(error_msg) == 0) then
+            print *, 'FAIL: a blank archive directory failed without a reason'
             nfail = nfail + 1
         end if
         call destroy(session)
-    end subroutine check_unset_preserves_inline_path
-
-    subroutine set_archive_dir(value)
-        character(len=*), intent(in) :: value
-        integer(c_int) :: stat
-
-        stat = setenv_c('FFC_RUNTIME_ARCHIVE_DIR'//achar(0), &
-                        trim(value)//achar(0), 1_c_int)
-        if (stat /= 0) print *, 'WARNING: setenv failed'
-    end subroutine set_archive_dir
-
-    subroutine unset_archive_dir()
-        integer(c_int) :: stat
-
-        stat = unsetenv_c('FFC_RUNTIME_ARCHIVE_DIR'//achar(0))
-        if (stat /= 0) print *, 'WARNING: unsetenv failed'
-    end subroutine unset_archive_dir
+    end subroutine check_blank_directory_is_an_error
 
 end program test_session_runtime_archive_compiler

--- a/test/test_session_scalar_procedure_call_compiler.f90
+++ b/test/test_session_scalar_procedure_call_compiler.f90
@@ -1,6 +1,6 @@
 program test_session_scalar_procedure_call_compiler
     use ffc_test_support, only: expect_error_contains, expect_exit_status, &
-                                expect_no_error
+                                expect_exe_has_symbol
     implicit none
 
     logical :: all_passed
@@ -158,6 +158,14 @@ contains
         ! An interface block at host level declares an external procedure whose
         ! body lives in another translation unit (#416), so it lowers to a call
         ! that the linker resolves rather than a "body unavailable" rejection.
+        !
+        ! The artifact that can legitimately carry the unresolved reference is
+        ! an object, so that is what this compiles. Linking the same source
+        ! into an executable on its own fails at the link step, because no
+        ! translation unit defines `missing_body` -- the same outcome gfortran
+        ! gives. That became visible in #565, when every emitted executable
+        ! started going through the system linker; before it, ffc produced a
+        ! binary that died with an undefined symbol only when run.
         character(len=*), parameter :: source = &
             'program main'//new_line('a')// &
             '  implicit none'//new_line('a')// &
@@ -169,8 +177,12 @@ contains
             '  stop missing_body(1)'//new_line('a')// &
             'end program main'
 
-        test_host_interface_is_external = expect_no_error( &
-            source, '/tmp/ffc_session_scalar_proc_missing')
+        test_host_interface_is_external = expect_exe_has_symbol( &
+            source, '/tmp/ffc_session_scalar_proc_missing.o', 'missing_body')
+        if (.not. test_host_interface_is_external) return
+        test_host_interface_is_external = expect_error_contains( &
+            source, 'linker failed', &
+            '/tmp/ffc_session_scalar_proc_missing')
     end function test_host_interface_is_external
 
 end program test_session_scalar_procedure_call_compiler


### PR DESCRIPTION
Closes #565.

## Decision: link the runtime into every emitted executable, with the runtime source carried inside the compiler

#374 and #376 landed backend-qualified runtime archives, but #376 made
installation opt-in through `FFC_RUNTIME_ARCHIVE_DIR` and preserved the inline
path when it was unset. Nothing in ffc set that variable, so a lowered call to
`_ffc_unit_open` would not have resolved in a normal `ffc` invocation. #396,
#423, #427 and #428 were blocked on that.

**Option 1 (unconditional installation from a discovered default directory) is
not available today.** `fo` selects exactly one backend per project: it walks
up to the nearest `fpm.toml` *or* `CMakeLists.txt`, and ffc's root `fpm.toml`
wins, so `fo build` cannot also drive `runtime/CMakeLists.txt`. CI compounds
this by building with plain `fpm build`/`fpm test`. Option 1 also leaves a
discovery problem behind: an installed artifact has to be found at run time
from a build tree, a worktree, or an install prefix, and every discovery rule
is a way for a compiler to pick up a runtime that does not match it.

**Option 2 is what shipped, in the form that removes the discovery problem
entirely.** `runtime/ffc_runtime.c` stays the single source of truth and is
embedded verbatim in the compiler binary as `src/ffc_runtime_source.f90`
(regenerated by `scripts/generate_runtime_source.sh`). At link time
`ffc_runtime_link` materialises it into a content-addressed file under
`TMPDIR` and passes it to `lr_session_emit_exe_objects`, which hands it to the
same system C compiler that already performs the link.

Measured, not assumed: an emitted executable that calls `_ffc_runtime_probe`
exits 42 for both the isel and copy-patch backends when the runtime is linked,
and dies with `undefined symbol` when it is not.

## The inline path is retired, not demoted to a fallback

- `install_runtime_archive` no longer reads any environment variable. The
  artifact directory is an explicit argument, and a blank directory, a missing
  archive, and a backend-mismatched archive are each an error.
- The lowering path no longer installs an archive at all. There is no
  unset-configuration case left to fall into.
- Nothing anywhere synthesises the runtime entry points inline.
- Exactly one convention survives for executables: the linked runtime. The
  archive facility remains for sessions that must resolve runtime calls
  without a system linker, and is not on the executable-emission path.

## Invariants preserved and stated

- **Versioned public interfaces.** `lr_session_set_runtime_archive` and
  `lr_session_emit_exe_objects` are used through the existing verified
  bindings (#375/#564); no LIRIC ABI declaration changed. The frozen session
  backend enumerators (LIRIC #527) are unchanged.
- **Verified ABI declarations.** `FFC_RUNTIME_SYMBOLS` is the authoritative
  list of entry points the lowerer may call, and
  `test_runtime_link_compiler` compiles the embedded runtime and fails unless
  every listed symbol is defined by it. Emitting a call to a symbol the
  runtime does not define is now caught at test time instead of producing a
  binary that dies at run time.
- **Matching runtime.** A compiler/runtime mismatch is impossible by
  construction: the runtime linked into a program is the one compiled into the
  compiler that produced it. There is no installed artifact to go missing or
  go stale. The archive path keeps its own strict check: magic, format, and
  recorded backend must match, or installation fails naming both backends.
- **Loud failure.** When the runtime cannot be materialised, lowering fails
  with a named error and emits nothing.
- **Ownership and view lifetimes.** Unchanged; this touches only how the link
  step is assembled.
- **Object output.** `ffc -c` still leaves runtime symbols undefined in the
  object, for the consuming link to resolve.

## Behavioral oracle

`test/test_runtime_link_compiler.f90` (new). It compiles an ordinary Fortran
program through `lower_program_to_liric_exe` and reads the runtime symbols out
of the emitted binary's symbol table; checks the linked runtime is callable
(exit 42); pins the failure mode it removes by emitting the same session
without the runtime and requiring it *not* to return 42; checks every declared
symbol is defined by the embedded source; and checks the embedded source is
byte-identical to `runtime/ffc_runtime.c`. All five fail on unmodified `main`.

## One deliberate behavior change

Every executable now goes through the system linker, which had previously only
happened when there were prerequisite module objects (#284). A program that
references a procedure no translation unit defines therefore now fails at link
naming the missing symbol, instead of producing a binary that dies with
`undefined symbol` when run. That matches gfortran.
`test_session_scalar_procedure_call_compiler`'s host-interface case was
updated accordingly and *strengthened*: it now checks the object really
carries an external reference to `missing_body` (the #416 guarantee that
lowering does not reject it), and separately that linking it alone fails. Two
corpus cases that previously reported `runtime exit 127` now report a link
error; both were already FAIL.

## Corpus delta

Gauntlet run before and after at the same base commit, with private report
directories (#547):

| suite | pass | xfail | xpass | fail | noref | skip |
|---|---|---|---|---|---|---|
| lfortran, base | 857 | 3337 | 74 | 11 | 162 | 1 |
| lfortran, this PR | 857 | 3336 | 75 | 11 | 162 | 1 |
| gfortran-dg, base | 1332 | 2090 | 40 | 177 | 6 | 2299 |
| gfortran-dg, this PR | 1332 | 2089 | 41 | 177 | 6 | 2299 |

No PASS regressed. Two cases flipped XFAIL to XPASS:

- `block_13.f90` (lfortran) passes on five consecutive runs and is promoted
  out of `test/conformance/xfail_lfortran.txt`.
- `minmaxloc_11.f90` (gfortran-dg) is *not* promoted: rerunning it alone gives
  PASS on 2 of 6 runs, because the compiled program's own exit status varies.
  It stays listed with its existing owner and reason.

`test_fortfront_corpus_conformance` and `test_parity_dashboard` fail on this
branch and fail identically on `main` at the same commit; the fortfront-f90
failure set is byte-identical apart from the two reason strings noted above.
