### PR TITLE
[pdt-01] instantiate parameterized derived types with constant kind and length parameters (closes #411)

### DIFF
--- a/src/session_program_lowering_derived_module_ops.inc
+++ b/src/session_program_lowering_derived_module_ops.inc
@@ -71,6 +71,18 @@
         call extracted_derived_type_name(node%type_name, type_name)
         if (len_trim(type_name) == 0) return
         type_index = find_derived_type(context, type_name)
+        if (type_index > 0) return
+        ! A parameterized type resolves to the concrete layout instantiated
+        ! for its actual type parameters (#411).
+        block
+            character(len=:), allocatable :: instance_name, pdt_error
+            logical :: is_pdt
+
+            call pdt_declaration_instance(context%arena, context, node, &
+                                          instance_name, is_pdt, pdt_error)
+            if (is_pdt .and. len_trim(pdt_error) == 0) &
+                type_index = find_derived_type(context, instance_name)
+        end block
     end function declaration_derived_type_index
 
     subroutine extracted_derived_type_name(type_spec, type_name)
@@ -217,6 +229,9 @@
             if (len_trim(error_msg) > 0) return
             if (len_trim(type_name) == 0) cycle
             if (.not. use_only_wants(use_node, trim(type_name))) cycle
+            ! A parameterized type has no layout of its own (#411): its
+            ! instances are registered per actual-parameter tuple instead.
+            if (find_pdt_template(context, type_name) > 0) cycle
             type_idx_in_context = find_derived_type(context, type_name)
             if (type_idx_in_context > 0) then
                 cycle

--- a/src/session_program_lowering_derived_types.inc
+++ b/src/session_program_lowering_derived_types.inc
@@ -564,23 +564,24 @@
     end subroutine emit_scope_exit_finalizers
 
     subroutine lower_derived_type_definition(node, context, error_msg)
+        ! Register a derived type definition. A parameterized type (#411)
+        ! carries no layout of its own: it registers as a template, and each
+        ! declaration that supplies constant actual parameters instantiates a
+        ! concrete layout under a mangled instance name.
         type(derived_type_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: type_index
 
+        call set_empty(error_msg)
         if (.not. allocated(node%name)) then
             error_msg = 'derived type definition did not expose a name'
             return
         end if
-
-        type_index = find_derived_type(context, node%name)
-        if (type_index > 0) then
-            call set_empty(error_msg)
+        if (derived_type_is_parameterized(node)) then
+            call record_pdt_template(context, trim(node%name))
             return
         end if
-
-        if (node%has_parameters .or. allocated(node%param_indices)) then
+        if (allocated(node%param_indices)) then
             call unsupported_feature_error('derived type parameters', &
                                            node%line, node%column, &
                                            'direct LIRIC session only supports '// &
@@ -588,10 +589,30 @@
                                            error_msg)
             return
         end if
+        call register_derived_type_layout(node, context, trim(node%name), &
+                                          error_msg)
+    end subroutine lower_derived_type_definition
+
+    subroutine register_derived_type_layout(node, context, layout_name, error_msg)
+        ! Record the concrete component layout of a derived type definition
+        ! under layout_name. For a plain type that is the type name; for a PDT
+        ! instance it is the mangled name carrying the actual parameters.
+        type(derived_type_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: layout_name
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: type_index
+
+        type_index = find_derived_type(context, layout_name)
+        if (type_index > 0) then
+            call set_empty(error_msg)
+            return
+        end if
+
         call grow_derived_types(context)
 
         type_index = context%derived_type_count + 1
-        context%derived_types(type_index)%name = trim(node%name)
+        context%derived_types(type_index)%name = trim(layout_name)
         context%derived_types(type_index)%binding_count = 0
         if (allocated(node%extends_parent)) then
             context%derived_types(type_index)%parent_name = trim(node%extends_parent)
@@ -620,7 +641,7 @@
 
         context%derived_type_count = type_index
         call set_empty(error_msg)
-    end subroutine lower_derived_type_definition
+    end subroutine register_derived_type_layout
 
     subroutine collect_type_bindings(node, context, type_index, error_msg)
         ! Record type-bound procedure bindings (procedure :: m => fn) as

--- a/src/session_program_lowering_pdt.inc
+++ b/src/session_program_lowering_pdt.inc
@@ -1,0 +1,320 @@
+    ! Parameterized derived types with constant integer KIND and LEN type
+    ! parameters (#411). A PDT definition has no layout of its own: it is
+    ! registered as a template, and every declaration that names it with
+    ! constant actual parameters instantiates one concrete derived type whose
+    ! components were laid out with the formals bound to those constants.
+    ! Instances are cached under the mangled name base(v1,v2,...), so two
+    ! declarations with the same actuals share one layout and two with
+    ! different actuals get distinct layouts.
+
+    logical function derived_type_is_parameterized(node) result(is_pdt)
+        type(derived_type_node), intent(in) :: node
+
+        is_pdt = .false.
+        if (.not. allocated(node%param_names)) return
+        is_pdt = size(node%param_names) > 0
+    end function derived_type_is_parameterized
+
+    subroutine record_pdt_template(context, name)
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: name
+        character(len=64), allocatable :: tmp(:)
+        integer :: slot
+
+        if (find_pdt_template(context, name) > 0) return
+        if (.not. allocated(context%pdt_template_names)) then
+            allocate (context%pdt_template_names(8))
+            context%pdt_template_names = ''
+        else if (context%pdt_template_count >= size(context%pdt_template_names)) then
+            call move_alloc(context%pdt_template_names, tmp)
+            allocate (context%pdt_template_names(2*size(tmp)))
+            context%pdt_template_names = ''
+            context%pdt_template_names(1:size(tmp)) = tmp
+        end if
+        slot = context%pdt_template_count + 1
+        context%pdt_template_names(slot) = trim(name)
+        context%pdt_template_count = slot
+    end subroutine record_pdt_template
+
+    integer function find_pdt_template(context, name) result(slot)
+        type(lowering_context_t), intent(in) :: context
+        character(len=*), intent(in) :: name
+        integer :: i
+
+        slot = 0
+        if (.not. allocated(context%pdt_template_names)) return
+        do i = 1, context%pdt_template_count
+            if (same_name(context%pdt_template_names(i), name)) then
+                slot = i
+                return
+            end if
+        end do
+    end function find_pdt_template
+
+    subroutine pdt_base_name(type_name, base)
+        ! Base type name of a derived-type spec inner text, i.e. box_t for
+        ! both "box_t" and "box_t(3, 8)".
+        character(len=*), intent(in) :: type_name
+        character(len=:), allocatable, intent(out) :: base
+        integer :: paren
+
+        paren = index(type_name, '(')
+        if (paren > 0) then
+            base = trim(adjustl(type_name(1:paren - 1)))
+        else
+            base = trim(adjustl(type_name))
+        end if
+    end subroutine pdt_base_name
+
+    subroutine pdt_instance_name(base, values, name)
+        ! Canonical instance name of a PDT with folded actual parameters.
+        character(len=*), intent(in) :: base
+        integer(c_int64_t), intent(in) :: values(:)
+        character(len=:), allocatable, intent(out) :: name
+        character(len=32) :: buffer
+        integer :: i
+
+        name = trim(base)//'('
+        do i = 1, size(values)
+            write (buffer, '(i0)') values(i)
+            if (i > 1) name = name//','
+            name = name//trim(buffer)
+        end do
+        name = name//')'
+    end subroutine pdt_instance_name
+
+    integer function pdt_template_node_index(arena, base) result(node_index)
+        ! Arena index of the PDT definition named base.
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: base
+        integer :: i
+
+        node_index = 0
+        do i = 1, arena%size
+            if (.not. node_exists(arena, i)) cycle
+            select type (node => arena%entries(i)%node)
+            type is (derived_type_node)
+                if (.not. allocated(node%name)) cycle
+                if (.not. same_name(node%name, base)) cycle
+                if (.not. derived_type_is_parameterized(node)) cycle
+                node_index = i
+                return
+            end select
+        end do
+    end function pdt_template_node_index
+
+    subroutine pdt_actual_values(arena, context, template_index, actuals, &
+                                 line, column, values, error_msg)
+        ! Fold the actual type parameters of one declaration to compile-time
+        ! integers, filling any omitted trailing parameter from its default.
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: template_index
+        integer, intent(in) :: actuals(:)
+        integer, intent(in) :: line, column
+        integer(c_int64_t), allocatable, intent(out) :: values(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: formal_count, i, source_index
+        character(len=:), allocatable :: fold_error
+
+        call set_empty(error_msg)
+        select type (template => arena%entries(template_index)%node)
+        type is (derived_type_node)
+            formal_count = size(template%param_names)
+            if (size(actuals) > formal_count) then
+                call unsupported_feature_error('derived type parameters', &
+                    line, column, 'too many actual type parameters for type "'// &
+                    trim(template%name)//'"', error_msg)
+                return
+            end if
+            allocate (values(formal_count))
+            values = 0_c_int64_t
+            do i = 1, formal_count
+                if (i <= size(actuals)) then
+                    source_index = actuals(i)
+                else
+                    source_index = template%param_defaults(i)
+                end if
+                if (source_index <= 0) then
+                    call unsupported_feature_error('derived type parameters', &
+                        line, column, 'type parameter "'// &
+                        trim(template%param_names(i)%s)//'" of type "'// &
+                        trim(template%name)//'" has no actual value and no '// &
+                        'default', error_msg)
+                    return
+                end if
+                call eval_i32_constant(arena, source_index, context, &
+                                       values(i), fold_error)
+                if (len_trim(fold_error) > 0) then
+                    call unsupported_feature_error('derived type parameters', &
+                        line, column, 'type parameter "'// &
+                        trim(template%param_names(i)%s)//'" of type "'// &
+                        trim(template%name)//'" must be a compile-time '// &
+                        'integer constant', error_msg)
+                    return
+                end if
+            end do
+        class default
+            error_msg = 'parameterized derived type template is not a type '// &
+                        'definition'
+        end select
+    end subroutine pdt_actual_values
+
+    subroutine pdt_declaration_instance(arena, context, node, instance_name, &
+                                        found, error_msg)
+        ! Instance name of the PDT a declaration names, e.g. box_t(3,4) for
+        ! `type(box_t(3, 4)) :: a`. found is false when the declaration does
+        ! not name a parameterized type.
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        type(declaration_node), intent(in) :: node
+        character(len=:), allocatable, intent(out) :: instance_name
+        logical, intent(out) :: found
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: spec_name, base
+        integer(c_int64_t), allocatable :: values(:)
+        integer :: template_index
+        integer, allocatable :: actuals(:)
+
+        found = .false.
+        instance_name = ''
+        call set_empty(error_msg)
+        if (.not. allocated(node%type_name)) return
+        call extracted_derived_type_name(node%type_name, spec_name)
+        if (len_trim(spec_name) == 0) return
+        call pdt_base_name(spec_name, base)
+        if (find_pdt_template(context, base) <= 0) return
+        template_index = pdt_template_node_index(arena, base)
+        if (template_index <= 0) return
+        if (allocated(node%type_param_indices)) then
+            actuals = node%type_param_indices
+        else
+            allocate (actuals(0))
+        end if
+        call pdt_actual_values(arena, context, template_index, actuals, &
+                               node%line, node%column, values, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call pdt_instance_name(base, values, instance_name)
+        found = .true.
+    end subroutine pdt_declaration_instance
+
+    subroutine instantiate_pdt_declarations(arena, context, error_msg)
+        ! Instantiate a concrete layout for every distinct tuple of actual
+        ! type parameters named by a declaration in the unit. Runs after the
+        ! ordinary derived-type definitions are collected, so a PDT component
+        ! of non-parameterized type resolves against them.
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        call set_empty(error_msg)
+        if (context%pdt_template_count <= 0) return
+        do i = 1, arena%size
+            if (.not. node_exists(arena, i)) cycle
+            select type (node => arena%entries(i)%node)
+            type is (declaration_node)
+                call instantiate_pdt_for_declaration(arena, context, node, &
+                                                     error_msg)
+                if (len_trim(error_msg) > 0) return
+            end select
+        end do
+    end subroutine instantiate_pdt_declarations
+
+    subroutine instantiate_pdt_for_declaration(arena, context, node, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(inout) :: context
+        type(declaration_node), intent(in) :: node
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: spec_name, base, instance_name
+        integer(c_int64_t), allocatable :: values(:)
+        integer :: template_index
+        integer, allocatable :: actuals(:)
+
+        call set_empty(error_msg)
+        if (.not. allocated(node%type_name)) return
+        call extracted_derived_type_name(node%type_name, spec_name)
+        if (len_trim(spec_name) == 0) return
+        call pdt_base_name(spec_name, base)
+        if (find_pdt_template(context, base) <= 0) return
+        template_index = pdt_template_node_index(arena, base)
+        if (template_index <= 0) return
+        if (allocated(node%type_param_indices)) then
+            actuals = node%type_param_indices
+        else
+            allocate (actuals(0))
+        end if
+        call pdt_actual_values(arena, context, template_index, actuals, &
+                               node%line, node%column, values, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call pdt_instance_name(base, values, instance_name)
+        if (find_derived_type(context, instance_name) > 0) return
+        call instantiate_pdt_layout(arena, context, template_index, values, &
+                                    instance_name, error_msg)
+    end subroutine instantiate_pdt_for_declaration
+
+    subroutine instantiate_pdt_layout(arena, context, template_index, values, &
+                                      instance_name, error_msg)
+        ! Lay out one PDT instance: bind the formals to their actual constants
+        ! so component kinds, character lengths, and array bounds fold against
+        ! them, register the layout, then drop the bindings again.
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: template_index
+        integer(c_int64_t), intent(in) :: values(:)
+        character(len=*), intent(in) :: instance_name
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: saved_symbol_count, i
+
+        call set_empty(error_msg)
+        saved_symbol_count = context%symbol_count
+        select type (template => arena%entries(template_index)%node)
+        type is (derived_type_node)
+            do i = 1, size(values)
+                call bind_pdt_parameter(context, trim(template%param_names(i)%s), &
+                                        values(i))
+            end do
+            call register_derived_type_layout(template, context, instance_name, &
+                                              error_msg)
+        class default
+            error_msg = 'parameterized derived type template is not a type '// &
+                        'definition'
+        end select
+        call unbind_pdt_parameters(context, saved_symbol_count)
+        if (len_trim(error_msg) > 0) return
+        call emit_type_info_constant(context, context%derived_type_count, &
+                                     error_msg)
+    end subroutine instantiate_pdt_layout
+
+    subroutine bind_pdt_parameter(context, name, value)
+        ! Bind one type-parameter formal as a compile-time integer constant so
+        ! specification expressions in the component declarations fold.
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: name
+        integer(c_int64_t), intent(in) :: value
+        integer :: index
+
+        call grow_symbols(context)
+        index = context%symbol_count + 1
+        context%symbols(index)%name = trim(name)
+        context%symbols(index)%value_kind = VALUE_I32
+        context%symbols(index)%is_parameter = .true.
+        context%symbols(index)%has_i32_constant = .true.
+        context%symbols(index)%i32_constant = value
+        context%symbols(index)%is_transient_i32_constant = .true.
+        context%symbol_count = index
+    end subroutine bind_pdt_parameter
+
+    subroutine unbind_pdt_parameters(context, saved_symbol_count)
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: saved_symbol_count
+        integer :: i
+
+        do i = saved_symbol_count + 1, context%symbol_count
+            context%symbols(i)%name = ''
+            context%symbols(i)%has_i32_constant = .false.
+            context%symbols(i)%is_transient_i32_constant = .false.
+            context%symbols(i)%is_parameter = .false.
+        end do
+        context%symbol_count = saved_symbol_count
+    end subroutine unbind_pdt_parameters

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -142,6 +142,13 @@
             call destroy(context%session)
             return
         end if
+        ! Parameterized derived types (#411): every declaration naming a PDT
+        ! with constant actual parameters gets a concrete cached layout.
+        call instantiate_pdt_declarations(arena, context, error_msg)
+        if (len_trim(error_msg) > 0) then
+            call destroy(context%session)
+            return
+        end if
         call collect_module_exports(arena, root_index, context, error_msg)
         if (len_trim(error_msg) > 0) then
             call destroy(context%session)
@@ -1244,6 +1251,7 @@
     include 'session_program_lowering_do_while.inc'
     include 'session_program_lowering_interface.inc'
     include 'session_program_lowering_derived_types.inc'
+    include 'session_program_lowering_pdt.inc'
     include 'session_program_lowering_derived_type_ops.inc'
     include 'session_program_lowering_derived_module_ops.inc'
     include 'session_program_lowering_derived_ctor.inc'

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -615,6 +615,12 @@ module session_program_lowering_types
         integer :: current_declaration_index = 0
         type(derived_type_info_t), allocatable :: derived_types(:)
         integer :: derived_type_count = 0
+        ! Parameterized derived types (#411). A PDT definition registers its
+        ! name here as a template instead of a concrete layout; every distinct
+        ! tuple of constant actual type parameters instantiates one concrete
+        ! derived type in derived_types, named base(v1,v2,...).
+        character(len=64), allocatable :: pdt_template_names(:)
+        integer :: pdt_template_count = 0
         type(module_exports_t), allocatable :: module_exports(:)
         integer :: module_export_count = 0
         integer(c_int32_t) :: current_block_id = 0_c_int32_t

--- a/test/test_session_pdt_constant_compiler.f90
+++ b/test/test_session_pdt_constant_compiler.f90
@@ -1,0 +1,171 @@
+program test_session_pdt_constant_compiler
+    ! Parameterized derived types with constant integer KIND and LEN type
+    ! parameters (#411). Each distinct tuple of actual type parameters is a
+    ! distinct concrete type: the actuals are folded at compile time,
+    ! substituted into component character lengths, array bounds, and kind
+    ! selectors, and the resulting layout is cached under a mangled instance
+    ! name so two declarations with the same actuals share it.
+    ! Missing, nonconstant, and excess actual parameters are diagnosed.
+    use ffc_test_support, only: expect_output, expect_exit_status, &
+        expect_error_contains
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session parameterized derived type compiler test ==='
+
+    all_passed = .true.
+    if (.not. test_two_lengths_and_one_kind()) all_passed = .false.
+    if (.not. test_module_pdt_instances()) all_passed = .false.
+    if (.not. test_shared_instance_layout()) all_passed = .false.
+    if (.not. test_nonconstant_actual_rejected()) all_passed = .false.
+    if (.not. test_missing_actual_rejected()) all_passed = .false.
+    if (.not. test_excess_actuals_rejected()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: constant PDT type parameters lower through direct LIRIC session'
+
+contains
+
+    logical function test_two_lengths_and_one_kind()
+        ! Two instances of one PDT with different LEN and KIND actuals. LEN
+        ! drives a character component length and an array component bound;
+        ! KIND drives a real component kind. Output matches gfortran.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type :: box_t(n, k)'//new_line('a')// &
+            '    integer, len :: n'//new_line('a')// &
+            '    integer, kind :: k = 4'//new_line('a')// &
+            '    character(len=n) :: label'//new_line('a')// &
+            '    real(k) :: value'//new_line('a')// &
+            '    integer :: items(n)'//new_line('a')// &
+            '  end type box_t'//new_line('a')// &
+            '  type(box_t(3, 4)) :: a'//new_line('a')// &
+            '  type(box_t(5, 8)) :: b'//new_line('a')// &
+            '  a%label = "abc"'//new_line('a')// &
+            '  b%label = "hello"'//new_line('a')// &
+            '  a%value = 0.5'//new_line('a')// &
+            '  b%value = 0.25'//new_line('a')// &
+            '  a%items(3) = 30'//new_line('a')// &
+            '  b%items(5) = 50'//new_line('a')// &
+            '  print *, len(a%label), len(b%label)'//new_line('a')// &
+            '  print *, a%label, " ", b%label'//new_line('a')// &
+            '  print *, a%items(3) + b%items(5)'//new_line('a')// &
+            '  if (abs(a%value - 0.5) > 1.0e-6) error stop 3'//new_line('a')// &
+            '  if (abs(b%value - 0.25d0) > 1.0d-12) error stop 4'//new_line('a')// &
+            'end program main'
+
+        test_two_lengths_and_one_kind = expect_output( &
+            source, &
+            '           3           5'//new_line('a')// &
+            ' abc hello'//new_line('a')// &
+            '          80'//new_line('a'), &
+            '/tmp/ffc_pdt_const_lengths')
+    end function test_two_lengths_and_one_kind
+
+    logical function test_module_pdt_instances()
+        ! A PDT defined in a module and instantiated twice in the program with
+        ! different LEN actuals.
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '  type :: buf_t(n)'//new_line('a')// &
+            '    integer, len :: n'//new_line('a')// &
+            '    character(len=n) :: text'//new_line('a')// &
+            '    integer :: count'//new_line('a')// &
+            '  end type buf_t'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  type(buf_t(4)) :: p'//new_line('a')// &
+            '  type(buf_t(2)) :: r'//new_line('a')// &
+            '  p%text = "abcd"'//new_line('a')// &
+            '  r%text = "hi"'//new_line('a')// &
+            '  p%count = 1'//new_line('a')// &
+            '  r%count = 2'//new_line('a')// &
+            '  print *, len(p%text), len(r%text), p%count + r%count'// &
+            new_line('a')// &
+            '  print *, p%text, r%text'//new_line('a')// &
+            'end program main'
+
+        test_module_pdt_instances = expect_output( &
+            source, &
+            '           4           2           3'//new_line('a')// &
+            ' abcdhi'//new_line('a'), &
+            '/tmp/ffc_pdt_const_module')
+    end function test_module_pdt_instances
+
+    logical function test_shared_instance_layout()
+        ! Two declarations with the same actuals share one cached layout, and a
+        ! third with different actuals keeps its own; assignment between the
+        ! matching pair is well formed and the program exits 0.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type :: pair_t(n)'//new_line('a')// &
+            '    integer, len :: n'//new_line('a')// &
+            '    integer :: items(n)'//new_line('a')// &
+            '  end type pair_t'//new_line('a')// &
+            '  type(pair_t(2)) :: a'//new_line('a')// &
+            '  type(pair_t(2)) :: b'//new_line('a')// &
+            '  type(pair_t(4)) :: c'//new_line('a')// &
+            '  a%items(1) = 11'//new_line('a')// &
+            '  a%items(2) = 22'//new_line('a')// &
+            '  b = a'//new_line('a')// &
+            '  c%items(4) = 44'//new_line('a')// &
+            '  if (b%items(2) /= 22) error stop 1'//new_line('a')// &
+            '  if (c%items(4) /= 44) error stop 2'//new_line('a')// &
+            'end program main'
+
+        test_shared_instance_layout = expect_exit_status( &
+            source, 0, '/tmp/ffc_pdt_const_shared')
+    end function test_shared_instance_layout
+
+    logical function test_nonconstant_actual_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type :: box_t(n)'//new_line('a')// &
+            '    integer, len :: n'//new_line('a')// &
+            '    integer :: items(n)'//new_line('a')// &
+            '  end type box_t'//new_line('a')// &
+            '  integer :: v'//new_line('a')// &
+            '  type(box_t(v)) :: a'//new_line('a')// &
+            '  a%items(1) = 1'//new_line('a')// &
+            'end program main'
+
+        test_nonconstant_actual_rejected = expect_error_contains( &
+            source, 'must be a compile-time integer constant', &
+            '/tmp/ffc_pdt_const_nonconst')
+    end function test_nonconstant_actual_rejected
+
+    logical function test_missing_actual_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type :: box_t(n)'//new_line('a')// &
+            '    integer, len :: n'//new_line('a')// &
+            '    integer :: items(n)'//new_line('a')// &
+            '  end type box_t'//new_line('a')// &
+            '  type(box_t) :: a'//new_line('a')// &
+            '  a%items(1) = 1'//new_line('a')// &
+            'end program main'
+
+        test_missing_actual_rejected = expect_error_contains( &
+            source, 'has no actual value and no default', &
+            '/tmp/ffc_pdt_const_missing')
+    end function test_missing_actual_rejected
+
+    logical function test_excess_actuals_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type :: box_t(n)'//new_line('a')// &
+            '    integer, len :: n'//new_line('a')// &
+            '    integer :: items(n)'//new_line('a')// &
+            '  end type box_t'//new_line('a')// &
+            '  type(box_t(3, 4)) :: a'//new_line('a')// &
+            '  a%items(1) = 1'//new_line('a')// &
+            'end program main'
+
+        test_excess_actuals_rejected = expect_error_contains( &
+            source, 'too many actual type parameters', &
+            '/tmp/ffc_pdt_const_excess')
+    end function test_excess_actuals_rejected
+
+end program test_session_pdt_constant_compiler


### PR DESCRIPTION
Closes #411. Unblocked by FortFront #2952/#2954 (derived-type parameters are now represented and queryable).

## What changed

A parameterized derived type used to be rejected outright ("direct LIRIC session only supports non-parameterized derived types"). It is now monomorphized:

- `lower_derived_type_definition` splits: a PDT registers its *name* as a template (`context%pdt_template_names`); a plain type registers a concrete layout through the new `register_derived_type_layout(node, context, layout_name, ...)`, which is the single lowering path for both plain types and PDT instances (no forked path, no fallback to the old rejection for supported forms).
- New `src/session_program_lowering_pdt.inc`: folds the actual type parameters of every declaration in the unit to compile-time integers (defaults fill omitted trailing formals), binds the formals as transient integer constants while the component declarations are laid out — so component character lengths, array bounds, and kind selectors substitute the actuals through the existing const-fold path — and caches the layout under the canonical mangled name `base(v1,v2,...)`.
- `declaration_derived_type_index` resolves a declaration naming a PDT to that instance, so equal actuals share one layout and distinct actuals get distinct layouts.
- The `USE`-import loop skips PDT templates, which have no layout of their own.

Preserved compiler invariant: a derived type name still maps to exactly one concrete layout in `context%derived_types`; a PDT contributes one entry per distinct constant actual-parameter tuple and none for the template itself, so component offsets, `type_info` sizes, and constructor slot counts are unchanged for every non-parameterized type.

Non-goals kept out: deferred type parameters, runtime PDT allocation, PDT inheritance, coarrays.

## Red evidence (unmodified main)

```
$ fo exec ffc /tmp/pdt411/a.f90 -o /tmp/pdt411/a
/tmp/pdt411/a.f90:1:1: error: unsupported derived type parameters: direct LIRIC session only supports non-parameterized derived types
```

## Green evidence

```
$ fo test test_session_pdt_constant_compiler
test_session_pdt_constant_compiler         PASS       0.08s
```

New behavioral test `test/test_session_pdt_constant_compiler.f90`: two LEN instances plus a KIND instance (character length, array bound, and `real(k)` component kind all driven by the parameters) whose stdout matches gfortran byte for byte; a module-defined PDT instantiated twice; a shared-layout/assignment case; and three negative fixtures (nonconstant actual, missing actual with no default, excess actuals) each checked for its diagnostic.

Full `fo` pipeline: only `test_parity_dashboard` (known `.wt/` worktree limitation) and `test_fortfront_corpus_conformance` fail. The corpus test fails identically on unmodified `origin/main` in a separate baseline worktree — same nine f90 failures and one lf failure, PASS=412 XFAIL=94 XPASS=2 FAIL=9 / PASS=208 XFAIL=55 FAIL=1 on both — so no corpus case regresses from PASS.