### PR TITLE
[corpus-segv-01] stop emitting undefined symbols; add RANDOM_NUMBER (refs #576)

### DIFF
--- a/scripts/conformance_gauntlet.sh
+++ b/scripts/conformance_gauntlet.sh
@@ -161,6 +161,18 @@ is_lazy_suite() {
     [ "$SUITE" = "fortfront-lf" ]
 }
 
+# lazy_negative_test <suite_relative_path>
+# A FortFront lazy-mode example named error_* is a deliberately invalid source
+# kept as a parser-rejection fixture. Its oracle is that ffc rejects it, so a
+# nonzero compiler exit is the expected result and acceptance is the failure
+# (#576). Without this the harness scored a correct rejection as FAIL.
+lazy_negative_test() {
+    case "$1" in
+        error_*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 dg_skip_reason() {
     local source="$1"
     if grep -Eq 'dg-additional-sources' "$source"; then
@@ -643,6 +655,25 @@ while IFS= read -r full_path <&3; do
         ffc_exit=0
     else
         ffc_exit=1
+    fi
+
+    # A lazy-mode rejection fixture is judged on the compiler exit alone: it
+    # has no runnable form and no reference to compare against.
+    if is_lazy_suite && lazy_negative_test "$rel_path"; then
+        if [ "$ffc_exit" -ne 0 ]; then
+            status="PASS"
+            note="invalid source rejected as expected"
+            PASS_COUNT=$((PASS_COUNT + 1))
+        else
+            status="FAIL"
+            note="invalid source was accepted"
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+            HAS_FAIL=1
+            echo "  FAIL: $rel_path (invalid source accepted)"
+        fi
+        write_result_record "$rel_path" "$status" "$ffc_exit" "$ref_exit" \
+            "$note" "$warning_expectation"
+        continue
     fi
 
     # Step 2: if ffc failed, classify immediately

--- a/src/liric_session_timing_bindings.f90
+++ b/src/liric_session_timing_bindings.f90
@@ -29,6 +29,12 @@ module liric_session_timing_bindings
 
     public :: emit_cpu_time_value
     public :: emit_system_clock_value
+    public :: emit_random_number_value
+
+    ! Scale from random()'s [0, 2^31-1] range into [0,1). 2**(-31) itself would
+    ! round 2^31-1 up to exactly 1.0 in f32; the next representable value below
+    ! it keeps every draw strictly less than one, as F2018 16.9.154 requires.
+    real(c_float), parameter :: RANDOM_SCALE_F32 = 4.6566126e-10_c_float
 
     interface
         function lr_session_declare(handle, name, ret, params, n, vararg, &
@@ -91,6 +97,31 @@ contains
         call set_empty(error_msg)
         emit_system_clock_value = .true.
     end function emit_system_clock_value
+
+    logical function emit_random_number_value(session, result, error_msg)
+        ! result (f32) = (real) random() * RANDOM_SCALE_F32, a draw in [0,1).
+        ! glibc's random() returns a fresh value in [0, 2^31-1] on every call,
+        ! so successive draws differ within a run. The generator is left
+        ! unseeded, which F2018 permits: the seed is processor dependent and
+        ! may repeat the same sequence across runs.
+        type(liric_session_t), intent(inout) :: session
+        type(lr_operand_desc_t), intent(out) :: result
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: draw_i64, draw_f32, scale
+
+        emit_random_number_value = .false.
+        if (.not. require_open_session(session, error_msg)) return
+        if (.not. declare_extern(session, 'random', &
+            lr_type_i64_s(session%handle), error_msg)) return
+        if (.not. call_extern_i64(session, 'random', draw_i64, error_msg)) return
+        if (.not. emit_cast(session, LR_OP_SITOFP, draw_i64, &
+            lr_type_f32_s(session%handle), draw_f32, error_msg)) return
+        scale = liric_f32_immediate(session, RANDOM_SCALE_F32)
+        if (.not. emit_liric_f32_binary(session, LR_OP_FMUL, draw_f32, scale, &
+            result, error_msg)) return
+        call set_empty(error_msg)
+        emit_random_number_value = .true.
+    end function emit_random_number_value
 
     function i64_null_ptr(session) result(operand)
         ! A null pointer immediate for the time(NULL) argument.

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -203,7 +203,7 @@ module session_program_lowering
         emit_liric_f64_load, &
         emit_liric_f64_store
     use liric_session_timing_bindings, only: emit_cpu_time_value, &
-        emit_system_clock_value
+        emit_system_clock_value, emit_random_number_value
     use session_lowering_ops, only: integer_compare_predicate, &
         integer_opcode, parse_i32_literal
     use ffc_strings, only: set_empty
@@ -348,6 +348,11 @@ module session_program_lowering
 
     ! Reduction kinds for dim-wise whole-array reductions (sum/product/count/
     ! any/all along one dimension). See lower_dim_reduction_assignment.
+    ! An argument-less call still goes through prepare_reference_args so that
+    ! callee diagnostics (a dummy procedure with no body in this unit) apply
+    ! whether or not actual arguments are present (#576).
+    integer, parameter :: NO_ACTUAL_ARGS(0) = [integer ::]
+
     integer, parameter :: DIM_REDUCE_SUM = 1
     integer, parameter :: DIM_REDUCE_PROD = 2
     integer, parameter :: DIM_REDUCE_COUNT = 3
@@ -1956,6 +1961,10 @@ contains
             call lower_system_clock(arena, arg_indices, context, error_msg)
             return
         end if
+        if (same_name(call_name, 'random_number')) then
+            call lower_random_number(arena, arg_indices, context, error_msg)
+            return
+        end if
         if (is_method_subroutine_call(call_name)) then
             call lower_method_subroutine_call(arena, call_name, arg_indices, &
                 context, error_msg)
@@ -2048,6 +2057,24 @@ contains
         if (.not. emit_system_clock_value(context%session, value, error_msg)) return
         call store_intrinsic_scalar_result(context, symbol_index, value, error_msg)
     end subroutine lower_system_clock
+
+    subroutine lower_random_number(arena, arg_indices, context, error_msg)
+        ! random_number(harvest): harvest = a pseudo-random real in [0,1).
+        ! Only a default-real scalar argument is supported; an array harvest
+        ! or a real(8) harvest is diagnosed by intrinsic_out_scalar.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: arg_indices(:)
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: value
+        integer :: symbol_index
+
+        call intrinsic_out_scalar(arena, arg_indices, context, 'random_number', &
+            VALUE_F32, symbol_index, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_random_number_value(context%session, value, error_msg)) return
+        call store_intrinsic_scalar_result(context, symbol_index, value, error_msg)
+    end subroutine lower_random_number
 
     subroutine intrinsic_out_scalar(arena, arg_indices, context, name, kind, &
             symbol_index, error_msg)

--- a/src/session_program_lowering_expr_lowering.inc
+++ b/src/session_program_lowering_expr_lowering.inc
@@ -239,8 +239,10 @@
                                         copyback_indices, error_msg)
             if (len_trim(error_msg) > 0) return
         else
-            allocate (args(0))
-            allocate (copyback_indices(0))
+            call prepare_reference_args(arena, NO_ACTUAL_ARGS, context, &
+                                        VALUE_LOGICAL, call_name, args, &
+                                        copyback_indices, error_msg)
+            if (len_trim(error_msg) > 0) return
         end if
 
         if (.not. emit_i32_call(context%session, call_emit_name(arena, call_name, &
@@ -566,8 +568,10 @@
                                         copyback_indices, error_msg)
             if (len_trim(error_msg) > 0) return
         else
-            allocate (args(0))
-            allocate (copyback_indices(0))
+            call prepare_reference_args(arena, NO_ACTUAL_ARGS, context, &
+                                        VALUE_F32, call_name, args, &
+                                        copyback_indices, error_msg)
+            if (len_trim(error_msg) > 0) return
         end if
 
         if (.not. emit_liric_f32_call(context%session, &
@@ -952,8 +956,10 @@
                                         copyback_indices, error_msg)
             if (len_trim(error_msg) > 0) return
         else
-            allocate (args(0))
-            allocate (copyback_indices(0))
+            call prepare_reference_args(arena, NO_ACTUAL_ARGS, context, &
+                                        VALUE_F64, call_name, args, &
+                                        copyback_indices, error_msg)
+            if (len_trim(error_msg) > 0) return
         end if
 
         if (.not. emit_liric_f64_call(context%session, &
@@ -1337,8 +1343,10 @@
                                         copyback_indices, error_msg)
             if (len_trim(error_msg) > 0) return
         else
-            allocate (args(0))
-            allocate (copyback_indices(0))
+            call prepare_reference_args(arena, NO_ACTUAL_ARGS, context, &
+                                        VALUE_I64, node%name, args, &
+                                        copyback_indices, error_msg)
+            if (len_trim(error_msg) > 0) return
         end if
 
         if (.not. emit_i64_call(context%session, &

--- a/src/session_program_lowering_integer.inc
+++ b/src/session_program_lowering_integer.inc
@@ -426,8 +426,10 @@
                                       copyback_indices, error_msg)
           if (len_trim(error_msg) > 0) return
       else
-          allocate (args(0))
-          allocate (copyback_indices(0))
+          call prepare_reference_args(arena, NO_ACTUAL_ARGS, context, &
+                                      VALUE_I32, call_name, args, &
+                                      copyback_indices, error_msg)
+          if (len_trim(error_msg) > 0) return
       end if
 
       if (.not. emit_i32_call(context%session, call_emit_name(arena, call_name, &

--- a/src/session_program_lowering_pointer.inc
+++ b/src/session_program_lowering_pointer.inc
@@ -670,8 +670,10 @@
                                             copyback_indices, error_msg)
                 if (len_trim(error_msg) > 0) return
             else
-                allocate (args(0))
-                allocate (copyback_indices(0))
+                call prepare_reference_args(arena, NO_ACTUAL_ARGS, context, &
+                                            pointee_kind, call_node%name, &
+                                            args, copyback_indices, error_msg)
+                if (len_trim(error_msg) > 0) return
             end if
             if (.not. emit_ptr_call(context%session, &
                     call_emit_name(arena, call_node%name, context), args, &

--- a/test/conformance/xfail_fortfront_f90.txt
+++ b/test/conformance/xfail_fortfront_f90.txt
@@ -28,7 +28,6 @@ issue_1619_nested_types_complex.f90 # owner=lazy-fortran/ffc#447; reason=central
 issue_1621_intent_out_array_shape.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
 issue_1738_derived_type_allocatable.f90 # owner=lazy-fortran/ffc#336; reason=migrate allocatable arrays to descriptors
 issue_1740_optional_keyword_arguments.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
-issue_1744_operator_interface.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 issue_1771_module_parameter_types.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
 issue_1782_procedure_pointer.f90 # owner=lazy-fortran/ffc#448; reason=lower same-unit scalar procedure calls
 issue_1827_submodule_simple.f90 # owner=lazy-fortran/ffc#297; reason=consume parent interfaces for separate submodules
@@ -90,7 +89,6 @@ undefined_var_recursive_type.f90 # owner=lazy-fortran/ffc#447; reason=centralize
 # pointers are not yet lowered by the direct LIRIC session.
 issue_2814_c_funloc.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 issue_2814_c_f_procpointer.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
-issue_2820_c_interop_pointers.f90 # owner=lazy-fortran/ffc#454; reason=lower ISO C pointer round-trips
 # Inline generic instantiation caret syntax name^(T)(...) is unsupported.
 issue_2817_inline_instantiate_caret.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
 # Implied-do upper bound references its own (out-of-scope) index; not lowered.

--- a/test/conformance/xfail_fortfront_lf.txt
+++ b/test/conformance/xfail_fortfront_lf.txt
@@ -12,7 +12,6 @@ boolean_assign_bare_false.lf # owner=lazy-fortran/ffc#447; reason=centralize typ
 boolean_assign_bare_true.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 debug_mixed_constructs.lf # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
 docs_unsigned_integers.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
-error_missing_then.lf # scope=harness; reason=FortFront Lazy parser rejection fixture
 implicit_do_print.lf # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 intrinsic_functions.lf # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
 issue_1330_missing_declarations.lf # owner=lazy-fortran/ffc#438; reason=apply Lazy Fortran default type and intent policy

--- a/test/test_fortfront_corpus_conformance.f90
+++ b/test/test_fortfront_corpus_conformance.f90
@@ -26,7 +26,7 @@ program test_fortfront_corpus_conformance
 
     failed = 0
     call verify_xpass_rejection(failed)
-    call run_suite('fortfront-f90', F90_REPORT, F90_LOG, 442, failed)
+    call run_suite('fortfront-f90', F90_REPORT, F90_LOG, 517, failed)
     call run_suite('fortfront-lf', LF_REPORT, LF_LOG, 264, failed)
 
     ! Keep the scratch directory when something failed: it holds the logs.

--- a/test/test_session_dummy_procedure_call_reject_compiler.f90
+++ b/test/test_session_dummy_procedure_call_reject_compiler.f90
@@ -1,0 +1,70 @@
+program test_session_dummy_procedure_call_reject
+    ! Calling a dummy procedure declared by an interface block inside a
+    ! contained scope has no body in the lowering unit (#576). Calls that pass
+    ! actual arguments already diagnose this; an argument-less call skipped the
+    ! check and emitted a reference to a nested-procedure symbol nothing ever
+    ! defines, so the linked program died at load time with
+    ! "undefined symbol: .ffc.nested.<n>.<m>.proc" (exit 127).
+    ! The compiler must reject such a call instead of emitting a dangling
+    ! reference.
+    use ffc_test_support, only: expect_error_contains
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== dummy procedure call rejection test ==='
+
+    all_passed = .true.
+    if (.not. test_argument_less_function_call_rejected()) all_passed = .false.
+    if (.not. test_uncalled_host_still_rejected()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: argument-less dummy procedure calls are diagnosed'
+
+contains
+
+    logical function test_argument_less_function_call_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  print *, 1'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  function g(proc) result(res)'//new_line('a')// &
+            '    integer :: res'//new_line('a')// &
+            '    interface'//new_line('a')// &
+            '      function proc()'//new_line('a')// &
+            '        integer :: proc'//new_line('a')// &
+            '      end function proc'//new_line('a')// &
+            '    end interface'//new_line('a')// &
+            '    res = proc()'//new_line('a')// &
+            '  end function g'//new_line('a')// &
+            'end program main'
+
+        test_argument_less_function_call_rejected = expect_error_contains( &
+            source, 'procedure body unavailable for call to proc', &
+            '/tmp/ffc_dummy_proc_argless')
+    end function test_argument_less_function_call_rejected
+
+    logical function test_uncalled_host_still_rejected()
+        ! The corpus shape (pure_formal_proc_3_valid.f90): the host functions
+        ! are never called, yet the dangling symbol still killed the program.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  pure function f(proc) result(res)'//new_line('a')// &
+            '    integer :: res'//new_line('a')// &
+            '    interface'//new_line('a')// &
+            '      pure function proc()'//new_line('a')// &
+            '        integer :: proc'//new_line('a')// &
+            '      end function proc'//new_line('a')// &
+            '    end interface'//new_line('a')// &
+            '    res = proc()'//new_line('a')// &
+            '  end function f'//new_line('a')// &
+            'end program main'
+
+        test_uncalled_host_still_rejected = expect_error_contains( &
+            source, 'procedure body unavailable for call to proc', &
+            '/tmp/ffc_dummy_proc_uncalled')
+    end function test_uncalled_host_still_rejected
+
+end program test_session_dummy_procedure_call_reject

--- a/test/test_session_random_number_compiler.f90
+++ b/test/test_session_random_number_compiler.f90
@@ -1,0 +1,82 @@
+program test_session_random_number
+    ! RANDOM_NUMBER intrinsic subroutine (#576). Before this support existed,
+    ! `call random_number(x)` lowered to a call to an undeclared external
+    ! symbol: the program linked and then died at load time with
+    ! "undefined symbol: random_number" (exit 127). The value is
+    ! nondeterministic, so the oracles are observable invariants: the draw
+    ! lies in [0,1), successive draws differ, and the argument round-trips.
+    use ffc_test_support, only: expect_output, expect_exit_status
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session random_number compiler test ==='
+
+    all_passed = .true.
+    if (.not. test_draw_in_unit_interval()) all_passed = .false.
+    if (.not. test_successive_draws_differ()) all_passed = .false.
+    if (.not. test_corpus_shape_runs()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: random_number lowers through LIRIC and runs'
+
+contains
+
+    logical function test_draw_in_unit_interval()
+        ! 0 <= x < 1 for every draw. The guards are separate tests because
+        ! .and. does not short-circuit and both operands are always valid here
+        ! only by accident; keeping them nested states the intent.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  real :: x'//new_line('a')// &
+            '  call random_number(x)'//new_line('a')// &
+            '  if (x < 0.0) then'//new_line('a')// &
+            '    print *, "LOW"'//new_line('a')// &
+            '  else if (x >= 1.0) then'//new_line('a')// &
+            '    print *, "HIGH"'//new_line('a')// &
+            '  else'//new_line('a')// &
+            '    print *, "INRANGE"'//new_line('a')// &
+            '  end if'//new_line('a')// &
+            'end program main'
+
+        test_draw_in_unit_interval = expect_output( &
+            source, ' INRANGE'//new_line('a'), '/tmp/ffc_random_number_range')
+    end function test_draw_in_unit_interval
+
+    logical function test_successive_draws_differ()
+        ! A constant would satisfy the range test; two draws must not be equal.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  real :: a, b'//new_line('a')// &
+            '  call random_number(a)'//new_line('a')// &
+            '  call random_number(b)'//new_line('a')// &
+            '  if (a == b) then'//new_line('a')// &
+            '    print *, "SAME"'//new_line('a')// &
+            '  else'//new_line('a')// &
+            '    print *, "DIFFER"'//new_line('a')// &
+            '  end if'//new_line('a')// &
+            'end program main'
+
+        test_successive_draws_differ = expect_output( &
+            source, ' DIFFER'//new_line('a'), '/tmp/ffc_random_number_differ')
+    end function test_successive_draws_differ
+
+    logical function test_corpus_shape_runs()
+        ! The shape of do_concurrent_3_valid.f90: the drawn value feeds a
+        ! DO CONCURRENT body and is printed. It must run, not exit 127.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  real :: array(4), val'//new_line('a')// &
+            '  call random_number(val)'//new_line('a')// &
+            '  do concurrent(i=1:4)'//new_line('a')// &
+            '    array(i) = val*real(i)'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            '  print *, array(1)'//new_line('a')// &
+            'end program main'
+
+        test_corpus_shape_runs = expect_exit_status( &
+            source, 0, '/tmp/ffc_random_number_corpus')
+    end function test_corpus_shape_runs
+
+end program test_session_random_number


### PR DESCRIPTION
Closes part of #576.

## Enumeration (unmodified main, full corpus)

fortfront-f90 `FAIL=9 XPASS=2`, fortfront-lf `FAIL=1` — 12 cases.

**Wrong code (program links, then dies at load — exit 127).** These are what
#576 forbids absorbing into a manifest:

| case | symptom |
|---|---|
| `do_concurrent_3_valid.f90` | `undefined symbol: random_number` |
| `pure_formal_proc_3_valid.f90` | `undefined symbol: .ffc.nested.15.9.proc` |

**Harness/manifest untruths.**

| case | symptom |
|---|---|
| `error_complete_garbage.lf` | correct ffc rejection scored FAIL |
| `issue_1744_operator_interface.f90` | XPASS |
| `issue_2820_c_interop_pointers.f90` | XPASS |

**Compile-time diagnostics (unimplemented features, not wrong code):**
`class_is_1_ok`, `type_is_1_ok`, `elemental_pointer_1_valid`,
`issue_2950_procedure_actual_argument`, `pr19936_3_ok`, `pr91715_ok`,
`submodule_module_prefix_valid`. Not touched here, not xfailed — follow-up
issue filed.

## Preserved compiler invariant

**ffc never emits a reference to a symbol nothing defines.** A construct it
cannot lower is diagnosed at compile time; it is never lowered into a binary
that links and then fails at load.

- `RANDOM_NUMBER(x)` is now lowered like CPU_TIME/SYSTEM_CLOCK, through glibc
  `random()` scaled into [0,1). The scale is the f32 value just below 2**-31 so
  no draw rounds up to exactly 1.0 (F2018 16.9.154).
- The "procedure body unavailable" check lived inside `prepare_reference_args`.
  Argument-less call sites skipped it by allocating an empty argument list
  directly, so a call to a dummy procedure declared by an interface block in a
  contained scope emitted a dangling `.ffc.nested.*` reference. All those sites
  now call `prepare_reference_args` with a zero-size actual list
  (`NO_ACTUAL_ARGS`): one path, one diagnostic, whether or not arguments are
  present. The `allocate (args(0))` shortcut is retired at those sites.
- fortfront-lf `error_*` examples are parser-rejection fixtures; the harness now
  treats them as negative tests (rejection = PASS, acceptance = FAIL), matching
  the gfortran-dg `dg-error` handling. The stale `error_missing_then.lf` xfail
  entry is removed.

## Red evidence (before)

```
test_session_random_number_compiler  FAIL
  /tmp/ffc_random_number_range: symbol lookup error: undefined symbol: random_number
test_session_dummy_procedure_call_reject_compiler  FAIL
  FAIL: unsupported source lowered without diagnostic
```

## Green evidence (after)

```
test_session_random_number_compiler                 PASS
test_session_dummy_procedure_call_reject_compiler   PASS

fortfront-f90: PASS=415 XFAIL=94 XPASS=0 FAIL=8  TOTAL=517   (was PASS=411 XPASS=2 FAIL=9)
fortfront-lf:  PASS=209 XFAIL=55 XPASS=0 FAIL=0  TOTAL=264   (was FAIL=1)
```

No corpus case regressed from PASS. Full `fo` pipeline: only the two known
environmental failures remain — `test_parity_dashboard` (resolves `../fortfront`
outside `.wt/` worktrees) and `test_fortfront_corpus_conformance`, which stays
red for the seven remaining feature gaps listed above.

Both XPASS promotions were confirmed on three consecutive runs (ffc #599).