### PR TITLE
[corpus-flake-01] record run-to-run unstable corpus cases as FLAKY (closes #599)

### DIFF
--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -139,6 +139,34 @@ scripts/conformance_check.sh --no-build --suite fortfront-f90 \
 Named selection requires `--suite`; the check forwards all `--file` and
 `--files-from` options to that suite.
 
+## Repeated runs and FLAKY records
+
+A single run cannot distinguish a stable result from a case that flips
+between runs, so promoting an XPASS on one run can convert a flake into a
+manifest entry that the next run breaks (#599). `--repeat N` runs the
+selection N times as independent child runs through the same classification
+path and merges them:
+
+```bash
+scripts/conformance_gauntlet.sh --suite lfortran --repeat 5 \
+    --files-from suspect_cases.txt --report /tmp/repeat.jsonl
+scripts/conformance_check.sh --no-build --suite lfortran --repeat 5
+```
+
+A file whose status is identical in every attempt keeps its record. A file
+whose status differs is recorded as
+
+```json
+{"suite":"lfortran","file":"kwargs_01.f90","status":"FLAKY",
+ "note":"unstable across 5 attempts","attempts":5,"observed":"PASS|FAIL"}
+```
+
+and counted in the SUMMARY `flaky` field, which is present only when the
+count is nonzero. FLAKY is a failure: both the gauntlet and the conformance
+check exit nonzero, and a FLAKY case is never reported as promotable XPASS.
+Never stabilise such a case by raising a timeout; reduce it and fix the
+underlying nondeterminism.
+
 The script auto-detects available suites by checking the suite root
 directories. If a suite root does not exist, it prints a SKIP message and
 continues with the remaining suites. Only `fortfront-f90` and `fortfront-lf`

--- a/scripts/conformance_check.sh
+++ b/scripts/conformance_check.sh
@@ -12,6 +12,8 @@
 #   --suite S    run only one suite instead of all available suites
 #   --file PATH  forward one suite-relative file (repeatable)
 #   --files-from PATH  forward a named-file list (repeatable)
+#   --repeat N   run each suite N times and fail on any case whose status is
+#                not identical in every attempt (recorded FLAKY)
 #
 # This script is the documented routine contributors run before pushing
 # and after dependency (fortfront, liric) updates.
@@ -30,6 +32,7 @@ GAUNTLET="$SCRIPT_DIR/conformance_gauntlet.sh"
 NO_BUILD=0
 SINGLE_SUITE=""
 TIMEOUT=5
+REPEAT=1
 NAMED_ARGS=()
 
 # Argument parsing
@@ -53,6 +56,11 @@ while [ $# -gt 0 ]; do
             NAMED_ARGS+=("--files-from" "$list_path"); shift 2 ;;
         --timeout)
             TIMEOUT="$2"; shift 2 ;;
+        --repeat)
+            if [ $# -lt 2 ]; then
+                echo "ERROR: --repeat requires a count" >&2; exit 1
+            fi
+            REPEAT="$2"; shift 2 ;;
         *)
             echo "ERROR: unknown option $1" >&2; exit 1 ;;
     esac
@@ -128,6 +136,7 @@ for SUITE in $SUITES; do
 
     gauntlet_args=(--suite "$SUITE" --ffc "$FFC_BIN" \
         --report "$REPORT" --timeout "$TIMEOUT")
+    gauntlet_args+=(--repeat "$REPEAT")
     gauntlet_args+=("${NAMED_ARGS[@]}")
     if bash "$GAUNTLET" "${gauntlet_args[@]}" > "$LOG" 2>&1; then
         suite_exit=0
@@ -151,8 +160,16 @@ for SUITE in $SUITES; do
 
             echo "  $SUITE: PASS=$pass_count XFAIL=$xfail_count XPASS=$xpass_count FAIL=$fail_count TOTAL=$total_count"
 
+            # The flaky field is present only when the count is nonzero.
+            flaky_count=$(echo "$summary" | grep -o '"flaky":[0-9]*' | \
+                grep -o '[0-9]*' || true)
             if [ "${fail_count:-0}" -gt 0 ]; then
                 HAS_FAIL=1
+            fi
+            if [ "${flaky_count:-0}" -gt 0 ]; then
+                HAS_FAIL=1
+                echo "  $SUITE: FLAKY=$flaky_count (unstable across attempts)"
+                grep '"status":"FLAKY"' "$REPORT" || true
             fi
             if [ "${xpass_count:-0}" -gt 0 ]; then
                 HAS_XPASS=1

--- a/scripts/conformance_gauntlet.sh
+++ b/scripts/conformance_gauntlet.sh
@@ -19,6 +19,9 @@
 #   --files-from PATH   read suite-relative files from PATH (repeatable)
 #   --max-files N       only test the first N files (for smoke runs)
 #   --timeout N         per-file timeout in seconds (default: 5)
+#   --repeat N          run the selection N times and merge; a file whose
+#                       status differs between attempts is recorded FLAKY
+#                       instead of taking the last result (default: 1)
 #   --require-provenance require clean inputs and a freshly built compiler
 #
 # Environment variables (suite roots):
@@ -44,6 +47,7 @@ FFC_BIN=""
 REPORT=""
 MAX_FILES=""
 TIMEOUT=5
+REPEAT=1
 REQUIRE_PROVENANCE=0
 HAS_FAIL=0
 SELECTOR_KINDS=()
@@ -53,6 +57,8 @@ fail() {
     echo "ERROR: $*" >&2
     exit 1
 }
+
+ORIGINAL_ARGS=("$@")
 
 # Argument parsing
 SUITE=""
@@ -78,12 +84,22 @@ while [ $# -gt 0 ]; do
             MAX_FILES="$2"; shift 2 ;;
         --timeout)
             TIMEOUT="$2"; shift 2 ;;
+        --repeat)
+            if [ $# -lt 2 ]; then fail "--repeat requires a count"; fi
+            REPEAT="$2"; shift 2 ;;
         --require-provenance)
             REQUIRE_PROVENANCE=1; shift ;;
         *)
             fail "unknown option $1" ;;
     esac
 done
