### PR TITLE
[lf-infer-derived-01] infer Lazy derived values from constructors (refs #429)

### DIFF
--- a/src/session_program_lowering_expr_lowering.inc
+++ b/src/session_program_lowering_expr_lowering.inc
@@ -341,6 +341,14 @@
             return
         end if
 
+        ! An integer derived-type component read (v%k, v%part%k) in a real
+        ! expression is an integer subexpression and needs the same int->real
+        ! coercion as an integer scalar identifier.
+        if (is_integer_component_access(arena, node_index, context)) then
+            is_int = .true.
+            return
+        end if
+
         if (is_binary_op(arena, node_index)) then
             call get_binary_op_info(arena, node_index, bin_op, bl, br, &
                                     blin, bcol, id_err)
@@ -349,6 +357,34 @@
                      is_integer_operand(arena, br, context)
         end if
     end function is_integer_operand
+
+    ! True when the node is a scalar derived-type component read whose
+    ! component is integer-valued. Allocatable, pointer and array components
+    ! keep their own lowering paths and are excluded.
+    logical function is_integer_component_access(arena, node_index, context) &
+        result(is_int)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(in) :: context
+        integer :: type_index, comp_index
+
+        is_int = .false.
+        if (.not. node_exists(arena, node_index)) return
+        select type (acc => arena%entries(node_index)%node)
+        type is (component_access_node)
+            ! A base that is not a declared derived value (a complex %re/%im
+            ! access, for instance) has no integer component to read.
+            type_index = component_base_type_index(arena, acc%base_expr_index, &
+                                                   context)
+            if (type_index <= 0) return
+            comp_index = find_derived_component(context, type_index, &
+                                                acc%component_name)
+            if (comp_index <= 0) return
+            if (component_is_allocatable(context, type_index, comp_index)) return
+            if (component_is_indirect(context, type_index, comp_index)) return
+            is_int = component_kind(context, type_index, comp_index) == VALUE_I32
+        end select
+    end function is_integer_component_access
 
     recursive subroutine lower_f32_expression(arena, node_index, context, &
                                               value, error_msg)
@@ -463,6 +499,11 @@
                     .true., value, matched, error_msg)
                 if (matched .or. len_trim(error_msg) > 0) return
             end block
+            if (is_integer_component_access(arena, node_index, context)) then
+                call lower_f32_operand(arena, node_index, context, value, &
+                                       error_msg)
+                return
+            end if
             call lower_derived_component_load(arena, node, context, value, error_msg)
         class default
             error_msg = 'ffc direct-session lowering only supports real(4) expressions'
@@ -817,6 +858,11 @@
                     .false., value, matched, error_msg)
                 if (matched .or. len_trim(error_msg) > 0) return
             end block
+            if (is_integer_component_access(arena, node_index, context)) then
+                call lower_f64_operand(arena, node_index, context, value, &
+                                       error_msg)
+                return
+            end if
             call lower_derived_component_load(arena, node, context, value, error_msg)
         class default
             error_msg = 'ffc direct-session lowering only supports real expressions'

