### PR TITLE
[arraydesc-03] migrate runtime automatic arrays to the canonical descriptor

### DIFF
--- a/src/session_program_lowering_arrays.inc
+++ b/src/session_program_lowering_arrays.inc
@@ -33,13 +33,14 @@
     end function declaration_is_assumed_shape
 
     logical function declaration_is_runtime_rank1(node, context) result(is_runtime)
-        ! A rank-1 explicit-shape array whose single extent is a runtime integer
-        ! expression (a dummy-argument value such as dimension(n)) rather than a
-        ! compile-time constant. Allocatable and assumed-shape declarations are
-        ! excluded; they have their own lowering paths.
+        ! A rank-1 or rank-2 explicit-shape array at least one of whose extents
+        ! is a runtime integer expression (a dummy-argument value such as
+        ! dimension(n)) rather than a compile-time constant. Allocatable and
+        ! assumed-shape declarations are excluded; they have their own lowering
+        ! paths.
         type(declaration_node), intent(in) :: node
         type(lowering_context_t), intent(in) :: context
-        integer :: dim_index
+        integer :: dim_index, d, rank
         integer(c_int64_t) :: folded
         character(len=:), allocatable :: fold_error
 
@@ -47,19 +48,22 @@
         if (.not. node%is_array) return
         if (node%is_allocatable) return
         if (.not. allocated(node%dimension_indices)) return
-        if (size(node%dimension_indices) /= 1) return
+        rank = size(node%dimension_indices)
+        if (rank < 1 .or. rank > 2) return
         if (declaration_is_assumed_shape(node, context)) return
-        dim_index = node%dimension_indices(1)
-        if (.not. node_exists(context%arena, dim_index)) return
-        select type (dim_node => context%arena%entries(dim_index)%node)
-        type is (range_expression_node)
-            call eval_i32_constant(context%arena, dim_node%end_index, context, &
-                                   folded, fold_error)
-        class default
-            call eval_i32_constant(context%arena, dim_index, context, folded, &
-                                   fold_error)
-        end select
-        is_runtime = len_trim(fold_error) > 0
+        do d = 1, rank
+            dim_index = node%dimension_indices(d)
+            if (.not. node_exists(context%arena, dim_index)) return
+            select type (dim_node => context%arena%entries(dim_index)%node)
+            type is (range_expression_node)
+                call eval_i32_constant(context%arena, dim_node%end_index, &
+                                       context, folded, fold_error)
+            class default
+                call eval_i32_constant(context%arena, dim_index, context, &
+                                       folded, fold_error)
+            end select
+            if (len_trim(fold_error) > 0) is_runtime = .true.
+        end do
     end function declaration_is_runtime_rank1
 
     recursive logical function bound_expr_references_variable(arena, idx, context) &
@@ -130,11 +134,16 @@
         type(declaration_node), intent(in) :: node
         type(lowering_context_t), intent(in) :: context
 
+        integer :: d
+
         is_var = .false.
         if (.not. allocated(node%dimension_indices)) return
-        if (size(node%dimension_indices) /= 1) return
-        is_var = bound_expr_references_variable(context%arena, &
-                                                node%dimension_indices(1), context)
+        if (size(node%dimension_indices) < 1 .or. &
+            size(node%dimension_indices) > 2) return
+        do d = 1, size(node%dimension_indices)
+            if (bound_expr_references_variable(context%arena, &
+                    node%dimension_indices(d), context)) is_var = .true.
+        end do
     end function declaration_bound_is_variable_driven
 
     logical function declaration_is_runtime_local_array(node, context, value_kind) &

--- a/src/session_program_lowering_runtime_alloc.inc
+++ b/src/session_program_lowering_runtime_alloc.inc
@@ -387,65 +387,98 @@
              value_kind == VALUE_F64 .or. value_kind == VALUE_LOGICAL
     end function runtime_local_array_kind_ok
 