+
+case "$REPEAT" in
+    ''|*[!0-9]*) fail "--repeat requires a positive integer" ;;
+esac
+if [ "$REPEAT" -lt 1 ]; then
+    fail "--repeat requires a positive integer"
+fi
 
 if [ -z "$SUITE" ]; then
     echo "ERROR: --suite is required. Choose from: $SUITES" >&2
@@ -340,6 +356,7 @@ FAIL_COUNT=0
 NOREF_COUNT=0
 SKIP_COUNT=0
 WARNING_UNCHECKED_COUNT=0
+FLAKY_COUNT=0
 TOTAL_COUNT=0
 IS_NOREF_RECORD=0
 NOREF_RECORD_REASON=""
@@ -361,14 +378,83 @@ if [ "${#SELECTOR_KINDS[@]}" -gt 0 ] || [ "${MAX_FILES:-0}" -gt 0 ] 2>/dev/null;
 fi
 
 write_summary() {
-    printf '{"suite":"%s","status":"SUMMARY","pass":%d,"xfail":%d,"xpass":%d,"fail":%d,"noref":%d,"skip":%d,"warning_unchecked":%d,"total":%d,"schema_version":1,"full_run":%s,"provenance_verified":%s,"ffc_revision":"%s","ffc_source_sha256":"%s","ffc_binary_sha256":"%s","fortfront_revision":"%s","fortfront_tree":"%s","liric_revision":"%s","liric_tree":"%s","corpus_revision":"%s","corpus_tree":"%s","corpus_files_sha256":"%s"}\n' \
+    local flaky_json=""
+    if [ "$FLAKY_COUNT" -gt 0 ]; then
+        flaky_json=$(printf ',"flaky":%d' "$FLAKY_COUNT")
+    fi
+    printf '{"suite":"%s","status":"SUMMARY","pass":%d,"xfail":%d,"xpass":%d,"fail":%d,"noref":%d,"skip":%d,"warning_unchecked":%d,"total":%d,"schema_version":1,"full_run":%s,"provenance_verified":%s,"ffc_revision":"%s","ffc_source_sha256":"%s","ffc_binary_sha256":"%s","fortfront_revision":"%s","fortfront_tree":"%s","liric_revision":"%s","liric_tree":"%s","corpus_revision":"%s","corpus_tree":"%s","corpus_files_sha256":"%s"%s}\n' \
         "$SUITE" "$PASS_COUNT" "$XFAIL_COUNT" "$XPASS_COUNT" "$FAIL_COUNT" \
         "$NOREF_COUNT" "$SKIP_COUNT" "$WARNING_UNCHECKED_COUNT" "$TOTAL_COUNT" \
         "$FULL_RUN" "$PROVENANCE_VERIFIED" "$FFC_REVISION" \
         "$FFC_SOURCE_SHA256" "$FFC_BINARY_SHA256" "$FORTFRONT_REVISION" \
         "$FORTFRONT_TREE" "$LIRIC_REVISION" "$LIRIC_TREE" \
-        "$CORPUS_REVISION" "$CORPUS_TREE" "$CORPUS_FILES_SHA256" >> "$REPORT"
+        "$CORPUS_REVISION" "$CORPUS_TREE" "$CORPUS_FILES_SHA256" \
+        "$flaky_json" >> "$REPORT"
 }
