### PR TITLE
[reject-false-01] stop rejecting valid EQUIVALENCEd BLOCK DATA objects, empty BIND(C) types and continued FORMAT statements

### DIFF
--- a/src/session_program_lowering_derived_types.inc
+++ b/src/session_program_lowering_derived_types.inc
@@ -1815,8 +1815,9 @@ subroutine collect_component_declaration(component_index, parent_line, &
     ! form is therefore the earliest - and here the only - layer with enough
     ! information:
     !
-    !   * a BIND(C) derived type must have at least one component
-    !     (gfortran: "with BIND(C) attribute ... has no components");
+    !   * a component-less BIND(C) derived type is accepted: gfortran only
+    !     warns that it may be inaccessible by the C companion processor
+    !     (lazy-fortran/ffc#581);
     !   * an INTENT(OUT) dummy argument of a type with default initialization
     !     may not be an assumed-size array, because the default initializer
     !     would have to be applied to an unknown number of elements
@@ -1841,24 +1842,21 @@ subroutine collect_component_declaration(component_index, parent_line, &
     end subroutine check_derived_type_definition_forms
 
     subroutine scan_derived_type_bodies(source, init_types, error_msg)
-        !! Walk every derived-type definition in the source. Reports the empty
-        !! BIND(C) type and the mangled TYPEIS guard, and returns the
+        !! Walk every derived-type definition in the source. Reports the
+        !! mangled TYPEIS guard, and returns the
         !! '|'-delimited set of type names that have a default-initialized
         !! component.
         character(len=*), intent(in) :: source
         character(len=:), allocatable, intent(out) :: init_types
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: line, code, packed, name, type_name
-        logical :: in_body, is_bind_c, has_component, is_header
-        integer :: pos, line_no, header_line
+        logical :: in_body, is_header
+        integer :: pos, line_no
         character(len=64) :: location
 
         call set_empty(error_msg)
         init_types = '|'
         in_body = .false.
-        is_bind_c = .false.
-        has_component = .false.
-        header_line = 0
         type_name = ''
         pos = 1
         line_no = 0
@@ -1871,19 +1869,11 @@ subroutine collect_component_declaration(component_index, parent_line, &
             if (in_body) then
                 if (len(packed) >= 7) then
                     if (packed(1:7) == 'endtype') then
-                        if (is_bind_c .and. .not. has_component) then
-                            write (location, '(" at line ",I0)') header_line
-                            error_msg = 'derived type '''//trim(type_name)// &
-                                ''' with BIND(C) attribute has no components'// &
-                                trim(location)
-                            return
-                        end if
                         in_body = .false.
                         cycle
                     end if
                 end if
                 if (is_type_body_keyword(packed)) cycle
-                has_component = .true.
                 if (has_default_initializer(code)) then
                     if (index(init_types, '|'//trim(type_name)//'|') == 0) then
                         init_types = init_types//trim(type_name)//'|'
@@ -1896,11 +1886,9 @@ subroutine collect_component_declaration(component_index, parent_line, &
                 error_msg = 'mangled derived type definition'//trim(location)
                 return
             end if
-            call derived_type_header_info(code, name, is_bind_c, is_header)
+            call derived_type_header_info(code, name, is_header)
             if (.not. is_header) cycle
             in_body = .true.
-            has_component = .false.
-            header_line = line_no
             type_name = name
         end do
     end subroutine scan_derived_type_bodies
@@ -1939,24 +1927,22 @@ subroutine collect_component_declaration(component_index, parent_line, &
         end do
     end subroutine check_assumed_size_dt_dummies
 
-    subroutine derived_type_header_info(code, name, is_bind_c, is_header)
+    subroutine derived_type_header_info(code, name, is_header)
         !! Decide whether a lowered statement opens a derived-type definition,
-        !! and if so return its name and whether it carries BIND(C).
+        !! and if so return its name.
         character(len=*), intent(in) :: code
         character(len=:), allocatable, intent(out) :: name
-        logical, intent(out) :: is_bind_c, is_header
+        logical, intent(out) :: is_header
         character(len=:), allocatable :: rest
         integer :: dc
 
         call set_empty(name)
-        is_bind_c = .false.
         is_header = .false.
         if (len(code) < 6) return
         if (code(1:4) /= 'type') return
         if (code(5:5) /= ' ' .and. code(5:5) /= ',' .and. code(5:5) /= ':') return
         rest = adjustl(code(5:))
         if (len_trim(rest) == 0) return
-        is_bind_c = index(remove_blanks(rest), 'bind(c)') > 0
         dc = index(rest, '::')
         if (dc > 0) then
             name = first_word_of(adjustl(rest(dc + 2:)))

--- a/src/session_program_lowering_reject_checks.inc
+++ b/src/session_program_lowering_reject_checks.inc
@@ -2188,16 +2188,18 @@
     ! format string").
     subroutine check_concatenated_format_source(arena, error_msg)
         type(ast_arena_t), intent(in) :: arena
-        character(len=:), allocatable :: source, line
+        character(len=:), allocatable :: source, line, logical_line
         character(len=:), allocatable, intent(out) :: error_msg
         logical :: found
-        integer :: pos, line_no, next_nl
+        integer :: pos, line_no, next_nl, first_line_no
 
         call set_empty(error_msg)
         call get_source_text(arena, source, found)
         if (.not. found) return
         pos = 1
         line_no = 1
+        logical_line = ''
+        first_line_no = 1
         do while (pos <= len(source))
             next_nl = index(source(pos:), new_line('a'))
             if (next_nl == 0) then
@@ -2207,11 +2209,52 @@
                 line = source(pos:pos + next_nl - 2)
                 pos = pos + next_nl
             end if
-            call check_transfer_line_format(line, line_no, error_msg)
-            if (len_trim(error_msg) > 0) return
+            if (len(logical_line) == 0) first_line_no = line_no
+            call append_continuation_line(logical_line, line)
             line_no = line_no + 1
+            if (ends_with_continuation(logical_line)) cycle
+            call check_transfer_line_format(logical_line, first_line_no, &
+                                            error_msg)
+            logical_line = ''
+            if (len_trim(error_msg) > 0) return
         end do
+        if (len(logical_line) > 0) then
+            call check_transfer_line_format(logical_line, first_line_no, &
+                                            error_msg)
+        end if
     end subroutine check_concatenated_format_source
+
+    ! Free-form continuation: a trailing '&' joins the next line, whose own
+    ! leading '&' (if any) is not part of the statement text. The check runs on
+    ! the joined logical line so a continued format specification is seen whole.
+    logical function ends_with_continuation(text)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: code
+
+        ends_with_continuation = .false.
+        call strip_line_comment(text, code)
+        code = trim(code)
+        if (len(code) == 0) return
+        ends_with_continuation = code(len(code):len(code)) == '&'
+    end function ends_with_continuation
+
+    subroutine append_continuation_line(logical_line, line)
+        character(len=:), allocatable, intent(inout) :: logical_line
+        character(len=*), intent(in) :: line
+        character(len=:), allocatable :: piece
+
+        if (len(logical_line) == 0) then
+            logical_line = line
+            return
+        end if
+        logical_line = trim(logical_line)
+        logical_line = logical_line(1:len(logical_line) - 1)
+        piece = adjustl(line)
+        if (len_trim(piece) > 0) then
+            if (piece(1:1) == '&') piece = piece(2:)
+        end if
+        logical_line = logical_line//piece
+    end subroutine append_continuation_line
 
     subroutine check_transfer_line_format(line, line_no, error_msg)
         character(len=*), intent(in) :: line

--- a/src/session_program_lowering_reject_storage.inc
+++ b/src/session_program_lowering_reject_storage.inc
@@ -53,7 +53,8 @@
         if (len_trim(error_msg) > 0) return
         call check_equivalence_bind_c_conflict(arena, lines, line_count, error_msg)
         if (len_trim(error_msg) > 0) return
-        call check_block_data_objects_in_common(arena, error_msg)
+        call check_block_data_objects_in_common(arena, lines, line_count, &
+                                                error_msg)
     end subroutine check_storage_association_restrictions
 
     subroutine storage_source_lines(arena, lines, line_count, found)
@@ -406,11 +407,14 @@
         end do
     end subroutine collect_equivalence_names
 
-    subroutine check_block_data_objects_in_common(arena, error_msg)
+    subroutine check_block_data_objects_in_common(arena, lines, line_count, &
+                                                  error_msg)
         ! F2018 C8105: a BLOCK DATA unit initialises COMMON storage only, so
         ! every object it names in a DATA statement must be in a COMMON block
-        ! of that unit.
+        ! of that unit, directly or through EQUIVALENCE association.
         type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: lines(:)
+        integer, intent(in) :: line_count
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: n
 
@@ -421,15 +425,18 @@
             type is (block_data_node)
                 if (.not. allocated(unit%statement_indices)) cycle
                 call check_one_block_data_unit(arena, unit%statement_indices, &
-                                               error_msg)
+                                               lines, line_count, error_msg)
                 if (len_trim(error_msg) > 0) return
             end select
         end do
     end subroutine check_block_data_objects_in_common
 
-    subroutine check_one_block_data_unit(arena, statement_indices, error_msg)
+    subroutine check_one_block_data_unit(arena, statement_indices, lines, &
+                                         line_count, error_msg)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: statement_indices(:)
+        character(len=*), intent(in) :: lines(:)
+        integer, intent(in) :: line_count
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=64) :: members(256)
         character(len=:), allocatable :: obj_name
@@ -448,6 +455,8 @@
                 end do
             end select
         end do
+        call add_equivalenced_common_names(lines, line_count, members, &
+                                           member_count)
         do s = 1, size(statement_indices)
             if (.not. node_exists(arena, statement_indices(s))) cycle
             select type (node => arena%entries(statement_indices(s))%node)
@@ -465,6 +474,90 @@
             end select
         end do
     end subroutine check_one_block_data_unit
+
+    ! An object EQUIVALENCEd to a COMMON member is itself in COMMON storage,
+    ! so a BLOCK DATA unit may initialise it (lazy-fortran/ffc#581). Association
+    ! chains through several groups are followed to a fixed point.
+    subroutine add_equivalenced_common_names(lines, line_count, members, &
+                                             member_count)
+        character(len=*), intent(in) :: lines(:)
+        integer, intent(in) :: line_count
+        character(len=*), intent(inout) :: members(:)
+        integer, intent(inout) :: member_count
+        character(len=64) :: group(64)
+        character(len=:), allocatable :: line
+        integer :: pass, i, j, group_count, pos
+        logical :: changed, in_common
+
+        do pass = 1, 16
+            changed = .false.
+            do i = 1, line_count
+                line = trim(lines(i))
+                if (.not. starts_with_word(line, 'equivalence')) cycle
+                pos = 1
+                do
+                    call next_equivalence_group(line, pos, group, group_count)
+                    if (group_count == 0) exit
+                    in_common = .false.
+                    do j = 1, group_count
+                        if (storage_name_listed(members, member_count, &
+                                                trim(group(j)))) in_common = .true.
+                    end do
+                    if (.not. in_common) cycle
+                    do j = 1, group_count
+                        if (storage_name_listed(members, member_count, &
+                                                trim(group(j)))) cycle
+                        call append_storage_name(members, member_count, &
+                                                 trim(group(j)))
+                        changed = .true.
+                    end do
+                end do
+            end do
+            if (.not. changed) exit
+        end do
+    end subroutine add_equivalenced_common_names
+
+    subroutine next_equivalence_group(text, pos, names, count)
+        !! Collect the object names of the next parenthesised EQUIVALENCE
+        !! group starting at pos; subscripts nested inside a designator are
+        !! skipped. Returns count == 0 when no further group is present.
+        character(len=*), intent(in) :: text
+        integer, intent(inout) :: pos
+        character(len=*), intent(out) :: names(:)
+        integer, intent(out) :: count
+        character(len=:), allocatable :: name
+        integer :: depth
+
+        count = 0
+        depth = 0
+        do while (pos <= len(text))
+            if (text(pos:pos) == '(') then
+                depth = depth + 1
+                pos = pos + 1
+                cycle
+            end if
+            if (text(pos:pos) == ')') then
+                depth = depth - 1
+                pos = pos + 1
+                if (depth <= 0) return
+                cycle
+            end if
+            if (depth /= 1) then
+                pos = pos + 1
+                cycle
+            end if
+            if (.not. is_fortran_identifier_char(text(pos:pos))) then
+                pos = pos + 1
+                cycle
+            end if
+            name = leading_identifier(text(pos:))
+            if (count < size(names)) then
+                count = count + 1
+                names(count) = lowercase_text(trim(name))
+            end if
+            pos = pos + len_trim(name)
+        end do
+    end subroutine next_equivalence_group
 
     subroutine data_object_base_name(arena, node_index, name)
         type(ast_arena_t), intent(in) :: arena

--- a/test/test_session_accept_reject_false_01_compiler.f90
+++ b/test/test_session_accept_reject_false_01_compiler.f90
@@ -1,0 +1,116 @@
+program test_session_accept_reject_false_01_compiler
+    !! Valid programs that ffc used to reject with a spurious semantic error
+    !! (lazy-fortran/ffc#581). gfortran compiles and runs all of them.
+    use ffc_test_support, only: expect_exit_status, expect_error_contains
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== spurious semantic rejection regression test ==='
+
+    all_passed = .true.
+    if (.not. test_block_data_equivalenced_into_common()) all_passed = .false.
+    if (.not. test_block_data_local_data_object_rejected()) all_passed = .false.
+    if (.not. test_empty_bind_c_type_accepted()) all_passed = .false.
+    if (.not. test_continued_format_statement_accepted()) all_passed = .false.
+    if (.not. test_unbalanced_format_still_rejected()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: valid specification parts and statements accepted'
+
+contains
+
+    logical function test_block_data_equivalenced_into_common()
+        !! F2018 C8105 is satisfied through EQUIVALENCE association: 'la'
+        !! shares storage with the COMMON member 'lb'.
+        character(len=*), parameter :: source = &
+            'block data bd_l'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  logical :: lb'//new_line('a')// &
+            '  common /blockl/ lb(2)'//new_line('a')// &
+            '  logical :: la(2)'//new_line('a')// &
+            '  equivalence (la, lb)'//new_line('a')// &
+            '  data la(2) / .false. /'//new_line('a')// &
+            'end'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  logical :: la(2)'//new_line('a')// &
+            '  common /blockl/ la'//new_line('a')// &
+            '  if (la(2)) stop 3'//new_line('a')// &
+            '  stop 4'//new_line('a')// &
+            'end program main'
+
+        test_block_data_equivalenced_into_common = expect_exit_status( &
+            source, 4, '/tmp/ffc_accept_581_blockdata')
+    end function test_block_data_equivalenced_into_common
+
+    logical function test_block_data_local_data_object_rejected()
+        !! Negative control: a DATA object with no COMMON association at all
+        !! is still rejected.
+        character(len=*), parameter :: source = &
+            'block data bd_l'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  logical :: lb'//new_line('a')// &
+            '  common /blockl/ lb(2)'//new_line('a')// &
+            '  logical :: la(2)'//new_line('a')// &
+            '  data la(2) / .false. /'//new_line('a')// &
+            'end'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  stop 4'//new_line('a')// &
+            'end program main'
+
+        test_block_data_local_data_object_rejected = expect_error_contains( &
+            source, 'must be in COMMON', '/tmp/ffc_accept_581_blockdata_neg')
+    end function test_block_data_local_data_object_rejected
+
+    logical function test_empty_bind_c_type_accepted()
+        !! A component-less BIND(C) type is legal; gfortran only warns.
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type, bind(C) :: junk'//new_line('a')// &
+            '  end type junk'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  stop 5'//new_line('a')// &
+            'end program main'
+
+        test_empty_bind_c_type_accepted = expect_exit_status( &
+            source, 5, '/tmp/ffc_accept_581_bindc')
+    end function test_empty_bind_c_type_accepted
+
+    logical function test_continued_format_statement_accepted()
+        !! The format specification is complete once the continuation lines
+        !! are joined, so it must not be diagnosed as unbalanced.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '35043 format (" ",16X,"COMPUTED: ",22X,1P/26X,F5.4,3X," ",&'// &
+            new_line('a')// &
+            '           (23X,F6.2),3X)'//new_line('a')// &
+            '  stop 6'//new_line('a')// &
+            'end program main'
+
+        test_continued_format_statement_accepted = expect_exit_status( &
+            source, 6, '/tmp/ffc_accept_581_format')
+    end function test_continued_format_statement_accepted
+
+    logical function test_unbalanced_format_still_rejected()
+        !! Negative control: joining continuations must not hide a genuinely
+        !! unbalanced format specification.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '100 format ("a",&'//new_line('a')// &
+            '           "b"'//new_line('a')// &
+            '  stop 6'//new_line('a')// &
+            'end program main'
+
+        test_unbalanced_format_still_rejected = expect_error_contains( &
+            source, 'unbalanced parenthes', '/tmp/ffc_accept_581_format_neg')
+    end function test_unbalanced_format_still_rejected
+
+end program test_session_accept_reject_false_01_compiler

--- a/test/test_session_reject_derived_01_compiler.f90
+++ b/test/test_session_reject_derived_01_compiler.f90
@@ -7,7 +7,7 @@ program test_session_reject_derived_01_compiler
     print *, '=== derived-type definition constraint rejection test ==='
 
     all_passed = .true.
-    if (.not. test_empty_bind_c_type_rejected()) all_passed = .false.
+    if (.not. test_empty_bind_c_type_accepted()) all_passed = .false.
     if (.not. test_bind_c_type_with_component_accepted()) all_passed = .false.
     if (.not. test_assumed_size_default_init_rejected()) all_passed = .false.
     if (.not. test_explicit_shape_default_init_accepted()) all_passed = .false.
@@ -25,16 +25,19 @@ program test_session_reject_derived_01_compiler
 
 contains
 
-    logical function test_empty_bind_c_type_rejected()
+    logical function test_empty_bind_c_type_accepted()
+        !! A component-less BIND(C) type is legal Fortran; gfortran only warns
+        !! that it may be inaccessible by the C companion (ffc#581).
         character(len=*), parameter :: source = &
             'program main'//new_line('a')// &
             '  type, bind(C) :: t'//new_line('a')// &
             '  end type t'//new_line('a')// &
+            '  stop 3'//new_line('a')// &
             'end program main'
 
-        test_empty_bind_c_type_rejected = expect_error_contains( &
-            source, 'has no components', '/tmp/ffc_reject_derived_01_bindc')
-    end function test_empty_bind_c_type_rejected
+        test_empty_bind_c_type_accepted = expect_exit_status( &
+            source, 3, '/tmp/ffc_reject_derived_01_bindc')
+    end function test_empty_bind_c_type_accepted
 
     logical function test_bind_c_type_with_component_accepted()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
Closes #581.

Three of the five programs listed in #581 were rejected by ffc's own
source-level semantic checks. (`submodule_52.f90` and `intent_01.f90` already
compile and run correctly on current main after the recent FortFront landings;
verified by hand.)

## Changes

- **BLOCK DATA / EQUIVALENCE (F2018 C8105).** `check_block_data_objects_in_common`
  now expands the COMMON member set through EQUIVALENCE groups to a fixed point,
  so an object storage-associated with a COMMON member counts as being in COMMON.
  `equivalence_27.f90` compiles and runs.
- **Empty BIND(C) derived type.** The rule "a BIND(C) type must have at least one
  component" is not a default-mode constraint: gfortran only warns that the type
  may be inaccessible by the C companion processor. The check is retired
  (not left as a fallback); `empty_derived_type.f90` compiles and runs.
  `empty_derived_type_2.f90` (a `-std=f2018` dg-error case) was already a
  documented FAIL and stays one.
- **Continued FORMAT statement.** The source-level format scanner read one
  physical line at a time, so a free-form continuation made a complete format
  specification look unbalanced. It now joins continuation lines into one
  logical line before checking. `pr52608.f90` compiles.

## Preserved invariant

Genuinely invalid programs are still rejected: a BLOCK DATA `DATA` object with no
COMMON association at all, and a format specification that stays unbalanced after
continuations are joined. Both are negative controls in the new test.

## Red evidence (unmodified main)

    equivalence_27.f90:1:1: error: DATA object 'la' in a BLOCK DATA unit must be in COMMON
    empty_derived_type.f90:1:1: error: derived type 'junk' with BIND(C) attribute has no components at line 5
    pr52608.f90:9:1: error: Unexpected end of format string: unbalanced parenthesis in '(" ",16X,...,+3P," ",&'

The same three shapes, reduced, fail in `test_session_accept_reject_false_01_compiler`
on main.

## Green evidence

- `fo test test_session_accept_reject_false_01_compiler` PASS (both accept cases
  and both negative controls).
- Full `fo` pipeline: 304/306 tests green. The two reds are the documented
  environmental ones: `test_parity_dashboard` (resolves `../fortfront` outside a
  worktree) and `test_fortfront_corpus_conformance`, which is byte-identical to a
  baseline run of the same commit on origin/main
  (PASS=412 XFAIL=94 XPASS=2 FAIL=9 for gfortran-dg; PASS=208 XFAIL=55 FAIL=1 for lf) —
  no corpus case regresses.