-    subroutine runtime_array_bounds(context, node, lower_bound, count_i32, &
-                                    error_msg)
-        ! Compile-time lower bound (default 1, or a constant a(L:...)) and the
-        ! runtime i32 element count of a rank-1 declaration whose upper bound is
-        ! a runtime expression. count = upper - lower + 1.
+    subroutine runtime_array_shape(context, node, rank, lowers, extents_i32, &
+                                   error_msg)
+        ! Per-dimension shape of a rank-1 or rank-2 automatic array. Each lower
+        ! bound must fold at compile time; each upper bound is evaluated once,
+        ! here, so the extent is fixed on entry to the scope (F2018 8.5.8.2) and
+        ! never re-read if the bound expression's variables change later.
         type(lowering_context_t), intent(inout) :: context
         type(declaration_node), intent(in) :: node
-        integer, intent(out) :: lower_bound
-        type(lr_operand_desc_t), intent(out) :: count_i32
+        integer, intent(out) :: rank
+        integer, intent(out) :: lowers(:)
+        type(lr_operand_desc_t), intent(out) :: extents_i32(:)
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: dim_index
+        integer :: dim_index, d
         integer(c_int64_t) :: lower_value
         type(lr_operand_desc_t) :: upper_op
 
-        lower_bound = 1
-        dim_index = node%dimension_indices(1)
-        select type (dim_node => context%arena%entries(dim_index)%node)
-        type is (range_expression_node)
-            call eval_i32_constant(context%arena, dim_node%start_index, context, &
-                                   lower_value, error_msg)
-            if (len_trim(error_msg) > 0) then
-                error_msg = 'runtime-sized array requires a compile-time '// &
-                            'lower bound'
-                return
-            end if
-            lower_bound = int(lower_value)
-            call lower_i32_expression(context%arena, dim_node%end_index, context, &
-                                      upper_op, error_msg)
-            if (len_trim(error_msg) > 0) return
-            if (lower_bound == 1) then
-                count_i32 = upper_op
-            else
-                if (.not. emit_i32_binary(context%session, LR_OP_SUB, upper_op, &
-                        i32_immediate(context%session, &
-                        int(lower_bound - 1, c_int64_t)), count_i32, error_msg)) &
+        lowers = 1
+        rank = 0
+        if (.not. allocated(node%dimension_indices)) then
+            error_msg = 'runtime-sized array requires explicit dimensions'
+            return
+        end if
+        rank = size(node%dimension_indices)
+        if (rank < 1 .or. rank > 2) then
+            error_msg = 'runtime-sized array supports rank 1 and rank 2 only'
+            return
+        end if
+
+        do d = 1, rank
+            dim_index = node%dimension_indices(d)
+            select type (dim_node => context%arena%entries(dim_index)%node)
+            type is (range_expression_node)
+                call eval_i32_constant(context%arena, dim_node%start_index, &
+                                       context, lower_value, error_msg)
+                if (len_trim(error_msg) > 0) then
+                    error_msg = 'runtime-sized array requires a compile-time '// &
+                                'lower bound'
                     return
-            end if
-        class default
-            call lower_i32_expression(context%arena, dim_index, context, &
-                                      count_i32, error_msg)
-            if (len_trim(error_msg) > 0) return
-        end select
+                end if
+                lowers(d) = int(lower_value)
+                call lower_i32_expression(context%arena, dim_node%end_index, &
+                                          context, upper_op, error_msg)
+                if (len_trim(error_msg) > 0) return
+                if (lowers(d) == 1) then
+                    extents_i32(d) = upper_op
+                else
+                    ! extent = upper - lower + 1
+                    if (.not. emit_i32_binary(context%session, LR_OP_SUB, &
+                            upper_op, i32_immediate(context%session, &
+                            int(lowers(d) - 1, c_int64_t)), extents_i32(d), &
+                            error_msg)) return
+                end if
+            class default
+                call lower_i32_expression(context%arena, dim_index, context, &
+                                          extents_i32(d), error_msg)
+                if (len_trim(error_msg) > 0) return
+            end select
+        end do
         call set_empty(error_msg)