+
+# Repeated runs: a single run cannot distinguish a stable result from a case
+# that flips between attempts. Each attempt is a fully independent child run
+# through the same classification path; the merge below records a file whose
+# status is not identical in every attempt as FLAKY, so nothing downstream can
+# read an intermittent pass as a stable one.
+run_repeated_attempts() {
+    local attempt child_args=() attempt_reports=() skip_next=0 arg
+    local attempt_dir merged_status
+
+    for arg in "${ORIGINAL_ARGS[@]}"; do
+        if [ "$skip_next" -eq 1 ]; then
+            skip_next=0
+            continue
+        fi
+        case "$arg" in
+            --repeat|--report) skip_next=1 ;;
+            *) child_args+=("$arg") ;;
+        esac
+    done
+
+    attempt_dir="$TMPDIR_WORK/attempts"
+    mkdir -p "$attempt_dir"
+    for attempt in $(seq 1 "$REPEAT"); do
+        echo "=== attempt $attempt/$REPEAT ==="
+        attempt_reports+=("$attempt_dir/attempt_${attempt}.jsonl")
+        bash "$0" "${child_args[@]}" --repeat 1 \
+            --report "$attempt_dir/attempt_${attempt}.jsonl" || true
+    done
+
+    : > "$REPORT"
+    awk -v suite="$SUITE" -f "$SCRIPT_DIR/merge_repeated_report.awk" \
+        "${attempt_reports[@]}" >> "$REPORT"
+
+    PASS_COUNT=$(count_merged_status PASS)
+    XFAIL_COUNT=$(count_merged_status XFAIL)
+    XPASS_COUNT=$(count_merged_status XPASS)
+    FAIL_COUNT=$(count_merged_status FAIL)
+    SKIP_COUNT=$(count_merged_status SKIP)
+    FLAKY_COUNT=$(count_merged_status FLAKY)
+    NOREF_COUNT=$(grep -c '"noref":true' "$REPORT" || true)
+    WARNING_UNCHECKED_COUNT=$(grep -c '"warning_expectation":' "$REPORT" || true)
+    TOTAL_COUNT=$(grep -c '"file":' "$REPORT" || true)
+    write_summary
+
+    echo ""
+    echo "=== $SUITE summary (merged over $REPEAT attempts) ==="
+    echo "  PASS=$PASS_COUNT  XFAIL=$XFAIL_COUNT  XPASS=$XPASS_COUNT  FAIL=$FAIL_COUNT  FLAKY=$FLAKY_COUNT  NOREF=$NOREF_COUNT  SKIP=$SKIP_COUNT  TOTAL=$TOTAL_COUNT"
+    echo "  Report: $REPORT"
+
+    if [ "$FAIL_COUNT" -gt 0 ] || [ "$FLAKY_COUNT" -gt 0 ]; then
+        return 1
+    fi
+    return 0
+}
+
+count_merged_status() {
+    grep -c "\"status\":\"$1\"" "$REPORT" || true
+}
+
+if [ "$REPEAT" -gt 1 ]; then
+    run_repeated_attempts
+    exit $?
+fi
 
 # Clear report
 > "$REPORT"

