### PR TITLE
[bom-include-01] decode a byte order mark at each include boundary

### DIFF
--- a/src/ffc_include_expansion.f90
+++ b/src/ffc_include_expansion.f90
@@ -7,6 +7,15 @@ module ffc_include_expansion
     ! place. The including file's own directory is searched first, then the
     ! user's -I directories. Include cycles and missing files are reported with
     ! the include site so the diagnostic still points at real source.
+    !
+    ! A byte order mark is only meaningful at the very start of a file, so an
+    ! included file's leading BOM is decoded away as its contents are spliced
+    ! in; leaving it would place a BOM mid-source, where it is not a BOM at all
+    ! but an invalid source character. The outermost file's own BOM is left
+    ! alone: it still starts the text the frontend decodes. Decoding reuses the
+    ! frontend's decoder, so ffc and the frontend recognize exactly the same
+    ! set of marks.
+    use source_bom, only: decode_source_bom
     implicit none
     private
 
@@ -45,6 +54,7 @@ contains
         character(len=:), allocatable, intent(out) :: source
         character(len=:), allocatable, intent(inout) :: error_msg
         character(len=:), allocatable :: text
+        character(len=:), allocatable :: decoded
         character(len=:), allocatable :: line
         character(len=:), allocatable :: name
         character(len=:), allocatable :: resolved
@@ -53,6 +63,13 @@ contains
 
         call read_whole_file(path, text)
         if (.not. allocated(text)) return
+        ! depth 0 is the file being compiled, whose leading BOM belongs to the
+        ! source the frontend decodes. Any deeper file is being spliced into
+        ! the middle of that source, so its own mark is decoded away here.
+        if (depth > 0) then
+            call decode_source_bom(text, decoded)
+            call move_alloc(decoded, text)
+        end if
         if (depth >= MAX_INCLUDE_DEPTH) then
             error_msg = 'include nesting too deep at '//trim(path)
             return

--- a/test/test_session_include_compiler.f90
+++ b/test/test_session_include_compiler.f90
@@ -15,6 +15,11 @@ program test_session_include_compiler
     if (.not. check_nested_include()) ok = .false.
     if (.not. check_missing_include()) ok = .false.
     if (.not. check_include_cycle()) ok = .false.
+    if (.not. check_bom_in_included_file()) ok = .false.
+    if (.not. check_bom_in_including_file()) ok = .false.
+    if (.not. check_bom_in_both_files()) ok = .false.
+    if (.not. check_interior_bom_still_rejected()) ok = .false.
+    if (.not. check_utf16le_included_file()) ok = .false.
     if (.not. ok) stop 1
 
     print *, 'PASS: include lines expand and report missing files and cycles'
