### PR TITLE
[arraydesc-02] pass assumed-shape arrays by descriptor

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -318,6 +318,16 @@ module session_program_lowering
         fmod_component_t, fmod_derived_type_t, &
         fmod_variable_t, fmod_procedure_t, fmod_generic_t, &
         write_fmod, read_fmod
+    use ffc_array_descriptor, only: ARRAY_DESCRIPTOR_BYTES, &
+        ARRAY_DESCRIPTOR_ELEMENT_SIZE_OFFSET, &
+        ARRAY_DESCRIPTOR_ELEMENT_TYPE_OFFSET, ARRAY_DESCRIPTOR_RANK_OFFSET, &
+        ARRAY_DESCRIPTOR_FLAGS_OFFSET, ARRAY_DESCRIPTOR_RESERVED_OFFSET, &
+        ARRAY_DESCRIPTOR_DIM_OFFSET, ARRAY_DIMENSION_BYTES, &
+        ARRAY_DIMENSION_LOWER_OFFSET, ARRAY_DIMENSION_EXTENT_OFFSET, &
+        ARRAY_DIMENSION_STRIDE_OFFSET, ARRAY_FLAG_ALLOCATED, &
+        ARRAY_FLAG_ASSOCIATED, ARRAY_FLAG_CONTIGUOUS, ARRAY_ELEMENT_INTEGER, &
+        ARRAY_ELEMENT_REAL, ARRAY_ELEMENT_LOGICAL, ARRAY_ELEMENT_COMPLEX, &
+        ARRAY_ELEMENT_CHARACTER, ARRAY_ELEMENT_DERIVED
     use ffc_character_descriptor, only: CHARACTER_STORAGE_STATIC, &
         CHARACTER_STORAGE_STACK, CHARACTER_STORAGE_OWNED
     implicit none
@@ -1689,6 +1699,7 @@ contains
     end subroutine try_lower_overloaded_assignment
     include 'session_program_lowering_arguments.inc'
     include 'session_program_lowering_assumed_shape_extent.inc'
+    include 'session_program_lowering_assumed_shape_descriptor.inc'
     include 'session_program_lowering_character.inc'
     include 'session_program_lowering_deferred_char.inc'
     subroutine lower_function_return(node, context, error_msg)
@@ -2107,6 +2118,12 @@ contains
 
         ok = .false.
         pcount = proc_param_count(context, name)
+        ! A module procedure is not a nested procedure of this scope, so its
+        ! dummy count only resolves through the arena. Without it an omitted
+        ! trailing optional would be left unpadded and the callee would read an
+        ! uninitialized parameter slot instead of a null reference.
+        if (pcount < 0) pcount = arena_proc_param_count(context%arena, &
+                                                       unmangled_proc_name(name))
         if (pcount <= size(args)) then
             ok = emit_void_call(context%session, name, args, error_msg)
             return
@@ -2123,6 +2140,21 @@ contains
         end do
         ok = emit_void_call(context%session, name, padded, error_msg)
     end function emit_call_with_optional_padding
+
+    function unmangled_proc_name(name) result(source_name)
+        ! Source name behind a module procedure's emitted symbol
+        ! `__<module>_MOD_<name>`; any other name is returned unchanged.
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: source_name
+        integer :: marker
+
+        source_name = trim(name)
+        if (len(source_name) < 8) return
+        if (source_name(1:2) /= '__') return
+        marker = index(source_name, '_MOD_')
+        if (marker <= 0) return
+        source_name = source_name(marker + 5:)
+    end function unmangled_proc_name
     recursive subroutine lower_i1_condition(arena, node_index, context, &
             value, error_msg)
         type(ast_arena_t), intent(in) :: arena

--- a/src/session_program_lowering_arguments.inc
+++ b/src/session_program_lowering_arguments.inc
@@ -61,7 +61,9 @@
                                      sp, arg_indices, error_msg)
         if (len_trim(error_msg) > 0) return
         visible_count = size(arg_indices)
