### PR TITLE
[poly-04] dispatch overridden type-bound procedures through vtables (closes #420)

### DIFF
--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -451,6 +451,36 @@ struct ffc_polymorphic_descriptor_t {
 - The descriptor never aliases the value: `data` points at storage held
   elsewhere, and copying a descriptor copies a reference, never the value.
 
+## Type-bound dispatch vtables
+
+Each derived type with type-bound bindings emits one const global,
+`__ffc_vtable_<typename>`, holding one 8-byte code address per binding slot.
+Slot `k` is the `k`-th binding of the type in declaration order, counting
+inherited bindings first: an extension copies its parent's slots in order and
+an override replaces the target of the slot it overrides, so slot `k` names the
+same binding in a type and in every extension of it. A slot whose
+implementation is not defined in the current compilation unit stays null rather
+than emitting an undefined relocation.
+
+One link-unit table, `__ffc_vtable_table`, maps a type identity to its vtable:
+entry `i` is the address of the vtable of the type whose `ffc_type_info_t.id`
+is `i`, and entry `0` is null for the reserved "no type" id. A type without
+bindings has a null entry.
+
+Dispatch through a polymorphic receiver is therefore
+
+```
+vtable = __ffc_vtable_table[descriptor.dynamic_type];
+callee = vtable[slot - 1];
+```
+
+Both loads read const, linker-initialised data; neither writes memory nor
+aliases the receiver's storage. Keeping the identity-to-vtable mapping in this
+table rather than in a fifth descriptor field leaves the 32-byte scalar class
+descriptor above unchanged. A receiver whose dynamic type is fixed at compile
+time (a `type(t)` entity) keeps a direct call: its dynamic type is its declared
+type by definition, so the vtable would only re-derive a known answer.
+
 ## Module artefact format
 
 `ffc -c <source>.f90` writes one `<modulename>.fmod` next to the object file

--- a/src/liric_session_format_bindings.f90
+++ b/src/liric_session_format_bindings.f90
@@ -37,6 +37,7 @@ module liric_session_format_bindings
     public :: create_printf_format_global
     public :: printf_format_ptr
     public :: create_type_info_global
+    public :: create_pointer_table_global
     public :: create_i8_format_global_no_newline
     public :: create_i16_format_global_no_newline
     public :: emit_e_en_format_call
@@ -92,6 +93,14 @@ module liric_session_format_bindings
             integer(c_size_t), value :: init_size
             integer(c_int32_t) :: global_id
         end function lr_session_global
+
+        subroutine lr_session_global_reloc(handle, global_id, offset, sym) bind(c)
+            import :: c_char, c_int32_t, c_ptr, c_size_t
+            type(c_ptr), value :: handle
+            integer(c_int32_t), value :: global_id
+            integer(c_size_t), value :: offset
+            character(kind=c_char), intent(in) :: sym(*)
+        end subroutine lr_session_global_reloc
 
         function lr_session_intern(handle, name) result(symbol_id) bind(c)
             import :: c_char, c_int32_t, c_ptr
@@ -345,6 +354,52 @@ contains
         end if
         call set_empty(error_msg)
     end subroutine create_type_info_global
+
+    subroutine create_pointer_table_global(session, name, symbols, error_msg)
+        ! Emit a const global holding size(symbols) 8-byte pointer slots. Each
+        ! slot whose symbol name is non-blank carries a data relocation to that
+        ! symbol; a blank name leaves the slot a null pointer. This backs the
+        ! per-type vtables and the link-unit vtable table of
+        ! docs/RUNTIME_ABI.md, both of which are arrays of code or data
+        ! addresses that only the linker (or the JIT's global materialiser) can
+        ! fill in.
+        type(liric_session_t), intent(inout) :: session
+        character(len=*), intent(in) :: name
+        character(len=*), intent(in) :: symbols(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(kind=c_char), allocatable :: c_name(:), c_sym(:)
+        character(kind=c_char), allocatable, target :: bytes(:)
+        type(c_ptr) :: array_type
+        integer :: slot
+        integer(c_size_t) :: nbytes
+        integer(c_int32_t) :: global_id
+
+        call set_empty(error_msg)
+        if (size(symbols) <= 0) return
+        nbytes = int(size(symbols), c_size_t) * 8_c_size_t
+        allocate (bytes(nbytes))
+        bytes = char(0, kind=c_char)
+
+        call to_c_chars(name, c_name)
+        array_type = lr_type_array_s(session%handle, lr_type_i8_s(session%handle), &
+            int(nbytes, c_int64_t))
+        if (.not. c_associated(array_type)) then
+            error_msg = 'LIRIC did not return a pointer-table array type'
+            return
+        end if
+        global_id = lr_session_global(session%handle, c_name, array_type, &
+            c_true, c_loc(bytes), nbytes)
+        if (global_id < 0_c_int32_t) then
+            error_msg = 'LIRIC could not create pointer table global '//trim(name)
+            return
+        end if
+        do slot = 1, size(symbols)
+            if (len_trim(symbols(slot)) == 0) cycle
+            call to_c_chars(trim(symbols(slot)), c_sym)
+            call lr_session_global_reloc(session%handle, global_id, &
+                int(slot - 1, c_size_t) * 8_c_size_t, c_sym)
+        end do
+    end subroutine create_pointer_table_global
 
     include 'liric_session_format_e_en.inc'
 

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -144,7 +144,7 @@ module session_program_lowering
         prepare_liric_print_runtime, &
         create_printf_format_global, &
         printf_format_ptr, &
-        create_type_info_global
+        create_type_info_global, create_pointer_table_global
     use liric_session_real_print_bindings, only: synthesize_real8_printer, &
         synthesize_real4_printer, &
         synthesize_get_arg_helper, &

--- a/src/session_program_lowering_derived_type_ops.inc
+++ b/src/session_program_lowering_derived_type_ops.inc
@@ -1201,7 +1201,8 @@
     end subroutine lower_derived_component_element_assignment
 
     subroutine method_call_info(arena, node, context, base_var_index, &
-                                impl_name, pass_name, found, error_msg)
+                                impl_name, pass_name, found, error_msg, &
+                                receiver_symbol, binding_slot)
         ! For obj%m(args): resolve m to its bound implementation via obj's
         ! derived type, returning the base variable's node index, the
         ! implementation name, and the pass(name) dummy (empty for default pass).
@@ -1213,11 +1214,15 @@
         character(len=:), allocatable, intent(out) :: pass_name
         logical, intent(out) :: found
         character(len=:), allocatable, intent(out) :: error_msg
+        integer, intent(out), optional :: receiver_symbol
+        integer, intent(out), optional :: binding_slot
         character(len=:), allocatable :: var_name, method_name
         integer :: symbol_index, type_index, b
 
         found = .false.
         base_var_index = 0
+        if (present(receiver_symbol)) receiver_symbol = 0
+        if (present(binding_slot)) binding_slot = 0
         call set_empty(error_msg)
         call set_empty(impl_name)
         call set_empty(pass_name)
@@ -1249,6 +1254,8 @@
                 if (allocated(context%derived_types(type_index)%binding_pass_names)) &
                     pass_name = trim(context%derived_types(type_index)% &
                                      binding_pass_names(b))
+                if (present(receiver_symbol)) receiver_symbol = symbol_index
+                if (present(binding_slot)) binding_slot = b
                 found = .true.
                 return
             end if
@@ -1358,8 +1365,9 @@
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: var_name, method_name, impl_name
         character(len=:), allocatable :: pass_name
-        integer :: pct, symbol_index, type_index, b, n, position, i, k
+        integer :: pct, symbol_index, type_index, b, n, position, i, k, slot
         type(lr_operand_desc_t), allocatable :: method_args(:), all_args(:)
+        type(lr_operand_desc_t) :: callee_ptr
         integer, allocatable :: copyback_indices(:)
 
         call set_empty(error_msg)
@@ -1416,8 +1424,22 @@
             k = k + 1
             all_args(i) = method_args(k)
         end do
-        if (.not. emit_void_call(context%session, &
-                call_emit_name(arena, impl_name, context), all_args, error_msg)) return
+        ! A receiver that carries a runtime type identity dispatches through
+        ! its dynamic type's vtable, so an override of the most-derived type is
+        ! reached instead of the declared type's implementation (#420).
+        slot = type_binding_slot(context, type_index, method_name)
+        if (slot > 0 .and. &
+            class_receiver_dispatches_dynamically(context, symbol_index)) then
+            call class_dispatch_callee(context, symbol_index, slot, callee_ptr, &
+                                       error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (.not. emit_void_indirect_call(context%session, callee_ptr, &
+                    all_args, error_msg)) return
+        else
+            if (.not. emit_void_call(context%session, &
+                    call_emit_name(arena, impl_name, context), all_args, &
+                    error_msg)) return
+        end if
         call copy_back_reference_args(context, method_args, copyback_indices, &
                                       error_msg)
     end subroutine lower_method_subroutine_call
@@ -1428,15 +1450,16 @@
         type(lowering_context_t), intent(inout) :: context
         type(lr_operand_desc_t), intent(out) :: value
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: base_var_index, position
+        integer :: base_var_index, position, receiver_symbol, slot
         character(len=:), allocatable :: impl_name, pass_name
         logical :: found
         integer, allocatable :: combined(:)
         type(lr_operand_desc_t), allocatable :: args(:)
+        type(lr_operand_desc_t) :: callee_ptr
         integer, allocatable :: copyback_indices(:)
 
         call method_call_info(arena, node, context, base_var_index, impl_name, &
-                              pass_name, found, error_msg)
+                              pass_name, found, error_msg, receiver_symbol, slot)
         if (len_trim(error_msg) > 0) return
         if (.not. found) then
             error_msg = 'not a type-bound method call'
@@ -1447,9 +1470,18 @@
         call prepare_reference_args(arena, combined, context, VALUE_I32, &
                                     impl_name, args, copyback_indices, error_msg)
         if (len_trim(error_msg) > 0) return
-        if (.not. emit_i32_call(context%session, call_emit_name(arena, impl_name, &
-                                                               context), &
-                                args, value, error_msg)) return
+        if (slot > 0 .and. &
+            class_receiver_dispatches_dynamically(context, receiver_symbol)) then
+            call class_dispatch_callee(context, receiver_symbol, slot, &
+                                       callee_ptr, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (.not. emit_i32_indirect_call(context%session, callee_ptr, args, &
+                    value, error_msg)) return
+        else
+            if (.not. emit_i32_call(context%session, &
+                    call_emit_name(arena, impl_name, context), args, value, &
+                    error_msg)) return
+        end if
         call copy_back_reference_args(context, args, copyback_indices, error_msg)
     end subroutine lower_method_call_i32
 

--- a/src/session_program_lowering_derived_types.inc
+++ b/src/session_program_lowering_derived_types.inc
@@ -112,6 +112,7 @@
         do i = 1, size(context%derived_types)
             context%derived_types(i)%name = ''
             context%derived_types(i)%component_count = 0
+            context%derived_types(i)%duplicate_binding_name = ''
             if (allocated(context%derived_types(i)%component_names)) then
                 deallocate(context%derived_types(i)%component_names)
             end if
@@ -753,6 +754,19 @@
                     end if
                 end do
                 if (.not. overrides) then
+                    ! A name declared twice in the same type has no single
+                    ! vtable slot occupant, so dispatch through it would be
+                    ! ambiguous: reject it instead of silently keeping one
+                    ! (#420).
+                    do b = inherited + 1, &
+                        context%derived_types(type_index)%binding_count
+                        if (trim(context%derived_types(type_index)% &
+                                 binding_method_names(b)) /= &
+                            trim(method_name_buf)) cycle
+                        context%derived_types(type_index)% &
+                            duplicate_binding_name = method_name_buf
+                        exit
+                    end do
                     slot = context%derived_types(type_index)%binding_count + 1
                     context%derived_types(type_index)%binding_method_names(slot) = &
                         method_name_buf

--- a/src/session_program_lowering_polymorphic.inc
+++ b/src/session_program_lowering_polymorphic.inc
@@ -183,6 +183,164 @@
         call set_empty(error_msg)
     end subroutine bind_class_dummy_descriptor
 
+    ! Type-bound dispatch through vtables (#420). Every derived type that has
+    ! type-bound bindings gets one const vtable global, `__ffc_vtable_<type>`,
+    ! holding one code address per binding slot. Slot numbering is the binding
+    ! numbering of the derived-type table: a child inherits its parent's slots
+    ! in order and an override replaces the target in place, so slot k names
+    ! the same binding in a type and in every extension of it. One link-unit
+    ! table, `__ffc_vtable_table`, maps a dynamic type id to that type's
+    ! vtable: the id is the dense index the class descriptor already carries,
+    ! so entry i of the table is the vtable of type id i and entry 0 is the
+    ! reserved "no type" null. Keeping the mapping in a link-unit table rather
+    ! than in a fifth descriptor field leaves the 32-byte scalar class
+    ! descriptor of #400 unchanged, so every existing descriptor producer and
+    ! consumer keeps working unmodified.
+
+    subroutine type_vtable_symbol_name(context, type_index, name)
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: type_index
+        character(len=:), allocatable, intent(out) :: name
+
+        name = '__ffc_vtable_'//trim(context%derived_types(type_index)%name)
+    end subroutine type_vtable_symbol_name
+
+    subroutine emit_type_vtables(arena, context, error_msg)
+        ! Emit every per-type vtable and the link-unit lookup table. Called
+        ! once, before any procedure body is compiled, because a global created
+        ! mid-compile loses its data-section initializer and relocations.
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=128), allocatable :: slots(:), table(:)
+        character(len=:), allocatable :: vtable_name
+        integer :: t, b, n
+
+        call set_empty(error_msg)
+        if (context%derived_type_count <= 0) return
+        allocate (table(context%derived_type_count + 1))
+        table = ''
+        do t = 1, context%derived_type_count
+            if (len_trim(context%derived_types(t)%duplicate_binding_name) > 0) then
+                error_msg = 'type "'//trim(context%derived_types(t)%name)// &
+                    '" declares the type-bound procedure "'// &
+                    trim(context%derived_types(t)%duplicate_binding_name)// &
+                    '" more than once'
+                return
+            end if
+            n = context%derived_types(t)%binding_count
+            if (n <= 0) cycle
+            if (.not. allocated(context%derived_types(t)%binding_target_names)) cycle
+            allocate (slots(n))
+            slots = ''
+            do b = 1, n
+                ! A binding whose implementation is not defined in this
+                ! compilation unit gets a null slot instead of a relocation, so
+                ! emitting a vtable never introduces an undefined symbol for a
+                ! binding the program never calls.
+                if (arena_proc_param_count(arena, &
+                        trim(context%derived_types(t)%binding_target_names(b))) &
+                    < 0) cycle
+                slots(b) = call_emit_name(arena, &
+                    trim(context%derived_types(t)%binding_target_names(b)))
+            end do
+            call type_vtable_symbol_name(context, t, vtable_name)
+            call create_pointer_table_global(context%session, vtable_name, &
+                                             slots, error_msg)
+            deallocate (slots)
+            if (len_trim(error_msg) > 0) return
+            table(t + 1) = vtable_name
+        end do
+        call create_pointer_table_global(context%session, '__ffc_vtable_table', &
+                                         table, error_msg)
+    end subroutine emit_type_vtables
+
+    integer function type_binding_slot(context, type_index, method_name) &
+            result(slot)
+        ! Binding slot of method_name in type_index, or 0 when it has none.
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: type_index
+        character(len=*), intent(in) :: method_name
+        integer :: b
+
+        slot = 0
+        if (type_index <= 0) return
+        if (type_index > context%derived_type_count) return
+        if (.not. allocated(context%derived_types(type_index)%binding_method_names)) &
+            return
+        do b = 1, context%derived_types(type_index)%binding_count
+            if (trim(context%derived_types(type_index)%binding_method_names(b)) == &
+                trim(method_name)) then
+                slot = b
+                return
+            end if
+        end do
+    end function type_binding_slot
+
+    logical function class_receiver_dispatches_dynamically(context, symbol_index)
+        ! True when the receiver carries a runtime type identity, i.e. it is a
+        ! class entity whose dynamic type is not fixed at compile time. A
+        ! type(t) receiver keeps direct dispatch: its dynamic type is its
+        ! declared type by definition.
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: symbol_index
+
+        class_receiver_dispatches_dynamically = .false.
+        if (symbol_index <= 0) return
+        if (.not. context%symbols(symbol_index)%is_polymorphic) return
+        class_receiver_dispatches_dynamically = &
+            context%symbols(symbol_index)%has_dynamic_type_address
+    end function class_receiver_dispatches_dynamically
+
+    subroutine class_dispatch_callee(context, symbol_index, slot, callee_ptr, &
+                                     error_msg)
+        ! Load the implementation address for binding slot `slot` from the
+        ! receiver's dynamic type:
+        !   vtable = __ffc_vtable_table[dynamic_type];
+        !   callee = vtable[slot - 1];
+        ! Both loads read const data the linker filled in, so the sequence
+        ! neither writes memory nor aliases the receiver's storage.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        integer, intent(in) :: slot
+        type(lr_operand_desc_t), intent(out) :: callee_ptr
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: dynamic_id, byte_offset, table_base
+        type(lr_operand_desc_t) :: entry_addr, vtable, slot_addr
+        character(kind=c_char), allocatable :: c_name(:)
+        integer(c_int32_t) :: symbol_id
+
+        call set_empty(error_msg)
+        if (.not. emit_i64_load(context%session, &
+                context%symbols(symbol_index)%dynamic_type_address, dynamic_id, &
+                error_msg)) return
+        if (.not. emit_i64_binary(context%session, LR_OP_MUL, dynamic_id, &
+                i64_immediate(context%session, 8_c_int64_t), byte_offset, &
+                error_msg)) return
+
+        call to_c_chars('__ffc_vtable_table', c_name)
+        symbol_id = lr_session_intern(context%session%handle, c_name)
+        if (symbol_id < 0_c_int32_t) then
+            error_msg = 'could not intern the vtable lookup table symbol'
+            return
+        end if
+        table_base%kind = LR_OP_KIND_GLOBAL
+        table_base%payload = int(symbol_id, c_int64_t)
+        table_base%typ = lr_type_ptr_s(context%session%handle)
+        table_base%global_offset = 0_c_int64_t
+
+        if (.not. emit_ptr_offset_dyn(context%session, table_base, byte_offset, &
+                entry_addr, error_msg)) return
+        if (.not. emit_ptr_load(context%session, entry_addr, vtable, &
+                error_msg)) return
+        if (.not. emit_ptr_offset(context%session, vtable, &
+                int(slot - 1, c_int64_t) * 8_c_int64_t, slot_addr, &
+                error_msg)) return
+        if (.not. emit_ptr_load(context%session, slot_addr, callee_ptr, &
+                error_msg)) return
+    end subroutine class_dispatch_callee
+
     subroutine class_receiver_argument(context, arena, impl_name, position, &
                                        symbol_index, argument, error_msg)
         ! Argument the receiver of a type-bound call occupies. The passed-object

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -149,6 +149,16 @@
             call destroy(context%session)
             return
         end if
+        ! Vtables are const globals with relocations: like every other global
+        ! with a data-section initializer they must exist before any procedure
+        ! body is compiled (#420). They come after PDT instantiation so an
+        ! instantiated layout is a registered type by the time its vtable is
+        ! emitted.
+        call emit_type_vtables(arena, context, error_msg)
+        if (len_trim(error_msg) > 0) then
+            call destroy(context%session)
+            return
+        end if
         call collect_module_exports(arena, root_index, context, error_msg)
         if (len_trim(error_msg) > 0) then
             call destroy(context%session)

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -463,6 +463,12 @@ module session_program_lowering_types
         ! Empty unless the binding declared pass(name); names the dummy that
         ! receives the passed object.
         character(len=64), allocatable :: binding_pass_names(:)
+        ! Non-empty when the type declares the same binding name twice. Such a
+        ! type has no single occupant for that vtable slot, so it is reported
+        ! when the vtables are emitted rather than when it is collected: a
+        ! collection error would be swallowed by the "skip a type ffc cannot
+        ! lower" path and reappear as an unrelated diagnostic (#420).
+        character(len=64) :: duplicate_binding_name = ''
     end type derived_type_info_t
 
     type, public :: module_exports_t

--- a/test/test_session_typebound_override_dispatch_compiler.f90
+++ b/test/test_session_typebound_override_dispatch_compiler.f90
@@ -1,0 +1,328 @@
+program test_session_typebound_override_dispatch_compiler
+    use ffc_test_support, only: expect_output, expect_error_contains, &
+        expect_exe_has_symbol
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== type-bound override dispatch tests ==='
+
+    all_passed = .true.
+    if (.not. test_override_dispatches_by_dynamic_type()) all_passed = .false.
+    if (.not. test_inherited_binding_still_reaches_parent()) all_passed = .false.
+    if (.not. test_three_level_hierarchy_picks_most_derived()) all_passed = .false.
+    if (.not. test_function_binding_dispatches()) all_passed = .false.
+    if (.not. test_identity_survives_repassing_before_dispatch()) &
+        all_passed = .false.
+    if (.not. test_monomorphic_receiver_stays_static()) all_passed = .false.
+    if (.not. test_vtable_symbols_are_emitted()) all_passed = .false.
+    if (.not. test_duplicate_binding_is_rejected()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: type-bound override dispatch'
+
+contains
+
+    character(len=:) function hierarchy() result(text)
+        ! base_t with two bindings; ext_t overrides only `speak`.
+        allocatable :: text
+        text = 'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: base_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: speak => base_speak'//new_line('a')// &
+            '    procedure :: tag => base_tag'//new_line('a')// &
+            '  end type base_t'//new_line('a')// &
+            '  type, extends(base_t) :: ext_t'//new_line('a')// &
+            '    integer :: y'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: speak => ext_speak'//new_line('a')// &
+            '  end type ext_t'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine base_speak(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    print *, 100'//new_line('a')// &
+            '  end subroutine base_speak'//new_line('a')// &
+            '  subroutine ext_speak(self)'//new_line('a')// &
+            '    class(ext_t), intent(in) :: self'//new_line('a')// &
+            '    print *, 200'//new_line('a')// &
+            '  end subroutine ext_speak'//new_line('a')// &
+            '  subroutine base_tag(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    print *, 300'//new_line('a')// &
+            '  end subroutine base_tag'//new_line('a')
+    end function hierarchy
+
+    logical function test_override_dispatches_by_dynamic_type()
+        ! One class(base_t) dummy, two dynamic types: each call reaches the
+        ! override of the value's dynamic type, not of the declared type.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            '  subroutine run(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    call self%speak()'//new_line('a')// &
+            '  end subroutine run'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(base_t) :: b'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  b%x = 1'//new_line('a')// &
+            '  e%x = 2'//new_line('a')// &
+            '  e%y = 3'//new_line('a')// &
+            '  call run(b)'//new_line('a')// &
+            '  call run(e)'//new_line('a')// &
+            'end program main'
+
+        test_override_dispatches_by_dynamic_type = expect_output(source, &
+            '         100'//new_line('a')//'         200'//new_line('a'), &
+            '/tmp/ffc_tbp_override_dispatch')
+    end function test_override_dispatches_by_dynamic_type
+
+    logical function test_inherited_binding_still_reaches_parent()
+        ! `tag` is not overridden by ext_t, so both dynamic types dispatch to
+        ! the inherited parent implementation through the same slot.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            '  subroutine run(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    call self%tag()'//new_line('a')// &
+            '  end subroutine run'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(base_t) :: b'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  b%x = 1'//new_line('a')// &
+            '  e%x = 2'//new_line('a')// &
+            '  e%y = 3'//new_line('a')// &
+            '  call run(b)'//new_line('a')// &
+            '  call run(e)'//new_line('a')// &
+            'end program main'
+
+        test_inherited_binding_still_reaches_parent = expect_output(source, &
+            '         300'//new_line('a')//'         300'//new_line('a'), &
+            '/tmp/ffc_tbp_inherited_slot')
+    end function test_inherited_binding_still_reaches_parent
+
+    logical function test_three_level_hierarchy_picks_most_derived()
+        ! a_t -> b_t (no override) -> c_t (override). A b_t value must still
+        ! reach a_t's implementation and a c_t value must reach c_t's, so the
+        ! slot number is stable across two inheritance steps.
+        character(len=:), allocatable :: source
+
+        source = 'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: a_t'//new_line('a')// &
+            '    integer :: v'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: who => a_who'//new_line('a')// &
+            '  end type a_t'//new_line('a')// &
+            '  type, extends(a_t) :: b_t'//new_line('a')// &
+            '  end type b_t'//new_line('a')// &
+            '  type, extends(b_t) :: c_t'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: who => c_who'//new_line('a')// &
+            '  end type c_t'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine a_who(self)'//new_line('a')// &
+            '    class(a_t), intent(in) :: self'//new_line('a')// &
+            '    print *, 11'//new_line('a')// &
+            '  end subroutine a_who'//new_line('a')// &
+            '  subroutine c_who(self)'//new_line('a')// &
+            '    class(c_t), intent(in) :: self'//new_line('a')// &
+            '    print *, 33'//new_line('a')// &
+            '  end subroutine c_who'//new_line('a')// &
+            '  subroutine run(self)'//new_line('a')// &
+            '    class(a_t), intent(in) :: self'//new_line('a')// &
+            '    call self%who()'//new_line('a')// &
+            '  end subroutine run'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(a_t) :: a'//new_line('a')// &
+            '  type(b_t) :: b'//new_line('a')// &
+            '  type(c_t) :: c'//new_line('a')// &
+            '  a%v = 1'//new_line('a')// &
+            '  b%v = 2'//new_line('a')// &
+            '  c%v = 3'//new_line('a')// &
+            '  call run(a)'//new_line('a')// &
+            '  call run(b)'//new_line('a')// &
+            '  call run(c)'//new_line('a')// &
+            'end program main'
+
+        test_three_level_hierarchy_picks_most_derived = expect_output(source, &
+            '          11'//new_line('a')//'          11'//new_line('a')// &
+            '          33'//new_line('a'), '/tmp/ffc_tbp_three_level')
+    end function test_three_level_hierarchy_picks_most_derived
+
+    logical function test_function_binding_dispatches()
+        ! A type-bound function used in an expression dispatches on the
+        ! dynamic type too, so dispatch is not limited to subroutine calls.
+        character(len=:), allocatable :: source
+
+        source = 'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: base_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: code => base_code'//new_line('a')// &
+            '  end type base_t'//new_line('a')// &
+            '  type, extends(base_t) :: ext_t'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: code => ext_code'//new_line('a')// &
+            '  end type ext_t'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  integer function base_code(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    base_code = 7'//new_line('a')// &
+            '  end function base_code'//new_line('a')// &
+            '  integer function ext_code(self)'//new_line('a')// &
+            '    class(ext_t), intent(in) :: self'//new_line('a')// &
+            '    ext_code = 9'//new_line('a')// &
+            '  end function ext_code'//new_line('a')// &
+            '  subroutine run(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    print *, self%code()'//new_line('a')// &
+            '  end subroutine run'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(base_t) :: b'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  b%x = 1'//new_line('a')// &
+            '  e%x = 2'//new_line('a')// &
+            '  call run(b)'//new_line('a')// &
+            '  call run(e)'//new_line('a')// &
+            'end program main'
+
+        test_function_binding_dispatches = expect_output(source, &
+            '           7'//new_line('a')//'           9'//new_line('a'), &
+            '/tmp/ffc_tbp_function_dispatch')
+    end function test_function_binding_dispatches
+
+    logical function test_identity_survives_repassing_before_dispatch()
+        ! The dynamic type reaches the dispatch site through two hand-offs, so
+        ! dispatch consults the original value's identity, not the type of the
+        ! nearest dummy.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            '  subroutine outer(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    call inner(self)'//new_line('a')// &
+            '  end subroutine outer'//new_line('a')// &
+            '  subroutine inner(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    call self%speak()'//new_line('a')// &
+            '  end subroutine inner'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  e%x = 2'//new_line('a')// &
+            '  e%y = 3'//new_line('a')// &
+            '  call outer(e)'//new_line('a')// &
+            'end program main'
+
+        test_identity_survives_repassing_before_dispatch = expect_output(source, &
+            '         200'//new_line('a'), '/tmp/ffc_tbp_repassed_dispatch')
+    end function test_identity_survives_repassing_before_dispatch
+
+    logical function test_monomorphic_receiver_stays_static()
+        ! A type(t) receiver has no runtime identity: it keeps direct dispatch
+        ! and still calls its own binding.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  e%x = 2'//new_line('a')// &
+            '  e%y = 3'//new_line('a')// &
+            '  call e%speak()'//new_line('a')// &
+            '  call e%tag()'//new_line('a')// &
+            'end program main'
+
+        test_monomorphic_receiver_stays_static = expect_output(source, &
+            '         200'//new_line('a')//'         300'//new_line('a'), &
+            '/tmp/ffc_tbp_monomorphic')
+    end function test_monomorphic_receiver_stays_static
+
+    logical function test_vtable_symbols_are_emitted()
+        ! One vtable per type carrying bindings, plus the link-unit table the
+        ! dynamic type id indexes, are present in the linked executable.
+        character(len=:), allocatable :: source
+        logical :: ok
+
+        source = hierarchy()// &
+            '  subroutine run(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    call self%speak()'//new_line('a')// &
+            '  end subroutine run'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  e%x = 2'//new_line('a')// &
+            '  e%y = 3'//new_line('a')// &
+            '  call run(e)'//new_line('a')// &
+            'end program main'
+
+        ok = expect_exe_has_symbol(source, '/tmp/ffc_tbp_vtable_syms.o', &
+            '__ffc_vtable_base_t')
+        if (.not. expect_exe_has_symbol(source, '/tmp/ffc_tbp_vtable_syms2.o', &
+            '__ffc_vtable_ext_t')) ok = .false.
+        if (.not. expect_exe_has_symbol(source, '/tmp/ffc_tbp_vtable_syms3.o', &
+            '__ffc_vtable_table')) ok = .false.
+        test_vtable_symbols_are_emitted = ok
+    end function test_vtable_symbols_are_emitted
+
+    logical function test_duplicate_binding_is_rejected()
+        ! Two bindings of the same name in one type have no single slot
+        ! occupant, so the vtable cannot be built and the program is rejected.
+        character(len=:), allocatable :: source
+
+        source = 'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: base_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: speak => one_speak'//new_line('a')// &
+            '    procedure :: speak => two_speak'//new_line('a')// &
+            '  end type base_t'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine one_speak(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    print *, 1'//new_line('a')// &
+            '  end subroutine one_speak'//new_line('a')// &
+            '  subroutine two_speak(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    print *, 2'//new_line('a')// &
+            '  end subroutine two_speak'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(base_t) :: b'//new_line('a')// &
+            '  b%x = 1'//new_line('a')// &
+            '  call b%speak()'//new_line('a')// &
+            'end program main'
+
+        test_duplicate_binding_is_rejected = expect_error_contains(source, &
+            'declares the type-bound procedure "speak" more than once', &
+            '/tmp/ffc_tbp_duplicate_binding')
+    end function test_duplicate_binding_is_rejected
+
+end program test_session_typebound_override_dispatch_compiler


### PR DESCRIPTION
Closes #420.

A type-bound call through a polymorphic receiver used to resolve statically
against the receiver's *declared* type, so an override was never reached:
`class(base_t) :: self; call self%speak()` always called `base_t`'s binding
even when the value's dynamic type was `ext_t`.

## Design: id-to-vtable lookup

Each derived type with bindings emits one const global
`__ffc_vtable_<typename>`, one 8-byte code address per binding slot. Slot
numbering is the existing derived-type binding numbering: `inherit_parent_bindings`
copies parent slots 1..n in order and `collect_type_bindings` replaces an
override in place, so slot k names the same binding in a type and in every
extension of it, across any number of inheritance steps.

The open question from the previous agent was how a dynamic type *id* finds its
vtable. **This PR takes the link-unit table, not a fifth descriptor field.**
`__ffc_vtable_table` is an array of vtable addresses indexed by the dense type
id the class descriptor already carries; entry 0 is the reserved "no type" null.
Dispatch is

```
vtable = __ffc_vtable_table[descriptor.dynamic_type];
callee = vtable[slot - 1];
```

Rationale: the ids are already dense and monotonic per link unit (#400), so the
indexed table is an O(1) load with no new metadata in the descriptor, and the
32-byte scalar class descriptor that #417 and #419 depend on stays byte-identical.
A fifth field would have forced a coordinated ABI change across three landed
slices to buy nothing the table does not already give within a link unit — the
id scheme, not the lookup, is what limits cross-unit dispatch today.

Both globals are const, linker-initialised data; the dispatch sequence performs
two loads, writes nothing, and does not alias the receiver's storage. They are
emitted up front, before any procedure body compiles, because a global created
mid-compile loses its data-section initializer and relocations.

## One canonical convention

There is no second dispatch path. A receiver dispatches through the vtable
exactly when it carries a runtime type identity (`class` entity with a dynamic
type slot). A `type(t)` receiver keeps a direct call, which is not a fallback:
its dynamic type *is* its declared type by definition, so the vtable could only
re-derive an answer already known at compile time. A binding whose implementation
is not defined in this compilation unit leaves a null slot rather than emitting
an undefined relocation, so emitting vtables never adds a link-time reference the
program did not already have.

## Invariants preserved

- Declared vs dynamic type: `declared_type` still fixed by the declaration,
  `dynamic_type` still travels with the value; dispatch consults only the latter.
- Dispatch correctness through overrides, including a non-overridden binding
  inherited across two levels and an override two levels down.
- Vtable layout and stability: slot k is stable across a type and all its
  extensions; the descriptor ABI is unchanged.
- Identity across hand-offs: a value re-passed through two `class` dummies still
  dispatches on the original value's type.
- Aliasing: dispatch reads const data only.

Lifetimes and finalization are untouched by this slice; allocation of class
scalars is #421.

## New

- `lr_session_global_reloc` Fortran binding and `create_pointer_table_global`,
  which emits a relocated array of code/data addresses.
- Duplicate binding names in one type are now rejected: two `procedure :: m => ...`
  for the same `m` have no single vtable slot occupant. The diagnostic is raised
  when the vtables are emitted, not during type collection, because a collection
  error is swallowed by the "skip a type ffc cannot lower" path and would surface
  as an unrelated message.
- `docs/RUNTIME_ABI.md` gains a "Type-bound dispatch vtables" section.

## Verification

`test/test_session_typebound_override_dispatch_compiler.f90` — recorded failing
on unmodified main with exactly the wrong-target outputs (`100/100` instead of
`100/200`, `11/11/11` instead of `11/11/33`, `7/7` instead of `7/9`) and three
missing vtable symbols. Two of its eight cases (inherited binding, monomorphic
receiver) passed before and after and act as negative controls. Symbol presence
is checked in the emitted object, not only via program output.

Corpus: fortfront-f90 `PASS=411 XFAIL=95 XPASS=2 FAIL=9` and fortfront-lf
`PASS=208 XFAIL=55 FAIL=1` — identical to unmodified main, same FAIL sets. The
lfortran suite's FAIL set differs from the older baseline only by
`file_open_08.f90`, which was re-run 8 times on unmodified current main and
failed 7 of 8 with a nondeterministic SIGSEGV: pre-existing, not from this
change. Nothing was promoted out of any xfail manifest.

`fo` is green apart from `test_fortfront_corpus_conformance` and
`test_parity_dashboard`, both of which fail identically on unmodified main.