--- a/test/test_session_lazy_derived_inference_compiler.f90
+++ b/test/test_session_lazy_derived_inference_compiler.f90
@@ -1,0 +1,215 @@
+program test_session_lazy_derived_inference_compiler
+    !! Lazy Fortran derived inference (#429). A bare `v = outer_t(...)` binding
+    !! in a .lf source has no declaration: FortFront resolves the constructor's
+    !! concrete derived type and hands ffc one binding-keyed symbol with the
+    !! nested layout. ffc must allocate that layout, run the constructor and
+    !! default component lowering, and read components back with the value kind
+    !! the component actually has -- an integer component used in a real
+    !! expression must be converted, not reinterpreted. A constructor whose
+    !! type contradicts the inferred binding, or a constructor naming a type
+    !! that does not exist, must be a compile-time diagnostic.
+    implicit none
+
+    logical :: ok
+
+    print *, '=== direct session lazy derived inference compiler test ==='
+
+    ok = .true.
+
+    ! Nested derived value inferred from the constructor: component chain reads
+    ! back through both levels.
+    if (.not. lazy_runs( &
+        'type :: inner_t'//new_line('a')// &
+        '    integer :: k'//new_line('a')// &
+        'end type inner_t'//new_line('a')// &
+        'type :: outer_t'//new_line('a')// &
+        '    type(inner_t) :: part'//new_line('a')// &
+        '    integer :: n'//new_line('a')// &
+        'end type outer_t'//new_line('a')// &
+        'v = outer_t(inner_t(7), 5)'//new_line('a')// &
+        'print *, v%part%k, v%n'//new_line('a'), &
+        '           7           5', &
+        'ffc_lazy_der_nested')) ok = .false.
+
+    ! An integer component chain feeding a second inferred binding. FortFront
+    ! infers `m` as the Lazy default real (real(8)), so the integer sum must be
+    ! converted to real: reinterpreting the integer bit pattern prints a
+    ! denormal instead of 12.
+    if (.not. lazy_runs( &
+        'type :: inner_t'//new_line('a')// &
+        '    integer :: k'//new_line('a')// &
+        'end type inner_t'//new_line('a')// &
+        'type :: outer_t'//new_line('a')// &
+        '    type(inner_t) :: part'//new_line('a')// &
+        '    integer :: n'//new_line('a')// &
+        'end type outer_t'//new_line('a')// &
+        'v = outer_t(inner_t(7), 5)'//new_line('a')// &
+        'm = v%part%k + v%n'//new_line('a')// &
+        'print *, m'//new_line('a'), &
+        '   12.000000000000000', &
+        'ffc_lazy_der_mixed')) ok = .false.
+
+    ! A single integer component read in a real context takes the same
+    ! conversion path as the mixed sum above.
+    if (.not. lazy_runs( &
+        'type :: inner_t'//new_line('a')// &
+        '    integer :: k'//new_line('a')// &
+        'end type inner_t'//new_line('a')// &
+        'type :: outer_t'//new_line('a')// &
+        '    type(inner_t) :: part'//new_line('a')// &
+        'end type outer_t'//new_line('a')// &
+        'v = outer_t(inner_t(3))'//new_line('a')// &
+        'r = v%part%k'//new_line('a')// &
+        'print *, r'//new_line('a'), &
+        '   3.0000000000000000', &
+        'ffc_lazy_der_scalar')) ok = .false.
+
+    ! Real and character components of a nested inferred value keep their own
+    ! kinds.
+    if (.not. lazy_runs( &
+        'type :: inner_t'//new_line('a')// &
+        '    real :: x'//new_line('a')// &
+        '    character(len=3) :: s'//new_line('a')// &
+        'end type inner_t'//new_line('a')// &
+        'type :: outer_t'//new_line('a')// &
+        '    type(inner_t) :: part'//new_line('a')// &
+        '    integer :: n'//new_line('a')// &
+        'end type outer_t'//new_line('a')// &
+        'v = outer_t(inner_t(1.5, "abc"), 2)'//new_line('a')// &
+        'print *, v%part%s, v%n'//new_line('a'), &
+        ' abc           2', &
+        'ffc_lazy_der_kinds')) ok = .false.
+
+    ! Negative: a later constructor of a different derived type contradicts the
+    ! inferred binding type.
+    if (.not. lazy_rejected( &
+        'type :: p_t'//new_line('a')// &
+        '    integer :: a'//new_line('a')// &
+        'end type p_t'//new_line('a')// &
+        'type :: q_t'//new_line('a')// &
+        '    integer :: a'//new_line('a')// &
+        'end type q_t'//new_line('a')// &
+        'v = p_t(1)'//new_line('a')// &
+        'v = q_t(2)'//new_line('a')// &
+        'print *, v%a'//new_line('a'), &
+        'ffc_lazy_der_conflict')) ok = .false.
+
+    ! Negative: a constructor naming a type that was never defined cannot
+    ! resolve to a derived identity.
+    if (.not. lazy_rejected( &
+        'type :: p_t'//new_line('a')// &
+        '    integer :: a'//new_line('a')// &
+        'end type p_t'//new_line('a')// &
+        'v = z_t(1)'//new_line('a')// &
+        'print *, v%a'//new_line('a'), &
+        'ffc_lazy_der_unknown')) ok = .false.
+
+    if (.not. ok) stop 1
+    print *, 'PASS: lazy derived inference lowers and runs'
+
+contains
+
+    ! Write a lazy fragment to a .lf file, drive it through the ffc CLI, run the
+    ! executable and compare the first stdout line.
+    logical function lazy_runs(source, expected, stem) result(ok)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        character(len=*), intent(in) :: stem
+        character(len=:), allocatable :: src_path, exe_path, out_path
+        character(len=:), allocatable :: actual
+        integer :: exit_stat, cmd_stat
+
+        ok = .false.
+        src_path = '/tmp/'//stem//'.lf'
+        exe_path = '/tmp/'//stem//'.exe'
+        out_path = '/tmp/'//stem//'.out'
+        call write_source(source, src_path, exe_path, out_path)
+
+        call compile_source(src_path, exe_path, exit_stat, cmd_stat)
+        if (cmd_stat /= 0 .or. exit_stat /= 0) then
+            print *, 'FAIL: ffc rejected lazy derived source ', stem, &
+                ' exit=', exit_stat
+            return
+        end if
+
+        call execute_command_line(exe_path//' > '//out_path, &
+                                  exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0 .or. exit_stat /= 0) then
+            print *, 'FAIL: lazy derived executable did not run cleanly: ', stem
+            return
+        end if
+
+        actual = read_first_line(out_path)
+        call execute_command_line('rm -f '//src_path//' '//exe_path//' '//out_path)
+        if (trim(actual) /= trim(expected)) then
+            print *, 'FAIL: ', stem, ' expected [', trim(expected), &
+                '] got [', trim(actual), ']'
+            return
+        end if
+        ok = .true.
+    end function lazy_runs
+
+    ! A lazy fragment that must not compile: ffc has to exit non-zero.
+    logical function lazy_rejected(source, stem) result(ok)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: stem
+        character(len=:), allocatable :: src_path, exe_path, out_path
+        integer :: exit_stat, cmd_stat
+
+        ok = .false.
+        src_path = '/tmp/'//stem//'.lf'
+        exe_path = '/tmp/'//stem//'.exe'
+        out_path = '/tmp/'//stem//'.out'
+        call write_source(source, src_path, exe_path, out_path)
+
+        call compile_source(src_path, exe_path, exit_stat, cmd_stat)
+        call execute_command_line('rm -f '//src_path//' '//exe_path//' '//out_path)
+        if (cmd_stat == 0 .and. exit_stat == 0) then
+            print *, 'FAIL: ffc accepted an invalid lazy derived binding: ', stem
+            return
+        end if
+        ok = .true.
+    end function lazy_rejected
+
+    subroutine write_source(source, src_path, exe_path, out_path)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: src_path
+        character(len=*), intent(in) :: exe_path
+        character(len=*), intent(in) :: out_path
+        integer :: unit
+
+        call execute_command_line('rm -f '//src_path//' '//exe_path//' '//out_path)
+        open (newunit=unit, file=src_path, status='replace', action='write')
+        write (unit, '(A)', advance='no') source
+        close (unit)
+    end subroutine write_source
+
+    subroutine compile_source(src_path, exe_path, exit_stat, cmd_stat)
+        character(len=*), intent(in) :: src_path
+        character(len=*), intent(in) :: exe_path
+        integer, intent(out) :: exit_stat
+        integer, intent(out) :: cmd_stat
+        character(len=:), allocatable :: command
+
+        command = "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc "// &
+            "2>/dev/null | head -n 1); test -n ""$exe"" && ""$exe"" "// &
+            src_path//' -o '//exe_path//"'"
+        call execute_command_line(command, exitstat=exit_stat, cmdstat=cmd_stat)
+    end subroutine compile_source
+
+    function read_first_line(path) result(line)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable :: line
+        character(len=256) :: buffer
+        integer :: unit, io_stat
+
+        line = ''
+        open (newunit=unit, file=path, status='old', action='read', iostat=io_stat)
+        if (io_stat == 0) then
+            read (unit, '(A)', iostat=io_stat) buffer
+            if (io_stat == 0) line = trim(buffer)
+            close (unit)
+        end if
+    end function read_first_line
+
+end program test_session_lazy_derived_inference_compiler


### PR DESCRIPTION
Closes #429.

## What

FortFront #2941 unblocked nested derived types in Lazy mode, so a bare
`v = outer_t(inner_t(7), 5)` binding now reaches ffc with the concrete
constructor type and nested layout. Lowering that binding exposed the
remaining ffc gap: an integer derived-type component read in a real
context was loaded and reinterpreted instead of converted, because
`is_integer_operand` only knew about integer literals, identifiers and
binary ops -- not component accesses. In Lazy mode FortFront infers a
follow-on binding like `m = v%part%k + v%n` as `real(8)`, so the wrong
bit pattern printed a denormal.

`is_integer_component_access` resolves the base derived type and the
component, excludes allocatable/pointer (indirect) components, and
reports an integer scalar component. The f32/f64 expression paths route
such a component read through the existing operand coercion
(SITOFP), and `is_integer_operand` treats it as an integer subexpression.
A base that is not a declared derived value (complex `%re`/`%im`) is
rejected by the strict resolution, so that path is untouched.

Preserved invariant: exactly one coercion mechanism -- the existing
`lower_f32_operand`/`lower_f64_operand` int->real path. No new lowering
fork, no fallback.

## Red evidence (unmodified main)

    real(8) :: r ; type(t_t) :: v ; v%k = 7 ; r = v%k ; print *, r
    -> 3.4584595208887258E-323      (integer bits reinterpreted)
    r = v%k + 1  -> 1.0000000000000000

Lazy: `v = outer_t(inner_t(7), 5); m = v%part%k + v%n; print *, m`
    -> 5.9287877500949585E-323

## Green evidence

    fo test test_session_lazy_derived_inference_compiler  -> PASS
    fo test test_session_complex_component_compiler       -> PASS (negative control)
    fo (full pipeline)  -> 304/306 tests pass

The two failures are pre-existing/environmental, not from this change:
`test_parity_dashboard` (resolves `../fortfront` and always fails inside
a `.wt/` worktree) and `test_fortfront_corpus_conformance`, which
produces byte-identical results on an unmodified origin/main baseline
worktree (PASS=412 XFAIL=94 XPASS=2 FAIL=9 / lf PASS=208 FAIL=1) and on
this branch.

## New test

`test/test_session_lazy_derived_inference_compiler.f90`: nested Lazy
constructor inference with component chain reads, integer component in a
real context (scalar and mixed sum), real/character components, plus two
negative fixtures (conflicting reassignment type, undefined constructor
name) that must be compile-time diagnostics.