### PR TITLE
[charown-01] give a character result temporary a statement-scoped owner

### DIFF
--- a/src/session_program_lowering_deferred_char.inc
+++ b/src/session_program_lowering_deferred_char.inc
@@ -109,8 +109,6 @@ integer function resolve_concat_operand(arena, node_index, context, &
         logical :: right_is_call
         logical :: left_is_view
         logical :: right_is_view
-        type(lr_operand_desc_t) :: left_call_data_addr, left_call_storage_addr
-        type(lr_operand_desc_t) :: right_call_data_addr, right_call_storage_addr
         type(lr_operand_desc_t) :: call_len_i32
         character(len=:), allocatable :: literal_text
         character(len=64) :: string_name
@@ -193,9 +191,7 @@ integer function resolve_concat_operand(arena, node_index, context, &
                     left_len, error_msg)) return
         else if (left_is_call) then
             call char_result_call_operands(arena, left_idx, context, left_data, &
-                                           call_len_i32, error_msg, &
-                                           left_call_data_addr, &
-                                           left_call_storage_addr)
+                                           call_len_i32, error_msg)
             if (len_trim(error_msg) > 0) return
             if (.not. emit_liric_i32_to_i64(context%session, call_len_i32, &
                     left_len, error_msg)) return
@@ -229,9 +225,7 @@ integer function resolve_concat_operand(arena, node_index, context, &
                     right_len, error_msg)) return
         else if (right_is_call) then
             call char_result_call_operands(arena, right_idx, context, right_data, &
-                                           call_len_i32, error_msg, &
-                                           right_call_data_addr, &
-                                           right_call_storage_addr)
+                                           call_len_i32, error_msg)
             if (len_trim(error_msg) > 0) return
             if (.not. emit_liric_i32_to_i64(context%session, call_len_i32, &
                     right_len, error_msg)) return
