### PR TITLE
[runtime-03] move file-unit state behind the runtime ABI (closes #396)

### DIFF
--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -623,9 +623,39 @@ The complete runtime ABI. Adding an entry point means editing
 | Symbol | Signature | Contract |
 |---|---|---|
 | `_ffc_runtime_probe` | `int _ffc_runtime_probe(void)` | Returns 42. Lets a consumer confirm end to end that the runtime it linked or loaded really resolves. |
+| `_ffc_unit_newunit` | `int _ffc_unit_newunit(void)` | Lowest free unit at or above 1000, above anything a program names explicitly. Returns -1 and sets status 5005 when none is free. |
+| `_ffc_unit_open` | `int _ffc_unit_open(int unit, const char *path, const char *status)` | Connects `unit`. `status` is the lower-cased Fortran `STATUS=` value. A null or empty `path`, or `status` `scratch`, connects a temporary file removed on close. |
+| `_ffc_unit_is_open` | `int _ffc_unit_is_open(int unit)` | 1 when the unit is connected, 0 otherwise. Never fails. |
+| `_ffc_unit_file` | `FILE *_ffc_unit_file(int unit)` | The stream behind a unit, connecting an unopened numeric unit to `fort.<N>` on first use. NULL only when the unit is unusable. |
+| `_ffc_unit_rewind` | `int _ffc_unit_rewind(int unit)` | Repositions to the first record. |
+| `_ffc_unit_close` | `int _ffc_unit_close(int unit)` | Disconnects the unit. Succeeds on a unit that is not connected. |
+| `_ffc_unit_status` | `int _ffc_unit_status(void)` | Status of the most recent unit operation. |
 
-Runtime entry points for file units, formatted output, IOSTAT/IOMSG, and
-descriptor allocation are added by their own issues (#396, #423, #427, #428).
+### File-unit state (#396)
+
+The runtime owns file-unit state: which units are connected, the `FILE*`
+behind each, and the status of the last operation. It is per process and keyed
+by the unit number the program computes at run time, so a unit opened inside a
+procedure is still connected after that procedure returns. Before #396 the
+compiler emitted one stack slot per unit inside the function that opened it,
+which scoped a connection to a lowered function.
+
+Units run from 0 through 2048. `NEWUNIT=` allocates from 1000 upwards and
+releases the number on `CLOSE`.
+
+Status codes are stable. They are the values `IOSTAT=` reports:
+
+| Code | Meaning |
+|---|---|
+| 0 | success |
+| 5001 | unit number outside the supported range |
+| 5002 | operation on a unit that is not connected |
+| 5003 | `OPEN` on a unit that is already connected |
+| 5004 | the file could not be opened |
+| 5005 | no free unit left for `NEWUNIT=` |
+
+Runtime entry points for formatted output, IOSTAT/IOMSG, and descriptor
+allocation are added by their own issues (#423, #427, #428).
 
 ### Dependencies
 

--- a/runtime/ffc_runtime.c
+++ b/runtime/ffc_runtime.c
@@ -25,3 +25,201 @@
 int _ffc_runtime_probe(void) {
     return 42;
 }
+
+/* ---- File units (issue #396) ----------------------------- */
+
+/* The runtime owns file-unit state: which units are connected,
+ * the FILE* behind each, and the status of the last operation.
+ * Before #396 the compiler emitted one stack slot per unit inside
+ * the function that opened it, so unit state was scoped to a
+ * lowered function and keyed by a compile-time constant. Here it
+ * is per process and keyed by the unit number the program
+ * computes at run time, which is what Fortran describes.
+ *
+ * Status codes are stable and are the values IOSTAT= reports:
+ *
+ *   0                  success
+ *   FFC_IOSTAT_BADUNIT unit number outside the supported range
+ *   FFC_IOSTAT_NOUNIT  operation on an unconnected unit
+ *   FFC_IOSTAT_INUSE   OPEN on an already connected unit
+ *   FFC_IOSTAT_OPEN    the file could not be opened
+ *   FFC_IOSTAT_NOSPACE no free unit left for NEWUNIT
+ */
+
+#include <stdio.h>
+
+#define FFC_UNIT_MIN 0
+#define FFC_UNIT_MAX 2048
+#define FFC_NEWUNIT_FIRST 1000
+
+#define FFC_IOSTAT_BADUNIT 5001
+#define FFC_IOSTAT_NOUNIT 5002
+#define FFC_IOSTAT_INUSE 5003
+#define FFC_IOSTAT_OPEN 5004
+#define FFC_IOSTAT_NOSPACE 5005
+
+struct ffc_unit {
+    FILE *fp;
+    int connected;
+};
+
+static struct ffc_unit ffc_units[FFC_UNIT_MAX + 1];
+static int ffc_unit_last_status = 0;
+
+static int ffc_unit_valid(int unit) {
+    return unit >= FFC_UNIT_MIN && unit <= FFC_UNIT_MAX;
+}
+
+/* Case-sensitive compare; the compiler lowers STATUS= values in
+ * lower case. */
+static int ffc_streq(const char *a, const char *b) {
+    if (a == NULL || b == NULL) {
+        return 0;
+    }
+    while (*a != '\0' && *a == *b) {
+        a++;
+        b++;
+    }
+    return *a == *b;
+}
+
+static int ffc_unit_fail(int status) {
+    ffc_unit_last_status = status;
+    return status;
+}
+
+/* Status of the most recent unit operation. */
+int _ffc_unit_status(void) {
+    return ffc_unit_last_status;
+}
+
+/* Lowest free unit at or above FFC_NEWUNIT_FIRST, which is above
+ * anything a program is expected to name explicitly. Returns -1
+ * on exhaustion, so a caller can store it and let the operation
+ * that follows fail on a bad unit number. */
+int _ffc_unit_newunit(void) {
+    int unit;
+    for (unit = FFC_NEWUNIT_FIRST; unit <= FFC_UNIT_MAX; unit++) {
+        if (!ffc_units[unit].connected) {
+            ffc_unit_last_status = 0;
+            return unit;
+        }
+    }
+    ffc_unit_fail(FFC_IOSTAT_NOSPACE);
+    return -1;
+}
+
+/* Opens the file for a Fortran STATUS= value. Units are readable
+ * and writable, so every mode is an update mode: a unit can be
+ * written, rewound, and read back. STATUS='UNKNOWN' and an absent
+ * STATUS keep an existing file's contents and create the file
+ * otherwise, which is what gfortran does; that is why it probes
+ * "r+" before falling back to "w+" rather than truncating. */
+static FILE *ffc_unit_fopen(const char *path,
+                            const char *status) {
+    FILE *fp;
+    if (ffc_streq(status, "old")) {
+        return fopen(path, "r+");
+    }
+    if (ffc_streq(status, "new") ||
+        ffc_streq(status, "replace")) {
+        return fopen(path, "w+");
+    }
+    fp = fopen(path, "r+");
+    if (fp != NULL) {
+        return fp;
+    }
+    return fopen(path, "w+");
+}
+
+/* Connects unit to path with the given Fortran STATUS= value. A
+ * null or empty path, or STATUS='SCRATCH', connects a temporary
+ * file that disappears when the unit is closed.
+ *
+ * Connecting a unit that is already connected is an error rather
+ * than a silent reconnection, so a leaked unit surfaces where it
+ * happens. */
+int _ffc_unit_open(int unit, const char *path,
+                   const char *status) {
+    FILE *fp;
+    if (!ffc_unit_valid(unit)) {
+        return ffc_unit_fail(FFC_IOSTAT_BADUNIT);
+    }
+    if (ffc_units[unit].connected) {
+        return ffc_unit_fail(FFC_IOSTAT_INUSE);
+    }
+    if (path == NULL || path[0] == '\0' ||
+        ffc_streq(status, "scratch")) {
+        fp = tmpfile();
+    } else {
+        fp = ffc_unit_fopen(path, status);
+    }
+    if (fp == NULL) {
+        return ffc_unit_fail(FFC_IOSTAT_OPEN);
+    }
+    ffc_units[unit].fp = fp;
+    ffc_units[unit].connected = 1;
+    ffc_unit_last_status = 0;
+    return 0;
+}
+
+/* Whether the unit is currently connected. */
+int _ffc_unit_is_open(int unit) {
+    if (!ffc_unit_valid(unit)) {
+        return 0;
+    }
+    return ffc_units[unit].connected ? 1 : 0;
+}
+
+/* The FILE* behind a unit, connecting a numeric unit to fort.<N>
+ * on first use the way an unopened preconnected unit behaves.
+ * Returns NULL only when the unit is unusable, recording why. */
+FILE *_ffc_unit_file(int unit) {
+    char name[32];
+    FILE *fp;
+    if (!ffc_unit_valid(unit)) {
+        ffc_unit_fail(FFC_IOSTAT_BADUNIT);
+        return NULL;
+    }
+    if (ffc_units[unit].connected) {
+        ffc_unit_last_status = 0;
+        return ffc_units[unit].fp;
+    }
+    snprintf(name, sizeof name, "fort.%d", unit);
+    fp = fopen(name, "w+");
+    if (fp == NULL) {
+        ffc_unit_fail(FFC_IOSTAT_OPEN);
+        return NULL;
+    }
+    ffc_units[unit].fp = fp;
+    ffc_units[unit].connected = 1;
+    ffc_unit_last_status = 0;
+    return fp;
+}
+
+/* Repositions the unit to its first record. */
+int _ffc_unit_rewind(int unit) {
+    FILE *fp = _ffc_unit_file(unit);
+    if (fp == NULL) {
+        return ffc_unit_last_status;
+    }
+    rewind(fp);
+    ffc_unit_last_status = 0;
+    return 0;
+}
+
+/* Disconnects the unit. CLOSE on a unit that is not connected is
+ * not an error in Fortran, so it reports success and leaves the
+ * unit free; only a bad unit number fails. */
+int _ffc_unit_close(int unit) {
+    if (!ffc_unit_valid(unit)) {
+        return ffc_unit_fail(FFC_IOSTAT_BADUNIT);
+    }
+    if (ffc_units[unit].connected) {
+        fclose(ffc_units[unit].fp);
+        ffc_units[unit].fp = NULL;
+        ffc_units[unit].connected = 0;
+    }
+    ffc_unit_last_status = 0;
+    return 0;
+}

--- a/src/ffc_runtime_link.f90
+++ b/src/ffc_runtime_link.f90
@@ -50,8 +50,11 @@ module ffc_runtime_link
     ! Every runtime entry point the lowerer is allowed to call. Each issue
     ! that moves compiler-emitted code behind the runtime ABI adds its symbols
     ! here and to docs/RUNTIME_ABI.md.
-    character(len=*), parameter :: FFC_RUNTIME_SYMBOLS(1) = &
-        [character(len=32) :: '_ffc_runtime_probe']
+    character(len=*), parameter :: FFC_RUNTIME_SYMBOLS(8) = &
+        [character(len=32) :: '_ffc_runtime_probe', &
+         '_ffc_unit_status', '_ffc_unit_newunit', '_ffc_unit_open', &
+         '_ffc_unit_is_open', '_ffc_unit_file', '_ffc_unit_rewind', &
+         '_ffc_unit_close']
 
 contains
 

--- a/src/ffc_runtime_source.f90
+++ b/src/ffc_runtime_source.f90
@@ -75,6 +75,384 @@ contains
             '    return 42;'//NL
         text = text// &
             '}'//NL
+        text = text//NL
+        text = text// &
+            '/* ---- File units (issue #396) ----------------------------- */'//NL
+        text = text//NL
+        text = text// &
+            '/* The runtime owns file-unit state: which units are connected,'//NL
+        text = text// &
+            ' * the FILE* behind each, and the status of the last operation.'//NL
+        text = text// &
+            ' * Before #396 the compiler emitted one stack slot per unit inside'//NL
+        text = text// &
+            ' * the function that opened it, so unit state was scoped to a'//NL
+        text = text// &
+            ' * lowered function and keyed by a compile-time constant. Here it'//NL
+        text = text// &
+            ' * is per process and keyed by the unit number the program'//NL
+        text = text// &
+            ' * computes at run time, which is what Fortran describes.'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' * Status codes are stable and are the values IOSTAT= reports:'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' *   0                  success'//NL
+        text = text// &
+            ' *   FFC_IOSTAT_BADUNIT unit number outside the supported range'//NL
+        text = text// &
+            ' *   FFC_IOSTAT_NOUNIT  operation on an unconnected unit'//NL
+        text = text// &
+            ' *   FFC_IOSTAT_INUSE   OPEN on an already connected unit'//NL
+        text = text// &
+            ' *   FFC_IOSTAT_OPEN    the file could not be opened'//NL
+        text = text// &
+            ' *   FFC_IOSTAT_NOSPACE no free unit left for NEWUNIT'//NL
+        text = text// &
+            ' */'//NL
+        text = text//NL
+        text = text// &
+            '#include <stdio.h>'//NL
+        text = text//NL
+        text = text// &
+            '#define FFC_UNIT_MIN 0'//NL
+        text = text// &
+            '#define FFC_UNIT_MAX 2048'//NL
+        text = text// &
+            '#define FFC_NEWUNIT_FIRST 1000'//NL
+        text = text//NL
+        text = text// &
+            '#define FFC_IOSTAT_BADUNIT 5001'//NL
+        text = text// &
+            '#define FFC_IOSTAT_NOUNIT 5002'//NL
+        text = text// &
+            '#define FFC_IOSTAT_INUSE 5003'//NL
+        text = text// &
+            '#define FFC_IOSTAT_OPEN 5004'//NL
+        text = text// &
+            '#define FFC_IOSTAT_NOSPACE 5005'//NL
+        text = text//NL
+        text = text// &
+            'struct ffc_unit {'//NL
+        text = text// &
+            '    FILE *fp;'//NL
+        text = text// &
+            '    int connected;'//NL
+        text = text// &
+            '};'//NL
+        text = text//NL
+        text = text// &
+            'static struct ffc_unit ffc_units[FFC_UNIT_MAX + 1];'//NL
+        text = text// &
+            'static int ffc_unit_last_status = 0;'//NL
+        text = text//NL
+        text = text// &
+            'static int ffc_unit_valid(int unit) {'//NL
+        text = text// &
+            '    return unit >= FFC_UNIT_MIN && unit <= FFC_UNIT_MAX;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Case-sensitive compare; the compiler lowers STATUS= values in'//NL
+        text = text// &
+            ' * lower case. */'//NL
+        text = text// &
+            'static int ffc_streq(const char *a, const char *b) {'//NL
+        text = text// &
+            '    if (a == NULL || b == NULL) {'//NL
+        text = text// &
+            '        return 0;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    while (*a != ''\0'' && *a == *b) {'//NL
+        text = text// &
+            '        a++;'//NL
+        text = text// &
+            '        b++;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    return *a == *b;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            'static int ffc_unit_fail(int status) {'//NL
+        text = text// &
+            '    ffc_unit_last_status = status;'//NL
+        text = text// &
+            '    return status;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Status of the most recent unit operation. */'//NL
+        text = text// &
+            'int _ffc_unit_status(void) {'//NL
+        text = text// &
+            '    return ffc_unit_last_status;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Lowest free unit at or above FFC_NEWUNIT_FIRST, which is above'//NL
+        text = text// &
+            ' * anything a program is expected to name explicitly. Returns -1'//NL
+        text = text// &
+            ' * on exhaustion, so a caller can store it and let the operation'//NL
+        text = text// &
+            ' * that follows fail on a bad unit number. */'//NL
+        text = text// &
+            'int _ffc_unit_newunit(void) {'//NL
+        text = text// &
+            '    int unit;'//NL
+        text = text// &
+            '    for (unit = FFC_NEWUNIT_FIRST; unit <= FFC_UNIT_MAX; unit++) {'//NL
+        text = text// &
+            '        if (!ffc_units[unit].connected) {'//NL
+        text = text// &
+            '            ffc_unit_last_status = 0;'//NL
+        text = text// &
+            '            return unit;'//NL
+        text = text// &
+            '        }'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    ffc_unit_fail(FFC_IOSTAT_NOSPACE);'//NL
+        text = text// &
+            '    return -1;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Opens the file for a Fortran STATUS= value. Units are readable'//NL
+        text = text// &
+            ' * and writable, so every mode is an update mode: a unit can be'//NL
+        text = text// &
+            ' * written, rewound, and read back. STATUS=''UNKNOWN'' and an absent'//NL
+        text = text// &
+            ' * STATUS keep an existing file''s contents and create the file'//NL
+        text = text// &
+            ' * otherwise, which is what gfortran does; that is why it probes'//NL
+        text = text// &
+            ' * "r+" before falling back to "w+" rather than truncating. */'//NL
+        text = text// &
+            'static FILE *ffc_unit_fopen(const char *path,'//NL
+        text = text// &
+            '                            const char *status) {'//NL
+        text = text// &
+            '    FILE *fp;'//NL
+        text = text// &
+            '    if (ffc_streq(status, "old")) {'//NL
+        text = text// &
+            '        return fopen(path, "r+");'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (ffc_streq(status, "new") ||'//NL
+        text = text// &
+            '        ffc_streq(status, "replace")) {'//NL
+        text = text// &
+            '        return fopen(path, "w+");'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    fp = fopen(path, "r+");'//NL
+        text = text// &
+            '    if (fp != NULL) {'//NL
+        text = text// &
+            '        return fp;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    return fopen(path, "w+");'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Connects unit to path with the given Fortran STATUS= value. A'//NL
+        text = text// &
+            ' * null or empty path, or STATUS=''SCRATCH'', connects a temporary'//NL
+        text = text// &
+            ' * file that disappears when the unit is closed.'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' * Connecting a unit that is already connected is an error rather'//NL
+        text = text// &
+            ' * than a silent reconnection, so a leaked unit surfaces where it'//NL
+        text = text// &
+            ' * happens. */'//NL
+        text = text// &
+            'int _ffc_unit_open(int unit, const char *path,'//NL
+        text = text// &
+            '                   const char *status) {'//NL
+        text = text// &
+            '    FILE *fp;'//NL
+        text = text// &
+            '    if (!ffc_unit_valid(unit)) {'//NL
+        text = text// &
+            '        return ffc_unit_fail(FFC_IOSTAT_BADUNIT);'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (ffc_units[unit].connected) {'//NL
+        text = text// &
+            '        return ffc_unit_fail(FFC_IOSTAT_INUSE);'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (path == NULL || path[0] == ''\0'' ||'//NL
+        text = text// &
+            '        ffc_streq(status, "scratch")) {'//NL
+        text = text// &
+            '        fp = tmpfile();'//NL
+        text = text// &
+            '    } else {'//NL
+        text = text// &
+            '        fp = ffc_unit_fopen(path, status);'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (fp == NULL) {'//NL
+        text = text// &
+            '        return ffc_unit_fail(FFC_IOSTAT_OPEN);'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    ffc_units[unit].fp = fp;'//NL
+        text = text// &
+            '    ffc_units[unit].connected = 1;'//NL
+        text = text// &
+            '    ffc_unit_last_status = 0;'//NL
+        text = text// &
+            '    return 0;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Whether the unit is currently connected. */'//NL
+        text = text// &
+            'int _ffc_unit_is_open(int unit) {'//NL
+        text = text// &
+            '    if (!ffc_unit_valid(unit)) {'//NL
+        text = text// &
+            '        return 0;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    return ffc_units[unit].connected ? 1 : 0;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* The FILE* behind a unit, connecting a numeric unit to fort.<N>'//NL
+        text = text// &
+            ' * on first use the way an unopened preconnected unit behaves.'//NL
+        text = text// &
+            ' * Returns NULL only when the unit is unusable, recording why. */'//NL
+        text = text// &
+            'FILE *_ffc_unit_file(int unit) {'//NL
+        text = text// &
+            '    char name[32];'//NL
+        text = text// &
+            '    FILE *fp;'//NL
+        text = text// &
+            '    if (!ffc_unit_valid(unit)) {'//NL
+        text = text// &
+            '        ffc_unit_fail(FFC_IOSTAT_BADUNIT);'//NL
+        text = text// &
+            '        return NULL;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (ffc_units[unit].connected) {'//NL
+        text = text// &
+            '        ffc_unit_last_status = 0;'//NL
+        text = text// &
+            '        return ffc_units[unit].fp;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    snprintf(name, sizeof name, "fort.%d", unit);'//NL
+        text = text// &
+            '    fp = fopen(name, "w+");'//NL
+        text = text// &
+            '    if (fp == NULL) {'//NL
+        text = text// &
+            '        ffc_unit_fail(FFC_IOSTAT_OPEN);'//NL
+        text = text// &
+            '        return NULL;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    ffc_units[unit].fp = fp;'//NL
+        text = text// &
+            '    ffc_units[unit].connected = 1;'//NL
+        text = text// &
+            '    ffc_unit_last_status = 0;'//NL
+        text = text// &
+            '    return fp;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Repositions the unit to its first record. */'//NL
+        text = text// &
+            'int _ffc_unit_rewind(int unit) {'//NL
+        text = text// &
+            '    FILE *fp = _ffc_unit_file(unit);'//NL
+        text = text// &
+            '    if (fp == NULL) {'//NL
+        text = text// &
+            '        return ffc_unit_last_status;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    rewind(fp);'//NL
+        text = text// &
+            '    ffc_unit_last_status = 0;'//NL
+        text = text// &
+            '    return 0;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Disconnects the unit. CLOSE on a unit that is not connected is'//NL
+        text = text// &
+            ' * not an error in Fortran, so it reports success and leaves the'//NL
+        text = text// &
+            ' * unit free; only a bad unit number fails. */'//NL
+        text = text// &
+            'int _ffc_unit_close(int unit) {'//NL
+        text = text// &
+            '    if (!ffc_unit_valid(unit)) {'//NL
+        text = text// &
+            '        return ffc_unit_fail(FFC_IOSTAT_BADUNIT);'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (ffc_units[unit].connected) {'//NL
+        text = text// &
+            '        fclose(ffc_units[unit].fp);'//NL
+        text = text// &
+            '        ffc_units[unit].fp = NULL;'//NL
+        text = text// &
+            '        ffc_units[unit].connected = 0;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    ffc_unit_last_status = 0;'//NL
+        text = text// &
+            '    return 0;'//NL
+        text = text// &
+            '}'//NL
     end subroutine ffc_runtime_source_text
 
 end module ffc_runtime_source

--- a/src/session_program_lowering_inquire.inc
+++ b/src/session_program_lowering_inquire.inc
@@ -270,26 +270,20 @@
         character(len=*), intent(in) :: unit_str, opened_var, exist_var
         character(len=*), intent(in) :: iostat_var
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: sym, ios, unit_number
-        logical :: is_opened
-        character(len=24) :: pseudo_name
+        type(lr_operand_desc_t) :: unit_args(1), opened_op
 
         call set_empty(error_msg)
-        is_opened = .false.
-        read (unit_str, *, iostat=ios) unit_number
-        if (ios == 0) then
-            write (pseudo_name, '(A,I0)') '.unit.', unit_number
-            sym = find_symbol_compat(context, trim(pseudo_name))
-        else
-            sym = find_symbol_compat(context, trim(unit_str))
-        end if
-        if (sym > 0) is_opened = context%symbols(sym)%is_file_unit
 
         if (len_trim(opened_var) > 0) then
+            ! Ask the runtime, which owns the connection, instead of reading a
+            ! compile-time flag that could not see a unit opened elsewhere in
+            ! the program (#396).
+            call unit_number_operand(unit_str, context, unit_args(1), error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (.not. emit_i32_call(context%session, '_ffc_unit_is_open', &
+                                    unit_args, opened_op, error_msg)) return
             call store_inquire_logical(context, node, opened_var, 'opened', &
-                i32_immediate(context%session, &
-                              merge(1_c_int64_t, 0_c_int64_t, is_opened)), &
-                error_msg)
+                                       opened_op, error_msg)
             if (len_trim(error_msg) > 0) return
         end if
 

--- a/src/session_program_lowering_open_close.inc
+++ b/src/session_program_lowering_open_close.inc
@@ -117,19 +117,20 @@
     ! --- OPEN ----------------------------------------------------------------
 
     subroutine lower_open(arena, node, context, error_msg)
-        ! Emit fopen(file, mode) and store FILE* in the unit-variable's slot.
-        use liric_session_memory_bindings, only: emit_ptr_alloca, emit_ptr_store, &
-                                                  emit_i32_alloca, emit_i32_store
+        ! Connect a unit through the runtime (#396). The compiler decides
+        ! which unit number and which STATUS= apply; the runtime owns the
+        ! connection itself, so a unit opened here stays connected for the
+        ! life of the process rather than for the life of a lowered function.
+        use liric_session_memory_bindings, only: emit_i32_alloca, emit_i32_store
         use, intrinsic :: iso_c_binding, only: c_int64_t
         type(ast_arena_t), intent(in) :: arena
         type(open_statement_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: ustr, nuvar, fpath, sstr, signstr
-        type(lr_operand_desc_t) :: file_handle
-        type(lr_operand_desc_t) :: uval_op, ptr_slot
-        type(lr_operand_desc_t), allocatable :: noargs(:)
-        integer :: unit_number, sym, ios
+        type(lr_operand_desc_t) :: unit_op, args(3), unused
+        integer :: sym, ios, unit_number
+
         call set_empty(error_msg)
         if (.not. allocated(node%unit_spec)) then
             call unsupported_feature_error('open statement', node%line, &
@@ -158,231 +159,135 @@
             context%stdout_force_plus_sign = (trim(signstr) == 'plus')
         end if
 
-        if (len_trim(fpath) == 0) then
-            ! A connection without file= is a scratch file. gfortran also
-            ! treats status='scratch' and a bare default connection as a
-            ! temporary; tmpfile() gives a read/write handle deleted on close.
-            allocate (noargs(0))
-            if (.not. emit_ptr_call(context%session, 'tmpfile', noargs, &
-                                     file_handle, error_msg)) return
-        else
-            ! Fortran units are read/write; use update modes so a unit can be
-            ! written, rewound, and read back within the same scope.
-            select case (trim(sstr))
-            case ('old')
-                call open_fixed_mode(context, fpath, 'r+', file_handle, &
-                                     error_msg)
-            case ('new', 'replace')
-                call open_fixed_mode(context, fpath, 'w+', file_handle, &
-                                     error_msg)
-            case default
-                ! No status, or status='unknown': gfortran preserves an
-                ! existing file's content and creates a fresh one otherwise.
-                call open_update_or_create(context, fpath, file_handle, &
-                                           error_msg)
-            end select
-            if (len_trim(error_msg) > 0) return
-        end if
-
         if (len_trim(nuvar) > 0) then
-            unit_number = int(context%next_file_unit)
-            context%next_file_unit = context%next_file_unit + 1_c_int32_t
-            uval_op = i32_immediate(context%session, int(unit_number, c_int64_t))
-            sym = find_symbol_compat(context, trim(nuvar))
-            if (sym > 0) then
-                if (.not. context%symbols(sym)%has_address) then
-                    if (.not. emit_i32_alloca(context%session, &
-                                               context%symbols(sym)%address, &
-                                               error_msg)) return
-                    context%symbols(sym)%has_address = .true.
-                    context%symbols(sym)%is_reference = .true.
-                end if
-                if (.not. emit_i32_store(context%session, uval_op, &
-                                          context%symbols(sym)%address, &
-                                          error_msg)) return
-                context%symbols(sym)%value = uval_op
-                if (.not. context%symbols(sym)%is_file_unit) then
-                    if (.not. emit_ptr_alloca(context%session, ptr_slot, &
-                                               error_msg)) return
-                    context%symbols(sym)%file_ptr_address = ptr_slot
-                    context%symbols(sym)%is_file_unit = .true.
-                end if
-                if (.not. emit_ptr_store(context%session, file_handle, &
-                                          context%symbols(sym)%file_ptr_address, &
-                                          error_msg)) return
-            end if
+            call allocate_newunit(context, nuvar, unit_op, error_msg)
+            if (len_trim(error_msg) > 0) return
         else if (len_trim(ustr) > 0) then
+            call unit_number_operand(ustr, context, unit_op, error_msg)
+            if (len_trim(error_msg) > 0) return
             read (ustr, *, iostat=ios) unit_number
             if (ios == 0) then
-                call track_literal_unit(context, unit_number, file_handle, &
-                                         error_msg)
+                call mark_unit_symbol(context, file_unit_pseudo_name(unit_number), &
+                                      error_msg)
             else
                 sym = find_symbol_compat(context, trim(ustr))
                 if (sym <= 0) then
                     error_msg = 'open unit= variable not declared: '//trim(ustr)
                     return
                 end if
-                if (.not. context%symbols(sym)%is_file_unit) then
-                    if (.not. emit_ptr_alloca(context%session, ptr_slot, &
-                                               error_msg)) return
-                    context%symbols(sym)%file_ptr_address = ptr_slot
-                    context%symbols(sym)%is_file_unit = .true.
-                end if
-                if (.not. emit_ptr_store(context%session, file_handle, &
-                                          context%symbols(sym)%file_ptr_address, &
-                                          error_msg)) return
-                ! Alias the numeric unit so references by literal number resolve
-                ! to the same FILE* slot as references by variable name.
+                context%symbols(sym)%is_file_unit = .true.
+                ! References by literal number reach the same connection,
+                ! because both resolve to the same runtime unit number.
                 if (context%symbols(sym)%has_unit_const) then
-                    call alias_unit_to_slot(context, &
-                        context%symbols(sym)%unit_const, &
-                        context%symbols(sym)%file_ptr_address, error_msg)
+                    call mark_unit_symbol(context, &
+                        file_unit_pseudo_name(context%symbols(sym)%unit_const), &
+                        error_msg)
                     if (len_trim(error_msg) > 0) return
                 end if
             end if
+            if (len_trim(error_msg) > 0) return
         else
             call unsupported_feature_error('open statement', node%line, &
                 node%column, 'unit= or newunit= required (#247 B5c)', error_msg)
             return
         end if
+
+        args(1) = unit_op
+        call unit_string_operand(context, 'open.file.', fpath, args(2), error_msg)
+        if (len_trim(error_msg) > 0) return
+        call unit_string_operand(context, 'open.status.', trim(sstr), args(3), &
+                                 error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_i32_call(context%session, '_ffc_unit_open', args, &
+                                unused, error_msg)) return
         call set_empty(error_msg)
     end subroutine lower_open
 
-    subroutine open_fixed_mode(context, fpath, mode_str, file_handle, error_msg)
-        ! fopen(fpath, mode_str) unconditionally.
+    subroutine unit_string_operand(context, tag, text, ptr_op, error_msg)
+        ! Materialise a NUL-terminated literal and yield a pointer to it.
         type(lowering_context_t), intent(inout) :: context
-        character(len=*), intent(in) :: fpath, mode_str
-        type(lr_operand_desc_t), intent(out) :: file_handle
+        character(len=*), intent(in) :: tag
+        character(len=*), intent(in) :: text
+        type(lr_operand_desc_t), intent(out) :: ptr_op
         character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: file_ptr_op, mode_ptr_op, fa(2)
-        integer(c_int32_t) :: fgid, mgid
-        character(len=64) :: fgn, mgn
+        character(len=64) :: gname
+        integer(c_int32_t) :: gid
 
         call set_empty(error_msg)
         context%string_literal_count = context%string_literal_count + 1
-        fgn = ffc_unit_global_name( &
-            context, 'open.file.', context%string_literal_count)
-        call create_printf_format_global(context%session, trim(fgn), &
-                                         trim(fpath), fgid, error_msg)
+        gname = ffc_unit_global_name(context, tag, context%string_literal_count)
+        call create_printf_format_global(context%session, trim(gname), &
+                                         trim(text), gid, error_msg)
         if (len_trim(error_msg) > 0) return
-        file_ptr_op = printf_format_ptr(context%session, fgid)
+        ptr_op = printf_format_ptr(context%session, gid)
+    end subroutine unit_string_operand
 
-        context%string_literal_count = context%string_literal_count + 1
-        mgn = ffc_unit_global_name( &
-            context, 'open.mode.', context%string_literal_count)
-        call create_printf_format_global(context%session, trim(mgn), &
-                                         trim(mode_str), mgid, error_msg)
-        if (len_trim(error_msg) > 0) return
-        mode_ptr_op = printf_format_ptr(context%session, mgid)
-
-        fa(1) = file_ptr_op
-        fa(2) = mode_ptr_op
-        if (.not. emit_ptr_call(context%session, 'fopen', fa, file_handle, &
-                                error_msg)) return
-        call set_empty(error_msg)
-    end subroutine open_fixed_mode
-
-    subroutine open_update_or_create(context, fpath, file_handle, error_msg)
-        ! fopen(fpath, "r+") preserves an existing file's content, matching
-        ! gfortran's default STATUS='UNKNOWN'; "w+" always truncates, so probe
-        ! with "r+" first and fall back to "w+" only when that fails (the file
-        ! does not exist yet).
-        use liric_session_memory_bindings, only: emit_ptr_alloca, emit_ptr_store, &
-                                                  emit_ptr_load
+    subroutine allocate_newunit(context, nuvar, unit_op, error_msg)
+        ! OPEN(newunit=u): the runtime picks the unit number, so two scopes
+        ! that both use NEWUNIT= can never be handed the same unit.
+        use liric_session_memory_bindings, only: emit_i32_alloca, emit_i32_store
         type(lowering_context_t), intent(inout) :: context
-        character(len=*), intent(in) :: fpath
-        type(lr_operand_desc_t), intent(out) :: file_handle
+        character(len=*), intent(in) :: nuvar
+        type(lr_operand_desc_t), intent(out) :: unit_op
         character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: is_null, slot
-        integer(c_int32_t) :: create_block, done_block
-
-        call set_empty(error_msg)
-        call open_fixed_mode(context, fpath, 'r+', file_handle, error_msg)
-        if (len_trim(error_msg) > 0) return
-
-        if (.not. emit_ptr_alloca(context%session, slot, error_msg)) return
-        if (.not. emit_ptr_store(context%session, file_handle, slot, &
-                                 error_msg)) return
-        if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, file_handle, &
-                null_ptr_operand(context), is_null, error_msg)) return
-        create_block = create_liric_block(context%session)
-        done_block = create_liric_block(context%session)
-        if (.not. emit_liric_condbr(context%session, is_null, create_block, &
-                                     done_block, error_msg)) return
-
-        if (.not. set_liric_block(context%session, create_block, error_msg)) return
-        call open_fixed_mode(context, fpath, 'w+', file_handle, error_msg)
-        if (len_trim(error_msg) > 0) return
-        if (.not. emit_ptr_store(context%session, file_handle, slot, &
-                                 error_msg)) return
-        if (.not. emit_liric_br(context%session, done_block, error_msg)) return
-
-        if (.not. set_liric_block(context%session, done_block, error_msg)) return
-        context%current_block_id = done_block
-        context%current_block_terminated = .false.
-        if (.not. emit_ptr_load(context%session, slot, file_handle, &
-                                error_msg)) return
-        call set_empty(error_msg)
-    end subroutine open_update_or_create
-
-    subroutine track_literal_unit(context, unit_number, file_handle, error_msg)
-        use liric_session_memory_bindings, only: emit_ptr_alloca, emit_ptr_store
-        type(lowering_context_t), intent(inout) :: context
-        integer, intent(in) :: unit_number
-        type(lr_operand_desc_t), intent(in) :: file_handle
-        character(len=:), allocatable, intent(out) :: error_msg
-        character(len=24) :: pseudo_name
-        type(lr_operand_desc_t) :: ptr_slot
-        integer :: sym
-
-        write (pseudo_name, '(A,I0)') '.unit.', unit_number
-        sym = find_symbol_compat(context, trim(pseudo_name))
-        if (sym <= 0) then
-            call define_symbol(context, trim(pseudo_name), VALUE_C_PTR, error_msg)
-            if (len_trim(error_msg) > 0) return
-            sym = find_symbol_compat(context, trim(pseudo_name))
-        end if
-        if (.not. context%symbols(sym)%is_file_unit) then
-            if (.not. emit_ptr_alloca(context%session, ptr_slot, error_msg)) return
-            context%symbols(sym)%file_ptr_address = ptr_slot
-            context%symbols(sym)%is_file_unit = .true.
-        end if
-        if (.not. emit_ptr_store(context%session, file_handle, &
-                                  context%symbols(sym)%file_ptr_address, &
-                                  error_msg)) return
-        call set_empty(error_msg)
-    end subroutine track_literal_unit
-
-    subroutine alias_unit_to_slot(context, unit_number, slot, error_msg)
-        ! Make the numeric pseudo-symbol .unit.<N> share an existing FILE* slot.
-        type(lowering_context_t), intent(inout) :: context
-        integer, intent(in) :: unit_number
-        type(lr_operand_desc_t), intent(in) :: slot
-        character(len=:), allocatable, intent(out) :: error_msg
-        character(len=24) :: pseudo_name
+        type(lr_operand_desc_t), allocatable :: noargs(:)
         integer :: sym
 
         call set_empty(error_msg)
-        write (pseudo_name, '(A,I0)') '.unit.', unit_number
-        sym = find_symbol_compat(context, trim(pseudo_name))
+        allocate (noargs(0))
+        if (.not. emit_i32_call(context%session, '_ffc_unit_newunit', noargs, &
+                                unit_op, error_msg)) return
+        sym = find_symbol_compat(context, trim(nuvar))
         if (sym <= 0) then
-            call define_symbol(context, trim(pseudo_name), VALUE_C_PTR, error_msg)
-            if (len_trim(error_msg) > 0) return
-            sym = find_symbol_compat(context, trim(pseudo_name))
+            error_msg = 'open newunit= variable not declared: '//trim(nuvar)
+            return
         end if
-        context%symbols(sym)%file_ptr_address = slot
+        if (.not. context%symbols(sym)%has_address) then
+            if (.not. emit_i32_alloca(context%session, &
+                                       context%symbols(sym)%address, &
+                                       error_msg)) return
+            context%symbols(sym)%has_address = .true.
+            context%symbols(sym)%is_reference = .true.
+        end if
+        if (.not. emit_i32_store(context%session, unit_op, &
+                                  context%symbols(sym)%address, error_msg)) return
+        context%symbols(sym)%value = unit_op
         context%symbols(sym)%is_file_unit = .true.
-    end subroutine alias_unit_to_slot
+    end subroutine allocate_newunit
+
+    subroutine mark_unit_symbol(context, pseudo_name, error_msg)
+        ! Record that a numeric unit is in use, so statement classification
+        ! and INQUIRE(opened=) can tell a file unit from a plain integer.
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: pseudo_name
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: sym
+
+        call set_empty(error_msg)
+        sym = find_symbol_compat(context, pseudo_name)
+        if (sym <= 0) then
+            call define_symbol(context, pseudo_name, VALUE_I32, error_msg)
+            if (len_trim(error_msg) > 0) return
+            sym = find_symbol_compat(context, pseudo_name)
+        end if
+        if (sym > 0) context%symbols(sym)%is_file_unit = .true.
+    end subroutine mark_unit_symbol
+
+
+
+
 
     ! --- CLOSE ---------------------------------------------------------------
 
     subroutine lower_close(node, context, error_msg)
-        use liric_session_memory_bindings, only: emit_ptr_load, emit_ptr_store
+        ! CLOSE hands the unit number to the runtime, which owns the
+        ! connection. Closing a unit that is not connected is not an error in
+        ! Fortran, and the runtime reports success for it, so the guard the
+        ! compiler used to emit around fclose is gone (#396).
         type(close_statement_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: fp, fa(1), is_open, slot
-        integer(c_int32_t) :: do_close, after_close
+        type(lr_operand_desc_t) :: args(1), unused
 
         call set_empty(error_msg)
         if (.not. allocated(node%unit_spec)) then
@@ -390,53 +295,71 @@
                 node%column, 'missing unit specifier (#247 B5c)', error_msg)
             return
         end if
-        call resolve_unit_slot(node%unit_spec, context, slot, error_msg)
+        call unit_number_operand(node%unit_spec, context, args(1), error_msg)
         if (len_trim(error_msg) > 0) return
-
-        ! Guard fclose on a non-null handle and null the slot afterwards.
-        ! Closing an already-closed unit is a no-op in Fortran; without the
-        ! guard a second CLOSE would fclose a freed FILE* and abort.
-        if (.not. emit_ptr_load(context%session, slot, fp, error_msg)) return
-        if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, fp, &
-                null_ptr_operand(context), is_open, error_msg)) return
-        do_close = create_liric_block(context%session)
-        after_close = create_liric_block(context%session)
-        if (.not. emit_liric_condbr(context%session, is_open, do_close, &
-                                     after_close, error_msg)) return
-
-        if (.not. set_liric_block(context%session, do_close, error_msg)) return
-        fa(1) = fp
-        if (.not. emit_void_call(context%session, 'fclose', fa, error_msg)) return
-        if (.not. emit_ptr_store(context%session, null_ptr_operand(context), &
-                                  slot, error_msg)) return
-        if (.not. emit_liric_br(context%session, after_close, error_msg)) return
-
-        if (.not. set_liric_block(context%session, after_close, error_msg)) return
+        if (.not. emit_i32_call(context%session, '_ffc_unit_close', args, &
+                                unused, error_msg)) return
         call set_empty(error_msg)
     end subroutine lower_close
 
-    subroutine resolve_unit_slot(unit_spec, context, slot, error_msg)
-        ! Resolve unit_spec (raw OPEN/CLOSE specifier text, e.g. "u", "10",
-        ! "unit=u") to the alloca'd ptr slot holding the unit's FILE*.
+    subroutine unit_number_operand(unit_spec, context, unit_op, error_msg)
+        ! Resolve unit_spec (raw OPEN/CLOSE/REWIND specifier text, e.g. "u",
+        ! "10", "unit=u", "(u)") to an i32 operand holding the unit number.
+        !
+        ! A variable unit is read at run time rather than folded to the
+        ! constant it happened to hold at the point of OPEN, so a unit number
+        ! computed at run time reaches the right connection (#396).
+        use liric_session_memory_bindings, only: emit_i32_load
+        use, intrinsic :: iso_c_binding, only: c_int64_t
         character(len=*), intent(in) :: unit_spec
         type(lowering_context_t), intent(inout) :: context
-        type(lr_operand_desc_t), intent(out) :: slot
+        type(lr_operand_desc_t), intent(out) :: unit_op
         character(len=:), allocatable, intent(out) :: error_msg
-        character(len=:), allocatable :: plain, head
-        integer :: unit_number, sym, ios, eq_pos, cpos
-        character(len=24) :: pseudo_name
+        character(len=:), allocatable :: plain
+        integer :: unit_number, sym, ios
 
         call set_empty(error_msg)
+        plain = unit_spec_text(unit_spec)
+
+        unit_number = -1
+        read (plain, *, iostat=ios) unit_number
+        if (ios == 0) then
+            unit_op = i32_immediate(context%session, &
+                                    int(unit_number, c_int64_t))
+            return
+        end if
+
+        sym = find_symbol_compat(context, trim(plain))
+        if (sym <= 0) then
+            error_msg = 'no open unit for: '//trim(unit_spec)//' (#247 B5c)'
+            return
+        end if
+        if (context%symbols(sym)%has_address .and. &
+            context%symbols(sym)%is_reference) then
+            if (.not. emit_i32_load(context%session, &
+                                     context%symbols(sym)%address, unit_op, &
+                                     error_msg)) return
+        else
+            unit_op = context%symbols(sym)%value
+        end if
+        call set_empty(error_msg)
+    end subroutine unit_number_operand
+
+    function unit_spec_text(unit_spec) result(plain)
+        ! Strip the surrounding parentheses REWIND/BACKSPACE keep, take the
+        ! first argument (CLOSE/REWIND carry trailing keywords such as
+        ! status="delete"), and drop a leading unit= keyword.
+        character(len=*), intent(in) :: unit_spec
+        character(len=:), allocatable :: plain
+        character(len=:), allocatable :: head
+        integer :: cpos, eq_pos
+
         plain = trim(adjustl(unit_spec))
-        ! REWIND/BACKSPACE keep the surrounding parentheses, e.g. "(u)".
         if (len(plain) >= 2) then
             if (plain(1:1) == '(' .and. plain(len(plain):len(plain)) == ')') then
                 plain = trim(adjustl(plain(2:len(plain) - 1)))
             end if
         end if
-        ! CLOSE/REWIND carry trailing keyword arguments (e.g. status="delete");
-        ! the unit is the first argument. Take only that argument, then drop a
-        ! leading unit= keyword if present.
         cpos = index(plain, ',')
         if (cpos > 0) then
             head = trim(adjustl(plain(1:cpos - 1)))
@@ -446,90 +369,25 @@
         eq_pos = index(head, '=')
         if (eq_pos > 0) head = adjustl(head(eq_pos + 1:))
         plain = trim(head)
-
-        unit_number = -1
-        read (plain, *, iostat=ios) unit_number
-        if (ios == 0) then
-            write (pseudo_name, '(A,I0)') '.unit.', unit_number
-            sym = find_symbol_compat(context, trim(pseudo_name))
-        else
-            unit_number = -1
-            sym = find_symbol_compat(context, trim(plain))
-            if (sym > 0) then
-                if (context%symbols(sym)%has_unit_const) &
-                    unit_number = context%symbols(sym)%unit_const
-            end if
-        end if
-        if (sym <= 0 .or. .not. context%symbols(sym)%is_file_unit) then
-            ! Implicit preconnection: a numeric unit used without OPEN connects
-            ! to fort.<N>, matching gfortran's default unit handling.
-            if (unit_number >= 0) then
-                call connect_implicit_unit(context, unit_number, sym, error_msg)
-                if (len_trim(error_msg) > 0) return
-            else
-                error_msg = 'no open unit for: '//trim(unit_spec)//' (#247 B5c)'
-                return
-            end if
-        end if
-        slot = context%symbols(sym)%file_ptr_address
-    end subroutine resolve_unit_slot
+    end function unit_spec_text
 
     subroutine load_unit_file_ptr(unit_spec, context, fp, error_msg)
-        ! Load the current FILE* for a unit from its alloca'd ptr slot.
-        use liric_session_memory_bindings, only: emit_ptr_load
+        ! The stream behind a unit, from the runtime. An unopened numeric unit
+        ! is connected to fort.<N> there, on first use, so implicit
+        ! preconnection no longer needs its own emitted fopen (#396).
         character(len=*), intent(in) :: unit_spec
         type(lowering_context_t), intent(inout) :: context
         type(lr_operand_desc_t), intent(out) :: fp
         character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: slot
+        type(lr_operand_desc_t) :: args(1)
 
-        call resolve_unit_slot(unit_spec, context, slot, error_msg)
+        call unit_number_operand(unit_spec, context, args(1), error_msg)
         if (len_trim(error_msg) > 0) return
-        if (.not. emit_ptr_load(context%session, slot, fp, error_msg)) return
+        if (.not. emit_ptr_call(context%session, '_ffc_unit_file', args, fp, &
+                                error_msg)) return
         call set_empty(error_msg)
     end subroutine load_unit_file_ptr
 
-    subroutine connect_implicit_unit(context, unit_number, sym, error_msg)
-        ! fopen("fort.<N>", "w+") for a numeric unit used without OPEN.
-        use liric_session_memory_bindings, only: emit_ptr_alloca, emit_ptr_store
-        type(lowering_context_t), intent(inout) :: context
-        integer, intent(in) :: unit_number
-        integer, intent(out) :: sym
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: file_ptr_op, mode_ptr_op, file_handle
-        type(lr_operand_desc_t) :: ptr_slot, fa(2)
-        character(len=64) :: fgn, mgn, fname
-        integer(c_int32_t) :: fgid, mgid
-
-        call set_empty(error_msg)
-        write (fname, '(A,I0)') 'fort.', unit_number
-        context%string_literal_count = context%string_literal_count + 1
-        fgn = ffc_unit_global_name( &
-            context, 'open.file.', context%string_literal_count)
-        call create_printf_format_global(context%session, trim(fgn), &
-                                         trim(fname), fgid, error_msg)
-        if (len_trim(error_msg) > 0) return
-        file_ptr_op = printf_format_ptr(context%session, fgid)
-
-        context%string_literal_count = context%string_literal_count + 1
-        mgn = ffc_unit_global_name( &
-            context, 'open.mode.', context%string_literal_count)
-        call create_printf_format_global(context%session, trim(mgn), 'w+', &
-                                         mgid, error_msg)
-        if (len_trim(error_msg) > 0) return
-        mode_ptr_op = printf_format_ptr(context%session, mgid)
-
-        fa(1) = file_ptr_op
-        fa(2) = mode_ptr_op
-        if (.not. emit_ptr_call(context%session, 'fopen', fa, file_handle, &
-                                error_msg)) return
-        if (.not. emit_ptr_alloca(context%session, ptr_slot, error_msg)) return
-        if (.not. emit_ptr_store(context%session, file_handle, ptr_slot, &
-                                 error_msg)) return
-        call alias_unit_to_slot(context, unit_number, ptr_slot, error_msg)
-        if (len_trim(error_msg) > 0) return
-        sym = find_symbol_compat(context, file_unit_pseudo_name(unit_number))
-    end subroutine connect_implicit_unit
 
     ! --- file-unit WRITE -----------------------------------------------------
 

--- a/src/session_program_lowering_read_ops.inc
+++ b/src/session_program_lowering_read_ops.inc
@@ -583,10 +583,12 @@
     end subroutine set_read_slot
 
     subroutine lower_rewind(node, context, error_msg)
+        ! REWIND repositions through the runtime, which knows whether the unit
+        ! is connected and connects an unopened numeric unit on the way (#396).
         type(rewind_statement_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: fp, fa(1)
+        type(lr_operand_desc_t) :: args(1), unused
 
         call set_empty(error_msg)
         if (.not. allocated(node%unit_spec)) then
@@ -594,15 +596,15 @@
                 node%column, 'missing unit specifier (#247)', error_msg)
             return
         end if
-        call load_unit_file_ptr(node%unit_spec, context, fp, error_msg)
+        call unit_number_operand(node%unit_spec, context, args(1), error_msg)
         if (len_trim(error_msg) > 0) then
             error_msg = ''
             call unsupported_feature_error('rewind statement', node%line, &
                 node%column, 'unit not opened in same scope (#247)', error_msg)
             return
         end if
-        fa(1) = fp
-        if (.not. emit_void_call(context%session, 'rewind', fa, error_msg)) return
+        if (.not. emit_i32_call(context%session, '_ffc_unit_rewind', args, &
+                                unused, error_msg)) return
         call set_empty(error_msg)
     end subroutine lower_rewind
 

--- a/test/conformance/xfail_gfortran_dg.txt
+++ b/test/conformance/xfail_gfortran_dg.txt
@@ -1039,7 +1039,6 @@ loc_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expressio
 logical_dot_product.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 logical_temp_io.f90 # owner=lazy-fortran/ffc#423; reason=move scalar formatted output behind runtime calls
 longnames.f90 # owner=lazy-fortran/ffc#327; reason=preserve distinct declaration bindings
-make_unit.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
 malloc_free_1.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 mapping_1.f90 # owner=lazy-fortran/ffc#413; reason=diagnose unsupported numeric kinds without narrowing
 mapping_2.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations

--- a/test/conformance/xfail_lfortran.txt
+++ b/test/conformance/xfail_lfortran.txt
@@ -2746,7 +2746,6 @@ read_78.f90 # owner=lazy-fortran/ffc#349; reason=migrate deferred scalar charact
 read_80.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
 read_81.f90 # owner=lazy-fortran/ffc#347; reason=migrate character arrays to contiguous descriptors
 read_82.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
-read_83.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 read_85.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input
 read_86.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
 read_87.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering

--- a/test/test_session_unit_runtime_compiler.f90
+++ b/test/test_session_unit_runtime_compiler.f90
@@ -1,0 +1,186 @@
+! Issue #396: file-unit state lives in the runtime, not in emitted globals.
+!
+! Behavioral oracle. Two halves, because the change has two consequences.
+!
+! The runtime half drives `_ffc_unit_*` directly from C and pins the status
+! codes IOSTAT= will report: opening a connected unit, operating on a unit
+! number outside the supported range, closing a unit that was never
+! connected, and NEWUNIT= reuse after CLOSE. These are contract values, so
+! the test names the numbers rather than only checking "nonzero".
+!
+! The compiler half proves the state really moved. Before #396 a unit's FILE*
+! lived in a stack slot in the function that opened it, so a unit opened in a
+! procedure was gone once that procedure returned: the cross-scope program
+! below prints 0 on the pre-#396 compiler and 64 here. The computed-unit
+! program is a regression guard rather than a discriminator; it passed before
+! and must keep passing now that the unit number is read at run time.
+program test_session_unit_runtime_compiler
+    use ffc_runtime_link, only: ffc_runtime_link_input
+    use ffc_test_support, only: expect_output
+    implicit none
+
+    character(len=*), parameter :: WORK = '/tmp/ffc_unit_runtime_396'
+    logical :: all_passed
+
+    print *, '=== runtime file-unit state tests (#396) ==='
+
+    call run_quiet('rm -rf '//WORK//' && mkdir -p '//WORK)
+
+    all_passed = .true.
+    if (.not. test_runtime_status_codes()) all_passed = .false.
+    if (.not. test_runtime_computed_unit_number()) all_passed = .false.
+    if (.not. test_unit_survives_the_opening_scope()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: file-unit state is owned by the runtime'
+
+contains
+
+    subroutine run_quiet(command)
+        character(len=*), intent(in) :: command
+        integer :: exit_stat, cmd_stat
+
+        call execute_command_line(command, exitstat=exit_stat, &
+                                  cmdstat=cmd_stat)
+    end subroutine run_quiet
+
+    integer function status_of(command) result(status)
+        character(len=*), intent(in) :: command
+        character(len=*), parameter :: rc_file = WORK//'/rc'
+        integer :: unit, ios, exit_stat, cmd_stat
+
+        status = -1
+        call execute_command_line('{ '//command//' ; } > '//WORK// &
+                                  '/out 2>&1; echo $? > '//rc_file, &
+                                  exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) return
+        open (newunit=unit, file=rc_file, status='old', iostat=ios)
+        if (ios /= 0) return
+        read (unit, *, iostat=ios) status
+        close (unit)
+        if (ios /= 0) status = -1
+    end function status_of
+
+    ! Drives the runtime entry points from C. Each failing check exits with
+    ! its own number, so a failure says which contract broke.
+    logical function test_runtime_status_codes() result(ok)
+        character(len=*), parameter :: driver = WORK//'/unit_driver.c'
+        character(len=*), parameter :: exe = WORK//'/unit_driver'
+        character(len=:), allocatable :: link_input, error_msg
+        integer :: unit, ios, status
+
+        ok = .false.
+        call ffc_runtime_link_input(link_input, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: runtime link input: ', trim(error_msg)
+            return
+        end if
+
+        open (newunit=unit, file=driver, status='replace', iostat=ios)
+        if (ios /= 0) then
+            print *, 'FAIL: cannot write the runtime driver'
+            return
+        end if
+        write (unit, '(a)') '#include <stdio.h>'
+        write (unit, '(a)') 'int _ffc_unit_open(int, const char *,'
+        write (unit, '(a)') '                   const char *);'
+        write (unit, '(a)') 'int _ffc_unit_close(int);'
+        write (unit, '(a)') 'int _ffc_unit_rewind(int);'
+        write (unit, '(a)') 'int _ffc_unit_is_open(int);'
+        write (unit, '(a)') 'int _ffc_unit_newunit(void);'
+        write (unit, '(a)') 'int _ffc_unit_status(void);'
+        write (unit, '(a)') 'FILE *_ffc_unit_file(int);'
+        write (unit, '(a)') 'int main(void) {'
+        write (unit, '(a)') '    int first, second;'
+        write (unit, '(a)') '    const char *p = "'//WORK//'/a.dat";'
+        write (unit, '(a)') '    if (_ffc_unit_is_open(11)) return 1;'
+        write (unit, '(a)') '    if (_ffc_unit_open(11, p, "replace"))'
+        write (unit, '(a)') '        return 2;'
+        write (unit, '(a)') '    if (!_ffc_unit_is_open(11)) return 3;'
+        write (unit, '(a)') '    /* a second OPEN on a connected unit */'
+        write (unit, '(a)') '    if (_ffc_unit_open(11, p, "replace")'
+        write (unit, '(a)') '        != 5003) return 4;'
+        write (unit, '(a)') '    if (_ffc_unit_status() != 5003) return 5;'
+        write (unit, '(a)') '    if (_ffc_unit_close(11)) return 6;'
+        write (unit, '(a)') '    if (_ffc_unit_is_open(11)) return 7;'
+        write (unit, '(a)') '    /* CLOSE of an unconnected unit succeeds */'
+        write (unit, '(a)') '    if (_ffc_unit_close(11)) return 8;'
+        write (unit, '(a)') '    /* an out-of-range unit is rejected */'
+        write (unit, '(a)') '    if (_ffc_unit_close(999999) != 5001)'
+        write (unit, '(a)') '        return 9;'
+        write (unit, '(a)') '    if (_ffc_unit_file(999999) != NULL)'
+        write (unit, '(a)') '        return 10;'
+        write (unit, '(a)') '    if (_ffc_unit_status() != 5001) return 11;'
+        write (unit, '(a)') '    if (_ffc_unit_rewind(999999) != 5001)'
+        write (unit, '(a)') '        return 12;'
+        write (unit, '(a)') '    /* NEWUNIT hands out a free unit, and the'
+        write (unit, '(a)') '       same one again once it is released */'
+        write (unit, '(a)') '    first = _ffc_unit_newunit();'
+        write (unit, '(a)') '    if (first < 0) return 13;'
+        write (unit, '(a)') '    if (_ffc_unit_open(first, p, "replace"))'
+        write (unit, '(a)') '        return 14;'
+        write (unit, '(a)') '    second = _ffc_unit_newunit();'
+        write (unit, '(a)') '    if (second == first) return 15;'
+        write (unit, '(a)') '    if (_ffc_unit_close(first)) return 16;'
+        write (unit, '(a)') '    if (_ffc_unit_newunit() != first) return 17;'
+        write (unit, '(a)') '    return 0;'
+        write (unit, '(a)') '}'
+        close (unit)
+
+        status = status_of('cc -o '//exe//' '//driver//' '//link_input)
+        if (status /= 0) then
+            print *, 'FAIL: the runtime unit driver does not build'
+            return
+        end if
+        status = status_of(exe)
+        if (status /= 0) then
+            print *, 'FAIL: runtime unit contract check ', status, ' failed'
+            return
+        end if
+        ok = .true.
+    end function test_runtime_status_codes
+
+    ! The unit number is only known at run time. Regression guard for the
+    ! switch from a compile-time-resolved slot to a run-time unit number.
+    logical function test_runtime_computed_unit_number() result(ok)
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: u, n'//new_line('a')// &
+            '  u = 17 + command_argument_count()'//new_line('a')// &
+            '  open(unit=u, file=''/tmp/ffc_unit_396_a.dat'', '// &
+            'status=''replace'')'//new_line('a')// &
+            '  write(u, *) 31'//new_line('a')// &
+            '  rewind(u)'//new_line('a')// &
+            '  read(u, *) n'//new_line('a')// &
+            '  close(u)'//new_line('a')// &
+            '  print *, n'//new_line('a')// &
+            'end program main'
+
+        ok = expect_output(source, '          31'//new_line('a'), &
+                           WORK//'/computed_unit')
+    end function test_runtime_computed_unit_number
+
+    ! A unit opened inside a procedure is still connected after that
+    ! procedure returns, because the connection belongs to the process.
+    logical function test_unit_survives_the_opening_scope() result(ok)
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: n'//new_line('a')// &
+            '  call fill()'//new_line('a')// &
+            '  rewind(23)'//new_line('a')// &
+            '  read(23, *) n'//new_line('a')// &
+            '  close(23)'//new_line('a')// &
+            '  print *, n'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine fill()'//new_line('a')// &
+            '    open(unit=23, file=''/tmp/ffc_unit_396_b.dat'', '// &
+            'status=''replace'')'//new_line('a')// &
+            '    write(23, *) 64'//new_line('a')// &
+            '  end subroutine fill'//new_line('a')// &
+            'end program main'
+
+        ok = expect_output(source, '          64'//new_line('a'), &
+                           WORK//'/cross_scope')
+    end function test_unit_survives_the_opening_scope
+
+end program test_session_unit_runtime_compiler


### PR DESCRIPTION
Closes #396. Follows #565 (#603).

## What moved

File-unit state — which units are connected, the `FILE*` behind each, and the
status of the last operation — now lives in `runtime/ffc_runtime.c` and is
reached through the runtime ABI.

Before this, the compiler emitted one `ptr` stack slot per unit inside the
function that opened it, keyed by a compile-time constant unit number. A unit
was therefore scoped to a lowered function, and a unit opened inside a
procedure was gone once that procedure returned.

New entry points, all documented in `docs/RUNTIME_ABI.md` and listed in
`FFC_RUNTIME_SYMBOLS`:

`_ffc_unit_newunit`, `_ffc_unit_open`, `_ffc_unit_is_open`, `_ffc_unit_file`,
`_ffc_unit_rewind`, `_ffc_unit_close`, `_ffc_unit_status`.

`OPEN`, `CLOSE`, `REWIND`, `INQUIRE(opened=)`, and every file read and write
go through them. The emitted `fopen`/`fclose`/`rewind`/`tmpfile` calls, the
`r+`-then-`w+` probe the compiler used to inline for `STATUS='UNKNOWN'`, the
implicit `fort.<N>` connection, the FILE*-slot alloca machinery, and the
`.unit.<N>` slot aliasing are all gone. Exactly one convention survives: a
unit is an integer the runtime resolves.

## Invariants preserved and stated

- **Versioned public interfaces.** No LIRIC ABI declaration changed; the
  lowerer emits ordinary calls through the bindings verified in #375/#564.
- **Verified ABI declarations.** Each new symbol is in `FFC_RUNTIME_SYMBOLS`,
  and `test_runtime_link_compiler` (#565) fails unless the runtime really
  defines every listed symbol, so an emitted call can never be to a symbol
  that is not there.
- **Matching runtime.** Unchanged from #565: the runtime linked into a
  program is the one compiled into the compiler that produced it. A missing
  runtime is a loud error, never a silent fallback, and no inline path
  survives for any of the migrated operations.
- **Stable status codes.** 0 success, 5001 bad unit number, 5002 unit not
  connected, 5003 `OPEN` on a connected unit, 5004 file could not be opened,
  5005 no free unit for `NEWUNIT=`. Documented as the values `IOSTAT=` will
  report, so #427 has a contract to plumb through rather than invent.
- **Ownership and view lifetimes.** The runtime owns each `FILE*` for the life
  of the connection; callers receive a borrowed stream from `_ffc_unit_file`
  and never close it themselves. `CLOSE` is the only release point, and it is
  idempotent, matching Fortran.
- **`NEWUNIT=` allocation.** Units 0..2048; `NEWUNIT=` allocates from 1000
  upward, above anything a program names explicitly, and releases the number
  on `CLOSE`.

## Behavioral oracle

`test/test_session_unit_runtime_compiler.f90` (new), two halves:

- A C driver linked against the runtime pins the status codes by name: second
  `OPEN` on a connected unit is 5003, an out-of-range unit is 5001 from
  `close`/`file`/`rewind`, `CLOSE` of an unconnected unit succeeds, and
  `NEWUNIT=` hands back the same number once it is released. Each check exits
  with its own number, so a failure says which contract broke.
- A Fortran program that opens unit 23 inside a contained subroutine, then
  reads it in the main program. It prints `0` on the pre-#396 compiler and
  `64` here.

A run-time-computed unit number is also covered, as a regression guard rather
than a discriminator.

`test_session_file_unit_io_compiler` (newunit round-trip, variable-unit and
literal-unit aliasing, implicit `fort.<N>` preconnection) passes unchanged.

## Corpus delta

Gauntlet before and after at the same base commit, private report directories:

| suite | pass | xfail | xpass | fail | noref | skip |
|---|---|---|---|---|---|---|
| lfortran, base | 870 | 3314 | 85 | 10 | 165 | 1 |
| lfortran, this PR | 871 | 3313 | 86 | 9 | 165 | 1 |
| gfortran-dg, base | 1327 | 2079 | 51 | 182 | 6 | 2299 |
| gfortran-dg, this PR | 1327 | 2077 | 53 | 182 | 6 | 2299 |

Every delta is an improvement; nothing regressed from PASS.

- `file_open_08.f90` (lfortran) FAIL to PASS.
- `read_83.f90` (lfortran) and `make_unit.f90` (gfortran-dg) XFAIL to XPASS on
  three consecutive runs each, and are promoted out of the xfail manifests.
  `make_unit.f90` was owned by #427, which this unblocks.
- `minmaxloc_11.f90` (gfortran-dg) also flipped, but it is not promoted: its
  compiled program's exit status varies run to run independently of this
  change, so it stays listed with its existing owner and reason.

The fortfront corpus test's per-file results are byte-identical to `main`.
`test_fortfront_corpus_conformance` and `test_parity_dashboard` fail here and
fail identically on `main` at the same commit.