--- a/scripts/merge_repeated_report.awk
+++ b/scripts/merge_repeated_report.awk
@@ -1,0 +1,53 @@
+# merge_repeated_report.awk: merge per-attempt conformance reports.
+#
+# Reads the JSONL result records of N attempts over the same selection and
+# writes one record per file. A file whose status is identical in every
+# attempt keeps its first record verbatim. A file whose status differs
+# between attempts becomes a FLAKY record listing the observed statuses, so
+# an intermittent pass can never be read as a stable one.
+#
+# Usage: awk -v suite=SUITE -f merge_repeated_report.awk attempt_*.jsonl
+
+function json_field(line, key,    pattern, piece) {
+    pattern = "\"" key "\":\"[^\"]*\""
+    if (match(line, pattern) == 0) return ""
+    piece = substr(line, RSTART, RLENGTH)
+    sub("^\"" key "\":\"", "", piece)
+    sub("\"$", "", piece)
+    return piece
+}
+
+/"status":"SUMMARY"/ { next }
+
+{
+    file_name = json_field($0, "file")
+    status = json_field($0, "status")
+    if (file_name == "" || status == "") next
+    if (!(file_name in seen)) {
+        order[++file_count] = file_name
+        seen[file_name] = 1
+        first_record[file_name] = $0
+        first_status[file_name] = status
+        observed[file_name] = status
+    } else if (index("|" observed[file_name] "|", "|" status "|") == 0) {
+        observed[file_name] = observed[file_name] "|" status
+    }
+    if (status != first_status[file_name]) unstable[file_name] = 1
+    attempts[file_name]++
+}
+
+END {
+    for (index_of_file = 1; index_of_file <= file_count; index_of_file++) {
+        file_name = order[index_of_file]
+        if (file_name in unstable) {
+            printf "{\"suite\":\"%s\",\"file\":\"%s\",\"status\":\"FLAKY\",", \
+                suite, file_name
+            printf "\"note\":\"unstable across %d attempts\",", \
+                attempts[file_name]
+            printf "\"attempts\":%d,\"observed\":\"%s\"}\n", \
+                attempts[file_name], observed[file_name]
+        } else {
+            print first_record[file_name]
+        }
+    }
+}