-        hidden_count = callee_hidden_extent_count(context, callee_name)
+        ! Assumed-shape dummies now travel as one descriptor pointer each
+        ! (#334), so no hidden extent arguments are appended any more.
+        hidden_count = 0
 
         ! More actual arguments than the callee (defined or interfaced in this
         ! unit) declares is always invalid, whatever the argument keywords or
@@ -159,6 +161,18 @@
                 call box_class_star_actual(arena, arg_indices(i), context, &
                                            args(i), error_msg)
                 if (len_trim(error_msg) > 0) return
+            else if (callee_dummy_assumed_shape_dims(arena, callee_name, &
+                                        call_arg_param_pos(i, sp)) >= 1) then
+                ! Assumed-shape dummy: pass one canonical array descriptor
+                ! (#334, docs/ARRAY_DESCRIPTOR_ABI.md). It carries the actual's
+                ! base address, element size and type, rank, extents, and
+                ! column-major byte strides, so the callee needs no hidden
+                ! extent arguments and no compile-time knowledge of the actual.
+                call build_assumed_shape_descriptor(arena, arg_indices(i), &
+                    context, callee_dummy_assumed_shape_dims(arena, &
+                        callee_name, call_arg_param_pos(i, sp)), callee_name, &
+                    args(i), error_msg)
+                if (len_trim(error_msg) > 0) return
             else if (actual_is_whole_array(arena, arg_indices(i), context) .and. &
                      callee_dummy_is_array_ctx(arena, context, callee_name, &
                                                i)) then
@@ -176,16 +190,6 @@
                 ! caller too, W11).
                 call allocatable_array_actual_descriptor_address(arena, &
                     arg_indices(i), context, args(i), error_msg)
-                if (len_trim(error_msg) > 0) return
-            else if (actual_is_allocatable_array(arena, arg_indices(i), context) &
-                     .and. callee_dummy_assumed_shape_runtime(arena, callee_name, &
-                                            call_arg_param_pos(i, sp))) then
-                ! Allocatable array actual to a rank-1/rank-2 assumed-shape dummy:
-                ! pass the descriptor's runtime data pointer (the W2 runtime-extent
-                ! ABI); its per-dimension extents travel separately as hidden i64
-                ! arguments appended below.
-                call allocatable_array_actual_data_address(arena, arg_indices(i), &
-                    context, args(i), error_msg)
                 if (len_trim(error_msg) > 0) return
             else if (actual_is_contiguous_section(arena, arg_indices(i), context) &
                      .and. callee_dummy_is_array_ctx(arena, context, &
@@ -206,13 +210,6 @@
                 if (len_trim(error_msg) > 0) return
             end if
         end do
-
-        if (hidden_count > 0) then
-            call append_hidden_extent_args(arena, arg_indices, context, &
-                                           callee_name, visible_count, args, &
-                                           error_msg, self_position=sp)
-            if (len_trim(error_msg) > 0) return
-        end if
 
         call set_empty(error_msg)
     end subroutine prepare_reference_args

--- a/src/session_program_lowering_arrays.inc
+++ b/src/session_program_lowering_arrays.inc
@@ -556,45 +556,82 @@
                 'a contained procedure', error_msg)
             return
         end if
+        ! Every assumed-shape dummy is bound from the caller's descriptor
+        ! (#334): bind_assumed_shape_descriptor_params already loaded the base
+        ! address and each dimension's extent from it before this declaration
+        ! ran, so element addressing and SIZE are always descriptor-driven and
+        ! two calls passing differently sized actuals each see their own shape.
+        !
+        ! resolve_assumed_shape_extents is only a compile-time SPECIALIZATION on
+        ! top of that binding: when every call site in this unit passes the same
+        ! constant shape, recording it as array_size lets whole-array operations
+        ! unroll. It never changes how the dummy is passed or how its extents are
+        ! read at run time.
         extents = 0
         call resolve_assumed_shape_extents(context, context%current_proc_name, &
                                            name, dim_count, extents, ok)
-        if (.not. ok) then
-            ! No compile-time-foldable actual: fall back to the hidden i64
-            ! runtime extent arguments already loaded for this dummy (one per
-            ! dimension, rank-1 or rank-2) by bind_hidden_extent_params before
-            ! this declaration ran.
+        if (ok) then
+            total = 1
+            do i = 1, dim_count
+                total = total*extents(i)
+            end do
+            ! The shape is a compile-time constant, so drop the descriptor's
+            ! cached runtime extents: has_runtime_dim_size means "shape known
+            ! only at run time", and leaving it set would send every whole-array
+            ! operation down the runtime loop even though a constant element
+            ! count is available. The base address still comes from the
+            ! descriptor; only the shape is specialized.
             index = find_symbol_compat(context, name)
-            if (dim_count >= 1 .and. dim_count <= 2 .and. index > 0) then
-                if (all(context%symbols(index)%has_runtime_dim_size(1:dim_count))) &
-                        then
-                    call define_declared_array_symbol(context, node, name, 1, 0, &
-                                                       value_kind, error_msg, &
-                                                       assumed_extents=spread(0, 1, &
-                                                                             dim_count))
-                    return
-                end if
+            if (index > 0) then
+                do i = 1, dim_count
+                    context%symbols(index)%has_runtime_dim_size(i) = .false.
+                end do
             end if
-            call unsupported_feature_error('assumed-shape array', node%line, &
-                node%column, 'assumed-shape dummy extent must come from a '// &
-                'whole-array actual of compile-time size', error_msg)
+            call define_declared_array_symbol(context, node, name, 1, total, &
+                                              value_kind, error_msg, &
+                                              assumed_extents=extents(1:dim_count))
             return
         end if
-        total = 1
-        do i = 1, dim_count
-            total = total * extents(i)
-        end do
-        call define_declared_array_symbol(context, node, name, 1, total, &
-                                          value_kind, error_msg, &
-                                          assumed_extents=extents(1:dim_count))
+
+        index = find_symbol_compat(context, name)
+        if (index > 0) then
+            if (all(context%symbols(index)%has_runtime_dim_size(1:dim_count))) then
+                call define_declared_array_symbol(context, node, name, 1, 0, &
+                                                  value_kind, error_msg, &
+                                                  assumed_extents=spread(0, 1, &
+                                                                     dim_count))
+                if (len_trim(error_msg) > 0) return
+                ! A rank-1 dummy with no constant shape has no compile-time
+                ! element count, exactly like a runtime-sized local automatic
+                ! array, so whole-array assign and print reuse that runtime-loop
+                ! machinery rather than a second lowering path of their own.
+                ! An OPTIONAL dummy keeps its parameter pointer as its address
+                ! so PRESENT can test it against null; the runtime-array
+                ! machinery would rebind that address to element storage.
+                if (dim_count == 1 .and. .not. node%is_optional) then
+                    index = find_symbol_compat(context, name)
+                    if (index > 0) context%symbols(index)%is_runtime_array = .true.
+                end if
+                return
+            end if
+        end if
+        call unsupported_feature_error('assumed-shape array', node%line, &
+            node%column, 'assumed-shape dummies are supported only for a '// &
+            'dummy bound through a caller-supplied array descriptor', error_msg)
     end subroutine bind_one_assumed_shape
 
     subroutine resolve_assumed_shape_extents(context, proc_name, param_name, &
                                              dim_count, extents, ok)
-        ! Recover an assumed-shape dummy's per-dimension extents from the
-        ! caller's actual. Find a call to proc_name whose actual at the dummy's
-        ! position is a whole-array identifier, then read that array's declared
-        ! compile-time shape. ok stays false when no constant extent is found.
+        ! Compile-time shape SPECIALIZATION for an assumed-shape dummy. This is
+        ! not an argument-passing path: since #334 every assumed-shape dummy is
+        ! bound through the caller's array descriptor and reads its extents from
+        ! there. This fold only recovers a constant element count so whole-array
+        ! operations can unroll instead of walking a runtime loop.
+        !
+        ! It is therefore only sound when EVERY call to proc_name in this unit
+        ! passes an actual of the same compile-time shape. If two call sites
+        ! disagree, or any call site's actual has no foldable shape, ok stays
+        ! false and the dummy keeps its runtime descriptor extents.
         type(lowering_context_t), intent(in) :: context
         character(len=*), intent(in) :: proc_name
         character(len=*), intent(in) :: param_name
@@ -602,28 +639,59 @@
         integer, intent(out) :: extents(:)
         logical, intent(out) :: ok
         integer :: param_pos
-        integer :: actual_index
-        character(len=:), allocatable :: actual_name
+        integer :: n
+        integer :: call_count
+        integer :: site_extents(ARRAY_MAX_RANK)
+        logical :: site_ok
+        character(len=:), allocatable :: call_name, name_err, actual_name
+        integer, allocatable :: arg_indices(:)
 
         ok = .false.
         extents = 0
+        call_count = 0
         param_pos = proc_param_position(context%arena, proc_name, param_name)
         if (param_pos <= 0) return
-        call find_call_actual_identifier(context%arena, proc_name, param_pos, &
-                                         actual_name)
-        if (allocated(actual_name)) then
-            if (len_trim(actual_name) > 0) then
-                call array_decl_extents(context, actual_name, dim_count, extents, &
-                                        ok)
-                if (ok) return
+
+        do n = 1, context%arena%size
+            if (.not. node_exists(context%arena, n)) cycle
+            if (.not. call_targets_proc(context%arena, n, proc_name, call_name, &
+                                        arg_indices)) cycle
+            if (call_is_within_proc(context%arena, n, proc_name)) cycle
+            if (.not. allocated(arg_indices)) cycle
+            if (param_pos < 1 .or. param_pos > size(arg_indices)) return
+            site_extents = 0
+            site_ok = .false.
+            if (is_identifier(context%arena, arg_indices(param_pos))) then
+                call get_identifier_name(context%arena, arg_indices(param_pos), &
+                                         actual_name, name_err)
+                if (len_trim(name_err) == 0) then
+                    call array_decl_extents(context, actual_name, dim_count, &
+                                            site_extents, site_ok)
+                end if
             end if
-        end if
-        call find_call_actual_expr(context%arena, proc_name, param_pos, &
-                                   actual_index)
-        if (actual_index > 0) then
-            call section_actual_decl_extents(context, actual_index, dim_count, &
-                                             extents, ok)
-        end if
+            if (.not. site_ok) then
+                call section_actual_decl_extents(context, &
+                    arg_indices(param_pos), dim_count, site_extents, site_ok)
+            end if
+            ! One unfoldable call site makes the whole specialization unsound.
+            if (.not. site_ok) then
+                extents = 0
+                ok = .false.
+                return
+            end if
+            if (call_count == 0) then
+                extents(1:dim_count) = site_extents(1:dim_count)
+            else if (any(extents(1:dim_count) /= site_extents(1:dim_count))) then
+                ! Call sites disagree: no single constant shape exists.
+                extents = 0
+                ok = .false.
+                return
+            end if
+            call_count = call_count + 1
+        end do
+
+        ok = call_count > 0
+        if (.not. ok) extents = 0
     end subroutine resolve_assumed_shape_extents
 
     integer function proc_param_position(arena, proc_name, param_name) &
@@ -3178,7 +3246,13 @@
             return
         end if
         if (nargs == 1) then
-            if (context%symbols(source_index)%has_runtime_dim_size(1)) then
+            ! Only walk the runtime loop when no constant element count is
+            ! known. A descriptor-bound dummy always caches its dimension
+            ! extents, so a dummy that ALSO carries a compile-time array_size
+            ! (the shape specialization) must still take the unrolled path,
+            ! which is the only one that handles rank 2 and every reduction.
+            if (context%symbols(source_index)%has_runtime_dim_size(1) .and. &
+                context%symbols(source_index)%array_size <= 0) then
                 ! A runtime-extent assumed-shape dummy: total = product of the
                 ! per-dimension runtime extents (rank 1 or 2).
                 value = context%symbols(source_index)%runtime_dim_size(1)
@@ -3327,18 +3401,20 @@
                             ' requires an array argument: '//trim(array_name)
                 return
             end if
-            ! A rank-1 assumed-shape dummy with a runtime-only extent (the
-            ! hidden i64 argument ABI) has no compile-time array_size to
-            ! unroll over; walk a genuine loop instead. Integer elements only.
+            ! An assumed-shape dummy bound through the caller's array
+            ! descriptor has a runtime-only extent and no compile-time
+            ! array_size to unroll over; walk a genuine loop instead.
             if (context%symbols(source_index)%has_runtime_dim_size(1)) then
                 if (trim(reduction_name) == 'sum' .and. &
-                    context%symbols(source_index)%value_kind == VALUE_I32) then
-                    call lower_runtime_i32_sum(context, source_index, value, &
-                                               error_msg)
+                    any(context%symbols(source_index)%value_kind == &
+                        [VALUE_I32, VALUE_F32, VALUE_F64])) then
+                    call lower_runtime_sum(context, source_index, value, &
+                                           error_msg)
                     return
                 end if
                 error_msg = trim(reduction_name)//' over a runtime-extent '// &
-                            'assumed-shape dummy supports integer sum only'
+                            'assumed-shape dummy supports integer and real '// &
+                            'sum only'
                 return
             end if
             array_size = context%symbols(source_index)%array_size

--- a/src/session_program_lowering_assumed_shape_descriptor.inc
+++ b/src/session_program_lowering_assumed_shape_descriptor.inc
@@ -1,0 +1,393 @@
+    ! Assumed-shape dummy ABI (#334). A rank-1 or rank-2 assumed-shape dummy
+    ! `a(:)` / `a(:,:)` is bound through exactly one canonical array descriptor
+    ! (`ffc_array_descriptor`, `docs/ARRAY_DESCRIPTOR_ABI.md`). The caller
+    ! materializes a descriptor for the actual and passes its address in the
+    ! dummy's single visible parameter slot. No hidden extent arguments are
+    ! appended, and the callee reads bounds, extents, and the base address from
+    ! that descriptor alone.
+    !
+    ! The descriptor describes the DUMMY's view of the actual, which is what
+    ! F2018 15.5.2.4 associates: `base` is the address of the actual's first
+    ! element and every `lower_bound` is 1, because an assumed-shape dummy
+    ! without an explicit lower bound has lower bound 1 whatever the actual's
+    ! own bounds are. Extents and byte strides are the actual's, so column-major
+    ! layout and element identity are preserved exactly.
+
+    integer(c_int64_t) function assumed_shape_dim_field_offset(dim, field) &
+            result(offset)
+        ! Byte offset of one per-dimension field inside the descriptor.
+        integer, intent(in) :: dim
+        integer(c_int64_t), intent(in) :: field
+
+        offset = int(ARRAY_DESCRIPTOR_DIM_OFFSET, c_int64_t) &
+                 + int(ARRAY_DIMENSION_BYTES, c_int64_t)*int(dim - 1, c_int64_t) &
+                 + field
+    end function assumed_shape_dim_field_offset
+
+    integer(c_int32_t) function assumed_shape_element_type(value_kind) &
+            result(element_type)
+        ! Canonical descriptor element type code for a lowering value kind.
+        integer, intent(in) :: value_kind
+
+        select case (value_kind)
+        case (VALUE_F32, VALUE_F64)
+            element_type = ARRAY_ELEMENT_REAL
+        case (VALUE_LOGICAL)
+            element_type = ARRAY_ELEMENT_LOGICAL
+        case (VALUE_C4, VALUE_C8)
+            element_type = ARRAY_ELEMENT_COMPLEX
+        case (VALUE_CHARACTER)
+            element_type = ARRAY_ELEMENT_CHARACTER
+        case (VALUE_DERIVED)
+            element_type = ARRAY_ELEMENT_DERIVED
+        case default
+            element_type = ARRAY_ELEMENT_INTEGER
+        end select
+    end function assumed_shape_element_type
+
+    integer function assumed_shape_actual_symbol(arena, node_index, context) &
+            result(symbol_index)
+        ! Symbol holding the storage an assumed-shape actual designates: the
+        ! identifier itself, or the source array of a contiguous section.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable :: id_name, err
+        type(array_section_info_t) :: info
+
+        symbol_index = 0
+        if (.not. node_exists(arena, node_index)) return
+        if (is_identifier(arena, node_index)) then
+            call get_identifier_name(arena, node_index, id_name, err)
+            if (len_trim(err) > 0) return
+            symbol_index = resolve_symbol_at_node(context, node_index, id_name)
+            return
+        end if
+        select type (slice => arena%entries(node_index)%node)
+        type is (array_slice_node)
+            call describe_array_section(arena, slice, context, info, err, &
+                                        allow_derived=.true.)
+            if (len_trim(err) > 0) return
+            symbol_index = info%source_index
+        end select
+    end function assumed_shape_actual_symbol
+
+    integer function assumed_shape_actual_rank(arena, node_index, context) &
+            result(rank)
+        ! Rank the actual presents to the dummy: a whole array's declared rank,
+        ! or 1 for a contiguous rank-1 section.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        integer :: symbol_index
+        character(len=:), allocatable :: id_name, err
+
+        rank = 0
+        if (actual_is_contiguous_section(arena, node_index, context)) then
+            rank = 1
+            return
+        end if
+        if (.not. is_identifier(arena, node_index)) return
+        symbol_index = assumed_shape_actual_symbol(arena, node_index, context)
+        if (symbol_index <= 0) return
+        if (.not. context%symbols(symbol_index)%is_array) then
+            if (.not. context%symbols(symbol_index)%is_allocatable) return
+        end if
+        rank = context%symbols(symbol_index)%array_rank
+        if (rank >= 1) return
+        ! An allocatable array symbol carries its rank only in its declaration
+        ! (its shape is not fixed at declaration time), so fall back to the
+        ! declared dimension count.
+        call get_identifier_name(arena, node_index, id_name, err)
+        if (len_trim(err) > 0) return
+        rank = declared_dimension_count(context, id_name)
+    end function assumed_shape_actual_rank
+
+    integer function declared_dimension_count(context, var_name) result(rank)
+        ! Declared rank of var_name: the number of dimensions on its array
+        ! declaration, colon-shaped or not.
+        type(lowering_context_t), intent(in) :: context
+        character(len=*), intent(in) :: var_name
+        integer :: n
+        type(declaration_node), pointer :: decl
+
+        rank = 0
+        do n = 1, context%arena%size
+            if (.not. node_exists(context%arena, n)) cycle
+            decl => declaration_named(context%arena, n, var_name)
+            if (.not. associated(decl)) cycle
+            if (.not. decl%is_array) cycle
+            if (.not. allocated(decl%dimension_indices)) cycle
+            rank = size(decl%dimension_indices)
+            return
+        end do
+    end function declared_dimension_count
+
+    subroutine assumed_shape_actual_base(arena, node_index, context, base, &
+                                         error_msg)
+        ! Address of the actual's first element, whatever storage class it has.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: base
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (actual_is_allocatable_array(arena, node_index, context)) then
+            call allocatable_array_actual_data_address(arena, node_index, &
+                                                       context, base, error_msg)
+        else if (actual_is_contiguous_section(arena, node_index, context)) then
+            call section_actual_address(arena, node_index, context, base, &
+                                        error_msg)
+        else if (actual_is_whole_array(arena, node_index, context)) then
+            call whole_array_actual_address(arena, node_index, context, base, &
+                                            error_msg)
+        else
+            error_msg = 'assumed-shape actual must be a whole array, an '// &
+                        'allocatable array, or a contiguous array section'
+        end if
+    end subroutine assumed_shape_actual_base
+
+    subroutine assumed_shape_actual_extent(arena, node_index, context, rank, &
+                                           dim, extent, error_msg)
+        ! Extent of the actual's dimension `dim` as an i64 operand. An
+        ! allocatable actual reads its live descriptor bounds; every other
+        ! supported actual folds to its declared compile-time extent.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: rank
+        integer, intent(in) :: dim
+        type(lr_operand_desc_t), intent(out) :: extent
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: extents(ARRAY_MAX_RANK)
+        character(len=:), allocatable :: id_name
+        logical :: ok
+
+        call set_empty(error_msg)
+        if (actual_is_allocatable_array(arena, node_index, context)) then
+            call actual_extent_i64(arena, node_index, context, dim, extent, &
+                                   error_msg)
+            return
+        end if
+
+        extents = 0
+        ok = .false.
+        if (actual_is_contiguous_section(arena, node_index, context)) then
+            call section_actual_decl_extents(context, node_index, 1, extents, ok)
+        else if (is_identifier(arena, node_index)) then
+            call get_identifier_name(arena, node_index, id_name, error_msg)
+            if (len_trim(error_msg) > 0) return
+            call array_decl_extents(context, id_name, rank, extents, ok)
+        end if
+        if (.not. ok) then
+            error_msg = 'assumed-shape actual has no resolvable extent'
+            return
+        end if
+        if (extents(dim) < 1) then
+            error_msg = 'assumed-shape actual has no resolvable extent'
+            return
+        end if
+        extent = i64_immediate(context%session, int(extents(dim), c_int64_t))
+    end subroutine assumed_shape_actual_extent
+
+    subroutine store_descriptor_i32(context, value, descriptor, offset, error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        integer(c_int32_t), intent(in) :: value
+        type(lr_operand_desc_t), intent(in) :: descriptor
+        integer(c_int64_t), intent(in) :: offset
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: field
+
+        if (.not. emit_ptr_offset(context%session, descriptor, offset, field, &
+                                  error_msg)) return
+        if (.not. emit_i32_store(context%session, &
+                i32_immediate(context%session, int(value, c_int64_t)), field, &
+                error_msg)) return
+        call set_empty(error_msg)
+    end subroutine store_descriptor_i32
+
+    subroutine build_assumed_shape_descriptor(arena, node_index, context, rank, &
+                                              callee_name, descriptor, error_msg)
+        ! Materialize the canonical descriptor an assumed-shape dummy receives.
+        ! One stack descriptor per call argument; it borrows the actual's
+        ! storage and never claims ownership, so passing an array never changes
+        ! the actual's allocation lifetime.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: rank
+        character(len=*), intent(in) :: callee_name
+        type(lr_operand_desc_t), intent(out) :: descriptor
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: base, extent, stride, running
+        integer :: symbol_index, value_kind, actual_rank, dim
+        integer(c_int64_t) :: element_bytes
+        integer(c_int32_t) :: flags
+        character(len=32) :: rank_text, actual_rank_text
+
+        actual_rank = assumed_shape_actual_rank(arena, node_index, context)
+        if (actual_rank /= rank) then
+            write (rank_text, '(I0)') rank
+            write (actual_rank_text, '(I0)') actual_rank
+            error_msg = 'Rank mismatch in argument to '//trim(callee_name)// &
+                        ': assumed-shape dummy of rank '//trim(rank_text)// &
+                        ' received an actual of rank '//trim(actual_rank_text)
+            return
+        end if
+
+        symbol_index = assumed_shape_actual_symbol(arena, node_index, context)
+        if (symbol_index <= 0) then
+            error_msg = 'assumed-shape actual was not declared'
+            return
+        end if
+        value_kind = context%symbols(symbol_index)%value_kind
+        element_bytes = int(equivalence_kind_size(value_kind), c_int64_t)
+
+        call assumed_shape_actual_base(arena, node_index, context, base, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        if (.not. emit_alloca_bytes(context%session, &
+                i64_immediate(context%session, &
+                    int(ARRAY_DESCRIPTOR_BYTES, c_int64_t)), descriptor, &
+                error_msg)) return
+
+        if (.not. emit_ptr_store(context%session, base, descriptor, error_msg)) &
+            return
+        if (.not. emit_i64_store_at(context%session, &
+                i64_immediate(context%session, element_bytes), descriptor, &
+                int(ARRAY_DESCRIPTOR_ELEMENT_SIZE_OFFSET, c_int64_t), &
+                error_msg)) return
+        call store_descriptor_i32(context, assumed_shape_element_type(value_kind), &
+            descriptor, int(ARRAY_DESCRIPTOR_ELEMENT_TYPE_OFFSET, c_int64_t), &
+            error_msg)
+        if (len_trim(error_msg) > 0) return
+        call store_descriptor_i32(context, int(rank, c_int32_t), descriptor, &
+            int(ARRAY_DESCRIPTOR_RANK_OFFSET, c_int64_t), error_msg)
+        if (len_trim(error_msg) > 0) return
+        ! The dummy borrows the actual's storage: allocated and associated, and
+        ! contiguous for every actual form this ABI accepts, but never owning.
+        flags = ARRAY_FLAG_ALLOCATED + ARRAY_FLAG_ASSOCIATED + ARRAY_FLAG_CONTIGUOUS
+        call store_descriptor_i32(context, flags, descriptor, &
+            int(ARRAY_DESCRIPTOR_FLAGS_OFFSET, c_int64_t), error_msg)
+        if (len_trim(error_msg) > 0) return
+        call store_descriptor_i32(context, 0_c_int32_t, descriptor, &
+            int(ARRAY_DESCRIPTOR_RESERVED_OFFSET, c_int64_t), error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        ! Column-major strides: dimension 1 steps one element, dimension d steps
+        ! the product of every lower dimension's extent.
+        running = i64_immediate(context%session, element_bytes)
+        do dim = 1, rank
+            call assumed_shape_actual_extent(arena, node_index, context, rank, &
+                                             dim, extent, error_msg)
+            if (len_trim(error_msg) > 0) return
+            ! An assumed-shape dummy without an explicit lower bound has lower
+            ! bound 1 regardless of the actual's own bounds (F2018 8.5.8.3).
+            if (.not. emit_i64_store_at(context%session, &
+                    i64_immediate(context%session, 1_c_int64_t), descriptor, &
+                    assumed_shape_dim_field_offset(dim, &
+                        int(ARRAY_DIMENSION_LOWER_OFFSET, c_int64_t)), &
+                    error_msg)) return
+            if (.not. emit_i64_store_at(context%session, extent, descriptor, &
+                    assumed_shape_dim_field_offset(dim, &
+                        int(ARRAY_DIMENSION_EXTENT_OFFSET, c_int64_t)), &
+                    error_msg)) return
+            stride = running
+            if (.not. emit_i64_store_at(context%session, stride, descriptor, &
+                    assumed_shape_dim_field_offset(dim, &
+                        int(ARRAY_DIMENSION_STRIDE_OFFSET, c_int64_t)), &
+                    error_msg)) return
+            if (dim < rank) then
+                if (.not. emit_i64_binary(context%session, LR_OP_MUL, running, &
+                                          extent, running, error_msg)) return
+            end if
+        end do
+
+        call set_empty(error_msg)
+    end subroutine build_assumed_shape_descriptor
+
+    subroutine bind_assumed_shape_descriptor_params(arena, param_indices, &
+                                                    context, callee_name, &
+                                                    error_msg)
+        ! Callee entry: every rank-1/rank-2 assumed-shape dummy's visible
+        ! parameter is a descriptor pointer. Replace the symbol's parameter
+        ! address with the descriptor's base address and cache each dimension's
+        ! extent, so element addressing and SIZE read the descriptor and nothing
+        ! else. Runs after define_reference_parameters and before the dummy's own
+        ! declaration is lowered (bind_one_assumed_shape).
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: param_indices(:)
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: callee_name
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i, sym_index, rank, dim
+        character(len=:), allocatable :: name
+        type(lr_operand_desc_t) :: descriptor, base, extent_i64, extent_i32
+
+        call set_empty(error_msg)
+        if (.not. allocated(param_indices)) return
+        do i = 1, size(param_indices)
+            rank = callee_dummy_assumed_shape_dims(arena, callee_name, i)
+            if (rank < 1) cycle
+            call parameter_name(arena, param_indices(i), name, error_msg)
+            if (len_trim(error_msg) > 0) return
+            sym_index = find_symbol_compat(context, name)
+            if (sym_index <= 0) then
+                error_msg = 'assumed-shape dummy was not registered: '//trim(name)
+                return
+            end if
+            descriptor = context%symbols(sym_index)%address
+            if (callee_dummy_assumed_shape_optional(arena, callee_name, i)) then
+                ! An absent OPTIONAL dummy receives a null descriptor pointer,
+                ! so the loads must not run unconditionally. Read through the
+                ! descriptor only when it is present and leave a null base and
+                ! zero extents otherwise; the program must test PRESENT before
+                ! using the dummy either way (F2018 15.5.2.12).
+                call bind_optional_assumed_shape_descriptor(context, sym_index, &
+                                                            rank, error_msg)
+                if (len_trim(error_msg) > 0) return
+                cycle
+            end if
+            if (.not. emit_ptr_load(context%session, descriptor, base, &
+                                    error_msg)) return
+            context%symbols(sym_index)%address = base
+            do dim = 1, rank
+                if (.not. emit_i64_load_at(context%session, descriptor, &
+                        assumed_shape_dim_field_offset(dim, &
+                            int(ARRAY_DIMENSION_EXTENT_OFFSET, c_int64_t)), &
+                        extent_i64, error_msg)) return
+                if (.not. emit_liric_i64_to_i32(context%session, extent_i64, &
+                                                extent_i32, error_msg)) return
+                context%symbols(sym_index)%has_runtime_dim_size(dim) = .true.
+                context%symbols(sym_index)%runtime_dim_size(dim) = extent_i32
+            end do
+        end do
+    end subroutine bind_assumed_shape_descriptor_params
+
+    subroutine bind_optional_assumed_shape_descriptor(context, sym_index, rank, &
+                                                       error_msg)
+        ! An OPTIONAL assumed-shape dummy is absent whenever its descriptor
+        ! pointer is null, so the descriptor must NOT be dereferenced in the
+        ! prologue: the binding keeps the parameter pointer itself as the
+        ! symbol's address, which is exactly what PRESENT tests against null.
+        !
+        ! Shape therefore cannot be read unconditionally here. The dummy still
+        ! binds, with zero cached extents, so a procedure that only tests
+        ! PRESENT lowers correctly. Referencing an absent optional's shape is
+        ! not conforming anyway (F2018 15.5.2.12); a PRESENT optional with a
+        ! usable shape is covered by the compile-time shape specialization in
+        ! bind_one_assumed_shape. Full runtime shape for a present optional
+        ! array dummy is an explicit non-goal of #334.
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: sym_index
+        integer, intent(in) :: rank
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: dim
+
+        do dim = 1, rank
+            context%symbols(sym_index)%has_runtime_dim_size(dim) = .true.
+            context%symbols(sym_index)%runtime_dim_size(dim) = &
+                i32_immediate(context%session, 0_c_int64_t)
+        end do
+        call set_empty(error_msg)
+    end subroutine bind_optional_assumed_shape_descriptor

--- a/src/session_program_lowering_assumed_shape_extent.inc
+++ b/src/session_program_lowering_assumed_shape_extent.inc
@@ -1,14 +1,6 @@
-    ! Runtime-extent ABI for a rank-1 assumed-shape dummy a(:) whose actual has
-    ! no compile-time-foldable shape (an allocatable actual). A hidden i64
-    ! extent argument is appended after the callee's visible pointer parameters,
-    ! one per such dummy, in dummy declaration order. See docs/RUNTIME_ABI.md.
-    !
-    ! The existing whole-arena compile-time fold (resolve_assumed_shape_extents,
-    ! session_program_lowering_arrays.inc) stays the fast path: only a dummy for
-    ! which that fold fails gets a hidden parameter, so an already-working
-    ! compile-time-resolved assumed-shape dummy keeps its original signature.
-    ! Only subroutines are covered in this slice; a function with a
-    ! non-foldable assumed-shape dummy keeps the pre-existing diagnostic.
+    ! Shape queries and runtime helpers shared by the assumed-shape descriptor
+    ! ABI (#334). The descriptor construction and binding themselves live in
+    ! session_program_lowering_assumed_shape_descriptor.inc.
 
     integer function dummy_assumed_shape_rank(arena, body_indices, param_name) &
             result(rank)
@@ -57,6 +49,91 @@
         end do
     end function dummy_assumed_shape_rank
 
+    logical function dummy_declared_optional(arena, body_indices, param_name) &
+            result(is_optional)
+        ! Whether the dummy named param_name is declared OPTIONAL in the body
+        ! whose declarations are body_indices.
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: param_name
+        integer :: i, k
+        logical :: name_matches
+
+        is_optional = .false.
+        if (.not. allocated(body_indices)) return
+        do i = 1, size(body_indices)
+            if (.not. node_exists(arena, body_indices(i))) cycle
+            select type (decl => arena%entries(body_indices(i))%node)
+            type is (declaration_node)
+                name_matches = .false.
+                if (allocated(decl%var_name)) then
+                    if (trim(decl%var_name) == trim(param_name)) &
+                        name_matches = .true.
+                end if
+                if (decl%is_multi_declaration .and. allocated(decl%var_names)) then
+                    do k = 1, size(decl%var_names)
+                        if (trim(decl%var_names(k)) == trim(param_name)) &
+                            name_matches = .true.
+                    end do
+                end if
+                if (name_matches) then
+                    is_optional = decl%is_optional
+                    return
+                end if
+            end select
+        end do
+    end function dummy_declared_optional
+
+    logical function callee_dummy_assumed_shape_optional(arena, callee_name, &
+                                                          param_pos) &
+            result(is_optional)
+        ! Whether callee_name's param_pos-th dummy is declared OPTIONAL.
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: callee_name
+        integer, intent(in) :: param_pos
+        integer :: n
+        character(len=:), allocatable :: name, name_err, node_type
+        type(subroutine_def_node), pointer :: sb_node
+        type(function_def_node), pointer :: fn_node
+
+        is_optional = .false.
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            node_type = get_node_type_at(arena, n)
+            if (node_type == 'subroutine_def_node' .or. &
+                node_type == 'subroutine_def') then
+                sb_node => get_node_as_subroutine_def(arena, n)
+                if (.not. associated(sb_node)) cycle
+                if (.not. allocated(sb_node%name)) cycle
+                if (.not. same_name(sb_node%name, callee_name)) cycle
+                if (.not. allocated(sb_node%param_indices)) return
+                if (param_pos < 1 .or. &
+                    param_pos > size(sb_node%param_indices)) return
+                call parameter_name(arena, sb_node%param_indices(param_pos), &
+                                    name, name_err)
+                if (len_trim(name_err) > 0) return
+                is_optional = dummy_declared_optional(arena, &
+                                                      sb_node%body_indices, name)
+                return
+            else if (node_type == 'function_def_node' .or. &
+                     node_type == 'function_def') then
+                fn_node => get_node_as_function_def(arena, n)
+                if (.not. associated(fn_node)) cycle
+                if (.not. allocated(fn_node%name)) cycle
+                if (.not. same_name(fn_node%name, callee_name)) cycle
+                if (.not. allocated(fn_node%param_indices)) return
+                if (param_pos < 1 .or. &
+                    param_pos > size(fn_node%param_indices)) return
+                call parameter_name(arena, fn_node%param_indices(param_pos), &
+                                    name, name_err)
+                if (len_trim(name_err) > 0) return
+                is_optional = dummy_declared_optional(arena, &
+                                                      fn_node%body_indices, name)
+                return
+            end if
+        end do
+    end function callee_dummy_assumed_shape_optional
+
     logical function dummy_is_assumed_shape_rank1(arena, body_indices, param_name) &
             result(is_match)
         type(ast_arena_t), intent(in) :: arena
@@ -78,24 +155,41 @@
         character(len=:), allocatable :: name, name_err
         character(len=:), allocatable :: node_type
         type(subroutine_def_node), pointer :: sb_node
+        type(function_def_node), pointer :: fn_node
 
         rank = 0
         do n = 1, arena%size
             if (.not. node_exists(arena, n)) cycle
             node_type = get_node_type_at(arena, n)
-            if (node_type /= 'subroutine_def_node' .and. &
-                node_type /= 'subroutine_def') cycle
-            sb_node => get_node_as_subroutine_def(arena, n)
-            if (.not. associated(sb_node)) cycle
-            if (.not. allocated(sb_node%name)) cycle
-            if (.not. same_name(sb_node%name, callee_name)) cycle
-            if (.not. allocated(sb_node%param_indices)) return
-            if (param_pos < 1 .or. param_pos > size(sb_node%param_indices)) return
-            call parameter_name(arena, sb_node%param_indices(param_pos), name, &
-                                name_err)
-            if (len_trim(name_err) > 0) return
-            rank = dummy_assumed_shape_rank(arena, sb_node%body_indices, name)
-            return
+            if (node_type == 'subroutine_def_node' .or. &
+                node_type == 'subroutine_def') then
+                sb_node => get_node_as_subroutine_def(arena, n)
+                if (.not. associated(sb_node)) cycle
+                if (.not. allocated(sb_node%name)) cycle
+                if (.not. same_name(sb_node%name, callee_name)) cycle
+                if (.not. allocated(sb_node%param_indices)) return
+                if (param_pos < 1 .or. &
+                    param_pos > size(sb_node%param_indices)) return
+                call parameter_name(arena, sb_node%param_indices(param_pos), &
+                                    name, name_err)
+                if (len_trim(name_err) > 0) return
+                rank = dummy_assumed_shape_rank(arena, sb_node%body_indices, name)
+                return
+            else if (node_type == 'function_def_node' .or. &
+                     node_type == 'function_def') then
+                fn_node => get_node_as_function_def(arena, n)
+                if (.not. associated(fn_node)) cycle
+                if (.not. allocated(fn_node%name)) cycle
+                if (.not. same_name(fn_node%name, callee_name)) cycle
+                if (.not. allocated(fn_node%param_indices)) return
+                if (param_pos < 1 .or. &
+                    param_pos > size(fn_node%param_indices)) return
+                call parameter_name(arena, fn_node%param_indices(param_pos), &
+                                    name, name_err)
+                if (len_trim(name_err) > 0) return
+                rank = dummy_assumed_shape_rank(arena, fn_node%body_indices, name)
+                return
+            end if
         end do
     end function callee_dummy_assumed_shape_dims
 
@@ -109,18 +203,6 @@
                                                    param_pos) == 1
     end function callee_dummy_assumed_shape_rank1
 
-    logical function callee_dummy_assumed_shape_runtime(arena, callee_name, &
-                                                         param_pos) result(is_match)
-        ! Whether the callee's param_pos-th dummy is a rank-1 or rank-2
-        ! assumed-shape array, so an allocatable actual is passed as a bare data
-        ! pointer plus hidden runtime extents rather than a whole descriptor.
-        type(ast_arena_t), intent(in) :: arena
-        character(len=*), intent(in) :: callee_name
-        integer, intent(in) :: param_pos
-
-        is_match = callee_dummy_assumed_shape_dims(arena, callee_name, &
-                                                   param_pos) >= 1
-    end function callee_dummy_assumed_shape_runtime
 
     subroutine callee_param_name_at(arena, callee_name, param_pos, name, error_msg)
         type(ast_arena_t), intent(in) :: arena
@@ -169,107 +251,9 @@
         end if
     end function call_arg_param_pos
 
-    integer function param_runtime_extent_rank(context, callee_name, param_pos) &
-            result(rank)
-        ! Number of hidden runtime extents callee_name's param_pos-th dummy
-        ! needs: its assumed-shape rank (1 or 2) when the whole-arena
-        ! compile-time fold fails, otherwise 0.
-        type(lowering_context_t), intent(in) :: context
-        character(len=*), intent(in) :: callee_name
-        integer, intent(in) :: param_pos
-        character(len=:), allocatable :: name, name_err
-        integer :: extents(2), dims
-        logical :: ok
 
-        rank = 0
-        dims = callee_dummy_assumed_shape_dims(context%arena, callee_name, &
-                                               param_pos)
-        if (dims < 1) return
-        call callee_param_name_at(context%arena, callee_name, param_pos, name, &
-                                  name_err)
-        if (len_trim(name_err) > 0) return
-        call resolve_assumed_shape_extents(context, callee_name, name, dims, &
-                                           extents, ok)
-        if (.not. ok) rank = dims
-    end function param_runtime_extent_rank
 
-    logical function param_needs_runtime_extent(context, callee_name, param_pos) &
-            result(needs_runtime)
-        type(lowering_context_t), intent(in) :: context
-        character(len=*), intent(in) :: callee_name
-        integer, intent(in) :: param_pos
 
-        needs_runtime = param_runtime_extent_rank(context, callee_name, &
-                                                  param_pos) > 0
-    end function param_needs_runtime_extent
-
-    integer function callee_hidden_extent_count(context, callee_name) result(count)
-        type(lowering_context_t), intent(in) :: context
-        character(len=*), intent(in) :: callee_name
-        integer :: n, i
-        character(len=:), allocatable :: node_type
-        type(subroutine_def_node), pointer :: sb_node
-
-        count = 0
-        do n = 1, context%arena%size
-            if (.not. node_exists(context%arena, n)) cycle
-            node_type = get_node_type_at(context%arena, n)
-            if (node_type /= 'subroutine_def_node' .and. &
-                node_type /= 'subroutine_def') cycle
-            sb_node => get_node_as_subroutine_def(context%arena, n)
-            if (.not. associated(sb_node)) cycle
-            if (.not. allocated(sb_node%name)) cycle
-            if (.not. same_name(sb_node%name, callee_name)) cycle
-            if (.not. allocated(sb_node%param_indices)) return
-            do i = 1, size(sb_node%param_indices)
-                count = count + param_runtime_extent_rank(context, callee_name, i)
-            end do
-            return
-        end do
-    end function callee_hidden_extent_count
-
-    subroutine bind_hidden_extent_params(arena, param_indices, context, &
-                                         callee_name, visible_count, error_msg)
-        ! Load each hidden i64 extent parameter (positions visible_count,
-        ! visible_count+1, ... 0-based) and stash it on the matching dummy's
-        ! symbol; the later assumed-shape declaration binding
-        ! (bind_one_assumed_shape) reads it when the compile-time fold fails.
-        type(ast_arena_t), intent(in) :: arena
-        integer, allocatable, intent(in) :: param_indices(:)
-        type(lowering_context_t), intent(inout) :: context
-        character(len=*), intent(in) :: callee_name
-        integer, intent(in) :: visible_count
-        character(len=:), allocatable, intent(out) :: error_msg
-        integer :: i, hidden_pos, sym_index, rank, d
-        character(len=:), allocatable :: name
-        type(lr_operand_desc_t) :: hidden_ptr, extent_i64, extent_i32
-
-        call set_empty(error_msg)
-        if (.not. allocated(param_indices)) return
-        hidden_pos = visible_count
-        do i = 1, size(param_indices)
-            rank = param_runtime_extent_rank(context, callee_name, i)
-            if (rank < 1) cycle
-            call parameter_name(arena, param_indices(i), name, error_msg)
-            if (len_trim(error_msg) > 0) return
-            sym_index = find_symbol_compat(context, name)
-            if (sym_index <= 0) then
-                error_msg = 'assumed-shape dummy was not registered: '// &
-                            trim(name)
-                return
-            end if
-            do d = 1, rank
-                hidden_ptr = ptr_param(context%session, hidden_pos)
-                if (.not. emit_i64_load(context%session, hidden_ptr, extent_i64, &
-                                        error_msg)) return
-                if (.not. emit_liric_i64_to_i32(context%session, extent_i64, &
-                                                extent_i32, error_msg)) return
-                context%symbols(sym_index)%has_runtime_dim_size(d) = .true.
-                context%symbols(sym_index)%runtime_dim_size(d) = extent_i32
-                hidden_pos = hidden_pos + 1
-            end do
-        end do
-    end subroutine bind_hidden_extent_params
 
     subroutine allocatable_array_actual_data_address(arena, node_index, context, &
                                                       address, error_msg)
@@ -354,49 +338,14 @@
         call set_empty(error_msg)
     end subroutine actual_extent_i64
 
-    subroutine append_hidden_extent_args(arena, arg_indices, context, &
-                                         callee_name, visible_count, args, &
-                                         error_msg, self_position)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: arg_indices(:)
-        type(lowering_context_t), intent(inout) :: context
-        character(len=*), intent(in) :: callee_name
-        integer, intent(in) :: visible_count
-        type(lr_operand_desc_t), intent(inout) :: args(:)
-        character(len=:), allocatable, intent(out) :: error_msg
-        integer, intent(in), optional :: self_position
-        integer :: i, hidden_pos, sp, rank, d
-        type(lr_operand_desc_t) :: extent_i64, slot
 
-        call set_empty(error_msg)
-        sp = 0
-        if (present(self_position)) sp = self_position
-        hidden_pos = visible_count
-        do i = 1, size(arg_indices)
-            rank = param_runtime_extent_rank(context, callee_name, &
-                                             call_arg_param_pos(i, sp))
-            if (rank < 1) cycle
-            do d = 1, rank
-                hidden_pos = hidden_pos + 1
-                call actual_extent_i64(arena, arg_indices(i), context, d, &
-                                       extent_i64, error_msg)
-                if (len_trim(error_msg) > 0) return
-                if (.not. emit_i64_alloca(context%session, slot, error_msg)) return
-                if (.not. emit_i64_store(context%session, extent_i64, slot, &
-                                         error_msg)) return
-                args(hidden_pos) = slot
-            end do
-        end do
-    end subroutine append_hidden_extent_args
-
-    subroutine load_array_element_at_runtime_index_i32(context, symbol_index, &
-                                                        index_i32, value, &
-                                                        error_msg)
+    subroutine load_array_element_at_runtime_index(context, symbol_index, &
+                                                   index_i32, value, error_msg)
         ! Element load at a runtime (non-immediate) 0-based i32 index for a
-        ! rank-1 integer array symbol. The GEP's declared array-size type
-        ! parameter does not affect the computed address for a single-index
-        ! rank-1 access, so it is harmless that a runtime-extent dummy's
-        ! array_size stays the 0 sentinel.
+        ! rank-1 array symbol of integer, real(4), or real(8) elements. The
+        ! GEP's declared array-size parameter does not affect the computed
+        ! address for a single-index rank-1 access, so it is harmless that a
+        ! descriptor-bound dummy's array_size stays the 0 sentinel.
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: symbol_index
         type(lr_operand_desc_t), intent(in) :: index_i32
@@ -404,37 +353,147 @@
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t) :: addr
 
-        if (.not. emit_i32_array_element_addr(context%session, &
-                context%symbols(symbol_index)%array_size, &
-                context%symbols(symbol_index)%element_address, index_i32, addr, &
-                error_msg)) return
-        if (.not. emit_i32_load(context%session, addr, value, error_msg)) return
+        select case (context%symbols(symbol_index)%value_kind)
+        case (VALUE_F32)
+            if (.not. emit_f32_array_element_addr(context%session, &
+                    context%symbols(symbol_index)%array_size, &
+                    context%symbols(symbol_index)%element_address, index_i32, &
+                    addr, error_msg)) return
+            if (.not. emit_liric_f32_load(context%session, addr, value, &
+                                          error_msg)) return
+        case (VALUE_F64)
+            if (.not. emit_f64_array_element_addr(context%session, &
+                    context%symbols(symbol_index)%array_size, &
+                    context%symbols(symbol_index)%element_address, index_i32, &
+                    addr, error_msg)) return
+            if (.not. emit_liric_f64_load(context%session, addr, value, &
+                                          error_msg)) return
+        case default
+            if (.not. emit_i32_array_element_addr(context%session, &
+                    context%symbols(symbol_index)%array_size, &
+                    context%symbols(symbol_index)%element_address, index_i32, &
+                    addr, error_msg)) return
+            if (.not. emit_i32_load(context%session, addr, value, error_msg)) &
+                return
+        end select
         call set_empty(error_msg)
-    end subroutine load_array_element_at_runtime_index_i32
+    end subroutine load_array_element_at_runtime_index
 
-    subroutine lower_runtime_i32_sum(context, source_index, value, error_msg)
-        ! sum(a) over a rank-1 integer array whose extent is only known at
-        ! runtime (the hidden extent argument ABI): no compile-time array_size
-        ! to unroll over, so walk a genuine LIRIC loop instead, using the same
-        ! reserved-backedge-vreg PHI technique as a counted DO
-        ! (session_program_lowering_loops.inc).
+    subroutine runtime_sum_accumulator_slot(context, value_kind, slot, zero, &
+                                            error_msg)
+        ! Accumulator stack slot and typed zero for a runtime reduction loop.
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: value_kind
+        type(lr_operand_desc_t), intent(out) :: slot
+        type(lr_operand_desc_t), intent(out) :: zero
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        select case (value_kind)
+        case (VALUE_F32)
+            if (.not. emit_liric_f32_alloca(context%session, slot, error_msg)) &
+                return
+            zero = liric_f32_immediate(context%session, 0.0_c_float)
+            if (.not. emit_liric_f32_store(context%session, zero, slot, &
+                                           error_msg)) return
+        case (VALUE_F64)
+            if (.not. emit_liric_f64_alloca(context%session, slot, error_msg)) &
+                return
+            zero = liric_f64_immediate(context%session, 0.0_c_double)
+            if (.not. emit_liric_f64_store(context%session, zero, slot, &
+                                           error_msg)) return
+        case default
+            if (.not. emit_i32_alloca(context%session, slot, error_msg)) return
+            zero = i32_immediate(context%session, 0_c_int64_t)
+            if (.not. emit_i32_store(context%session, zero, slot, error_msg)) &
+                return
+        end select
+        call set_empty(error_msg)
+    end subroutine runtime_sum_accumulator_slot
+
+    subroutine runtime_sum_accumulate(context, value_kind, slot, element, &
+                                      error_msg)
+        ! One accumulation step of a runtime reduction loop: slot = slot + element.
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: value_kind
+        type(lr_operand_desc_t), intent(in) :: slot
+        type(lr_operand_desc_t), intent(in) :: element
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: current, updated
+
+        select case (value_kind)
+        case (VALUE_F32)
+            if (.not. emit_liric_f32_load(context%session, slot, current, &
+                                          error_msg)) return
+            if (.not. emit_liric_f32_binary(context%session, LR_OP_FADD, current, &
+                                            element, updated, error_msg)) return
+            if (.not. emit_liric_f32_store(context%session, updated, slot, &
+                                           error_msg)) return
+        case (VALUE_F64)
+            if (.not. emit_liric_f64_load(context%session, slot, current, &
+                                          error_msg)) return
+            if (.not. emit_liric_f64_binary(context%session, LR_OP_FADD, current, &
+                                            element, updated, error_msg)) return
+            if (.not. emit_liric_f64_store(context%session, updated, slot, &
+                                           error_msg)) return
+        case default
+            if (.not. emit_i32_load(context%session, slot, current, error_msg)) &
+                return
+            if (.not. emit_i32_binary(context%session, LR_OP_ADD, current, &
+                                      element, updated, error_msg)) return
+            if (.not. emit_i32_store(context%session, updated, slot, error_msg)) &
+                return
+        end select
+        call set_empty(error_msg)
+    end subroutine runtime_sum_accumulate
+
+    subroutine runtime_sum_result(context, value_kind, slot, value, error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: value_kind
+        type(lr_operand_desc_t), intent(in) :: slot
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        select case (value_kind)
+        case (VALUE_F32)
+            if (.not. emit_liric_f32_load(context%session, slot, value, &
+                                          error_msg)) return
+        case (VALUE_F64)
+            if (.not. emit_liric_f64_load(context%session, slot, value, &
+                                          error_msg)) return
+        case default
+            if (.not. emit_i32_load(context%session, slot, value, error_msg)) &
+                return
+        end select
+        call set_empty(error_msg)
+    end subroutine runtime_sum_result
+
+    subroutine lower_runtime_sum(context, source_index, value, error_msg)
+        ! sum(a) over a rank-1 array whose extent is known only at run time (an
+        ! assumed-shape dummy bound through the caller's array descriptor):
+        ! there is no compile-time array_size to unroll over, so walk a genuine
+        ! LIRIC loop. The loop counter uses the reserved-backedge-vreg PHI
+        ! technique of a counted DO; the accumulator lives in a stack slot so
+        ! integer and real element kinds share one loop shape.
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: source_index
         type(lr_operand_desc_t), intent(out) :: value
         character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: extent
-        type(lr_operand_desc_t) :: entry_acc, entry_idx
-        type(lr_operand_desc_t) :: header_acc, header_idx
-        type(lr_operand_desc_t) :: backedge_acc, backedge_idx
-        type(lr_operand_desc_t) :: condition, element, next_acc, next_idx
+        type(lr_operand_desc_t) :: extent, accumulator, zero
+        type(lr_operand_desc_t) :: entry_idx, header_idx, backedge_idx
+        type(lr_operand_desc_t) :: condition, element, next_idx
         integer(c_int32_t) :: entry_block, header_block, body_block, &
                               latch_block, exit_block
-        integer(c_int32_t) :: acc_vreg, idx_vreg
+        integer(c_int32_t) :: idx_vreg
+        integer :: value_kind
 
-        value = i32_immediate(context%session, 0_c_int64_t)
+        value_kind = context%symbols(source_index)%value_kind
         extent = context%symbols(source_index)%runtime_dim_size(1)
 
-        entry_acc = i32_immediate(context%session, 0_c_int64_t)
+        call runtime_sum_accumulator_slot(context, value_kind, accumulator, &
+                                          zero, error_msg)
+        if (len_trim(error_msg) > 0) return
+        value = zero
+
         entry_idx = i32_immediate(context%session, 0_c_int64_t)
         entry_block = context%current_block_id
 
@@ -448,19 +507,14 @@
         context%current_block_id = header_block
         context%current_block_terminated = .false.
 
-        acc_vreg = reserve_i32_vreg(context%session)
-        if (acc_vreg == 0_c_int32_t) acc_vreg = reserve_i32_vreg(context%session)
         idx_vreg = reserve_i32_vreg(context%session)
         if (idx_vreg == 0_c_int32_t) idx_vreg = reserve_i32_vreg(context%session)
-        if (acc_vreg <= 0_c_int32_t .or. idx_vreg <= 0_c_int32_t) then
+        if (idx_vreg <= 0_c_int32_t) then
             error_msg = 'LIRIC could not reserve a positive backedge vreg'
             return
         end if
-        backedge_acc = i32_vreg(context%session, acc_vreg)
         backedge_idx = i32_vreg(context%session, idx_vreg)
 
-        if (.not. emit_liric_i32_phi(context%session, entry_acc, entry_block, &
-                backedge_acc, latch_block, header_acc, error_msg)) return
         if (.not. emit_liric_i32_phi(context%session, entry_idx, entry_block, &
                 backedge_idx, latch_block, header_idx, error_msg)) return
 
@@ -472,12 +526,12 @@
         if (.not. set_liric_block(context%session, body_block, error_msg)) return
         context%current_block_id = body_block
         context%current_block_terminated = .false.
-        call load_array_element_at_runtime_index_i32(context, source_index, &
-                                                      header_idx, element, &
-                                                      error_msg)
+        call load_array_element_at_runtime_index(context, source_index, &
+                                                 header_idx, element, error_msg)
         if (len_trim(error_msg) > 0) return
-        if (.not. emit_i32_binary(context%session, LR_OP_ADD, header_acc, &
-                element, next_acc, error_msg)) return
+        call runtime_sum_accumulate(context, value_kind, accumulator, element, &
+                                    error_msg)
+        if (len_trim(error_msg) > 0) return
         if (.not. emit_liric_br(context%session, latch_block, error_msg)) return
 
         if (.not. set_liric_block(context%session, latch_block, error_msg)) return
@@ -486,13 +540,10 @@
         if (.not. emit_i32_binary_into(context%session, LR_OP_ADD, header_idx, &
                 i32_immediate(context%session, 1_c_int64_t), idx_vreg, next_idx, &
                 error_msg)) return
-        if (.not. emit_i32_copy_to(context%session, next_acc, acc_vreg, &
-                backedge_acc, error_msg)) return
         if (.not. emit_liric_br(context%session, header_block, error_msg)) return
 
         if (.not. set_liric_block(context%session, exit_block, error_msg)) return
         context%current_block_id = exit_block
         context%current_block_terminated = .false.
-        value = header_acc
-        call set_empty(error_msg)
-    end subroutine lower_runtime_i32_sum
+        call runtime_sum_result(context, value_kind, accumulator, value, error_msg)
+    end subroutine lower_runtime_sum

--- a/src/session_program_lowering_functions.inc
+++ b/src/session_program_lowering_functions.inc
@@ -2859,6 +2859,12 @@
         end if
         if (len_trim(error_msg) > 0) return
 
+        ! Rebind every assumed-shape dummy from its descriptor parameter (#334).
+        call bind_assumed_shape_descriptor_params(arena, node%param_indices, &
+                                                  context, trim(node%name), &
+                                                  error_msg)
+        if (len_trim(error_msg) > 0) return
+
         ! Host-associate scalar module variables as addressed globals (#263).
         call bind_module_variables_in_context(context, error_msg)
         if (len_trim(error_msg) > 0) return

--- a/src/session_program_lowering_functions_tail.inc
+++ b/src/session_program_lowering_functions_tail.inc
@@ -61,10 +61,10 @@
 
         param_count = 0
         if (allocated(node%param_indices)) param_count = size(node%param_indices)
-        ! A rank-1 assumed-shape dummy whose extent does not fold at compile
-        ! time (an allocatable actual) carries one hidden i64 extent argument
-        ! appended after the visible parameters (#W2 runtime-extent ABI).
-        hidden_extent_count = callee_hidden_extent_count(context, trim(node%name))
+        ! Assumed-shape dummies are passed as one descriptor pointer each in
+        ! their own visible parameter slot (#334), so no hidden extent
+        ! parameters are appended to the signature.
+        hidden_extent_count = 0
         ! Each `*` dummy is a positional alternate-return slot, not a passed
         ! argument: the slots collapse into one hidden trailing selector
         ! parameter (#353).
@@ -93,12 +93,11 @@
                                          error_msg, node%body_indices)
         if (len_trim(error_msg) > 0) return
 
-        if (hidden_extent_count > 0) then
-            call bind_hidden_extent_params(arena, node%param_indices, context, &
-                                           trim(node%name), visible_param_count, &
-                                           error_msg)
-            if (len_trim(error_msg) > 0) return
-        end if
+        ! Rebind every assumed-shape dummy from its descriptor parameter.
+        call bind_assumed_shape_descriptor_params(arena, node%param_indices, &
+                                                  context, trim(node%name), &
+                                                  error_msg)
+        if (len_trim(error_msg) > 0) return
 
         ! Host-associate scalar module variables as addressed globals (#263).
         call bind_module_variables_in_context(context, error_msg)

--- a/src/session_program_lowering_runtime_alloc.inc
+++ b/src/session_program_lowering_runtime_alloc.inc
@@ -52,7 +52,7 @@
     subroutine lower_runtime_alloc_i32_sum(context, sym, value, error_msg)
         ! sum(a) over a rank-1 integer allocatable whose extent is only known at
         ! runtime. Walks a counted LIRIC loop reading the descriptor extent and
-        ! each element, mirroring lower_runtime_i32_sum's backedge-PHI shape.
+        ! each element, mirroring lower_runtime_sum's backedge-PHI shape.
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: sym
         type(lr_operand_desc_t), intent(out) :: value

--- a/test/conformance/xfail_fortfront_f90.txt
+++ b/test/conformance/xfail_fortfront_f90.txt
@@ -35,7 +35,6 @@ issue_1827_submodule_simple.f90 # owner=lazy-fortran/ffc#297; reason=consume par
 issue_1827_submodule_with_contents.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
 issue_1960_pointer_assignment_if.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
 issue_2014_elemental_function_lost.f90 # owner=lazy-fortran/ffc#405; reason=lower elemental procedures through array expressions
-issue_2017_assumed_shape_duplicate_monomorph.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
 issue_2024_char_function_duplicate_and_missing.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
 issue_2070_entry_loses_argument_declarations.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
 # Source INCLUDE expansion is unsupported; ffc now rejects instead of silently

--- a/test/conformance/xfail_lfortran.txt
+++ b/test/conformance/xfail_lfortran.txt
@@ -1341,7 +1341,6 @@ func_parameter_type_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolve
 functions_03.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
 functions_06.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
 functions_09.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
-functions_10.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
 functions_11.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
 functions_12.f90 # owner=lazy-fortran/ffc#453; reason=centralize scalar intrinsic calls
 functions_13.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
@@ -2516,7 +2515,6 @@ pass_array_by_data_02.f90 # owner=lazy-fortran/ffc#457; reason=register resolved
 pass_array_by_data_03.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
 pass_array_by_data_05.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
 pass_array_by_data_07.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
-pass_array_by_data_08.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
 pass_array_by_data_09.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type identity for class scalars
 pass_array_by_data_10.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
 pass_array_by_data_11.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
@@ -2892,8 +2890,6 @@ select_type_49.f90 # owner=lazy-fortran/ffc#417; reason=track runtime type ident
 select_type_50.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
 select_type_51.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
 select_type_52.f90 # owner=lazy-fortran/ffc#458; reason=migrate core array declarations
-separate_compilation_03a.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
-separate_compilation_03b.f90 # owner=lazy-fortran/ffc#334; reason=pass assumed-shape arrays by descriptor
 separate_compilation_03.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
 separate_compilation_04a.f90 # owner=lazy-fortran/ffc#343; reason=lower reductions through descriptor iteration
 separate_compilation_04b.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
@@ -3183,7 +3179,6 @@ submodule_50c.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces
 submodule_51a.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
 submodule_51b.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
 submodule_53a.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
-submodule_53b.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
 submodule_54.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
 submodule_55.f90 # owner=lazy-fortran/ffc#422; reason=pass and allocate polymorphic arrays
 subroutines_03.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering

--- a/test/test_session_assumed_shape_rank2_runtime_compiler.f90
+++ b/test/test_session_assumed_shape_rank2_runtime_compiler.f90
@@ -1,5 +1,5 @@
 program test_session_assumed_shape_rank2_runtime
-    use ffc_test_support, only: expect_output
+    use ffc_test_support, only: expect_output, expect_error_contains
     implicit none
 
     logical :: all_passed
@@ -9,6 +9,10 @@ program test_session_assumed_shape_rank2_runtime
     all_passed = .true.
     if (.not. test_integer_rank2_actual()) all_passed = .false.
     if (.not. test_real_rank2_write()) all_passed = .false.
+    if (.not. test_two_call_sites_differ()) all_passed = .false.
+    if (.not. test_rank2_actual_extents_and_last_element()) all_passed = .false.
+    if (.not. test_nonunit_actual_bounds_rebind_to_one()) all_passed = .false.
+    if (.not. test_rank1_actual_to_rank2_dummy_rejected()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: rank-2 assumed-shape dummies read runtime allocatable extents'
@@ -75,5 +79,115 @@ contains
         test_real_rank2_write = expect_output(source, expected, &
             '/tmp/ffc_session_assumed_shape_rank2_real')
     end function test_real_rank2_write
+
+    logical function test_two_call_sites_differ()
+        ! Two calls to the same procedure with differently sized actuals. Each
+        ! call builds its own descriptor, so each callee invocation sees its own
+        ! extent. Before #334 the callee folded ONE call site's compile-time
+        ! shape for every call, so the second call reported the first call's
+        ! size.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'integer :: p(3), q(5)'//new_line('a')// &
+            'p = 1'//new_line('a')// &
+            'q = 2'//new_line('a')// &
+            'call show(p)'//new_line('a')// &
+            'call show(q)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine show(a)'//new_line('a')// &
+            'integer, intent(in) :: a(:)'//new_line('a')// &
+            'print *, size(a), a(1), sum(a)'//new_line('a')// &
+            'end subroutine show'//new_line('a')// &
+            'end program main'
+        character(len=*), parameter :: expected = &
+            '           3           1           3'//new_line('a')// &
+            '           5           2          10'//new_line('a')
+
+        test_two_call_sites_differ = expect_output(source, expected, &
+            '/tmp/ffc_session_assumed_shape_two_sites')
+    end function test_two_call_sites_differ
+
+    logical function test_rank2_actual_extents_and_last_element()
+        ! A runtime-sized rank-2 allocatable actual: the callee reports both
+        ! extents and the last element, all read from the caller''s descriptor.
+        ! Column-major order is preserved, so element (n1, n2) is the last one.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'integer, allocatable :: m(:,:)'//new_line('a')// &
+            'integer :: i, j'//new_line('a')// &
+            'allocate(m(4, 3))'//new_line('a')// &
+            'do j = 1, 3'//new_line('a')// &
+            'do i = 1, 4'//new_line('a')// &
+            'm(i,j) = i*10 + j'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'call report(m)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine report(a)'//new_line('a')// &
+            'integer, intent(in) :: a(:,:)'//new_line('a')// &
+            'print *, size(a,1), size(a,2)'//new_line('a')// &
+            'print *, a(size(a,1), size(a,2))'//new_line('a')// &
+            'end subroutine report'//new_line('a')// &
+            'end program main'
+        character(len=*), parameter :: expected = &
+            '           4           3'//new_line('a')// &
+            '          43'//new_line('a')
+
+        test_rank2_actual_extents_and_last_element = expect_output(source, &
+            expected, '/tmp/ffc_session_assumed_shape_rank2_last')
+    end function test_rank2_actual_extents_and_last_element
+
+    logical function test_nonunit_actual_bounds_rebind_to_one()
+        ! An actual allocated with non-unit lower bounds still presents lower
+        ! bound 1 to an assumed-shape dummy (F2018 8.5.8.3), while extents and
+        ! element identity are unchanged: a(1,1) is the actual''s first element
+        ! in column-major order.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'integer :: m(0:1, -1:1)'//new_line('a')// &
+            'integer :: i, j'//new_line('a')// &
+            'do j = -1, 1'//new_line('a')// &
+            'do i = 0, 1'//new_line('a')// &
+            'm(i,j) = (i+1)*10 + (j+2)'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'call bounds(m)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine bounds(a)'//new_line('a')// &
+            'integer, intent(in) :: a(:,:)'//new_line('a')// &
+            'print *, lbound(a,1), lbound(a,2)'//new_line('a')// &
+            'print *, ubound(a,1), ubound(a,2)'//new_line('a')// &
+            'print *, a(1,1), a(2,3)'//new_line('a')// &
+            'end subroutine bounds'//new_line('a')// &
+            'end program main'
+        character(len=*), parameter :: expected = &
+            '           1           1'//new_line('a')// &
+            '           2           3'//new_line('a')// &
+            '          11          23'//new_line('a')
+
+        test_nonunit_actual_bounds_rebind_to_one = expect_output(source, &
+            expected, '/tmp/ffc_session_assumed_shape_nonunit')
+    end function test_nonunit_actual_bounds_rebind_to_one
+
+    logical function test_rank1_actual_to_rank2_dummy_rejected()
+        ! Negative: a rank-1 actual bound to a rank-2 assumed-shape dummy is a
+        ! rank mismatch (F2018 15.5.2.4), diagnosed while the caller builds the
+        ! descriptor rather than lowered into a wrong-shaped call.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'integer :: v(6)'//new_line('a')// &
+            'v = 1'//new_line('a')// &
+            'call take2(v)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine take2(a)'//new_line('a')// &
+            'integer, intent(in) :: a(:,:)'//new_line('a')// &
+            'print *, size(a)'//new_line('a')// &
+            'end subroutine take2'//new_line('a')// &
+            'end program main'
+
+        test_rank1_actual_to_rank2_dummy_rejected = expect_error_contains( &
+            source, 'Rank mismatch in argument to take2', &
+            '/tmp/ffc_session_assumed_shape_rank_mismatch')
+    end function test_rank1_actual_to_rank2_dummy_rejected
 
 end program test_session_assumed_shape_rank2_runtime

--- a/test/test_session_pointer_proc_compiler.f90
+++ b/test/test_session_pointer_proc_compiler.f90
@@ -101,8 +101,10 @@ program test_session_pointer_proc
 
     ! #362 negative: a scalar actual passed through the pointer to an
     ! assumed-shape dummy is rejected with the same source diagnostic a direct
-    ! call to the same procedure produces (no extent-bearing whole-array
-    ! actual), instead of silently lowering a rank-mismatched call.
+    ! call to the same procedure produces, instead of silently lowering a
+    ! rank-mismatched call. Since #334 an assumed-shape dummy is bound through
+    ! a caller-built array descriptor, so the rejection names the actual rank
+    ! mismatch rather than a missing compile-time extent.
     if (.not. expect_error_contains( &
         'program main'//new_line('a')// &
         'implicit none'//new_line('a')// &
@@ -119,7 +121,7 @@ program test_session_pointer_proc
         'end do'//new_line('a')// &
         'end function total'//new_line('a')// &
         'end program main', &
-        'assumed-shape dummy extent must come from a whole-array actual', &
+        'scalar actual passed to array dummy argument', &
         '/tmp/ffc_proc_ptr_rank_mismatch_test')) stop 1
 
     print *, 'PASS: procedure pointer to function and subroutine'


### PR DESCRIPTION
Closes #334.

An assumed-shape dummy `a(:)` / `a(:,:)` is now bound through exactly one
canonical array descriptor (`ffc_array_descriptor`, `docs/ARRAY_DESCRIPTOR_ABI.md`)
passed in its single visible parameter slot. The hidden-extent ABI is retired.

## What changed

**Caller.** `build_assumed_shape_descriptor` materializes one stack descriptor
per assumed-shape actual and passes its address. It fills base, element size and
type, rank, flags, and per-dimension `(lower_bound, extent, stride_bytes)`. One
branch serves every supported actual form — explicit-shape whole array,
allocatable array, contiguous section — where previously only an allocatable
actual could reach the runtime path at all.

**Callee.** `bind_assumed_shape_descriptor_params` loads the base address and
each dimension's extent from that descriptor at entry. Functions are covered as
well as subroutines (`callee_dummy_assumed_shape_dims` now inspects
`function_def_node`).

**Retired, not left as a fallback.** `callee_hidden_extent_count`,
`append_hidden_extent_args`, `bind_hidden_extent_params`,
`param_runtime_extent_rank`, `param_needs_runtime_extent`, and
`callee_dummy_assumed_shape_runtime` are deleted. No signature carries hidden
extent parameters any more; `hidden_extent_count` is gone from the callee
prologue and from call-site argument sizing.

## The one design point worth calling out

`resolve_assumed_shape_extents` survives, but it is no longer an
argument-passing path — it is a compile-time **shape specialization** layered on
top of the descriptor binding. Extents and base address always come from the
descriptor at run time; the fold only records a constant element count so
whole-array operations can unroll instead of walking a runtime loop.

It was also unsound before and is now correct: it used to fold *one* call site's
shape and apply it to every call. It now requires that **every** call site in
the unit pass an actual of the same constant shape, and bails out to the runtime
descriptor extents if any call site disagrees or is unfoldable. When it does
apply, the cached runtime extents are cleared, so exactly one shape source is
live per symbol — never two in parallel.

That old unsoundness is the behavioral oracle below.

## Behavioral oracle, recorded failing on main first

```fortran
integer :: p(3), q(5)
call show(p)   ! size(a) must be 3
call show(q)   ! size(a) must be 5
```

On unmodified main ffc printed `3` for both calls (gfortran prints `3` then
`5`), because the callee folded the first call site's shape for every call.
With this change ffc matches gfortran. Landed as
`test_two_call_sites_differ`.

Also added, all failing on main beforehand:
- `test_rank2_actual_extents_and_last_element`: runtime-sized rank-2 allocatable
  actual reports both extents and the last element.
- `test_nonunit_actual_bounds_rebind_to_one`: an actual declared `m(0:1,-1:1)`
  presents `lbound == 1` to the dummy while element identity is unchanged.
- `test_rank1_actual_to_rank2_dummy_rejected`: negative fixture, rank mismatch
  diagnostic.

`test_session_pointer_proc_compiler`'s negative case still rejects a scalar
actual to an assumed-shape dummy; only the expected diagnostic text changed,
from a missing-compile-time-extent message to the accurate
`scalar actual passed to array dummy argument`.

## Invariants preserved and how

- **Fortran column-major layout.** The caller writes
  `stride_bytes(1) = element_size` and `stride_bytes(d) = stride_bytes(d-1) *
  extent(d-1)`, so the leftmost subscript varies fastest. Verified by
  `issue_88_double_free_complex.f90` (`sum` over a `100x100` rank-2 dummy must
  be 25502500, not the 5050 a rank-1 misread gives) and by the rank-2
  last-element oracle.
- **Lower-bound and extent semantics.** `base` is the address of the actual's
  first element and every descriptor `lower_bound` is 1, which is exactly what
  F2018 8.5.8.3 gives an assumed-shape dummy declared without explicit bounds,
  whatever the actual's own bounds. Asserted by the non-unit-bounds oracle.
- **Overlap and aliasing.** The descriptor borrows the actual's storage; no
  element is copied when building or binding it, so writes through the dummy are
  the caller's writes. `test_real_rank2_write` reads back in the caller after an
  `intent(inout)` fill.
- **Allocation and finalization lifetimes.** The descriptor is a caller stack
  temporary that never sets `ARRAY_FLAG_OWNS_DATA`, so argument passing cannot
  free, reallocate, or extend the lifetime of the actual's storage, and the
  callee never releases a descriptor it received.
- **View lifetimes.** A contiguous section actual is passed as a borrowed
  descriptor over the parent's storage, valid for the call only, again with no
  ownership bit.

## Two fixes required to keep the corpus green

- **Real reductions over runtime extents.** `lower_runtime_i32_sum` became
  `lower_runtime_sum`, handling `real(4)`/`real(8)` as well as integer, with the
  accumulator in a stack slot so one loop shape serves all element kinds.
  Reductions with a known constant shape still take the unrolled path.
- **Absent optionals at module procedures.** `emit_call_with_optional_padding`
  resolved its dummy count only for nested procedures, so an omitted trailing
  optional at a module procedure was left unpadded and the callee read an
  uninitialized parameter slot. It now falls back to the arena count under the
  procedure's source name. This is what `present_01.f90` needed. An OPTIONAL
  assumed-shape dummy is bound without dereferencing its descriptor, since an
  absent one is null; per this issue's non-goals, full runtime shape for a
  present optional array dummy is still out of scope.

## Corpus delta

Measured against `origin/main` with both trees freshly built (ffc #547 isolation
in place).

| Suite | PASS | FAIL | XPASS |
|---|---|---|---|
| lfortran | 859 -> 864 | 9 -> 9 | 78 -> 76 |
| fortfront-f90 | 410 -> 411 | 10 -> 10 | 2 -> 2 |

No case regresses from PASS, and none becomes FAIL from any state. Six cases go
XFAIL -> PASS and are removed from the xfail manifests in this PR:
`functions_10`, `pass_array_by_data_08`, `separate_compilation_03a`,
`separate_compilation_03b`, `submodule_53b` (lfortran) and
`issue_2017_assumed_shape_duplicate_monomorph` (fortfront-f90).

`test_fortfront_corpus_conformance` and `test_parity_dashboard` still fail; both
were reproduced failing identically on a clean `origin/main` worktree and are
owned elsewhere. `expr_11.f90` (#566) fails on this branch and on the same
`origin/main` baseline with `assignment target was not declared: x`, which is
not an assumed-shape path, so this chain did not cause it.