-    end subroutine runtime_array_bounds
+    end subroutine runtime_array_shape
 
     subroutine define_runtime_array_symbol(context, node, name, value_kind, &
                                            error_msg)
-        ! Allocate dynamic storage for a rank-1 local automatic array and record
-        ! its runtime element count on a fresh symbol.
+        ! Allocate dynamic storage for a rank-1 or rank-2 local automatic array
+        ! and describe it with one canonical array descriptor (#335). The
+        ! descriptor is the stored shape of record: lower bound, extent, and
+        ! contiguous column-major byte stride per dimension. The symbol's cached
+        ! per-dimension extents are loaded back out of that descriptor, so no
+        ! second shape representation exists.
         type(lowering_context_t), intent(inout) :: context
         type(declaration_node), intent(in) :: node
         character(len=*), intent(in) :: name
         integer, intent(in) :: value_kind
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: index, lower_bound
+        integer :: index, rank, d
+        integer :: lowers(ARRAY_MAX_RANK)
+        type(lr_operand_desc_t) :: extents_i32(2)
         type(lr_operand_desc_t) :: count_i32, count_i64, bytes, storage
+        type(lr_operand_desc_t) :: product_i32
+        type(lr_operand_desc_t) :: descriptor, extent_i64, extent_i32
 
-        call runtime_array_bounds(context, node, lower_bound, count_i32, error_msg)
+        call runtime_array_shape(context, node, rank, lowers, extents_i32, &
+                                 error_msg)
         if (len_trim(error_msg) > 0) return
+
+        ! Total element count is the product of the per-dimension extents.
+        count_i32 = extents_i32(1)
+        do d = 2, rank
+            if (.not. emit_i32_binary(context%session, LR_OP_MUL, count_i32, &
+                    extents_i32(d), product_i32, error_msg)) return
+            count_i32 = product_i32
+        end do
 
         if (.not. emit_liric_i32_to_i64(context%session, count_i32, count_i64, &
                 error_msg)) return
@@ -457,23 +490,124 @@
             return
         end if
 
+        call emit_runtime_array_descriptor(context, storage, rank, lowers, &
+                                           extents_i32, value_kind, descriptor, &
+                                           error_msg)
+        if (len_trim(error_msg) > 0) return
+
         call grow_symbols(context)
         index = context%symbol_count + 1
         context%symbols(index)%name = trim(name)
         context%symbols(index)%value_kind = value_kind
         context%symbols(index)%is_array = .true.
         context%symbols(index)%is_runtime_array = .true.
-        context%symbols(index)%array_rank = 1
+        context%symbols(index)%has_runtime_descriptor = .true.
+        context%symbols(index)%runtime_descriptor_address = descriptor
+        context%symbols(index)%array_rank = rank
         context%symbols(index)%array_size = 0
-        context%symbols(index)%array_lower_bound = lower_bound
-        context%symbols(index)%array_dim_lowers(1) = lower_bound
-        context%symbols(index)%array_dim_sizes(1) = 0
-        context%symbols(index)%has_runtime_dim_size(1) = .true.
-        context%symbols(index)%runtime_dim_size(1) = count_i32
+        context%symbols(index)%array_lower_bound = lowers(1)
         context%symbols(index)%element_address = storage
+        do d = 1, rank
+            context%symbols(index)%array_dim_lowers(d) = lowers(d)
+            context%symbols(index)%array_dim_sizes(d) = 0
+            ! Read the extent back out of the descriptor so the descriptor, not
+            ! the bound expression, is what every later shape query observes.
+            if (.not. emit_i64_load_at(context%session, descriptor, &
+                    runtime_descriptor_dim_offset(d, &
+                        int(ARRAY_DIMENSION_EXTENT_OFFSET, c_int64_t)), &
+                    extent_i64, error_msg)) return
+            if (.not. emit_liric_i64_to_i32(context%session, extent_i64, &
+                    extent_i32, error_msg)) return
+            context%symbols(index)%has_runtime_dim_size(d) = .true.
+            context%symbols(index)%runtime_dim_size(d) = extent_i32
+        end do
         context%symbol_count = index
         call set_empty(error_msg)
     end subroutine define_runtime_array_symbol
+
+    integer(c_int64_t) function runtime_descriptor_dim_offset(dim, field) &
+            result(offset)
+        integer, intent(in) :: dim
+        integer(c_int64_t), intent(in) :: field
+
+        offset = int(ARRAY_DESCRIPTOR_DIM_OFFSET, c_int64_t) &
+                 + int(ARRAY_DIMENSION_BYTES, c_int64_t)*int(dim - 1, c_int64_t) &
+                 + field
+    end function runtime_descriptor_dim_offset
+
+    subroutine emit_runtime_array_descriptor(context, base, rank, lowers, &
+                                             extents_i32, value_kind, &
+                                             descriptor, error_msg)
+        ! Fill one canonical array descriptor for a runtime automatic array.
+        ! The array owns its storage for the lifetime of its scope, so the
+        ! descriptor is contiguous and allocated but never carries the ownership
+        ! bit: the storage is a stack allocation reclaimed with the frame, not a
+        ! heap block any deallocator may free.
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: base
+        integer, intent(in) :: rank
+        integer, intent(in) :: lowers(:)
+        type(lr_operand_desc_t), intent(in) :: extents_i32(:)
+        integer, intent(in) :: value_kind
+        type(lr_operand_desc_t), intent(out) :: descriptor
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: extent_i64, running, next_running, stride
+        integer(c_int64_t) :: element_bytes
+        integer(c_int32_t) :: flags
+        integer :: d
+
+        element_bytes = allocatable_elem_size(value_kind)
+        if (.not. emit_alloca_bytes(context%session, &
+                i64_immediate(context%session, &
+                    int(ARRAY_DESCRIPTOR_BYTES, c_int64_t)), descriptor, &
+                error_msg)) return
+        if (.not. emit_ptr_store(context%session, base, descriptor, error_msg)) &
+            return
+        if (.not. emit_i64_store_at(context%session, &
+                i64_immediate(context%session, element_bytes), descriptor, &
+                int(ARRAY_DESCRIPTOR_ELEMENT_SIZE_OFFSET, c_int64_t), &
+                error_msg)) return
+        call store_descriptor_i32(context, assumed_shape_element_type(value_kind), &
+            descriptor, int(ARRAY_DESCRIPTOR_ELEMENT_TYPE_OFFSET, c_int64_t), &
+            error_msg)
+        if (len_trim(error_msg) > 0) return
+        call store_descriptor_i32(context, int(rank, c_int32_t), descriptor, &
+            int(ARRAY_DESCRIPTOR_RANK_OFFSET, c_int64_t), error_msg)
+        if (len_trim(error_msg) > 0) return
+        flags = ARRAY_FLAG_ALLOCATED + ARRAY_FLAG_ASSOCIATED + ARRAY_FLAG_CONTIGUOUS
+        call store_descriptor_i32(context, flags, descriptor, &
+            int(ARRAY_DESCRIPTOR_FLAGS_OFFSET, c_int64_t), error_msg)
+        if (len_trim(error_msg) > 0) return
+        call store_descriptor_i32(context, 0_c_int32_t, descriptor, &
+            int(ARRAY_DESCRIPTOR_RESERVED_OFFSET, c_int64_t), error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        running = i64_immediate(context%session, element_bytes)
+        do d = 1, rank
+            if (.not. emit_liric_i32_to_i64(context%session, extents_i32(d), &
+                    extent_i64, error_msg)) return
+            if (.not. emit_i64_store_at(context%session, &
+                    i64_immediate(context%session, int(lowers(d), c_int64_t)), &
+                    descriptor, runtime_descriptor_dim_offset(d, &
+                        int(ARRAY_DIMENSION_LOWER_OFFSET, c_int64_t)), &
+                    error_msg)) return
+            if (.not. emit_i64_store_at(context%session, extent_i64, descriptor, &
+                    runtime_descriptor_dim_offset(d, &
+                        int(ARRAY_DIMENSION_EXTENT_OFFSET, c_int64_t)), &
+                    error_msg)) return
+            stride = running
+            if (.not. emit_i64_store_at(context%session, stride, descriptor, &
+                    runtime_descriptor_dim_offset(d, &
+                        int(ARRAY_DIMENSION_STRIDE_OFFSET, c_int64_t)), &
+                    error_msg)) return
+            if (d < rank) then
+                if (.not. emit_i64_binary(context%session, LR_OP_MUL, running, &
+                        extent_i64, next_running, error_msg)) return
+                running = next_running
+            end if
+        end do
+        call set_empty(error_msg)
+    end subroutine emit_runtime_array_descriptor
 
     logical function symbol_is_runtime_local_array(context, sym) result(is_rt)
         type(lowering_context_t), intent(in) :: context

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -279,6 +279,12 @@ module session_program_lowering_types
         ! the 0 sentinel. Whole-array print/assign and size()/sum() walk a
         ! genuine LIRIC loop over runtime_dim_size(1) instead of unrolling.
         logical :: is_runtime_array = .false.
+        ! Canonical array descriptor backing a runtime-sized automatic array
+        ! (#335). It is the stored shape of record: base address, element size
+        ! and type, rank, flags, and per-dimension lower bound, extent, and byte
+        ! stride, laid out by docs/ARRAY_DESCRIPTOR_ABI.md.
+        logical :: has_runtime_descriptor = .false.
+        type(lr_operand_desc_t) :: runtime_descriptor_address
         logical :: is_derived = .false.
         integer :: derived_type_index = 0
         ! Polymorphism (#417). is_polymorphic marks an entity declared class(t):

--- a/test/conformance/xfail_fortfront_f90.txt
+++ b/test/conformance/xfail_fortfront_f90.txt
@@ -17,7 +17,6 @@ dtio_interface_unformatted.f90 # owner=lazy-fortran/ffc#427; reason=return stabl
 f2003_abstract_interface.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 f2003_block_construct.f90 # owner=lazy-fortran/ffc#329; reason=resolve specification expressions by binding identity
 f2003_type_bound_array_call.f90 # owner=lazy-fortran/ffc#368; reason=deduplicate derived array declaration collection
-issue_1324_if_inside_do_loop.f90 # owner=lazy-fortran/ffc#376; reason=select and load the matching runtime archive
 issue_1353_class_pointer_declaration.f90 # owner=lazy-fortran/ffc#452; reason=lower scalar data-pointer association
 issue_1570_pure_elemental_preservation.f90 # owner=lazy-fortran/ffc#405; reason=lower elemental procedures through array expressions
 issue_1607_final_procedures.f90 # owner=lazy-fortran/ffc#403; reason=invoke scalar final procedures once

--- a/test/test_session_runtime_local_array_compiler.f90
+++ b/test/test_session_runtime_local_array_compiler.f90
@@ -11,6 +11,8 @@ program test_session_runtime_local_array
     if (.not. test_real_broadcast_and_copy()) all_passed = .false.
     if (.not. test_lower_bound_array()) all_passed = .false.
     if (.not. test_entry_extent_survives_bound_mutation()) all_passed = .false.
+    if (.not. test_rank2_nonunit_lower_bounds()) all_passed = .false.
+    if (.not. test_rank2_unit_bounds_column_major()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: runtime-sized local automatic arrays lower end to end'
@@ -133,5 +135,73 @@ contains
         test_entry_extent_survives_bound_mutation = expect_output(source, &
             expected, '/tmp/ffc_session_runtime_local_array_entry')
     end function test_entry_extent_survives_bound_mutation
+
+    logical function test_rank2_nonunit_lower_bounds()
+        ! A rank-2 automatic array with runtime upper bounds and non-unit lower
+        ! bounds. Its canonical descriptor carries lower bound, extent, and
+        ! column-major byte stride per dimension, so SIZE, LBOUND, UBOUND, and
+        ! boundary element access all agree with gfortran.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'integer :: n, m'//new_line('a')// &
+            'n = 3'//new_line('a')// &
+            'm = 4'//new_line('a')// &
+            'call work(n, m)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine work(nn, mm)'//new_line('a')// &
+            'integer, intent(in) :: nn, mm'//new_line('a')// &
+            'integer :: a(0:nn, 2:mm)'//new_line('a')// &
+            'a(0,2) = 2'//new_line('a')// &
+            'a(nn,mm) = 34'//new_line('a')// &
+            'a(1,3) = 13'//new_line('a')// &
+            'print *, size(a), size(a,1), size(a,2)'//new_line('a')// &
+            'print *, lbound(a,1), ubound(a,1), lbound(a,2), ubound(a,2)'// &
+            new_line('a')// &
+            'print *, a(0,2), a(nn,mm), a(1,3)'//new_line('a')// &
+            'end subroutine work'//new_line('a')// &
+            'end program main'
+        character(len=*), parameter :: expected = &
+            '          12           4           3'//new_line('a')// &
+            '           0           3           2           4'//new_line('a')// &
+            '           2          34          13'//new_line('a')
+
+        test_rank2_nonunit_lower_bounds = expect_output(source, expected, &
+            '/tmp/ffc_session_runtime_local_array_rank2_bounds')
+    end function test_rank2_nonunit_lower_bounds
+
+    logical function test_rank2_unit_bounds_column_major()
+        ! Column-major identity for a rank-2 runtime automatic array: the
+        ! descriptor stride for dimension 2 is the element size times the
+        ! dimension-1 extent, so a(i,j) and a(i+1,j) are adjacent.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'integer :: n'//new_line('a')// &
+            'n = 3'//new_line('a')// &
+            'call work(n)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine work(k)'//new_line('a')// &
+            'integer, intent(in) :: k'//new_line('a')// &
+            'integer :: a(k, 2)'//new_line('a')// &
+            'integer :: i'//new_line('a')// &
+            'do i = 1, k'//new_line('a')// &
+            'a(i,1) = i'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'a(1,2) = 71'//new_line('a')// &
+            'a(k,2) = 79'//new_line('a')// &
+            'print *, size(a), size(a,1), size(a,2)'//new_line('a')// &
+            'print *, a(1,1), a(2,1), a(3,1)'//new_line('a')// &
+            'print *, a(1,2), a(k,2)'//new_line('a')// &
+            'end subroutine work'//new_line('a')// &
+            'end program main'
+        character(len=*), parameter :: expected = &
+            '           6           3           2'//new_line('a')// &
+            '           1           2           3'//new_line('a')// &
+            '          71          79'//new_line('a')
+
+        test_rank2_unit_bounds_column_major = expect_output(source, expected, &
+            '/tmp/ffc_session_runtime_local_array_rank2_cm')
+    end function test_rank2_unit_bounds_column_major
 
 end program test_session_runtime_local_array


### PR DESCRIPTION
Closes #335.

A runtime-sized local automatic array is now described by one canonical array
descriptor (`ffc_array_descriptor`, `docs/ARRAY_DESCRIPTOR_ABI.md`) instead of a
bare data pointer plus a single cached extent, and rank 2 is supported.

## What changed

- `define_runtime_array_symbol` builds a descriptor for every runtime automatic
  array: base, element size and type, rank, flags, and per-dimension
  `(lower_bound, extent, stride_bytes)`. It is stored on the symbol as
  `runtime_descriptor_address`.
- `runtime_array_bounds` (rank-1, one extent) becomes `runtime_array_shape`,
  which evaluates every dimension's lower bound and extent.
- `declaration_is_runtime_rank1` and `declaration_bound_is_variable_driven`
  accept rank 2, and treat a declaration as runtime-shaped when *any* dimension
  fails to fold.
- The symbol's cached per-dimension extents are **loaded back out of the
  descriptor** rather than taken from the bound expression, so the descriptor is
  the single stored shape and no second representation is live. Retiring the
  cache itself is #339's job.

Before this change `integer :: a(0:n, 2:m)` was rejected outright with
`compile-time integer parameter was not declared: n`.

## Behavioral oracle, recorded failing on main first

```fortran
integer :: a(0:nn, 2:mm)   ! nn, mm are runtime dummy values
print *, size(a), size(a,1), size(a,2)
print *, lbound(a,1), ubound(a,1), lbound(a,2), ubound(a,2)
print *, a(0,2), a(nn,mm), a(1,3)
```

main rejects this. With the descriptor it prints `12 4 3` / `0 3 2 4` /
`2 34 13`, matching gfortran exactly. Landed as
`test_rank2_nonunit_lower_bounds`, plus
`test_rank2_unit_bounds_column_major` for column-major adjacency.

## Invariants preserved and how

- **Fortran column-major layout.** The descriptor's stride for dimension 1 is
  the element size and for dimension `d` the product of every lower dimension's
  extent, so `a(i,j)` and `a(i+1,j)` are adjacent.
  `test_rank2_unit_bounds_column_major` asserts exactly that.
- **Lower-bound and extent semantics.** Each dimension's lower bound is folded
  at compile time and written into the descriptor; extents are `upper - lower +
  1`. `lbound`/`ubound`/`size` all agree with gfortran for `a(0:nn, 2:mm)`.
- **Extent fixed at entry.** Every bound expression is evaluated once, where the
  array comes into scope (F2018 8.5.8.2), so later mutation of the bound
  variables cannot change the array's shape. The pre-existing
  `test_entry_extent_survives_bound_mutation` still passes and now guards the
  descriptor path.
- **Overlap and aliasing.** Storage is a single contiguous block and the
  descriptor points at it directly; nothing is copied, so no new aliasing is
  introduced.
- **Allocation and finalization lifetimes.** The storage is a stack allocation
  reclaimed with the frame, so the descriptor is marked allocated, associated,
  and contiguous but deliberately **never** carries `ARRAY_FLAG_OWNS_DATA` — no
  deallocator may ever be handed this base pointer. This is the one place where
  getting the ownership bit wrong would produce exactly the use-after-free class
  seen elsewhere in the descriptor migrations.
- **View lifetimes.** No views are created here.
- **One convention.** The old `runtime_dim_size`-as-source-of-truth arrangement
  is gone for automatic arrays; the cached operands are now loads from the
  descriptor. No forked lowering path was added.

## Corpus delta

Measured **within a single worktree**, before and after the patch, each with a
clean rebuild. Cross-worktree comparison proved unreliable here: with pristine
`origin/main` sources and a clean build, this worktree fails `pdt_08.f90` while
a second worktree at the identical commit passes it, so any A/B across two
checkouts reports phantom regressions. Same-tree A/B removes that.

| Suite | PASS | FAIL | XPASS |
|---|---|---|---|
| lfortran | 870 -> 871 | 10 -> 9 | 87 -> 87 |
| fortfront-f90 | 414 -> 414 | 9 -> 9 | 0 -> 1 |

No case regresses from PASS and none becomes FAIL from any state.
`file_open_08.f90` goes FAIL -> PASS. `issue_1324_if_inside_do_loop.f90` goes
XFAIL -> XPASS (confirmed on two consecutive runs) and is removed from the
fortfront-f90 xfail manifest in this PR.

`test_fortfront_corpus_conformance` and `test_parity_dashboard` still fail; both
fail identically on clean `origin/main` and are owned elsewhere.

## Adjacent defect found, not fixed here

A statement following a **nested** `do` loop is dropped from the emitted code.
This reproduces on unmodified `main` with an ordinary fixed-size array and has
nothing to do with descriptors, so it is out of scope for this PR; the new tests
avoid nested loops for that reason. Worth its own issue.