@@ -179,6 +184,151 @@ contains
     subroutine reset_work()
         call execute_command_line('rm -rf '//WORK//' && mkdir -p '//WORK)
     end subroutine reset_work
+
+    logical function check_bom_in_included_file() result(ok)
+        ! A byte order mark is only meaningful at the start of a file. An
+        ! included file's BOM must not be spliced into the middle of the
+        ! expanded source, where it would be an invalid source character
+        ! (gfortran.dg/bom_include.f90).
+        character(len=:), allocatable :: output
+
+        ok = .false.
+        call reset_work()
+        call write_file(WORK//'/value.inc', &
+                        utf8_bom()//'integer, parameter :: v = 42')
+        call write_file(WORK//'/main.f90', &
+                        'program main'//new_line('a')// &
+                        'implicit none'//new_line('a')// &
+                        "include 'value.inc'"//new_line('a')// &
+                        "print '(I0)', v"//new_line('a')// &
+                        'end program main')
+        if (.not. compile_ok(WORK//'/main.f90', '')) return
+        call run_exe(output)
+        if (first_line(output) /= '42') then
+            print *, 'FAIL: BOM-prefixed include output was ', &
+                first_line(output)
+            return
+        end if
+        ok = .true.
+    end function check_bom_in_included_file
+
+    logical function check_bom_in_including_file() result(ok)
+        ! The outermost file keeps its own BOM: it is at the start of the
+        ! source the frontend decodes, so it stays valid.
+        character(len=:), allocatable :: output
+
+        ok = .false.
+        call reset_work()
+        call write_file(WORK//'/value.inc', 'integer, parameter :: v = 42')
+        call write_file(WORK//'/main.f90', &
+                        utf8_bom()//'program main'//new_line('a')// &
+                        'implicit none'//new_line('a')// &
+                        "include 'value.inc'"//new_line('a')// &
+                        "print '(I0)', v"//new_line('a')// &
+                        'end program main')
+        if (.not. compile_ok(WORK//'/main.f90', '')) return
+        call run_exe(output)
+        if (first_line(output) /= '42') then
+            print *, 'FAIL: BOM-prefixed includer output was ', &
+                first_line(output)
+            return
+        end if
+        ok = .true.
+    end function check_bom_in_including_file
+
+    logical function check_bom_in_both_files() result(ok)
+        ! Both ends carrying a BOM is the combination of the two cases above.
+        character(len=:), allocatable :: output
+
+        ok = .false.
+        call reset_work()
+        call write_file(WORK//'/value.inc', &
+                        utf8_bom()//'integer, parameter :: v = 42')
+        call write_file(WORK//'/main.f90', &
+                        utf8_bom()//'program main'//new_line('a')// &
+                        'implicit none'//new_line('a')// &
+                        "include 'value.inc'"//new_line('a')// &
+                        "print '(I0)', v"//new_line('a')// &
+                        'end program main')
+        if (.not. compile_ok(WORK//'/main.f90', '')) return
+        call run_exe(output)
+        if (first_line(output) /= '42') then
+            print *, 'FAIL: BOM at both ends produced ', first_line(output)
+            return
+        end if
+        ok = .true.
+    end function check_bom_in_both_files
+
+    logical function check_interior_bom_still_rejected() result(ok)
+        ! Only a BOM at a file boundary is removed. One sitting in the middle
+        ! of a file is not a byte order mark at all, and stays an invalid
+        ! source character (gfortran.dg/bom_error.f90).
+        ok = .false.
+        call reset_work()
+        call write_file(WORK//'/value.inc', 'integer, parameter :: v = 42')
+        call write_file(WORK//'/main.f90', &
+                        'program main'//new_line('a')// &
+                        'implicit none'//new_line('a')// &
+                        "include 'value.inc'"//new_line('a')// &
+                        utf8_bom()//"print '(I0)', v"//new_line('a')// &
+                        'end program main')
+        ok = compile_fails_with(WORK//'/main.f90', '', 'Invalid character')
+    end function check_interior_bom_still_rejected
+
+    function utf8_bom() result(bom)
+        character(len=3) :: bom
+
+        bom = achar(239)//achar(187)//achar(191)
+    end function utf8_bom
+
+    logical function check_utf16le_included_file() result(ok)
+        ! A UTF-16 BOM selects a wide encoding of the payload, so the included
+        ! file needs decoding and not merely stripping. The frontend's decoder
+        ! does both, which is why expansion calls it rather than matching bytes
+        ! itself.
+        character(len=:), allocatable :: output
+        character(len=*), parameter :: decl = 'integer, parameter :: v = 42'
+        character(len=:), allocatable :: wide
+        integer :: i
+
+        ok = .false.
+        call reset_work()
+        wide = achar(255)//achar(254)
+        do i = 1, len(decl)
+            wide = wide//decl(i:i)//achar(0)
+        end do
+        call write_bytes(WORK//'/value.inc', wide)
+        call write_file(WORK//'/main.f90', &
+                        'program main'//new_line('a')// &
+                        'implicit none'//new_line('a')// &
+                        "include 'value.inc'"//new_line('a')// &
+                        "print '(I0)', v"//new_line('a')// &
+                        'end program main')
+        if (.not. compile_ok(WORK//'/main.f90', '')) return
+        call run_exe(output)
+        if (first_line(output) /= '42') then
+            print *, 'FAIL: UTF-16LE include output was ', first_line(output)
+            return
+        end if
+        ok = .true.
+    end function check_utf16le_included_file
+
+    subroutine write_bytes(path, contents)
+        ! Writes exactly the given bytes, with no record terminator, so a
+        ! wide-encoded file keeps the byte count its decoder requires.
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: contents
+        integer :: unit, io_stat
+
+        open (newunit=unit, file=path, status='replace', action='write', &
+              access='stream', form='unformatted', iostat=io_stat)
+        if (io_stat /= 0) then
+            print *, 'FAIL: cannot write ', path
+            return
+        end if
+        write (unit) contents
+        close (unit)
+    end subroutine write_bytes
 
     subroutine write_file(path, contents)
         character(len=*), intent(in) :: path


### PR DESCRIPTION
Closes #597.

`gfortran.dg/bom_include.f90` failed with
`Invalid character 0xEF at line 2, column 1`. INCLUDE expansion spliced the
included file's bytes in verbatim, so a UTF-8 BOM at the start of
`bom_include.inc` landed in the middle of the expanded source. The lexer was
right to reject it: a BOM is only a BOM at the start of a file, and anywhere
else `0xEF` is just an invalid source character.

Expansion now decodes the mark at each include boundary. The outermost file is
left byte-identical, because its BOM still starts the text the frontend
decodes; every file spliced in below it (`depth > 0`) is decoded as it is read.

## One decoder, not two

The fix calls the frontend's `source_bom::decode_source_bom` rather than
matching BOM bytes in ffc. That matters beyond taste:

- ffc and the frontend now recognize exactly the same set of marks by
  construction, so the two cannot drift into disagreeing about what a BOM is.
- UTF-16 and UTF-32 marks do not merely need *stripping*, they select a wide
  encoding of the payload. Byte-matching a prefix would have silently spliced
  in undecoded wide text. The shared decoder handles the decode, which is why
  the UTF-16LE case in the test passes.

The existing line-level `strip_bom` stays. It does a different job — it lets a
BOM'd first line still be recognized as an INCLUDE line, and trims a trailing
carriage return — and it is not a second copy of the content path.

## Behaviour preserved

- **An interior BOM is still rejected.** Only a mark at a file boundary is
  decoded, so one sitting mid-file is untouched and remains an invalid source
  character. `bom_error.f90` is PASS (`negative test rejected`) before and
  after, and the new `check_interior_bom_still_rejected` case pins it directly:
  a BOM placed mid-file in the *includer* must still produce
  `Invalid character`.
- **Include resolution, cycles, depth limits and diagnostics.** Untouched. The
  decode happens after the read and before line splitting; every search path,
  cycle check, and error message is unchanged, and their cases still pass.
- **The outermost file.** Byte-identical to before, since the decode is gated
  on `depth > 0`. A file with no includes takes exactly the same path it did.

## Coverage

Four cases added to the maintained include test, the three the issue asks for
plus two the fix implies:

- BOM'd included file (the reported bug).
- BOM'd includer with a plain include.
- Both files BOM'd.
- BOM mid-file, which must still error.
- UTF-16LE included file, covering decode rather than strip.

Written first: on unmodified main exactly the two cases where the *included*
file carries a BOM fail, and the other cases already pass — which is the same
split the issue reports.

## Conformance gauntlet

Baseline is a separate worktree at the same `origin/main` commit with its own
`fo build`.

| Suite | main | branch |
|---|---|---|
| gfortran-dg | PASS=1327 XFAIL=2082 XPASS=48 FAIL=182 | PASS=1328 XFAIL=2082 XPASS=48 FAIL=181 |
| lfortran | PASS=865 XFAIL=3327 XPASS=78 FAIL=9 | PASS=865 XFAIL=3327 XPASS=78 FAIL=9 |
| fortfront-f90 | PASS=410 XFAIL=95 XPASS=2 FAIL=10 | PASS=410 XFAIL=95 XPASS=2 FAIL=10 |
| fortfront-lf | PASS=208 XFAIL=55 XPASS=0 FAIL=1 | PASS=208 XFAIL=55 XPASS=0 FAIL=1 |

Per-case in gfortran-dg exactly one case moved: `bom_include.f90` FAIL -> PASS.
No FAIL introduced, no case lost PASS, XPASS set identical. The other three
suites are byte-identical per case.

`bom_include.f90` compiles and prints `Hello world!` on five consecutive runs
(ffc#599 cautions that single-run corpus evidence is not enough). It is in no
xfail or fail-owners manifest, so there is no entry to remove.

`fo` is green apart from `test_parity_dashboard` and
`test_fortfront_corpus_conformance`, both of which fail identically on
unmodified `origin/main`.