@@ -360,19 +354,6 @@ integer function resolve_concat_operand(arena, node_index, context, &
         call set_character_storage(context, dest_symbol_index, total_len, &
                                    new_storage_class, error_msg)
         if (len_trim(error_msg) > 0) return
-
-        ! An operand that was a function result is a temporary this statement
-        ! took ownership of; its bytes are now in the concatenated buffer.
-        if (left_is_call) then
-            call release_character_descriptor_storage(context, &
-                left_call_data_addr, left_call_storage_addr, error_msg)
-            if (len_trim(error_msg) > 0) return
-        end if
-        if (right_is_call) then
-            call release_character_descriptor_storage(context, &
-                right_call_data_addr, right_call_storage_addr, error_msg)
-            if (len_trim(error_msg) > 0) return
-        end if
 
         context%symbols(dest_symbol_index)%value = new_ptr
         context%symbols(dest_symbol_index)%has_character_value = .true.
@@ -531,6 +512,86 @@ integer function resolve_concat_operand(arena, node_index, context, &
         context%symbols(dest_symbol_index)%has_character_value = .true.
         call set_empty(error_msg)
     end subroutine lower_deferred_folded_literal_assignment
+
+    subroutine register_char_temp(context, data_addr, storage_addr)
+        ! Record a character result temporary so the statement that created it
+        ! releases it. Registration is unconditional: a consumer that wants
+        ! ownership takes it back with adopt_char_temp, which is a smaller and
+        ! more obvious set of places than every consumer that does not.
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: data_addr
+        type(lr_operand_desc_t), intent(in) :: storage_addr
+        type(lr_operand_desc_t), allocatable :: grown_data(:)
+        type(lr_operand_desc_t), allocatable :: grown_storage(:)
+        integer :: capacity
+
+        if (.not. allocated(context%char_temp_data)) then
+            allocate (context%char_temp_data(8))
+            allocate (context%char_temp_storage(8))
+            context%char_temp_count = 0
+        end if
+        capacity = size(context%char_temp_data)
+        if (context%char_temp_count >= capacity) then
+            allocate (grown_data(capacity*2))
+            allocate (grown_storage(capacity*2))
+            grown_data(1:capacity) = context%char_temp_data
+            grown_storage(1:capacity) = context%char_temp_storage
+            call move_alloc(grown_data, context%char_temp_data)
+            call move_alloc(grown_storage, context%char_temp_storage)
+        end if
+        context%char_temp_count = context%char_temp_count + 1
+        context%char_temp_data(context%char_temp_count) = data_addr
+        context%char_temp_storage(context%char_temp_count) = storage_addr
+    end subroutine register_char_temp
+
+    subroutine adopt_char_temp(context, mark)
+        ! A consumer took ownership of the temporaries created since mark, so
+        ! the statement must not release them. Used where a deferred
+        ! destination rebinds onto the return descriptor: the destination's own
+        ! descriptor now owns the block and releases it at its next assignment
+        ! or deallocate.
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: mark
+
+        if (mark < 0) return
+        if (mark > context%char_temp_count) return
+        context%char_temp_count = mark
+    end subroutine adopt_char_temp
+
+    integer function char_temp_mark(context) result(mark)
+        ! How many temporaries are outstanding before lowering something.
+        type(lowering_context_t), intent(in) :: context
+
+        mark = context%char_temp_count
+    end function char_temp_mark
+
+    subroutine release_char_temps_since(context, mark, error_msg)
+        ! Release every character result temporary registered since mark, in
+        ! reverse order of creation, and forget them. Releasing is a no-op for
+        ! a borrowed result: release_character_descriptor_storage frees only a
+        ! descriptor whose storage class says it owns its bytes.
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: mark
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        call set_empty(error_msg)
+        if (context%char_temp_count <= mark) return
+        ! A terminated block takes no more instructions; the frame is going
+        ! away with the process or the callee's return, so there is nothing to
+        ! release into.
+        if (context%current_block_terminated) then
+            context%char_temp_count = mark
+            return
+        end if
+        do i = context%char_temp_count, mark + 1, -1
+            call release_character_descriptor_storage(context, &
+                context%char_temp_data(i), context%char_temp_storage(i), &
+                error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+        context%char_temp_count = mark
+    end subroutine release_char_temps_since
 
     subroutine allocate_deferred_char_descriptor(context, descriptor_ptr, &
                                                   data_addr, len_addr, &
@@ -747,9 +808,11 @@ integer function resolve_concat_operand(arena, node_index, context, &
         type(lr_operand_desc_t) :: capacity_addr
         type(lr_operand_desc_t) :: storage_addr
         integer :: i
+        integer :: temp_mark
         character(len=:), allocatable :: func_name
 
         call set_empty(error_msg)
+        temp_mark = char_temp_mark(context)
         if (.not. node_exists(arena, node%value_index)) then
             error_msg = 'deferred char call assignment value does not reference an AST node'
             return
@@ -773,6 +836,7 @@ integer function resolve_concat_operand(arena, node_index, context, &
         call release_owned_character_storage(context, dest_symbol_index, error_msg)
         if (len_trim(error_msg) > 0) return
 
+        temp_mark = char_temp_mark(context)
         call allocate_deferred_char_descriptor(context, descriptor_ptr, &
                                                data_addr, len_addr, error_msg, &
                                                capacity_addr, storage_addr)
@@ -807,6 +871,10 @@ integer function resolve_concat_operand(arena, node_index, context, &
         if (.not. emit_ptr_load(context%session, data_addr, &
             context%symbols(dest_symbol_index)%value, error_msg)) return
         context%symbols(dest_symbol_index)%has_character_value = .true.
+        ! The destination now owns this descriptor, so the statement must not
+        ! release it: that is the ownership transfer #348 established. Any
+        ! temporary produced by the argument expressions stays registered.
+        call adopt_char_temp(context, temp_mark)
         call set_empty(error_msg)
     end subroutine lower_deferred_char_result_call
 
@@ -823,22 +891,16 @@ integer function resolve_concat_operand(arena, node_index, context, &
         integer, intent(in) :: dest_symbol_index
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t) :: data_ptr, length
-        type(lr_operand_desc_t) :: data_addr, storage_addr
 
         call char_result_call_operands(arena, node%value_index, context, &
-                                       data_ptr, length, error_msg, &
-                                       data_addr, storage_addr)
+                                       data_ptr, length, error_msg)
         if (len_trim(error_msg) > 0) return
         call store_fixed_character_value(context, dest_symbol_index, data_ptr, &
                                          length, error_msg)
-        if (len_trim(error_msg) > 0) return
-        call release_character_descriptor_storage(context, data_addr, &
-                                                  storage_addr, error_msg)
     end subroutine lower_fixed_char_result_call
 
     subroutine char_result_call_operands(arena, node_index, context, data_ptr, &
-                                         length, error_msg, out_data_addr, &
-                                         out_storage_addr)
+                                         length, error_msg)
         ! Emit a call to a character-returning contained function through the
         ! deferred-character descriptor ABI (hidden first descriptor argument),
         ! then load the returned {data, len} as a scalar character expression.
@@ -853,8 +915,6 @@ integer function resolve_concat_operand(arena, node_index, context, &
         type(lr_operand_desc_t), allocatable :: user_args(:)
         type(lr_operand_desc_t), allocatable :: all_args(:)
         integer, allocatable :: copyback_indices(:)
-        type(lr_operand_desc_t), intent(out), optional :: out_data_addr
-        type(lr_operand_desc_t), intent(out), optional :: out_storage_addr
         type(lr_operand_desc_t) :: descriptor_ptr
         type(lr_operand_desc_t) :: data_addr
         type(lr_operand_desc_t) :: len_addr
@@ -906,10 +966,10 @@ integer function resolve_concat_operand(arena, node_index, context, &
                                 error_msg)) return
         if (.not. emit_i32_load(context%session, len_addr, length, &
                                 error_msg)) return
-        ! A consumer that copies the value out can release the temporary; one
-        ! that keeps the pointer alive simply does not ask for the addresses.
-        if (present(out_data_addr)) out_data_addr = data_addr
-        if (present(out_storage_addr)) out_storage_addr = storage_addr
+        ! The result is a temporary owned by the statement being lowered, which
+        ! releases it once it has finished with it. Every consumer therefore
+        ! reads it the same way and none of them has to know it is a temporary.
+        call register_char_temp(context, data_addr, storage_addr)
         call set_empty(error_msg)
     end subroutine char_result_call_operands
 
@@ -938,6 +998,8 @@ integer function resolve_concat_operand(arena, node_index, context, &
                                                data_addr, len_addr, error_msg, &
                                                storage_addr=storage_addr)
         if (len_trim(error_msg) > 0) return
+        ! The printed result is a temporary the statement owns and releases.
+        call register_char_temp(context, data_addr, storage_addr)
 
         if (allocated(node%arg_indices)) then
             call prepare_deferred_char_call_args(arena, node%arg_indices, &
@@ -965,12 +1027,6 @@ integer function resolve_concat_operand(arena, node_index, context, &
         ! The list-directed leading blank is emitted by the print loop.
         if (.not. emit_liric_print_string_operand_value(context%session, &
             context%str_print_format_id, data_value, error_msg)) return
-        ! The result has been consumed by the transfer statement, so the
-        ! caller releases the temporary it took ownership of. A borrowed
-        ! result (a static literal) is left alone.
-        call release_character_descriptor_storage(context, data_addr, &
-                                                  storage_addr, error_msg)
-        if (len_trim(error_msg) > 0) return
         call set_empty(error_msg)
     end subroutine lower_print_deferred_char_call
 

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -903,6 +903,32 @@
     include 'session_program_lowering_functions.inc'
     recursive subroutine lower_statement(arena, node_index, context, value, &
                                          error_msg)
+        ! A statement owns the character result temporaries created while it is
+        ! lowered, and releases them once it is done. Doing it here, around the
+        ! whole dispatch, covers every consumer of a character-returning call
+        ! at one point and survives the early returns below. Nested statements
+        ! inside a construct take their own mark, so a construct never releases
+        ! a temporary belonging to the statement that contains it.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: release_error
+        integer :: temp_mark
+
+        temp_mark = char_temp_mark(context)
+        call lower_statement_body(arena, node_index, context, value, error_msg)
+        if (len_trim(error_msg) > 0) then
+            context%char_temp_count = min(context%char_temp_count, temp_mark)
+            return
+        end if
+        call release_char_temps_since(context, temp_mark, release_error)
+        if (len_trim(release_error) > 0) error_msg = release_error
+    end subroutine lower_statement
+
+    recursive subroutine lower_statement_body(arena, node_index, context, value, &
+                                              error_msg)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: node_index
         type(lowering_context_t), intent(inout) :: context
@@ -1210,7 +1236,8 @@
                                                 error_msg)
             end if
         end select
-    end subroutine lower_statement
+    end subroutine lower_statement_body
+
     subroutine unsupported_statement_node(arena, node_index, node_type, error_msg)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: node_index

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -697,6 +697,18 @@ module session_program_lowering_types
         ! USE-associated procedure with the same spelling (#330).
         integer :: current_proc_node_index = 0
         integer :: current_function_result_index = 0
+        ! Character result temporaries created while lowering the current
+        ! statement. A character-returning call writes its result through a
+        ! return descriptor the caller stack-allocates; whoever consumes that
+        ! result reads the bytes but does not own them, so the temporary needs
+        ! an owner of its own. The statement is that owner: each temporary is
+        ! registered here as it is created and released once the statement
+        ! that produced it has finished with it. A consumer that takes
+        ! ownership instead - a deferred destination adopting the returned
+        ! descriptor - deregisters it, so a block is released exactly once.
+        type(lr_operand_desc_t), allocatable :: char_temp_data(:)
+        type(lr_operand_desc_t), allocatable :: char_temp_storage(:)
+        integer :: char_temp_count = 0
         logical :: current_block_terminated = .false.
         integer(c_int32_t) :: current_loop_exit_block = 0_c_int32_t
         integer(c_int32_t) :: current_loop_latch_block = 0_c_int32_t

--- a/test/test_session_character_function_result_compiler.f90
+++ b/test/test_session_character_function_result_compiler.f90
@@ -223,6 +223,102 @@ program test_session_character_function_result_compiler
         'end program main', &
         '/tmp/ffc_charfn_result_transfer_leak')) all_passed = .false.
 
+    ! A character result consumed through the generic character-expression
+    ! path is a temporary belonging to the statement that produced it. These
+    ! cases pin its output and, through expect_no_leaks, that it is released
+    ! exactly once. They passed while leaking before this was fixed, which is
+    ! why the leak check and not the output is what makes them meaningful.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  character(len=:), allocatable :: s'//new_line('a')// &
+        '  s = trim(pad(3))'//new_line('a')// &
+        '  print *, len(s), "[", s, "]"'//new_line('a')// &
+        '  deallocate(s)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function pad(k) result(t)'//new_line('a')// &
+        '    integer, intent(in) :: k'//new_line('a')// &
+        '    character(len=8) :: t'//new_line('a')// &
+        '    t = repeat("z", k)'//new_line('a')// &
+        '  end function pad'//new_line('a')// &
+        'end program main', &
+        'trim_of_result')) all_passed = .false.
+
+    if (.not. expect_no_leaks( &
+        'program main'//new_line('a')// &
+        '  character(len=:), allocatable :: s'//new_line('a')// &
+        '  character(len=8) :: f'//new_line('a')// &
+        '  s = trim(pad(3))'//new_line('a')// &
+        '  print *, len(s)'//new_line('a')// &
+        '  f = trim(pad(4))'//new_line('a')// &
+        '  print *, "[", f, "]"'//new_line('a')// &
+        '  print *, trim(pad(5))'//new_line('a')// &
+        '  print *, len_trim(pad(6))'//new_line('a')// &
+        '  if (trim(pad(3)) == "zzz") print *, "eq"'//new_line('a')// &
+        '  deallocate(s)'//new_line('a')// &
+        '  stop 0'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function pad(k) result(t)'//new_line('a')// &
+        '    integer, intent(in) :: k'//new_line('a')// &
+        '    character(len=8) :: t'//new_line('a')// &
+        '    t = repeat("z", k)'//new_line('a')// &
+        '  end function pad'//new_line('a')// &
+        'end program main', &
+        '/tmp/ffc_charfn_expr_temp_leak')) all_passed = .false.
+
+    ! Two result temporaries alive at once in a single statement: both are
+    ! consumed by the concatenation and both must be released.
+    if (.not. matches_gfortran( &
+        'program main'//new_line('a')// &
+        '  character(len=:), allocatable :: s'//new_line('a')// &
+        '  s = tag(2) // tag(3)'//new_line('a')// &
+        '  print *, len(s), "[", s, "]"'//new_line('a')// &
+        '  deallocate(s)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function tag(k) result(t)'//new_line('a')// &
+        '    integer, intent(in) :: k'//new_line('a')// &
+        '    character(len=k) :: t'//new_line('a')// &
+        '    t = repeat("z", k)'//new_line('a')// &
+        '  end function tag'//new_line('a')// &
+        'end program main', &
+        'two_result_operands')) all_passed = .false.
+
+    if (.not. expect_no_leaks( &
+        'program main'//new_line('a')// &
+        '  character(len=:), allocatable :: s'//new_line('a')// &
+        '  s = tag(2) // tag(3)'//new_line('a')// &
+        '  print *, len(s)'//new_line('a')// &
+        '  deallocate(s)'//new_line('a')// &
+        '  stop 0'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function tag(k) result(t)'//new_line('a')// &
+        '    integer, intent(in) :: k'//new_line('a')// &
+        '    character(len=k) :: t'//new_line('a')// &
+        '    t = repeat("z", k)'//new_line('a')// &
+        '  end function tag'//new_line('a')// &
+        'end program main', &
+        '/tmp/ffc_charfn_two_operand_leak')) all_passed = .false.
+
+    ! A result temporary inside a loop must be released each iteration rather
+    ! than accumulating, which a single-shot release would miss.
+    if (.not. expect_no_leaks( &
+        'program main'//new_line('a')// &
+        '  character(len=:), allocatable :: s'//new_line('a')// &
+        '  integer :: i'//new_line('a')// &
+        '  do i = 1, 4'//new_line('a')// &
+        '    s = trim(pad(i))'//new_line('a')// &
+        '    print *, len(s)'//new_line('a')// &
+        '  end do'//new_line('a')// &
+        '  deallocate(s)'//new_line('a')// &
+        '  stop 0'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function pad(k) result(t)'//new_line('a')// &
+        '    integer, intent(in) :: k'//new_line('a')// &
+        '    character(len=8) :: t'//new_line('a')// &
+        '    t = repeat("z", k)'//new_line('a')// &
+        '  end function pad'//new_line('a')// &
+        'end program main', &
+        '/tmp/ffc_charfn_loop_temp_leak')) all_passed = .false.
+
     if (.not. all_passed) stop 1
     print *, 'PASS: character function results lower through direct LIRIC session'
 


### PR DESCRIPTION
Closes #615.

`s = trim(f(x))` leaked. A character-returning call writes its result through a
return descriptor the caller stack-allocates, and #348 arranged for the
consumers it knew about to release it. Every other consumer reached the same
call through the generic `char_expr_operands` path, read the bytes, and left the
block owned by nobody. `trim(f(x))`, `print *, trim(f(x))`, `len_trim(f(x))`
and `trim(f(x)) == "..."` all leaked; the assignment forms did not, which is
exactly the split #348 left behind.

## The statement owns the temporary

Rather than teaching each consumer to release, the temporary now has a single
owner: the statement that produced it.

- `char_result_call_operands` registers every result descriptor it creates.
- `lower_statement` takes a mark before dispatch and releases everything
  registered since, around the whole statement. That is one point, it survives
  the early returns in the dispatch, and nested statements take their own mark
  so a construct never releases a temporary belonging to the statement that
  contains it.
- A consumer that genuinely takes ownership calls `adopt_char_temp` — only the
  deferred destination does, which is the ownership transfer #348 established.

This **retires** the previous mechanism rather than sitting beside it. The
`out_data_addr`/`out_storage_addr` out-arguments on `char_result_call_operands`
are gone, along with the three explicit release sites in the fixed-destination,
print, and concat-operand paths. There is now exactly one way a result
temporary is released, so a consumer added later inherits it by default instead
of having to remember.

Release is a no-op for a borrowed result:
`release_character_descriptor_storage` frees only a descriptor whose storage
class says it owns its bytes, which is the #349 rule. Temporaries are released
in reverse order of creation, and a statement whose block was terminated
(`return`, `stop`) releases nothing, since there is no longer a frame to
release into.

## Behaviour preserved

- **Release exactly once.** Adoption deregisters, so a deferred destination
  that rebinds onto the return descriptor is not also released by the
  statement. `s = f(x)` and `f = f(x)` are unchanged and still leak-free.
- **Ownership rules from #349/#348.** Owned versus borrowed is still the
  storage class; nothing here frees a static literal or a stack buffer.
- **Character length semantics, padding and truncation.** Untouched. No
  padding, truncation, or length path was modified — only when the temporary
  behind a value is released.
- **Aliasing.** Unchanged: the release happens after the statement has finished
  with the value, so the copy-before-release ordering from #348 and #350 still
  holds.

## Coverage

Added to the maintained test, with gfortran as the output reference and
`expect_no_leaks` (valgrind) as the ownership oracle:

- `trim(f(x))` into a deferred destination, output and leak.
- One program exercising all four leaking consumers at once: deferred
  destination, fixed destination, `print`, `len_trim`, and a comparison.
- `f(x) // g(y)`, two temporaries alive in one statement, output and leak.
- A result temporary in a `do` loop, which a single-shot release would miss but
  a per-statement one handles, since the loop body's statement releases each
  iteration.

On the parent commit the two leak cases fail with definitely-lost blocks and
the output cases pass — which is the point of the issue: the existing tests
passed while leaking, so output alone could never have caught this.

Passing a result temporary directly as an actual argument is not covered
because it does not lower at all yet (`call show(f(x))` gives
`unsupported scalar function call or array expression`). That is a missing
feature rather than an ownership defect, so it is not silently folded in here.

## Conformance gauntlet

Baseline is a separate worktree at this branch's exact parent commit with its
own `fo build`.

| Suite | main | branch |
|---|---|---|
| lfortran | PASS=870 XFAIL=3310 XPASS=89 FAIL=10 | PASS=870 XFAIL=3310 XPASS=89 FAIL=10 |
| gfortran-dg | PASS=1334 XFAIL=2078 XPASS=52 FAIL=175 | PASS=1334 XFAIL=2079 XPASS=51 FAIL=175 |
| fortfront-f90 | PASS=414 XFAIL=94 XPASS=0 FAIL=9 | PASS=414 XFAIL=94 XPASS=0 FAIL=9 |
| fortfront-lf | PASS=210 XFAIL=54 XPASS=0 FAIL=0 | PASS=210 XFAIL=54 XPASS=0 FAIL=0 |

Per-case across all four suites: no new FAIL, no case lost PASS, no case gained
PASS, no new XPASS.

The one difference is `minmaxloc_11.f90` reporting XPASS on the baseline run and
XFAIL on the branch run. It is not a regression: running each build's binary
twelve times, the baseline binary matches gfortran 4/12 and the branch binary
6/12, so the case is nondeterministic at run time on both sides and a single run
decides its status by luck. It is already in the xfail manifest owned by
ffc#343, so XFAIL is the manifest-consistent outcome and there is nothing to
promote. Flagging it for the flaky-case tracker (ffc#599 / ffc#618); it is a
reduction case, not a character one.

`fo` is green apart from `test_parity_dashboard`,
`test_fortfront_corpus_conformance` and `test_session_type_extends_compiler`,
all three of which fail identically on the parent commit.
