### PR TITLE
[proc-elemental-01] lower multi-argument elemental procedures through array expressions (closes #405)

### DIFF
--- a/src/session_program_lowering_functions.inc
+++ b/src/session_program_lowering_functions.inc
@@ -2074,6 +2074,91 @@
             contained_function_kind(context, name) == VALUE_ARRAY_RESULT
     end function is_contained_array_function
 
+    ! Signature facts a contained procedure must satisfy before an elemental
+    ! call over array actuals may be expanded element-by-element (#405):
+    ! how many dummies it takes, whether its prefix says ELEMENTAL, and
+    ! whether every dummy is declared INTENT(IN) as F2018 15.8.1 requires of
+    ! an elemental function. found stays .false. when the procedure is not a
+    ! contained function visible in the arena.
+    subroutine contained_elemental_signature(arena, name, found, param_count, &
+                                             is_elemental, all_intent_in, &
+                                             bad_dummy)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        logical, intent(out) :: found
+        integer, intent(out) :: param_count
+        logical, intent(out) :: is_elemental
+        logical, intent(out) :: all_intent_in
+        character(len=:), allocatable, intent(out) :: bad_dummy
+        character(len=:), allocatable :: dummy_name, err
+        integer :: i, p
+
+        found = .false.
+        param_count = 0
+        is_elemental = .false.
+        all_intent_in = .true.
+        bad_dummy = ''
+        do i = 1, arena%size
+            if (.not. allocated(arena%entries(i)%node)) cycle
+            select type (fn => arena%entries(i)%node)
+            type is (function_def_node)
+                if (.not. allocated(fn%name)) cycle
+                if (.not. same_name(fn%name, name)) cycle
+                found = .true.
+                if (allocated(fn%param_indices)) param_count = size(fn%param_indices)
+                if (allocated(fn%prefix_keywords)) then
+                    do p = 1, size(fn%prefix_keywords)
+                        if (same_name(trim(fn%prefix_keywords(p)), 'elemental')) &
+                            is_elemental = .true.
+                    end do
+                end if
+                if (.not. allocated(fn%param_indices)) return
+                if (.not. allocated(fn%body_indices)) return
+                do p = 1, size(fn%param_indices)
+                    call parameter_name(arena, fn%param_indices(p), dummy_name, err)
+                    if (len_trim(err) > 0) cycle
+                    if (dummy_is_intent_in(arena, fn%body_indices, dummy_name)) cycle
+                    all_intent_in = .false.
+                    if (len_trim(bad_dummy) == 0) bad_dummy = trim(dummy_name)
+                end do
+                return
+            end select
+        end do
+    end subroutine contained_elemental_signature
+
+    ! True when dummy_name is declared INTENT(IN) among the body declarations.
+    logical function dummy_is_intent_in(arena, body_indices, dummy_name) &
+        result(is_in)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: dummy_name
+        integer :: i, k
+        logical :: matches
+
+        is_in = .false.
+        do i = 1, size(body_indices)
+            if (.not. node_exists(arena, body_indices(i))) cycle
+            select type (decl => arena%entries(body_indices(i))%node)
+            type is (declaration_node)
+                matches = .false.
+                if (allocated(decl%var_name)) then
+                    if (same_name(trim(decl%var_name), dummy_name)) matches = .true.
+                end if
+                if (decl%is_multi_declaration .and. allocated(decl%var_names)) then
+                    do k = 1, size(decl%var_names)
+                        if (same_name(trim(decl%var_names(k)), dummy_name)) &
+                            matches = .true.
+                    end do
+                end if
+                if (.not. matches) cycle
+                if (.not. decl%has_intent) return
+                if (.not. allocated(decl%intent)) return
+                is_in = trim(lowercase_text(decl%intent)) == 'in'
+                return
+            end select
+        end do
+    end function dummy_is_intent_in
+
     subroutine contained_array_result_info(arena, context, name, element_kind, &
                                            array_size, error_msg)
         ! Element scalar kind and total element count of a rank-1 array function

--- a/src/session_program_lowering_where.inc
+++ b/src/session_program_lowering_where.inc
@@ -574,12 +574,63 @@
             if (n%is_array_access) return
             if (.not. allocated(n%name)) return
             if (.not. allocated(n%arg_indices)) return
-            if (size(n%arg_indices) /= 1) return
+            if (size(n%arg_indices) < 1) return
             is_call = is_contained_f32_function(context, n%name) .or. &
                       is_contained_f64_function(context, n%name) .or. &
                       is_contained_i32_function(context, n%name)
+            if (.not. is_call) return
+            ! One dummy keeps the historical path (a contained scalar function
+            ! applied element-wise). More than one dummy is only elementwise
+            ! when the callee really is ELEMENTAL (#405).
+            if (size(n%arg_indices) > 1) &
+                is_call = elemental_multi_arg_callee(arena, n%name, &
+                                                     size(n%arg_indices))
         end select
     end function is_elemental_user_call
+
+    ! True when callee_name is a contained ELEMENTAL function taking exactly
+    ! nargs dummies. Arity mismatches decline so the ordinary call path (and
+    ! its diagnostics) stays in charge.
+    logical function elemental_multi_arg_callee(arena, callee_name, nargs) &
+        result(ok)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: callee_name
+        integer, intent(in) :: nargs
+        character(len=:), allocatable :: bad_dummy
+        integer :: param_count
+        logical :: found, is_elemental, all_intent_in
+
+        ok = .false.
+        call contained_elemental_signature(arena, callee_name, found, &
+                                           param_count, is_elemental, &
+                                           all_intent_in, bad_dummy)
+        if (.not. found) return
+        if (.not. is_elemental) return
+        ok = param_count == nargs
+    end function elemental_multi_arg_callee
+
+    ! Reject an elemental call whose dummies violate the elemental
+    ! restrictions: every dummy of an elemental function must be INTENT(IN)
+    ! (F2018 15.8.1).
+    subroutine check_elemental_dummy_attributes(arena, callee_name, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: callee_name
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: bad_dummy
+        integer :: param_count
+        logical :: found, is_elemental, all_intent_in
+
+        call set_empty(error_msg)
+        call contained_elemental_signature(arena, callee_name, found, &
+                                           param_count, is_elemental, &
+                                           all_intent_in, bad_dummy)
+        if (.not. found) return
+        if (.not. is_elemental) return
+        if (all_intent_in) return
+        error_msg = 'elemental procedure "'//trim(callee_name)// &
+                    '" requires INTENT(IN) for every dummy argument, but "'// &
+                    trim(bad_dummy)//'" is not INTENT(IN)'
+    end subroutine check_elemental_dummy_attributes
 
     ! Apply a user-defined elemental real function to one array element: load the
     ! argument's element, materialise it as a by-reference scalar (the contained
@@ -594,29 +645,37 @@
         type(lowering_context_t), intent(inout) :: context
         type(lr_operand_desc_t), intent(out) :: value
         character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: elem, arg(1)
-        integer :: vk
+        type(lr_operand_desc_t) :: elem
+        type(lr_operand_desc_t), allocatable :: arg(:)
+        integer :: vk, i
         logical :: derived_actual
 
         call set_empty(error_msg)
         select type (n => arena%entries(node_index)%node)
         type is (call_or_subscript_node)
             vk = context%symbols(target_symbol_index)%value_kind
-            ! A derived or polymorphic actual is passed by reference at its own
-            ! element stride, not loaded as a target-kind scalar (#369).
-            call elementwise_derived_actual_address(arena, n%arg_indices(1), &
-                                                    n%name, linear_index, context, &
-                                                    arg(1), derived_actual, error_msg)
+            call check_elemental_dummy_attributes(arena, n%name, error_msg)
             if (len_trim(error_msg) > 0) return
-            if (.not. derived_actual) then
-                call lower_array_elementwise_value(arena, n%arg_indices(1), &
+            allocate (arg(size(n%arg_indices)))
+            do i = 1, size(n%arg_indices)
+                ! A derived or polymorphic actual is passed by reference at its
+                ! own element stride, not loaded as a target-kind scalar (#369).
+                call elementwise_derived_actual_address(arena, n%arg_indices(i), &
+                                                        n%name, linear_index, &
+                                                        context, arg(i), &
+                                                        derived_actual, error_msg)
+                if (len_trim(error_msg) > 0) return
+                if (derived_actual) cycle
+                ! Array actuals contribute their own element; scalar actuals
+                ! broadcast (both handled by the shared element iterator).
+                call lower_array_elementwise_value(arena, n%arg_indices(i), &
                                                    target_symbol_index, &
                                                    linear_index, context, elem, &
                                                    error_msg)
                 if (len_trim(error_msg) > 0) return
-                call make_reference_argument(context, vk, elem, arg(1), error_msg)
+                call make_reference_argument(context, vk, elem, arg(i), error_msg)
                 if (len_trim(error_msg) > 0) return
-            end if
+            end do
             select case (vk)
             case (VALUE_F32)
                 if (.not. emit_liric_f32_call(context%session, &

--- a/test/test_session_elemental_procedure_compiler.f90
+++ b/test/test_session_elemental_procedure_compiler.f90
@@ -1,0 +1,203 @@
+program test_session_elemental_procedure_compiler
+    ! Verify that a user-defined ELEMENTAL function with more than one dummy
+    ! lowers through the shared array-expression iterator: array-array and
+    ! array-scalar actuals produce one scalar call per result element, and the
+    ! printed arrays match gfortran byte-for-byte (#405). Also verify the
+    ! negative controls: nonconformable actuals and an elemental dummy that is
+    ! not INTENT(IN) are rejected with a source diagnostic.
+    use session_program_lowering, only: lower_program_to_liric_exe
+    use fortfront_compiler, only: compiler_frontend_options_t, &
+        compiler_frontend_result_t, &
+        compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session elemental procedure test ==='
+
+    all_passed = .true.
+
+    ! Integer elemental function with array-array and array-scalar actuals.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  implicit none'//new_line('a')// &
+        '  integer :: a(3), b(3), c(3)'//new_line('a')// &
+        '  a = [1, 2, 3]'//new_line('a')// &
+        '  b = [10, 20, 30]'//new_line('a')// &
+        '  c = iadd(a, b)'//new_line('a')// &
+        '  print *, c'//new_line('a')// &
+        '  c = iadd(a, 5)'//new_line('a')// &
+        '  print *, c'//new_line('a')// &
+        '  c = iadd(7, b)'//new_line('a')// &
+        '  print *, c'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  elemental integer function iadd(u, v)'//new_line('a')// &
+        '    integer, intent(in) :: u, v'//new_line('a')// &
+        '    iadd = u + v'//new_line('a')// &
+        '  end function iadd'//new_line('a')// &
+        'end program main', &
+        'integer')) all_passed = .false.
+
+    ! Real elemental function, array-array and array-scalar actuals.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  implicit none'//new_line('a')// &
+        '  real :: x(4), y(4), z(4)'//new_line('a')// &
+        '  x = [1.0, 2.0, 3.0, 4.0]'//new_line('a')// &
+        '  y = [0.5, 1.5, 2.5, 3.5]'//new_line('a')// &
+        '  z = blend(x, y)'//new_line('a')// &
+        '  print *, z'//new_line('a')// &
+        '  z = blend(x, 2.0)'//new_line('a')// &
+        '  print *, z'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  elemental real function blend(u, v)'//new_line('a')// &
+        '    real, intent(in) :: u, v'//new_line('a')// &
+        '    blend = u * v + u'//new_line('a')// &
+        '  end function blend'//new_line('a')// &
+        'end program main', &
+        'real')) all_passed = .false.
+
+    ! Three dummies, mixing array and scalar actuals inside an expression.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  implicit none'//new_line('a')// &
+        '  integer :: a(3), b(3), c(3)'//new_line('a')// &
+        '  a = [1, 2, 3]'//new_line('a')// &
+        '  b = [4, 5, 6]'//new_line('a')// &
+        '  c = combine(a, b, 2) + 1'//new_line('a')// &
+        '  print *, c'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  elemental integer function combine(u, v, w)'//new_line('a')// &
+        '    integer, intent(in) :: u, v, w'//new_line('a')// &
+        '    combine = u * w + v'//new_line('a')// &
+        '  end function combine'//new_line('a')// &
+        'end program main', &
+        'three')) all_passed = .false.
+
+    ! Negative: nonconformable array actuals must be diagnosed.
+    if (.not. rejects( &
+        'program main'//new_line('a')// &
+        '  implicit none'//new_line('a')// &
+        '  integer :: a(3), d(4), c(3)'//new_line('a')// &
+        '  a = 1'//new_line('a')// &
+        '  d = 2'//new_line('a')// &
+        '  c = iadd(a, d)'//new_line('a')// &
+        '  print *, c'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  elemental integer function iadd(u, v)'//new_line('a')// &
+        '    integer, intent(in) :: u, v'//new_line('a')// &
+        '    iadd = u + v'//new_line('a')// &
+        '  end function iadd'//new_line('a')// &
+        'end program main', &
+        'shape')) all_passed = .false.
+
+    ! Negative: an elemental dummy that is not INTENT(IN) must be diagnosed.
+    if (.not. rejects( &
+        'program main'//new_line('a')// &
+        '  implicit none'//new_line('a')// &
+        '  integer :: a(3), b(3), c(3)'//new_line('a')// &
+        '  a = 1'//new_line('a')// &
+        '  b = 2'//new_line('a')// &
+        '  c = ibad(a, b)'//new_line('a')// &
+        '  print *, c'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  elemental integer function ibad(u, v)'//new_line('a')// &
+        '    integer, intent(in) :: u'//new_line('a')// &
+        '    integer, intent(inout) :: v'//new_line('a')// &
+        '    ibad = u + v'//new_line('a')// &
+        '  end function ibad'//new_line('a')// &
+        'end program main', &
+        'intent')) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: multi-argument elemental procedures lower through the '// &
+        'array-expression iterator'
+
+contains
+
+    logical function rejects(source, stem)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: stem
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: frontend_result
+        character(len=:), allocatable :: error_msg
+
+        rejects = .false.
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        call compile_frontend_from_string(source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            rejects = .true.
+            return
+        end if
+        call lower_program_to_liric_exe(frontend_result%arena, &
+            frontend_result%root_index, '/tmp/ffc_elemproc_'//stem, error_msg)
+        if (len_trim(error_msg) == 0) then
+            print *, 'FAIL[', trim(stem), ']: invalid elemental call was '// &
+                'accepted without a diagnostic'
+            return
+        end if
+        rejects = .true.
+    end function rejects
+
+    logical function matches_gfortran(source, stem)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: stem
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: frontend_result
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: base, src, exe, ref, ffc_out, ref_out
+        integer :: unit, exit_stat, status
+
+        matches_gfortran = .false.
+        base = '/tmp/ffc_elemproc_'//trim(stem)
+        src = base//'.f90'
+        exe = base//'.ffc'
+        ref = base//'.gf'
+        ffc_out = base//'.ffc.out'
+        ref_out = base//'.gf.out'
+
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        call compile_frontend_from_string(source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            print *, 'FAIL[', trim(stem), ']: FortFront rejected source: ', &
+                trim(frontend_result%diagnostic_text)
+            return
+        end if
+
+        call lower_program_to_liric_exe(frontend_result%arena, &
+            frontend_result%root_index, exe, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL[', trim(stem), ']: ffc lowering failed: ', trim(error_msg)
+            return
+        end if
+
+        open (newunit=unit, file=src, status='replace', action='write')
+        write (unit, '(A)') source
+        close (unit)
+        call execute_command_line('gfortran -w '//src//' -o '//ref, &
+            exitstat=exit_stat)
+        if (exit_stat /= 0) then
+            print *, 'FAIL[', trim(stem), ']: gfortran rejected source'
+            return
+        end if
+
+        call execute_command_line(exe//' > '//ffc_out//' 2>&1', exitstat=exit_stat)
+        call execute_command_line(ref//' > '//ref_out//' 2>&1', exitstat=exit_stat)
+        call execute_command_line('diff '//ffc_out//' '//ref_out// &
+            ' > /dev/null 2>&1', exitstat=status)
+        if (status /= 0) then
+            print *, 'FAIL[', trim(stem), ']: ffc output differs from gfortran'
+            call execute_command_line('diff '//ffc_out//' '//ref_out)
+            return
+        end if
+        call execute_command_line('rm -f '//src//' '//exe//' '//ref// &
+            ' '//ffc_out//' '//ref_out)
+        matches_gfortran = .true.
+    end function matches_gfortran
+
+end program test_session_elemental_procedure_compiler


### PR DESCRIPTION
Closes #405.

## What changed

- `src/session_program_lowering_where.inc`: the whole-array elemental user-call
  path now handles any number of dummies. Each actual is lowered through the
  shared array-expression iterator, so array actuals contribute their own
  element and scalar actuals broadcast; one scalar call is emitted per result
  index. A call with more than one actual is only treated as elementwise when
  the contained callee actually carries the `ELEMENTAL` prefix and its arity
  matches the actual count (`elemental_multi_arg_callee`), so ordinary
  multi-argument calls keep their existing lowering path unchanged.
- New `check_elemental_dummy_attributes` rejects an elemental call whose dummy
  is not `INTENT(IN)` (F2018 15.8.1).
- `src/session_program_lowering_functions.inc`: new
  `contained_elemental_signature` / `dummy_is_intent_in` queries (dummy count,
  ELEMENTAL prefix, per-dummy intent) read from the contained procedure's own
  declarations.
- New `test/test_session_elemental_procedure_compiler.f90`: behavioral oracle -
  compiles and runs each program and diffs stdout against gfortran, plus two
  negative controls.

## Preserved compiler invariant

Single-dummy elemental lowering, derived/class actual handling (#369), and all
non-elemental call lowering are untouched: the new multi-argument path is only
entered for a contained ELEMENTAL function whose arity matches, and every
argument still goes through the one canonical element iterator
(`lower_array_elementwise_value`) - no forked lowering path was added.

## Red evidence (unmodified main)

```
$ ffc t1.f90 -o t1
t1.f90:7:18: error: unsupported whole-array expression: whole-array assignment
requires array operands and +, -, or *
```
for `c = iadd(a, b)` with `elemental integer function iadd(u, v)`.

## Green evidence

```
$ fo test test_session_elemental_procedure_compiler
test_session_elemental_procedure_compiler  PASS  0.27s
```
Program output now matches gfortran byte-for-byte (11 22 33 / 6 7 8 / real cases).
Negative controls diagnose:
- `whole-array assignment requires conforming shapes: c and d differ in extent`
- `elemental procedure "ibad" requires INTENT(IN) for every dummy argument, but "v" is not INTENT(IN)`

Full `fo` pipeline: Build OK, all tests green except the two known
environment-bound ones, both of which fail identically on an unmodified
`origin/main` worktree built and run side by side:
`test_parity_dashboard` (resolves `../fortfront` outside `.wt/`) and
`test_fortfront_corpus_conformance` (same 9 fortfront-f90 FAILs, same 1
fortfront-lf FAIL, same 2 XPASS on main; my branch shows PASS 412 vs 411 on
main, i.e. one case improved, none regressed).