--- a/scripts/validate_parity_report.awk
+++ b/scripts/validate_parity_report.awk
@@ -155,14 +155,16 @@ function row_field_allowed(key) {
     return key == "suite" || key == "file" || key == "status" ||
         key == "ffc_exit" || key == "ref_exit" || key == "note" ||
         key == "noref" || key == "noref_reason" ||
-        key == "warning_expectation"
+        key == "warning_expectation" ||
+        key == "attempts" || key == "observed"
 }
 
 function summary_field_allowed(key) {
     return key == "suite" || key == "status" || key == "pass" ||
         key == "xfail" || key == "xpass" || key == "fail" ||
         key == "noref" || key == "skip" || key == "warning_unchecked" ||
-        key == "total" || key == "schema_version" || key == "full_run" ||
+        key == "total" || key == "flaky" ||
+        key == "schema_version" || key == "full_run" ||
         key == "provenance_verified" ||
         key == "ffc_revision" || key == "ffc_source_sha256" ||
         key == "ffc_binary_sha256" || key == "fortfront_revision" ||
@@ -173,7 +175,7 @@ function summary_field_allowed(key) {
 
 function validate_summary(    key, suite, pass_count, xfail_count, xpass_count,
         fail_count, noref_count, skip_count, warning_count, total_count,
-        ffc_revision, source_digest, binary_digest, fortfront_revision,
+        flaky_count, ffc_revision, source_digest, binary_digest, fortfront_revision,
         fortfront_tree, liric_revision, liric_tree, corpus_revision,
         corpus_tree, corpus_files_digest) {
     for (key in field_value) {
@@ -190,6 +192,9 @@ function validate_summary(    key, suite, pass_count, xfail_count, xpass_count,
     skip_count = require_integer("skip", 1)
     warning_count = require_integer("warning_unchecked", 1)
     total_count = require_integer("total", 1)
+    flaky_count = 0
+    if ("flaky" in field_value) flaky_count = require_integer("flaky", 1)
+    if (counts["FLAKY"] != flaky_count) report_error("SUMMARY flaky mismatch")
     if (require_integer("schema_version", 1) != 1) {
         report_error("unknown report schema version")
     }
@@ -240,7 +245,7 @@ function validate_row(    key, suite, status, file_name, has_ffc, has_ref,
     if (suite != expected_suite) report_error("mixed or unexpected suite: " suite)
     status = require_string("status")
     if (status != "PASS" && status != "XFAIL" && status != "XPASS" &&
-            status != "FAIL" && status != "SKIP") {
+            status != "FAIL" && status != "SKIP" && status != "FLAKY") {
         report_error("unknown status: " status)
     }
     file_name = require_string("file")
@@ -253,9 +258,19 @@ function validate_row(    key, suite, status, file_name, has_ffc, has_ref,
     if (has_ffc) {
         require_integer("ffc_exit", 0)
         require_integer("ref_exit", 0)
-    } else if (status != "SKIP" &&
+    } else if (status != "SKIP" && status != "FLAKY" &&
             !(status == "FAIL" && field_value["note"] ~ /directive/)) {
         report_error("result is missing exit fields")
+    }
+    if (status == "FLAKY") {
+        if (require_integer("attempts", 1) < 2) {
+            report_error("FLAKY row needs at least two attempts")
+        }
+        if (require_string("observed") !~ /\|/) {
+            report_error("FLAKY row needs differing observed statuses")
+        }
+    } else if ("attempts" in field_value || "observed" in field_value) {
+        report_error("attempt fields outside a FLAKY row")
     }
     is_noref = 0
     if ("noref" in field_value) {

--- a/test/test_conformance_flake_detection.f90
+++ b/test/test_conformance_flake_detection.f90
@@ -1,0 +1,147 @@
+program test_conformance_flake_detection
+    ! A single conformance run cannot tell a stable result from a case that
+    ! flips between runs (ffc #599). These checks drive the gauntlet with a
+    ! compiler wrapper that alternates between compiling and failing, so the
+    ! same file is a PASS on one attempt and a FAIL on the next, and require
+    ! the merged report to record it as FLAKY instead of taking one result.
+    use conformance_temp_dir, only: make_temp_root, remove_temp_root
+    implicit none
+
+    character(len=*), parameter :: SCRIPT = 'scripts/conformance_gauntlet.sh'
+    character(len=*), parameter :: CASE_FILE = 'api_pipeline_minimal_program.f90'
+    character(len=:), allocatable :: root, wrapper, counter
+    character(len=:), allocatable :: flaky_report, stable_report
+    logical :: all_passed
+
+    print *, '=== conformance flake detection test ==='
+
+    root = make_temp_root('flake_detect')
+    wrapper = root//'/alternating_ffc.sh'
+    counter = root//'/attempt_counter'
+    flaky_report = root//'/flaky.jsonl'
+    stable_report = root//'/stable.jsonl'
+    all_passed = .true.
+
+    call write_alternating_wrapper(wrapper)
+
+    ! A case that flips PASS/FAIL between attempts must be recorded FLAKY.
+    if (run_command(repeated_run(flaky_report, wrapper, 3)) == 0) then
+        print *, 'FAIL: repeated run with an unstable case exited 0'
+        all_passed = .false.
+    end if
+    if (.not. file_contains(flaky_report, '"file":"'//CASE_FILE// &
+                            '","status":"FLAKY"')) all_passed = .false.
+    if (.not. file_contains(flaky_report, '"observed":"PASS|FAIL"')) &
+        all_passed = .false.
+    if (.not. file_contains(flaky_report, '"flaky":1')) all_passed = .false.
+
+    ! The same case under the real compiler is stable and must not be flagged.
+    if (run_command('timeout 300 bash '//SCRIPT//' --suite fortfront-f90'// &
+                    ' --file '//CASE_FILE//' --repeat 3 --report '// &
+                    stable_report) /= 0) then
+        print *, 'FAIL: repeated run of a stable case did not exit 0'
+        all_passed = .false.
+    end if
+    if (.not. file_contains(stable_report, '"file":"'//CASE_FILE// &
+                            '","status":"PASS"')) all_passed = .false.
+    if (file_contains_quiet(stable_report, '"status":"FLAKY"')) then
+        print *, 'FAIL: stable case reported as FLAKY'
+        all_passed = .false.
+    end if
+
+    ! Negative control: a malformed repeat count is rejected.
+    if (run_command('bash '//SCRIPT//' --suite fortfront-f90 --repeat zero'// &
+                    ' > /dev/null 2>&1') == 0) then
+        print *, 'FAIL: --repeat zero was accepted'
+        all_passed = .false.
+    end if
+
+    if (all_passed) call remove_temp_root(root)
+
+    if (all_passed) then
+        print *, 'PASS: repeated runs record unstable cases as FLAKY'
+    else
+        print *, 'FAIL: flake detection test failed (scratch kept: ', root, ')'
+        stop 1
+    end if
+
+contains
+
+    function repeated_run(report, wrapper_path, attempts) result(command)
+        character(len=*), intent(in) :: report, wrapper_path
+        integer, intent(in) :: attempts
+        character(len=:), allocatable :: command
+        character(len=16) :: attempt_text
+
+        write (attempt_text, '(i0)') attempts
+        command = 'export FLAKE_COUNTER='//counter//'; echo 0 > $FLAKE_COUNTER; '// &
+                  'export FLAKE_REAL_FFC=$(PROJECT_DIR=$PWD bash -c '// &
+                  '". scripts/lib_conformance.sh; find_ffc"); '// &
+                  'test -x "$FLAKE_REAL_FFC" || exit 2; '// &
+                  'timeout 300 bash '//SCRIPT//' --suite fortfront-f90 --file '// &
+                  CASE_FILE//' --ffc '//wrapper_path//' --repeat '// &
+                  trim(attempt_text)//' --report '//report
+    end function repeated_run
+
+    subroutine write_alternating_wrapper(path)
+        character(len=*), intent(in) :: path
+        integer :: unit_number, exit_status
+
+        open (newunit=unit_number, file=path, status='replace', action='write')
+        write (unit_number, '(a)') '#!/usr/bin/env bash'
+        write (unit_number, '(a)') '# Compiles on even invocations, fails on odd ones.'
+        write (unit_number, '(a)') 'n=$(cat "$FLAKE_COUNTER" 2>/dev/null || echo 0)'
+        write (unit_number, '(a)') 'echo $((n + 1)) > "$FLAKE_COUNTER"'
+        write (unit_number, '(a)') 'if [ $((n % 2)) -eq 1 ]; then'
+        write (unit_number, '(a)') '    echo "alternating wrapper: failure" >&2'
+        write (unit_number, '(a)') '    exit 1'
+        write (unit_number, '(a)') 'fi'
+        write (unit_number, '(a)') 'exec "$FLAKE_REAL_FFC" "$@"'
+        close (unit_number)
+        call execute_command_line('chmod +x '//path, exitstat=exit_status)
+        if (exit_status /= 0) then
+            print *, 'FAIL: could not make the wrapper executable'
+            stop 1
+        end if
+    end subroutine write_alternating_wrapper
+
+    integer function run_command(command) result(exit_status)
+        character(len=*), intent(in) :: command
+        integer :: command_status
+
+        call execute_command_line(command, exitstat=exit_status, &
+                                  cmdstat=command_status)
+        if (command_status /= 0) exit_status = -1
+    end function run_command
+
+    logical function file_contains(path, needle) result(found)
+        character(len=*), intent(in) :: path, needle
+
+        found = file_contains_quiet(path, needle)
+        if (.not. found) then
+            print *, 'FAIL: ', trim(path), ' lacks ', trim(needle)
+        end if
+    end function file_contains
+
+    logical function file_contains_quiet(path, needle) result(found)
+        character(len=*), intent(in) :: path, needle
+        integer :: unit_number, io_status
+        character(len=4096) :: line
+        logical :: exists
+
+        found = .false.
+        inquire (file=path, exist=exists)
+        if (.not. exists) return
+        open (newunit=unit_number, file=path, status='old', action='read')
+        do
+            read (unit_number, '(a)', iostat=io_status) line
+            if (io_status /= 0) exit
+            if (index(line, needle) > 0) then
+                found = .true.
+                exit
+            end if
+        end do
+        close (unit_number)
+    end function file_contains_quiet
+
+end program test_conformance_flake_detection


### PR DESCRIPTION
Closes #599.

## Problem

On an unmodified tree, repeated corpus runs produce different XPASS totals.
A single run cannot distinguish a stable result from a case that flips, so
reclassifying an XPASS out of an xfail manifest on one run's evidence can
turn a flake into a manifest entry that the next run breaks.

## Change

`scripts/conformance_gauntlet.sh --repeat N` runs the selection N times as
independent child runs *through the same, single classification path* (the
child is the same script with `--repeat 1`; there is no second lowering or
classification mechanism), then merges the attempt reports with
`scripts/merge_repeated_report.awk`:

- identical status in every attempt: the record is kept verbatim;
- differing status: one `FLAKY` record with `attempts` and
  `observed` (e.g. `"PASS|FAIL"`), counted in the SUMMARY `flaky` field
  (emitted only when nonzero).

FLAKY is a failure: the gauntlet and `conformance_check.sh --repeat N`
both exit nonzero, and a flaky case never appears in the promotable XPASS
list. `validate_parity_report.awk` accepts and cross-checks the new row
status and summary field. Default `--repeat 1` behaviour is unchanged.

## Preserved compiler invariant

No compiler or lowering code is touched; classification of any single
attempt is byte-identical to before. What changes is only that a case whose
status is not reproducible is reported as unstable rather than taking the
last result.

## Red evidence

On unmodified main:

```
$ bash scripts/conformance_gauntlet.sh --suite fortfront-f90 \
      --file api_pipeline_minimal_program.f90 --repeat 3 --report /tmp/red.jsonl
ERROR: unknown option --repeat
exit=1
```

so the new behavioural test `test/test_conformance_flake_detection` (which
drives the gauntlet through a compiler wrapper that alternates between
compiling and failing, and requires the merged report to record FLAKY)
fails on main.

## Green evidence

- `fo test test_conformance_flake_detection` passes; the report contains
  `"status":"FLAKY"`, `"observed":"PASS|FAIL"`, `"flaky":1`, the run exits
  nonzero, the same case under the real compiler stays PASS over 3 attempts,
  and `--repeat zero` is rejected.
- Full `fo` pipeline green except the two known environmental failures:
  `test_parity_dashboard` (resolves sibling repos as `../fortfront`, fails in
  any `.wt/` worktree) and `test_fortfront_corpus_conformance`, which fails
  identically on unmodified main in the primary checkout (corpus drift:
  `class_is_1_ok.f90`, `issue_2950_procedure_actual_argument.f90`,
  `pr91715_ok.f90` all FAIL there too).