### PR TITLE
[vector-subscript-02] lower vector-subscript assignment as alias-safe scatter (closes #418)

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -1082,6 +1082,7 @@ contains
     include 'session_program_lowering_arrays.inc'
     include 'session_program_lowering_const_fold.inc'
     include 'session_program_lowering_array_elements.inc'
+    include 'session_program_lowering_vector_subscript.inc'
     include 'session_program_lowering_char_arrays.inc'
     include 'session_program_lowering_allocatable.inc'
     include 'session_program_lowering_runtime_alloc.inc'
@@ -1440,6 +1441,9 @@ contains
                     target, context, error_msg)
                 return
             end if
+            call lower_vector_subscript_assignment(arena, node, target, context, &
+                handled, error_msg)
+            if (handled .or. len_trim(error_msg) > 0) return
             if (target%is_array_access) then
                 call lower_array_element_assignment(arena, node, target, context, &
                     value, error_msg)

--- a/src/session_program_lowering_vector_subscript.inc
+++ b/src/session_program_lowering_vector_subscript.inc
@@ -1,0 +1,349 @@
+    ! Vector-subscript assignment: a(v) = rhs, where v is a rank-1 integer
+    ! array (a named array or an integer array constructor). Fortran requires
+    ! the index vector and the whole right-hand side to be evaluated before any
+    ! element of the target is redefined, so the lowering here is a two-phase
+    ! scatter: every right-hand-side value and every subscript is materialised
+    ! first, and only then are the stores emitted. That makes a self-referential
+    ! assignment such as a(v) = a(w) alias-safe without a heap temporary,
+    ! because the extents are compile-time constants and the whole scatter
+    ! unrolls. Repeated indices therefore scatter in array element order, so the
+    ! last write wins, matching gfortran.
+
+    subroutine describe_vector_subscript(arena, target, context, base_index, &
+                                         vector_index, literal_index, extent, &
+                                         handled, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: target
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(out) :: base_index
+        integer, intent(out) :: vector_index
+        integer, intent(out) :: literal_index
+        integer, intent(out) :: extent
+        logical, intent(out) :: handled
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: id_name
+        integer :: subscript_index
+        integer :: sym
+
+        handled = .false.
+        base_index = 0
+        vector_index = 0
+        literal_index = 0
+        extent = 0
+        call set_empty(error_msg)
+
+        if (.not. allocated(target%name)) return
+        if (.not. allocated(target%arg_indices)) return
+        if (size(target%arg_indices) /= 1) return
+        base_index = find_symbol_compat(context, target%name)
+        if (base_index <= 0) then
+            base_index = 0
+            return
+        end if
+        if (.not. context%symbols(base_index)%is_array) then
+            base_index = 0
+            return
+        end if
+        if (context%symbols(base_index)%is_allocatable) then
+            base_index = 0
+            return
+        end if
+        if (context%symbols(base_index)%array_rank /= 1) then
+            base_index = 0
+            return
+        end if
+
+        subscript_index = target%arg_indices(1)
+        if (.not. node_exists(arena, subscript_index)) then
+            base_index = 0
+            return
+        end if
+
+        if (is_identifier(arena, subscript_index)) then
+            call get_identifier_name(arena, subscript_index, id_name, error_msg)
+            if (len_trim(error_msg) > 0) return
+            sym = find_symbol_compat(context, id_name)
+            if (sym <= 0) then
+                base_index = 0
+                return
+            end if
+            if (.not. context%symbols(sym)%is_array) then
+                base_index = 0
+                return
+            end if
+            if (context%symbols(sym)%is_allocatable) then
+                base_index = 0
+                return
+            end if
+            if (context%symbols(sym)%array_rank /= 1) then
+                base_index = 0
+                return
+            end if
+            if (context%symbols(sym)%value_kind /= VALUE_I32) then
+                error_msg = 'vector subscript requires an integer index vector: '// &
+                            trim(id_name)
+                return
+            end if
+            vector_index = sym
+            extent = context%symbols(sym)%array_size
+            handled = .true.
+            return
+        end if
+
+        select type (subscript => arena%entries(subscript_index)%node)
+        type is (array_literal_node)
+            if (.not. allocated(subscript%element_indices)) then
+                base_index = 0
+                return
+            end if
+            literal_index = subscript_index
+            extent = size(subscript%element_indices)
+            handled = extent > 0
+            if (.not. handled) base_index = 0
+        end select
+    end subroutine describe_vector_subscript
+
+    subroutine lower_vector_subscript_assignment(arena, node, target, context, &
+                                                 handled, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(assignment_node), intent(in) :: node
+        type(call_or_subscript_node), intent(in) :: target
+        type(lowering_context_t), intent(inout) :: context
+        logical, intent(out) :: handled
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t), allocatable :: values(:)
+        type(lr_operand_desc_t), allocatable :: indices(:)
+        integer :: base_index, vector_index, literal_index, extent
+        integer :: vk, k
+
+        call describe_vector_subscript(arena, target, context, base_index, &
+                                       vector_index, literal_index, extent, &
+                                       handled, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. handled) return
+
+        vk = context%symbols(base_index)%value_kind
+        select case (vk)
+        case (VALUE_I32, VALUE_F32, VALUE_F64)
+            ! supported scatter element kinds
+        case default
+            error_msg = 'vector subscript assignment supports integer, '// &
+                        'real(4), and real(8) arrays'
+            return
+        end select
+
+        allocate (values(extent))
+        allocate (indices(extent))
+
+        ! Phase 1: materialise the right-hand side, then the subscripts.
+        call materialise_vector_subscript_rhs(arena, node%value_index, context, &
+                                              vk, extent, values, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call materialise_vector_subscript_indices(arena, context, base_index, &
+                                                  vector_index, literal_index, &
+                                                  extent, indices, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        ! Phase 2: scatter in array element order.
+        do k = 1, extent
+            call store_array_element_at_operand(context, base_index, indices(k), &
+                                                values(k), error_msg)
+            if (len_trim(error_msg) > 0) then
+                error_msg = 'vector_subscript_store: '//error_msg
+                return
+            end if
+        end do
+        call set_empty(error_msg)
+    end subroutine lower_vector_subscript_assignment
+
+    subroutine materialise_vector_subscript_indices(arena, context, base_index, &
+                                                    vector_index, literal_index, &
+                                                    extent, indices, error_msg)
+        ! Produce the zero-based linear offsets of the scatter targets. A named
+        ! index vector is read element by element at run time; a constructor
+        ! subscript folds to constants, which lets bounds be checked here.
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: base_index
+        integer, intent(in) :: vector_index
+        integer, intent(in) :: literal_index
+        integer, intent(in) :: extent
+        type(lr_operand_desc_t), intent(inout) :: indices(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: raw
+        integer(c_int64_t) :: lower_bound, index_value
+        integer :: k
+
+        lower_bound = int(context%symbols(base_index)%array_lower_bound, c_int64_t)
+        if (vector_index > 0) then
+            do k = 1, extent
+                call load_array_linear_element(context, vector_index, &
+                                               int(k - 1, c_int64_t), raw, &
+                                               error_msg)
+                if (len_trim(error_msg) > 0) return
+                if (.not. emit_i32_binary(context%session, LR_OP_SUB, raw, &
+                        i32_immediate(context%session, lower_bound), indices(k), &
+                        error_msg)) then
+                    error_msg = 'vector_subscript_index: '//error_msg
+                    return
+                end if
+            end do
+            call set_empty(error_msg)
+            return
+        end if
+
+        select type (subscript => arena%entries(literal_index)%node)
+        type is (array_literal_node)
+            do k = 1, extent
+                call eval_i32_constant(arena, subscript%element_indices(k), &
+                                       context, index_value, error_msg)
+                if (len_trim(error_msg) > 0) then
+                    error_msg = 'vector subscript requires an integer index vector'
+                    return
+                end if
+                if (index_value < lower_bound) then
+                    error_msg = 'vector subscript index is out of bounds'
+                    return
+                end if
+                if (index_value > lower_bound + &
+                    int(context%symbols(base_index)%array_size, c_int64_t) - &
+                    1_c_int64_t) then
+                    error_msg = 'vector subscript index is out of bounds'
+                    return
+                end if
+                indices(k) = i32_immediate(context%session, index_value - lower_bound)
+            end do
+        class default
+            error_msg = 'vector subscript requires an integer index vector'
+            return
+        end select
+        call set_empty(error_msg)
+    end subroutine materialise_vector_subscript_indices
+
+    subroutine materialise_vector_subscript_rhs(arena, value_index, context, vk, &
+                                                extent, values, error_msg)
+        ! Evaluate the right-hand side into `extent` operands before any store.
+        ! Array constructors, whole rank-1 arrays, gathers a(w), and scalar
+        ! broadcasts are covered; anything else is rejected rather than silently
+        ! mis-scattered.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: value_index
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: vk
+        integer, intent(in) :: extent
+        type(lr_operand_desc_t), intent(inout) :: values(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t), allocatable :: gather_indices(:)
+        type(lr_operand_desc_t) :: scalar_value
+        integer :: source_index, source_vector, source_literal, source_extent
+        integer :: k, sym
+        logical :: is_vector_gather
+
+        call set_empty(error_msg)
+        if (.not. node_exists(arena, value_index)) then
+            error_msg = 'vector subscript assignment has no right-hand side'
+            return
+        end if
+
+        select type (rhs => arena%entries(value_index)%node)
+        type is (array_literal_node)
+            if (.not. allocated(rhs%element_indices)) then
+                error_msg = 'array constructor has no elements'
+                return
+            end if
+            if (size(rhs%element_indices) /= extent) then
+                error_msg = 'vector subscript assignment is nonconformable: '// &
+                            'index vector and right-hand side differ in size'
+                return
+            end if
+            do k = 1, extent
+                call lower_vector_subscript_scalar(arena, rhs%element_indices(k), &
+                                                   context, vk, values(k), &
+                                                   error_msg)
+                if (len_trim(error_msg) > 0) return
+            end do
+            return
+        type is (identifier_node)
+            sym = find_symbol_compat(context, rhs%name)
+            if (sym > 0) then
+                if (context%symbols(sym)%is_array) then
+                    if (context%symbols(sym)%is_allocatable) then
+                        error_msg = 'vector subscript assignment requires a '// &
+                                    'fixed-size right-hand side'
+                        return
+                    end if
+                    if (context%symbols(sym)%array_rank /= 1) then
+                        error_msg = 'vector subscript assignment requires a '// &
+                                    'rank-1 right-hand side'
+                        return
+                    end if
+                    if (context%symbols(sym)%array_size /= extent) then
+                        error_msg = 'vector subscript assignment is '// &
+                                    'nonconformable: index vector and '// &
+                                    'right-hand side differ in size'
+                        return
+                    end if
+                    do k = 1, extent
+                        call load_array_linear_element(context, sym, &
+                                                       int(k - 1, c_int64_t), &
+                                                       values(k), error_msg)
+                        if (len_trim(error_msg) > 0) return
+                    end do
+                    return
+                end if
+            end if
+        type is (call_or_subscript_node)
+            call describe_vector_subscript(arena, rhs, context, source_index, &
+                                           source_vector, source_literal, &
+                                           source_extent, is_vector_gather, &
+                                           error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (is_vector_gather) then
+                if (source_extent /= extent) then
+                    error_msg = 'vector subscript assignment is nonconformable: '// &
+                                'index vector and right-hand side differ in size'
+                    return
+                end if
+                allocate (gather_indices(extent))
+                call materialise_vector_subscript_indices(arena, context, &
+                                                          source_index, &
+                                                          source_vector, &
+                                                          source_literal, extent, &
+                                                          gather_indices, error_msg)
+                if (len_trim(error_msg) > 0) return
+                do k = 1, extent
+                    call load_array_element_at_operand(context, source_index, &
+                                                       gather_indices(k), &
+                                                       values(k), error_msg)
+                    if (len_trim(error_msg) > 0) return
+                end do
+                return
+            end if
+        end select
+
+        ! Scalar broadcast.
+        call lower_vector_subscript_scalar(arena, value_index, context, vk, &
+                                           scalar_value, error_msg)
+        if (len_trim(error_msg) > 0) return
+        do k = 1, extent
+            values(k) = scalar_value
+        end do
+    end subroutine materialise_vector_subscript_rhs
+
+    subroutine lower_vector_subscript_scalar(arena, expr_index, context, vk, &
+                                             value, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: expr_index
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: vk
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (vk == VALUE_F32) then
+            call lower_f32_operand(arena, expr_index, context, value, error_msg)
+        else if (vk == VALUE_F64) then
+            call lower_f64_operand(arena, expr_index, context, value, error_msg)
+        else
+            call lower_i32_expression(arena, expr_index, context, value, error_msg)
+        end if
+    end subroutine lower_vector_subscript_scalar

--- a/test/test_session_vector_subscript_assignment_compiler.f90
+++ b/test/test_session_vector_subscript_assignment_compiler.f90
@@ -1,0 +1,176 @@
+program test_session_vector_subscript_assignment_compiler
+    ! Behavioural coverage for assignment to a vector subscript, a(v) = rhs.
+    ! Fortran requires the RHS and the index vector to be evaluated before any
+    ! element of the target is redefined, so a self-referential scatter such as
+    ! a(v) = a(w) must observe the original values of a.
+    use ffc_test_support, only: expect_output, expect_error_contains
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session vector subscript assignment test ==='
+
+    all_passed = .true.
+    if (.not. test_reordered_scatter()) all_passed = .false.
+    if (.not. test_repeated_indices()) all_passed = .false.
+    if (.not. test_self_referential()) all_passed = .false.
+    if (.not. test_scalar_rhs()) all_passed = .false.
+    if (.not. test_real_scatter()) all_passed = .false.
+    if (.not. test_literal_vector()) all_passed = .false.
+    if (.not. test_out_of_bounds_rejected()) all_passed = .false.
+    if (.not. test_nonconformable_rejected()) all_passed = .false.
+    if (.not. test_noninteger_vector_rejected()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+
+    print *, 'PASS: vector subscript assignment lowers as an alias-safe scatter'
+
+contains
+
+    logical function test_reordered_scatter()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(5), v(3)'//new_line('a')// &
+            '  a = [1, 2, 3, 4, 5]'//new_line('a')// &
+            '  v = [5, 1, 3]'//new_line('a')// &
+            '  a(v) = [10, 20, 30]'//new_line('a')// &
+            '  print *, a'//new_line('a')// &
+            'end program main'
+
+        test_reordered_scatter = expect_output( &
+            source, &
+            '          20           2          30           4          10'// &
+            new_line('a'), &
+            '/tmp/ffc_session_vector_subscript_reorder_test')
+    end function test_reordered_scatter
+
+    logical function test_repeated_indices()
+        ! Repeated indices are not standard-conforming for a variable target,
+        ! but gfortran scatters in array element order so the last write wins.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(4), v(3)'//new_line('a')// &
+            '  a = 0'//new_line('a')// &
+            '  v = [2, 2, 4]'//new_line('a')// &
+            '  a(v) = [7, 8, 9]'//new_line('a')// &
+            '  print *, a'//new_line('a')// &
+            'end program main'
+
+        test_repeated_indices = expect_output( &
+            source, &
+            '           0           8           0           9'//new_line('a'), &
+            '/tmp/ffc_session_vector_subscript_repeat_test')
+    end function test_repeated_indices
+
+    logical function test_self_referential()
+        ! a(v) = a(w) must read the original a before any element is stored.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(4), v(4), w(4)'//new_line('a')// &
+            '  a = [1, 2, 3, 4]'//new_line('a')// &
+            '  v = [1, 2, 3, 4]'//new_line('a')// &
+            '  w = [2, 1, 4, 3]'//new_line('a')// &
+            '  a(v) = a(w)'//new_line('a')// &
+            '  print *, a'//new_line('a')// &
+            'end program main'
+
+        test_self_referential = expect_output( &
+            source, &
+            '           2           1           4           3'//new_line('a'), &
+            '/tmp/ffc_session_vector_subscript_self_test')
+    end function test_self_referential
+
+    logical function test_scalar_rhs()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(5), v(2)'//new_line('a')// &
+            '  a = [1, 2, 3, 4, 5]'//new_line('a')// &
+            '  v = [4, 2]'//new_line('a')// &
+            '  a(v) = 99'//new_line('a')// &
+            '  print *, a'//new_line('a')// &
+            'end program main'
+
+        test_scalar_rhs = expect_output( &
+            source, &
+            '           1          99           3          99           5'// &
+            new_line('a'), &
+            '/tmp/ffc_session_vector_subscript_scalar_test')
+    end function test_scalar_rhs
+
+    logical function test_real_scatter()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  real(8) :: a(3)'//new_line('a')// &
+            '  integer :: v(2)'//new_line('a')// &
+            '  a = [1.0d0, 2.0d0, 3.0d0]'//new_line('a')// &
+            '  v = [3, 1]'//new_line('a')// &
+            '  a(v) = [7.5d0, 8.5d0]'//new_line('a')// &
+            '  print *, a(1) + a(2) + a(3)'//new_line('a')// &
+            'end program main'
+
+        test_real_scatter = expect_output( &
+            source, '   18.000000000000000     '//new_line('a'), &
+            '/tmp/ffc_session_vector_subscript_real_test')
+    end function test_real_scatter
+
+    logical function test_literal_vector()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(4)'//new_line('a')// &
+            '  a = [1, 2, 3, 4]'//new_line('a')// &
+            '  a([4, 2]) = [70, 80]'//new_line('a')// &
+            '  print *, a'//new_line('a')// &
+            'end program main'
+
+        test_literal_vector = expect_output( &
+            source, &
+            '           1          80           3          70'//new_line('a'), &
+            '/tmp/ffc_session_vector_subscript_literal_test')
+    end function test_literal_vector
+
+    logical function test_out_of_bounds_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(4)'//new_line('a')// &
+            '  a = 0'//new_line('a')// &
+            '  a([1, 9]) = [1, 2]'//new_line('a')// &
+            '  print *, a'//new_line('a')// &
+            'end program main'
+
+        test_out_of_bounds_rejected = expect_error_contains( &
+            source, 'out of bounds', &
+            '/tmp/ffc_session_vector_subscript_bounds_test')
+    end function test_out_of_bounds_rejected
+
+    logical function test_nonconformable_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(5), v(3)'//new_line('a')// &
+            '  a = 0'//new_line('a')// &
+            '  v = [1, 2, 3]'//new_line('a')// &
+            '  a(v) = [1, 2]'//new_line('a')// &
+            '  print *, a'//new_line('a')// &
+            'end program main'
+
+        test_nonconformable_rejected = expect_error_contains( &
+            source, 'nonconformable', &
+            '/tmp/ffc_session_vector_subscript_shape_test')
+    end function test_nonconformable_rejected
+
+    logical function test_noninteger_vector_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(5)'//new_line('a')// &
+            '  real(8) :: v(2)'//new_line('a')// &
+            '  a = 0'//new_line('a')// &
+            '  v = [1.0d0, 2.0d0]'//new_line('a')// &
+            '  a(v) = [1, 2]'//new_line('a')// &
+            '  print *, a'//new_line('a')// &
+            'end program main'
+
+        test_noninteger_vector_rejected = expect_error_contains( &
+            source, 'integer', &
+            '/tmp/ffc_session_vector_subscript_kind_test')
+    end function test_noninteger_vector_rejected
+
+end program test_session_vector_subscript_assignment_compiler


### PR DESCRIPTION
Closes #418.

## What changed

New `src/session_program_lowering_vector_subscript.inc` lowers `a(v) = rhs`,
where `v` is a rank-1 integer array or an integer array constructor, as a
two-phase scatter. `lower_assignment` tries this path before the scalar
array-element path; when the subscript is not a vector it declines
(`handled = .false.`) and the existing lowering runs unchanged.

## Preserved compiler invariant

Fortran requires the index vector and the entire right-hand side to be
evaluated before any element of the target is redefined. The lowering
therefore materialises **all** RHS operands, then **all** subscript operands,
and only then emits the stores. Since the extents are compile-time constants
the scatter fully unrolls, so a self-referential assignment `a(v) = a(w)` is
alias-safe without a heap temporary. Repeated indices scatter in array element
order, so the last write wins — matching gfortran.

RHS forms covered: array constructor, whole rank-1 array, gather `a(w)`, and
scalar broadcast. Anything else is rejected rather than silently mis-scattered.

Diagnostics: nonconformable index vector vs. RHS, non-integer index vector,
and (for constructor subscripts, whose indices fold to constants)
out-of-bounds subscripts.

## Red evidence (unmodified main)

`fo test test_session_vector_subscript_assignment_compiler`:

```
 FAIL: ffc direct-session lowering only supports integer expressions
 FAIL: ffc direct-session lowering only supports integer expressions
 FAIL: unsupported array subscript at line 6, column 12: ... not non-integer identifiers
 FAIL: unsupported array subscript at line 5, column 5: ... not non-integer identifiers
 FAIL: ffc direct-session lowering only supports real expressions
 FAIL: diagnostic did not contain "nonconformable"
Summary: 0 passed, 1 failed
```

## Green evidence

`fo test test_session_vector_subscript_assignment_compiler` after rebase onto
origin/main: `1 passed, 0 failed`. Nine behavioural cases: reordered scatter,
repeated indices, self-referential `a(v) = a(w)`, scalar broadcast, real(8)
scatter, constructor subscript, plus three negative controls
(out-of-bounds, nonconformable, non-integer index vector). Expected outputs
are gfortran's.

Full `fo` pipeline in the worktree: everything green except
`test_parity_dashboard` (known: resolves `../fortfront` and always fails inside
`.wt/` worktrees) and `test_fortfront_corpus_conformance`. The corpus test was
re-run against a clean `origin/main` worktree and produces the **identical**
failing set (`class_is_1_ok`, `do_concurrent_3_valid`, `elemental_pointer_1_valid`,
`error_complete_garbage.lf`, `issue_2950_procedure_actual_argument`,
`pr19936_3_ok`, `pr91715_ok`, `pure_formal_proc_3_valid`,
`submodule_module_prefix_valid`, `type_is_1_ok`) with the same
`PASS=411 XFAIL=95 XPASS=2 FAIL=9` f90 summary — pre-existing, not a regression
from this change. No corpus case regressed from PASS.
