### PR TITLE
[fmod-submodule-02] compile a submodule as its own unit (closes #297)

### DIFF
--- a/src/session_program_lowering_fmod.inc
+++ b/src/session_program_lowering_fmod.inc
@@ -591,7 +591,10 @@
         type(ast_arena_t), intent(in) :: arena
         type(lowering_context_t), intent(in) :: context
         integer, intent(in) :: node_index
-        type(module_node), intent(in) :: mod_node
+        ! Absent when the caller is checking a procedure against an imported
+        ! interface rather than exporting this module's own: there is then no
+        ! module node to read accessibility from (#297).
+        type(module_node), intent(in), optional :: mod_node
         character(len=:), allocatable, intent(out) :: kind_text
         integer, intent(out) :: nargs
         character(len=:), allocatable, intent(out) :: arg_tokens
@@ -609,7 +612,9 @@
         fn_node => get_node_as_function_def(arena, node_index)
         if (associated(fn_node)) then
             if (.not. allocated(fn_node%name)) return
-            if (module_symbol_is_private(arena, mod_node, fn_node%name)) return
+            if (present(mod_node)) then
+                if (module_symbol_is_private(arena, mod_node, fn_node%name)) return
+            end if
             if (procedure_has_nested_contains(arena, fn_node%body_indices)) return
             if (.not. fmod_function_result_is_integer(arena, fn_node)) return
             if (.not. params_all_supported(arena, context, &
@@ -622,7 +627,9 @@
         sb_node => get_node_as_subroutine_def(arena, node_index)
         if (associated(sb_node)) then
             if (.not. allocated(sb_node%name)) return
-            if (module_symbol_is_private(arena, mod_node, sb_node%name)) return
+            if (present(mod_node)) then
+                if (module_symbol_is_private(arena, mod_node, sb_node%name)) return
+            end if
             if (procedure_has_nested_contains(arena, sb_node%body_indices)) return
             if (.not. params_all_supported(arena, context, &
                                     sb_node%param_indices, sb_node%body_indices, &

--- a/src/session_program_lowering_functions.inc
+++ b/src/session_program_lowering_functions.inc
@@ -38,6 +38,11 @@
             else
                 allocate(body_indices(0))
             end if
+        type is (submodule_node)
+            ! A submodule compiled as its own unit contributes no main-body
+            ! statement: its procedures are emitted separately against the
+            ! parent module's mangling (#297).
+            allocate(body_indices(0))
         class default
             call get_program_body_info(arena, root_index, prog_name, &
                                        body_indices, ff_error)
@@ -160,6 +165,13 @@
             ! sibling-call inside a module procedure resolves (e.g. a recursive
             ! module function referencing itself).
             call register_module_procedures(arena, root_index, context, error_msg)
+            return
+        end if
+        if (is_submodule_unit(node_type)) then
+            ! A submodule compiled as its own unit: its procedures register
+            ! against the parent module named in its header (#297).
+            call register_one_submodule_procedures(arena, root_index, context, &
+                                                   error_msg)
             return
         end if
         if (node_type == 'block_data_node' .or. node_type == 'block_data') return
@@ -2191,6 +2203,11 @@
         call set_empty(error_msg)
         node_type = get_node_type_at(arena, root_index)
         if (node_type == 'module_node' .or. node_type == 'module') return
+        if (is_submodule_unit(node_type)) then
+            call lower_one_submodule_procedures(arena, root_index, context, &
+                                                error_msg)
+            return
+        end if
         if (node_type == 'block_data_node' .or. node_type == 'block_data') return
         call get_unit_body_indices(arena, root_index, body_indices, ff_error)
         if (len_trim(ff_error) > 0) then

--- a/src/session_program_lowering_submodules.inc
+++ b/src/session_program_lowering_submodules.inc
@@ -218,19 +218,185 @@
             error_msg = ff_error
             return
         end if
-        if (.not. module_node_defined(arena, parent_module)) then
-            call unsupported_feature_error('submodule', &
-                get_node_line(arena, submodule_index), &
-                get_node_column(arena, submodule_index), &
-                'submodule parent module not found', error_msg)
-            return
-        end if
+        call bind_submodule_parent(arena, submodule_index, parent_module, &
+                                   proc_indices, context, error_msg)
+        if (len_trim(error_msg) > 0) return
         do p = 1, size(proc_indices)
             call lower_one_submodule_procedure(arena, proc_indices(p), &
                                                parent_module, context, error_msg)
             if (len_trim(error_msg) > 0) return
         end do
     end subroutine lower_one_submodule_procedures
+
+    subroutine bind_submodule_parent(arena, submodule_index, parent_module, &
+                                     proc_indices, context, error_msg)
+        ! Bind a submodule to the parent module it extends. The parent is either
+        ! compiled in this unit or described by its .fmod artefact on the include
+        ! path; a submodule compiled on its own reads its parent's interfaces
+        ! from that artefact and is checked against them, so an implementation
+        ! that does not match the interface it claims is diagnosed here rather
+        ! than emitted under a symbol callers would then miscall (#297).
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: submodule_index
+        character(len=*), intent(in) :: parent_module
+        integer, allocatable, intent(in) :: proc_indices(:)
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(module_info_t) :: parent_info
+        character(len=:), allocatable :: path
+        integer :: p
+
+        call set_empty(error_msg)
+        if (module_node_defined(arena, parent_module)) return
+        path = find_fmod_on_path(context, trim(parent_module))
+        if (len_trim(path) == 0) then
+            call unsupported_feature_error('submodule', &
+                get_node_line(arena, submodule_index), &
+                get_node_column(arena, submodule_index), &
+                'submodule parent module not found: '//trim(parent_module)// &
+                ' is not compiled in this unit and no '//trim(parent_module)// &
+                '.fmod was found on the include path', error_msg)
+            return
+        end if
+        call read_fmod(path, parent_info, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. allocated(proc_indices)) return
+        do p = 1, size(proc_indices)
+            call check_submodule_procedure_against_parent(arena, &
+                proc_indices(p), parent_module, parent_info, context, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine bind_submodule_parent
+
+    subroutine check_submodule_procedure_against_parent(arena, proc_index, &
+                                                        parent_module, &
+                                                        parent_info, context, &
+                                                        error_msg)
+        ! Check one implemented module procedure against the interface the
+        ! parent artefact declares for it: the parent must declare it, and the
+        ! implementation must restate the same dummy count and dummy kinds.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: proc_index
+        character(len=*), intent(in) :: parent_module
+        type(module_info_t), intent(in) :: parent_info
+        type(lowering_context_t), intent(in) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: proc_name, kind_text, arg_tokens
+        character(len=:), allocatable :: rank_tokens, extent_tokens
+        integer :: idx, nargs
+
+        call set_empty(error_msg)
+        proc_name = procedure_fortran_name(arena, proc_index)
+        if (len_trim(proc_name) == 0) return
+        idx = fmod_procedure_index(parent_info, proc_name)
+        if (idx <= 0) then
+            call unsupported_feature_error('submodule procedure', &
+                get_node_line(arena, proc_index), &
+                get_node_column(arena, proc_index), &
+                'module procedure '//trim(proc_name)//' is not declared by '// &
+                'module '//trim(parent_module), error_msg)
+            return
+        end if
+        if (.not. submodule_body_restates_signature(arena, proc_index)) then
+            ! A `module procedure P` body inherits its dummy declarations from
+            ! the parent's interface, which this unit does not have as source.
+            call unsupported_feature_error('submodule procedure', &
+                get_node_line(arena, proc_index), &
+                get_node_column(arena, proc_index), &
+                'module procedure '//trim(proc_name)//' compiled apart from '// &
+                'module '//trim(parent_module)//' must restate its interface', &
+                error_msg)
+            return
+        end if
+        call fmod_procedure_signature(arena, context, proc_index, &
+                                      kind_text=kind_text, nargs=nargs, &
+                                      arg_tokens=arg_tokens, &
+                                      rank_tokens=rank_tokens, &
+                                      extent_tokens=extent_tokens)
+        if (len_trim(kind_text) == 0) return
+        if (nargs /= parent_info%procedures(idx)%nargs) then
+            call submodule_signature_mismatch(arena, proc_index, proc_name, &
+                parent_module, 'dummy argument count', error_msg)
+            return
+        end if
+        if (trim(arg_tokens) /= trim(field_text(parent_info%procedures(idx)% &
+                                                arg_kinds))) then
+            call submodule_signature_mismatch(arena, proc_index, proc_name, &
+                parent_module, 'dummy argument kinds', error_msg)
+            return
+        end if
+        if (trim(kind_text) /= trim(field_text(parent_info%procedures(idx)%kind))) &
+            call submodule_signature_mismatch(arena, proc_index, proc_name, &
+                parent_module, 'result kind', error_msg)
+    end subroutine check_submodule_procedure_against_parent
+
+    subroutine submodule_signature_mismatch(arena, proc_index, proc_name, &
+                                            parent_module, what, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: proc_index
+        character(len=*), intent(in) :: proc_name
+        character(len=*), intent(in) :: parent_module
+        character(len=*), intent(in) :: what
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call unsupported_feature_error('submodule procedure', &
+            get_node_line(arena, proc_index), &
+            get_node_column(arena, proc_index), &
+            'module procedure '//trim(proc_name)//' does not match the '// &
+            what//' its interface in module '//trim(parent_module)//' declares', &
+            error_msg)
+    end subroutine submodule_signature_mismatch
+
+    logical function submodule_body_restates_signature(arena, proc_index) &
+            result(restates)
+        ! Whether a submodule procedure restates its dummy list, as
+        ! `module function f(x) result(y)` does and `module procedure f` does
+        ! not.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: proc_index
+        type(function_def_node), pointer :: fn_node
+        type(subroutine_def_node), pointer :: sb_node
+
+        restates = .false.
+        fn_node => get_node_as_function_def(arena, proc_index)
+        if (associated(fn_node)) then
+            restates = allocated(fn_node%param_indices)
+            if (restates) restates = size(fn_node%param_indices) > 0
+            return
+        end if
+        sb_node => get_node_as_subroutine_def(arena, proc_index)
+        if (.not. associated(sb_node)) return
+        restates = allocated(sb_node%param_indices)
+        if (restates) restates = size(sb_node%param_indices) > 0
+    end function submodule_body_restates_signature
+
+    integer function fmod_procedure_index(info, name) result(idx)
+        ! Index of the module procedure the artefact records under name, or 0.
+        type(module_info_t), intent(in) :: info
+        character(len=*), intent(in) :: name
+        integer :: i
+
+        idx = 0
+        if (.not. allocated(info%procedures)) return
+        do i = 1, size(info%procedures)
+            if (.not. allocated(info%procedures(i)%name)) cycle
+            if (same_name(info%procedures(i)%name, name)) then
+                idx = i
+                return
+            end if
+        end do
+    end function fmod_procedure_index
+
+    function field_text(text) result(out)
+        character(len=:), allocatable, intent(in) :: text
+        character(len=:), allocatable :: out
+
+        if (allocated(text)) then
+            out = text
+        else
+            out = ''
+        end if
+    end function field_text
 
     subroutine lower_one_submodule_procedure(arena, proc_index, parent_module, &
                                              context, error_msg)

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -356,6 +356,7 @@
 
         node_type = get_node_type_at(arena, root_index)
         if (node_type == 'module_node' .or. node_type == 'module' .or. &
+            is_submodule_unit(node_type) .or. &
             node_type == 'block_data_node' .or. node_type == 'block_data') then
             has_main = .false.
             return
@@ -594,6 +595,12 @@
             ! lower_program_return walks the body and emits targeted diagnostics
             ! for module-defined procedures, types, and constants.
             continue
+        else if (is_submodule_unit(get_node_type_at(arena, root_index))) then
+            ! A submodule compiled as its own unit contributes only its module
+            ! procedures, emitted under the parent module's mangling; the unit
+            ! itself has no main program, so it lowers to an empty main exactly
+            ! as a bare module unit does (#297).
+            continue
         else if (get_node_type_at(arena, root_index) == 'block_data_node' .or. &
                  get_node_type_at(arena, root_index) == 'block_data') then
             ! A standalone BLOCK DATA unit only initialises COMMON storage; with
@@ -774,6 +781,11 @@
             end if
             call lower_module_unit(arena, mod_name, mod_declaration_indices, &
                                    mod_procedure_indices, context, error_msg)
+        else if (is_submodule_unit(get_node_type_at(arena, root_index))) then
+            ! A submodule compiled as its own unit emits only its module
+            ! procedures, which lower_module_procedures already emitted under
+            ! the parent module's mangling; the unit itself has no body (#297).
+            call set_empty(error_msg)
         else if (get_node_type_at(arena, root_index) == 'block_data_node' .or. &
                  get_node_type_at(arena, root_index) == 'block_data') then
             ! A standalone BLOCK DATA unit emits no executable code; its COMMON

--- a/test/test_session_submodule_compiler.f90
+++ b/test/test_session_submodule_compiler.f90
@@ -3,6 +3,39 @@ program test_session_submodule_compiler
     implicit none
 
     logical :: all_passed
+    ! Parent, submodule, and caller for the three-file separate-compilation
+    ! fixtures (#297).
+    character(len=*), parameter :: parent_source = &
+        'module fmod297_parent'//new_line('a')// &
+        '    implicit none'//new_line('a')// &
+        '    interface'//new_line('a')// &
+        '        module function twice(x) result(r)'//new_line('a')// &
+        '            integer, intent(in) :: x'//new_line('a')// &
+        '            integer :: r'//new_line('a')// &
+        '        end function twice'//new_line('a')// &
+        '    end interface'//new_line('a')// &
+        'end module fmod297_parent'
+    character(len=*), parameter :: submodule_source = &
+        'submodule (fmod297_parent) fmod297_impl'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '    module function twice(x) result(r)'//new_line('a')// &
+        '        integer, intent(in) :: x'//new_line('a')// &
+        '        integer :: r'//new_line('a')// &
+        '        r = 2 * x'//new_line('a')// &
+        '    end function twice'//new_line('a')// &
+        'end submodule fmod297_impl'
+    character(len=*), parameter :: submodule_source_unrestated = &
+        'submodule (fmod297_parent) fmod297_impl'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '    module procedure twice'//new_line('a')// &
+        '        r = 2 * x'//new_line('a')// &
+        '    end procedure twice'//new_line('a')// &
+        'end submodule fmod297_impl'
+    character(len=*), parameter :: caller_source = &
+        'program main'//new_line('a')// &
+        '    use fmod297_parent, only: twice'//new_line('a')// &
+        '    stop twice(21)'//new_line('a')// &
+        'end program main'
 
     print *, '=== submodule compiler test ==='
 
@@ -14,6 +47,8 @@ program test_session_submodule_compiler
     if (.not. test_parent_module_not_found()) all_passed = .false.
     if (.not. test_caller_links_deferred_module_procedure()) all_passed = .false.
     if (.not. test_plain_interface_is_not_exported()) all_passed = .false.
+    if (.not. test_submodule_compiles_as_its_own_unit()) all_passed = .false.
+    if (.not. test_submodule_parent_diagnostics()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: single-file submodules lower against the parent module'
@@ -244,6 +279,131 @@ contains
         call remove_scratch_dir(dir)
         ok = .true.
     end function test_plain_interface_is_not_exported
+
+    logical function test_submodule_compiles_as_its_own_unit() result(ok)
+        ! Parent, submodule, and caller compile as three independent ffc
+        ! invocations and link. The submodule unit never sees the parent's
+        ! source: it binds to the interface the parent's .fmod carries, and
+        ! emits its body under the parent's mangled symbol (#297).
+        character(len=:), allocatable :: dir
+        integer :: status
+        integer :: exit_stat, cmd_stat
+
+        ok = .false.
+        call make_scratch_dir('fmod297_threefile', dir)
+        if (.not. write_source(dir//'/par.f90', parent_source)) return
+        if (.not. write_source(dir//'/sub.f90', submodule_source)) return
+        if (.not. write_source(dir//'/main.f90', caller_source)) return
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; exe=$PWD/$exe; '// &
+            'cd '//dir//' || exit 90; '// &
+            '"$exe" -c par.f90 -o par.o >>log 2>&1 || exit 91; '// &
+            '"$exe" -c sub.f90 -o sub.o >>log 2>&1 || exit 92; '// &
+            '"$exe" main.f90 par.o sub.o -o main >>log 2>&1 || exit 93; '// &
+            "./main; exit $((100 + $?))'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        status = exit_stat
+        if (cmd_stat /= 0) status = 90
+        if (status /= 142) then
+            print *, 'FAIL: three-file submodule build status ', status
+            call show_log(dir)
+            return
+        end if
+        call remove_scratch_dir(dir)
+        ok = .true.
+    end function test_submodule_compiles_as_its_own_unit
+
+    logical function test_submodule_parent_diagnostics() result(ok)
+        ! Every way a separately compiled submodule can fail to match the
+        ! parent interface it claims is diagnosed against the artefact, rather
+        ! than emitted under a symbol callers would then miscall.
+        character(len=:), allocatable :: dir
+
+        ok = .false.
+        call make_scratch_dir('fmod297_diag', dir)
+        if (.not. write_source(dir//'/par.f90', parent_source)) return
+        if (.not. compile_parent_object(dir)) then
+            print *, 'FAIL: parent object did not compile'
+            call show_log(dir)
+            return
+        end if
+        if (.not. expect_submodule_error(dir, &
+            'submodule (fmod297_absent_parent) s'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '    module function twice(x) result(r)'//new_line('a')// &
+            '        integer, intent(in) :: x'//new_line('a')// &
+            '        integer :: r'//new_line('a')// &
+            '        r = 2 * x'//new_line('a')// &
+            '    end function twice'//new_line('a')// &
+            'end submodule s', 'parent module not found')) return
+        if (.not. expect_submodule_error(dir, &
+            'submodule (fmod297_parent) s'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '    module function nosuch(x) result(r)'//new_line('a')// &
+            '        integer, intent(in) :: x'//new_line('a')// &
+            '        integer :: r'//new_line('a')// &
+            '        r = x'//new_line('a')// &
+            '    end function nosuch'//new_line('a')// &
+            'end submodule s', 'is not declared by module')) return
+        if (.not. expect_submodule_error(dir, &
+            'submodule (fmod297_parent) s'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '    module function twice(x, y) result(r)'//new_line('a')// &
+            '        integer, intent(in) :: x'//new_line('a')// &
+            '        integer, intent(in) :: y'//new_line('a')// &
+            '        integer :: r'//new_line('a')// &
+            '        r = x + y'//new_line('a')// &
+            '    end function twice'//new_line('a')// &
+            'end submodule s', 'does not match the dummy argument count')) return
+        if (.not. expect_submodule_error(dir, submodule_source_unrestated, &
+            'must restate its interface')) return
+        call remove_scratch_dir(dir)
+        ok = .true.
+    end function test_submodule_parent_diagnostics
+
+    logical function compile_parent_object(dir) result(ok)
+        character(len=*), intent(in) :: dir
+        integer :: exit_stat, cmd_stat
+
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; exe=$PWD/$exe; '// &
+            'cd '//dir//' || exit 90; '// &
+            '"$exe" -c par.f90 -o par.o >>log 2>&1'//"'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        ok = cmd_stat == 0 .and. exit_stat == 0
+    end function compile_parent_object
+
+    logical function expect_submodule_error(dir, source, fragment) result(ok)
+        ! Compiling this submodule alone must fail with a diagnostic naming the
+        ! given fragment.
+        character(len=*), intent(in) :: dir
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: fragment
+        integer :: exit_stat, cmd_stat, grep_stat
+
+        ok = .false.
+        if (.not. write_source(dir//'/bad.f90', source)) return
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; exe=$PWD/$exe; '// &
+            'cd '//dir//' || exit 90; '// &
+            '"$exe" -c bad.f90 -o bad.o >bad.log 2>&1'//"'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0 .or. exit_stat == 0) then
+            print *, 'FAIL: submodule was accepted, expected: ', fragment
+            return
+        end if
+        call execute_command_line('grep -q "'//fragment//'" '//dir//'/bad.log', &
+                                  exitstat=grep_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0 .or. grep_stat /= 0) then
+            print *, 'FAIL: diagnostic did not mention: ', fragment
+            call execute_command_line('cat '//dir//'/bad.log')
+            return
+        end if
+        ok = .true.
+    end function expect_submodule_error
 
     integer function run_separate_compilation(dir, mod_source, prog_source) &
             result(status)


### PR DESCRIPTION
Closes #297. Second and final step; the caller half landed in #600.

## What changed

A submodule was only ever compilable alongside its parent. `ffc -c sub.f90` was
rejected at the driver level (*"direct LIRIC session only lowers top-level
programs"*), and the parent check demanded a `module_node` in the same arena.

A submodule now compiles as its own translation unit. Like a bare module unit it
defines no `main` and contributes no body statement; its module procedures are
emitted under the parent module's mangled symbols, so the object links against a
separately compiled parent and caller.

The parent is resolved exactly the way a `USE` is: from a module compiled in this
unit, or from its `.fmod` on the include path. **When it comes from the artifact,
the interfaces the artifact carries are what the submodule body is checked
against.**

## Design: what was reworked and what was not

Per the steer, and confirmed at the seam: **no AST synthesis, no mutable arena,
no forked lowering path.** A restated submodule body already lowered through
`lower_one_module_procedure` under the parent's mangling, and that remains the
single lowering path. Two things are new:

1. the compilation unit may *be* the submodule — one more case in the same
   unit-shape dispatch that already handles bare modules and block data, not a
   parallel mechanism;
2. the parent contract is *read from the artifact* instead of required as source.

The `module procedure P` (non-restated) form is the one case that genuinely needs
the parent's dummy *declarations* as AST. Rather than synthesize a fake AST for
it, compiling it apart from its parent is **diagnosed** — an explicit limitation,
not a silent fallback that would emit a zero-dummy body under a symbol callers
pass arguments to.

## Invariants preserved

- **Imported interfaces drive separate compilation**: the submodule unit never
  sees the parent's source; it binds to, and is validated against, the `.fmod`.
- **No source rescan, no signature guess**: dummy count, dummy kinds and result
  kind are compared against the artifact's records.
- **One convention**: same mangled symbol, same signature records, same lowering
  path as an in-unit submodule.
- **Negative controls** (all four the issue requires): missing parent artifact;
  parent declares no such procedure; signature mismatch (dummy count / kinds /
  result kind); non-restated body compiled apart.
- Artifact version contract (#397), derived layouts (#414) and generic ranks
  (#415) untouched and still round-tripping.

## Oracles

In `test/test_session_submodule_compiler.f90` (all seven earlier tests kept
unchanged):

- `test_submodule_compiles_as_its_own_unit` — parent, submodule and caller as
  **three independent `ffc` invocations**, linked, exit 142. Every step of this
  was a hard compile error on main.
- `test_submodule_parent_diagnostics` — the four negative fixtures above.

## Corpus delta

Failure set on this branch is **identical** to `origin/main` measured at the same
commit (10 cases): no new failures, none newly passing, no xfail manifest entries
move.

Note for the coordinator: `issue_2950_procedure_actual_argument.f90`
(*"procedure body unavailable for call to f"*) regressed on `main` from a
concurrent chain between my two measurements — it fails identically on an
unmodified `main` worktree, and is not from this PR.