### PR TITLE
[poly-05] allocate class scalars from SOURCE (closes #421)

### DIFF
--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -481,6 +481,37 @@ descriptor above unchanged. A receiver whose dynamic type is fixed at compile
 time (a `type(t)` entity) keeps a direct call: its dynamic type is its declared
 type by definition, so the vtable would only re-derive a known answer.
 
+## Type size table
+
+`__ffc_type_size_table` is a link-unit array of `i64` byte sizes indexed the
+same way as `__ffc_vtable_table`: entry `i` is the exact storage size of the
+type whose `ffc_type_info_t.id` is `i`, and entry `0` is the reserved zero.
+Allocating a class value whose dynamic type is only known at run time reads its
+concrete size from here, so the storage is the dynamic type's whole layout and
+not the declared type's prefix.
+
+## Scalar class allocatables
+
+A `class(t), allocatable` scalar owns one class descriptor in its frame — the
+same 32-byte descriptor above, no separate convention. Unallocated is the null
+descriptor with `declared_type` already filled in and `data == 0`,
+`dynamic_type == 0`, `ownership == 0`.
+
+`ALLOCATE` picks the concrete dynamic type — from `SOURCE=` (the source's own
+dynamic type, loaded from its descriptor when the source is itself
+polymorphic), from an explicit type-spec, or the declared type — allocates that
+type's exact size, copies the whole source value for `SOURCE=`, and stores
+`data`, `dynamic_type`, and `ownership = 2 (owned)`.
+
+`DEALLOCATE` finalizes the value, frees the storage once, and resets the
+descriptor to null, so the released address is no longer reachable and
+ownership is given up exactly once. The type-compatibility rule of F2018 C946
+is enforced at compile time: a `SOURCE=` or type-spec type must be the declared
+type or an extension of it.
+
+Because this is the same descriptor a class dummy receives, `SELECT TYPE` and
+type-bound dispatch consult it with no path of their own.
+
 ## Module artefact format
 
 `ffc -c <source>.f90` writes one `<modulename>.fmod` next to the object file

--- a/src/liric_session_format_bindings.f90
+++ b/src/liric_session_format_bindings.f90
@@ -38,6 +38,7 @@ module liric_session_format_bindings
     public :: printf_format_ptr
     public :: create_type_info_global
     public :: create_pointer_table_global
+    public :: create_i64_table_global
     public :: create_i8_format_global_no_newline
     public :: create_i16_format_global_no_newline
     public :: emit_e_en_format_call
@@ -400,6 +401,46 @@ contains
                 int(slot - 1, c_size_t) * 8_c_size_t, c_sym)
         end do
     end subroutine create_pointer_table_global
+
+    subroutine create_i64_table_global(session, name, values, error_msg)
+        ! Emit a const global holding size(values) little-endian i64 entries.
+        ! This backs the link-unit type size table of docs/RUNTIME_ABI.md, which
+        ! a dense type id indexes to get the exact storage size of that type.
+        type(liric_session_t), intent(inout) :: session
+        character(len=*), intent(in) :: name
+        integer(c_int64_t), intent(in) :: values(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(kind=c_char), allocatable :: c_name(:)
+        character(kind=c_char), allocatable, target :: bytes(:)
+        type(c_ptr) :: array_type
+        integer :: slot, k
+        integer(c_size_t) :: nbytes
+        integer(c_int32_t) :: global_id
+
+        call set_empty(error_msg)
+        if (size(values) <= 0) return
+        nbytes = int(size(values), c_size_t) * 8_c_size_t
+        allocate (bytes(nbytes))
+        do slot = 1, size(values)
+            do k = 0, 7
+                bytes((slot - 1) * 8 + 1 + k) = char(int(iand( &
+                    ishft(values(slot), -8 * k), 255_c_int64_t)), kind=c_char)
+            end do
+        end do
+
+        call to_c_chars(name, c_name)
+        array_type = lr_type_array_s(session%handle, lr_type_i8_s(session%handle), &
+            int(nbytes, c_int64_t))
+        if (.not. c_associated(array_type)) then
+            error_msg = 'LIRIC did not return an i64-table array type'
+            return
+        end if
+        global_id = lr_session_global(session%handle, c_name, array_type, &
+            c_true, c_loc(bytes), nbytes)
+        if (global_id < 0_c_int32_t) then
+            error_msg = 'LIRIC could not create i64 table global '//trim(name)
+        end if
+    end subroutine create_i64_table_global
 
     include 'liric_session_format_e_en.inc'
 

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -59,7 +59,9 @@ module session_program_lowering
         POLYMORPHIC_DESCRIPTOR_DECLARED_TYPE_OFFSET, &
         POLYMORPHIC_DESCRIPTOR_DYNAMIC_TYPE_OFFSET, &
         POLYMORPHIC_DESCRIPTOR_OWNERSHIP_OFFSET, &
-        POLYMORPHIC_DESCRIPTOR_SIZE, POLYMORPHIC_OWNERSHIP_BORROWED
+        POLYMORPHIC_DESCRIPTOR_SIZE, POLYMORPHIC_OWNERSHIP_BORROWED, &
+        POLYMORPHIC_OWNERSHIP_NONE, POLYMORPHIC_OWNERSHIP_OWNED, &
+        POLYMORPHIC_TYPE_ID_NONE
     use liric_session_bindings, only: destroy, begin_i32_main, &
         liric_session_t, &
         begin_i32_function, begin_i64_function, begin_void_subroutine, &
@@ -144,7 +146,8 @@ module session_program_lowering
         prepare_liric_print_runtime, &
         create_printf_format_global, &
         printf_format_ptr, &
-        create_type_info_global, create_pointer_table_global
+        create_type_info_global, create_pointer_table_global, &
+        create_i64_table_global
     use liric_session_real_print_bindings, only: synthesize_real8_printer, &
         synthesize_real4_printer, &
         synthesize_get_arg_helper, &

--- a/src/session_program_lowering_allocatable.inc
+++ b/src/session_program_lowering_allocatable.inc
@@ -465,9 +465,10 @@
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: name, spec_lc
-        integer :: symbol_index
+        integer :: symbol_index, spec_type_index
 
         call set_empty(error_msg)
+        spec_type_index = 0
         if (.not. node_exists(arena, node%var_indices(1)) .or. &
             .not. is_identifier(arena, node%var_indices(1))) then
             call unsupported_feature_error('allocate statement', node%line, &
@@ -501,7 +502,23 @@
         if (context%symbols(symbol_index)%is_derived .and. &
             context%symbols(symbol_index)%is_allocatable .and. &
             context%symbols(symbol_index)%array_rank == 0) then
-            call lower_allocate_scalar_derived(symbol_index, context, error_msg)
+            ! allocate(t :: x) names the dynamic type explicitly. For a class
+            ! allocatable it may be an extension of the declared type, in which
+            ! case that extension's layout is allocated and recorded (#421).
+            spec_type_index = find_derived_type(context, trim(spec_lc))
+            if (spec_type_index > 0) then
+                if (.not. derived_type_extends(context, spec_type_index, &
+                        context%symbols(symbol_index)%derived_type_index)) then
+                    error_msg = 'allocate type-spec "'//trim(spec_lc)// &
+                        '" is not type compatible with "'//trim(name)// &
+                        '" of declared type "'// &
+                        trim(context%derived_types(context%symbols( &
+                            symbol_index)%derived_type_index)%name)//'"'
+                    return
+                end if
+            end if
+            call lower_allocate_scalar_derived(symbol_index, context, error_msg, &
+                                               spec_type_index)
             return
         end if
         if (context%symbols(symbol_index)%is_derived) then

--- a/src/session_program_lowering_derived_module_ops.inc
+++ b/src/session_program_lowering_derived_module_ops.inc
@@ -125,9 +125,10 @@
 
         declaration_is_class_polymorphic = .false.
         if (.not. allocated(node%type_name)) return
-        ! An allocatable or pointer class entity keeps its existing
-        ! allocatable/pointer descriptor ABI until #421 gives it a dynamic
-        ! type; only a plain class(t) scalar takes the class descriptor.
+        ! A plain class(t) scalar takes the class descriptor here. A class
+        ! allocatable also carries one, but it is bound at its own declaration
+        ! path (#421) because its storage is deferred until ALLOCATE; a class
+        ! pointer still has no dynamic type.
         if (node%is_allocatable) return
         if (node%is_pointer) return
         declaration_is_class_polymorphic = is_class_derived_type_spec(node%type_name)

--- a/src/session_program_lowering_polymorphic.inc
+++ b/src/session_program_lowering_polymorphic.inc
@@ -253,7 +253,282 @@
         end do
         call create_pointer_table_global(context%session, '__ffc_vtable_table', &
                                          table, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call emit_type_size_table(context, error_msg)
     end subroutine emit_type_vtables
+
+    subroutine emit_type_size_table(context, error_msg)
+        ! Link-unit table of exact storage sizes, indexed the same way as
+        ! __ffc_vtable_table: entry i is the byte size of the type whose id is
+        ! i, entry 0 is the reserved "no type" zero (#421). Allocating a class
+        ! value whose dynamic type is only known at run time reads its concrete
+        ! size from here, so the storage is the dynamic type's layout rather
+        ! than the declared type's prefix.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer(c_int64_t), allocatable :: sizes(:)
+        integer :: t
+
+        call set_empty(error_msg)
+        if (context%derived_type_count <= 0) return
+        allocate (sizes(context%derived_type_count + 1))
+        sizes = 0_c_int64_t
+        do t = 1, context%derived_type_count
+            sizes(t + 1) = int(total_component_slots(context, t), c_int64_t) * &
+                4_c_int64_t
+        end do
+        call create_i64_table_global(context%session, '__ffc_type_size_table', &
+                                     sizes, error_msg)
+    end subroutine emit_type_size_table
+
+    ! Scalar class allocatables (#421). A `class(t), allocatable` scalar owns a
+    ! 32-byte class descriptor in its frame, the same canonical descriptor a
+    ! class dummy receives. Unallocated is the fully null descriptor. ALLOCATE
+    ! chooses the concrete dynamic type (from SOURCE=, from the type-spec, or
+    ! the declared type), allocates exactly that type's layout, records the
+    ! identity and OWNED ownership in the descriptor, and DEALLOCATE finalizes,
+    ! frees once, and resets the descriptor to null. Because the descriptor is
+    ! the same one #417 defined, SELECT TYPE (#419) and type-bound dispatch
+    ! (#420) work through it with no path of their own.
+
+    subroutine bind_class_allocatable_descriptor(context, symbol_index, &
+                                                 declared_index, error_msg)
+        ! Reserve and null the descriptor of a class allocatable at its
+        ! declaration, so an unallocated entity reads as the null descriptor.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        integer, intent(in) :: declared_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: descriptor, field_addr
+
+        if (.not. emit_alloca_bytes(context%session, &
+                i64_immediate(context%session, &
+                    int(POLYMORPHIC_DESCRIPTOR_SIZE, c_int64_t)), descriptor, &
+                error_msg)) return
+        if (.not. emit_ptr_store(context%session, &
+                null_ptr_operand(context), descriptor, error_msg)) return
+        if (.not. emit_ptr_offset(context%session, descriptor, &
+                int(POLYMORPHIC_DESCRIPTOR_DECLARED_TYPE_OFFSET, c_int64_t), &
+                field_addr, error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+                i64_immediate(context%session, int(declared_index, c_int64_t)), &
+                field_addr, error_msg)) return
+        if (.not. emit_ptr_offset(context%session, descriptor, &
+                int(POLYMORPHIC_DESCRIPTOR_DYNAMIC_TYPE_OFFSET, c_int64_t), &
+                field_addr, error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+                i64_immediate(context%session, &
+                    int(POLYMORPHIC_TYPE_ID_NONE, c_int64_t)), field_addr, &
+                error_msg)) return
+        if (.not. emit_ptr_offset(context%session, descriptor, &
+                int(POLYMORPHIC_DESCRIPTOR_OWNERSHIP_OFFSET, c_int64_t), &
+                field_addr, error_msg)) return
+        if (.not. emit_i32_store(context%session, &
+                i32_immediate(context%session, &
+                    int(POLYMORPHIC_OWNERSHIP_NONE, c_int64_t)), field_addr, &
+                error_msg)) return
+
+        context%symbols(symbol_index)%class_descriptor_address = descriptor
+        if (.not. emit_ptr_offset(context%session, descriptor, &
+                int(POLYMORPHIC_DESCRIPTOR_DYNAMIC_TYPE_OFFSET, c_int64_t), &
+                field_addr, error_msg)) return
+        context%symbols(symbol_index)%dynamic_type_address = field_addr
+        context%symbols(symbol_index)%has_dynamic_type_address = .true.
+        context%symbols(symbol_index)%is_polymorphic = .true.
+        call set_empty(error_msg)
+    end subroutine bind_class_allocatable_descriptor
+
+    subroutine record_class_allocation(context, symbol_index, data_ptr, &
+                                       dynamic_id, error_msg)
+        ! Publish an allocation into the entity's class descriptor: the data
+        ! address, the dynamic type just allocated, and OWNED ownership, so the
+        ! value is released exactly once by whoever holds the descriptor.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        type(lr_operand_desc_t), intent(in) :: data_ptr
+        type(lr_operand_desc_t), intent(in) :: dynamic_id
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: field_addr
+
+        call set_empty(error_msg)
+        if (.not. context%symbols(symbol_index)%has_dynamic_type_address) return
+        if (.not. emit_ptr_store(context%session, data_ptr, &
+                context%symbols(symbol_index)%class_descriptor_address, &
+                error_msg)) return
+        if (.not. emit_i64_store(context%session, dynamic_id, &
+                context%symbols(symbol_index)%dynamic_type_address, &
+                error_msg)) return
+        if (.not. emit_ptr_offset(context%session, &
+                context%symbols(symbol_index)%class_descriptor_address, &
+                int(POLYMORPHIC_DESCRIPTOR_OWNERSHIP_OFFSET, c_int64_t), &
+                field_addr, error_msg)) return
+        if (.not. emit_i32_store(context%session, &
+                i32_immediate(context%session, &
+                    int(POLYMORPHIC_OWNERSHIP_OWNED, c_int64_t)), field_addr, &
+                error_msg)) return
+    end subroutine record_class_allocation
+
+    subroutine release_class_allocation(context, symbol_index, error_msg)
+        ! Reset the descriptor after the storage is freed, so the entity reads
+        ! as unallocated and the released address can never be handed out or
+        ! freed a second time.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: field_addr
+
+        call set_empty(error_msg)
+        if (.not. context%symbols(symbol_index)%has_dynamic_type_address) return
+        if (.not. emit_ptr_store(context%session, null_ptr_operand(context), &
+                context%symbols(symbol_index)%class_descriptor_address, &
+                error_msg)) return
+        if (.not. emit_i64_store(context%session, &
+                i64_immediate(context%session, &
+                    int(POLYMORPHIC_TYPE_ID_NONE, c_int64_t)), &
+                context%symbols(symbol_index)%dynamic_type_address, &
+                error_msg)) return
+        if (.not. emit_ptr_offset(context%session, &
+                context%symbols(symbol_index)%class_descriptor_address, &
+                int(POLYMORPHIC_DESCRIPTOR_OWNERSHIP_OFFSET, c_int64_t), &
+                field_addr, error_msg)) return
+        if (.not. emit_i32_store(context%session, &
+                i32_immediate(context%session, &
+                    int(POLYMORPHIC_OWNERSHIP_NONE, c_int64_t)), field_addr, &
+                error_msg)) return
+    end subroutine release_class_allocation
+
+    subroutine dynamic_type_size_bytes(context, symbol_index, dynamic_id, &
+                                       static_type_index, size_bytes, error_msg)
+        ! Exact storage size of the type being allocated. A statically known
+        ! dynamic type folds to an immediate; a source whose dynamic type is
+        ! only known at run time reads its size from __ffc_type_size_table.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        type(lr_operand_desc_t), intent(in) :: dynamic_id
+        integer, intent(in) :: static_type_index
+        type(lr_operand_desc_t), intent(out) :: size_bytes
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: byte_offset, table_base, entry_addr
+        character(kind=c_char), allocatable :: c_name(:)
+        integer(c_int32_t) :: table_symbol
+        integer :: slots
+
+        call set_empty(error_msg)
+        if (symbol_index <= 0) then
+            slots = total_component_slots(context, static_type_index)
+            if (slots <= 0) slots = 1
+            size_bytes = i64_immediate(context%session, &
+                int(slots, c_int64_t) * 4_c_int64_t)
+            return
+        end if
+
+        if (.not. emit_i64_binary(context%session, LR_OP_MUL, dynamic_id, &
+                i64_immediate(context%session, 8_c_int64_t), byte_offset, &
+                error_msg)) return
+        call to_c_chars('__ffc_type_size_table', c_name)
+        table_symbol = lr_session_intern(context%session%handle, c_name)
+        if (table_symbol < 0_c_int32_t) then
+            error_msg = 'could not intern the type size table symbol'
+            return
+        end if
+        table_base%kind = LR_OP_KIND_GLOBAL
+        table_base%payload = int(table_symbol, c_int64_t)
+        table_base%typ = lr_type_ptr_s(context%session%handle)
+        table_base%global_offset = 0_c_int64_t
+        if (.not. emit_ptr_offset_dyn(context%session, table_base, byte_offset, &
+                entry_addr, error_msg)) return
+        if (.not. emit_i64_load(context%session, entry_addr, size_bytes, &
+                error_msg)) return
+    end subroutine dynamic_type_size_bytes
+
+    subroutine lower_derived_allocate_source(arena, node, target_sym, context, &
+                                             error_msg)
+        ! allocate(x, source=y) where x is a scalar allocatable of derived or
+        ! class type. The dynamic type is y's: for a monomorphic y it is y's
+        ! declared type, for a polymorphic y it is the identity y carries. The
+        ! allocation is that type's exact layout and the value is copied whole,
+        ! so an extension source keeps the components the declared type does
+        ! not name.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(ast_arena_t), intent(in) :: arena
+        type(allocate_statement_node), intent(in) :: node
+        integer, intent(in) :: target_sym
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: source_name
+        integer :: source_sym, declared_index, source_type_index, dyn_symbol
+        type(lr_operand_desc_t) :: dynamic_id, size_bytes, data_ptr
+
+        call set_empty(error_msg)
+        if (node%source_expr_index <= 0) then
+            call unsupported_feature_error('allocate statement', node%line, &
+                node%column, 'direct LIRIC session supports SOURCE= but not '// &
+                'MOLD= for a scalar derived or class allocatable', error_msg)
+            return
+        end if
+        if (.not. is_identifier(arena, node%source_expr_index)) then
+            call unsupported_feature_error('allocate statement', node%line, &
+                node%column, 'SOURCE= for a scalar derived or class '// &
+                'allocatable must name a variable', error_msg)
+            return
+        end if
+        call get_identifier_name(arena, node%source_expr_index, source_name, &
+                                 error_msg)
+        if (len_trim(error_msg) > 0) return
+        source_sym = find_symbol_compat(context, source_name)
+        if (source_sym <= 0) then
+            error_msg = 'allocate SOURCE= references an undeclared variable: '// &
+                trim(source_name)
+            return
+        end if
+        if (.not. context%symbols(source_sym)%is_derived) then
+            error_msg = 'allocate SOURCE= for "'// &
+                trim(context%symbols(target_sym)%name)// &
+                '" must name a derived value, not '//trim(source_name)
+            return
+        end if
+
+        declared_index = context%symbols(target_sym)%derived_type_index
+        source_type_index = context%symbols(source_sym)%derived_type_index
+        ! F2018 C946: SOURCE= must be type compatible with the allocatable.
+        if (.not. derived_type_extends(context, source_type_index, &
+                                       declared_index)) then
+            error_msg = 'allocate SOURCE= type "'// &
+                trim(context%derived_types(source_type_index)%name)// &
+                '" is not type compatible with "'// &
+                trim(context%symbols(target_sym)%name)//'" of declared type "'// &
+                trim(context%derived_types(declared_index)%name)//'"'
+            return
+        end if
+
+        call class_actual_dynamic_type(context, source_sym, dynamic_id, error_msg)
+        if (len_trim(error_msg) > 0) return
+        dyn_symbol = 0
+        if (context%symbols(source_sym)%is_polymorphic .and. &
+            context%symbols(source_sym)%has_dynamic_type_address) dyn_symbol = &
+            source_sym
+        call dynamic_type_size_bytes(context, dyn_symbol, dynamic_id, &
+                                     source_type_index, size_bytes, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        if (.not. emit_malloc(context%session, size_bytes, data_ptr, &
+                              error_msg)) return
+        if (.not. emit_memcpy(context%session, data_ptr, &
+                context%symbols(source_sym)%element_address, size_bytes, &
+                error_msg)) return
+
+        context%symbols(target_sym)%element_address = data_ptr
+        context%symbols(target_sym)%array_size = &
+            max(total_component_slots(context, source_type_index), 1)
+        context%symbols(target_sym)%has_address = .true.
+        call record_class_allocation(context, target_sym, data_ptr, dynamic_id, &
+                                     error_msg)
+    end subroutine lower_derived_allocate_source
 
     integer function type_binding_slot(context, type_index, method_name) &
             result(slot)

--- a/src/session_program_lowering_scalar_allocatable.inc
+++ b/src/session_program_lowering_scalar_allocatable.inc
@@ -105,26 +105,37 @@
         integer, intent(in) :: derived_type_index
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: i
+        logical :: is_class
+
+        ! class(t), allocatable is polymorphic: it gets the canonical class
+        ! descriptor so ALLOCATE can record a dynamic type that differs from
+        ! the declared type (#421). type(t), allocatable keeps the plain
+        ! heap-pointer form.
+        is_class = .false.
+        if (allocated(node%type_name)) &
+            is_class = is_class_derived_type_spec(node%type_name)
 
         if (node%is_multi_declaration .and. allocated(node%var_names)) then
             do i = 1, size(node%var_names)
                 call declare_one_scalar_allocatable_derived(context, &
-                    node%var_names(i), derived_type_index, error_msg)
+                    node%var_names(i), derived_type_index, is_class, error_msg)
                 if (len_trim(error_msg) > 0) return
             end do
         else if (allocated(node%var_name)) then
             call declare_one_scalar_allocatable_derived(context, node%var_name, &
-                derived_type_index, error_msg)
+                derived_type_index, is_class, error_msg)
         else
             error_msg = 'allocatable derived declaration did not expose a name'
         end if
     end subroutine declare_scalar_allocatable_derived
 
     subroutine declare_one_scalar_allocatable_derived(context, name, &
-                                                      derived_type_index, error_msg)
+                                                      derived_type_index, &
+                                                      is_class, error_msg)
         type(lowering_context_t), intent(inout) :: context
         character(len=*), intent(in) :: name
         integer, intent(in) :: derived_type_index
+        logical, intent(in) :: is_class
         character(len=:), allocatable, intent(out) :: error_msg
         integer :: index
 
@@ -169,9 +180,13 @@
         context%symbols(index)%has_address = .false.
         context%symbol_count = index
         call set_empty(error_msg)
+        if (.not. is_class) return
+        call bind_class_allocatable_descriptor(context, index, &
+                                               derived_type_index, error_msg)
     end subroutine declare_one_scalar_allocatable_derived
 
-    subroutine lower_allocate_scalar_derived(symbol_index, context, error_msg)
+    subroutine lower_allocate_scalar_derived(symbol_index, context, error_msg, &
+                                             dynamic_type_index)
         ! allocate(x) for a scalar allocatable derived variable: malloc one
         ! instance (total_component_slots i32 slots), adopt the heap pointer as
         ! element_address, and run the type's default-init so component defaults
@@ -180,10 +195,17 @@
         integer, intent(in) :: symbol_index
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
+        integer, intent(in), optional :: dynamic_type_index
         type(lr_operand_desc_t) :: data_ptr
         integer :: type_index, slots
 
+        ! Without a type-spec the dynamic type of a class allocatable is its
+        ! declared type; allocate(ext_t :: p) names an extension instead and
+        ! allocates that concrete layout (#421).
         type_index = context%symbols(symbol_index)%derived_type_index
+        if (present(dynamic_type_index)) then
+            if (dynamic_type_index > 0) type_index = dynamic_type_index
+        end if
         slots = total_component_slots(context, type_index)
         if (slots <= 0) slots = 1
         if (.not. emit_malloc(context%session, &
@@ -194,6 +216,9 @@
         context%symbols(symbol_index)%has_address = .true.
         call init_derived_component_defaults(context, symbol_index, type_index, &
                                              error_msg)
+        if (len_trim(error_msg) > 0) return
+        call record_class_allocation(context, symbol_index, data_ptr, &
+            i64_immediate(context%session, int(type_index, c_int64_t)), error_msg)
     end subroutine lower_allocate_scalar_derived
 
     subroutine lower_deallocate_scalar(symbol_index, context, error_msg)
@@ -215,7 +240,9 @@
             if (.not. emit_free(context%session, &
                     context%symbols(symbol_index)%element_address, error_msg)) return
             context%symbols(symbol_index)%has_address = .false.
-            call set_empty(error_msg)
+            ! The released address must not stay reachable through the class
+            ! descriptor, so ownership is given up exactly once (#421).
+            call release_class_allocation(context, symbol_index, error_msg)
             return
         end if
         if (.not. emit_free(context%session, &
@@ -239,6 +266,14 @@
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t) :: value
 
+        ! A derived or class allocatable takes the whole-value SOURCE= path:
+        ! its dynamic type, its exact storage size, and the copy all come from
+        ! the source value rather than from the target's element kind (#421).
+        if (context%symbols(target_sym)%is_derived) then
+            call lower_derived_allocate_source(arena, node, target_sym, context, &
+                                               error_msg)
+            return
+        end if
         call lower_allocate_scalar(target_sym, context, error_msg)
         if (len_trim(error_msg) > 0) return
         if (node%source_expr_index <= 0) then

--- a/src/session_program_lowering_select.inc
+++ b/src/session_program_lowering_select.inc
@@ -847,9 +847,9 @@
         if (context%symbols(sel_index)%value_kind /= VALUE_CLASS_STAR) then
             call unsupported_feature_error('select type statement', 0, 0, &
                 'direct LIRIC session supports select type on a class(*) '// &
-                'selector or a monomorphic declared-type class(t) object; '// &
-                'dynamic dispatch on an allocatable/pointer polymorphic '// &
-                'object needs a runtime vtable', error_msg)
+                'selector, a monomorphic declared-type class(t) object, or '// &
+                'any class entity carrying a class descriptor; a class '// &
+                'pointer has no dynamic type yet', error_msg)
             return
         end if
 

--- a/test/test_session_class_allocatable_source_compiler.f90
+++ b/test/test_session_class_allocatable_source_compiler.f90
@@ -1,0 +1,311 @@
+program test_session_class_allocatable_source_compiler
+    use ffc_test_support, only: expect_output, expect_error_contains
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== class(t) allocatable SOURCE= tests ==='
+
+    all_passed = .true.
+    if (.not. test_allocate_from_base_source()) all_passed = .false.
+    if (.not. test_allocate_from_extension_source()) all_passed = .false.
+    if (.not. test_extension_storage_is_exact()) all_passed = .false.
+    if (.not. test_dynamic_source_propagates_identity()) all_passed = .false.
+    if (.not. test_typebound_dispatch_through_allocatable()) all_passed = .false.
+    if (.not. test_reallocate_changes_dynamic_type()) all_passed = .false.
+    if (.not. test_final_runs_once_on_deallocate()) all_passed = .false.
+    if (.not. test_incompatible_source_is_rejected()) all_passed = .false.
+    if (.not. test_double_deallocate_is_rejected()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: class(t) allocatable SOURCE='
+
+contains
+
+    character(len=:) function hierarchy() result(text)
+        allocatable :: text
+        text = 'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: base_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: speak => base_speak'//new_line('a')// &
+            '  end type base_t'//new_line('a')// &
+            '  type, extends(base_t) :: ext_t'//new_line('a')// &
+            '    integer :: y'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: speak => ext_speak'//new_line('a')// &
+            '  end type ext_t'//new_line('a')// &
+            '  type :: other_t'//new_line('a')// &
+            '    integer :: z'//new_line('a')// &
+            '  end type other_t'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine base_speak(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    print *, 100'//new_line('a')// &
+            '  end subroutine base_speak'//new_line('a')// &
+            '  subroutine ext_speak(self)'//new_line('a')// &
+            '    class(ext_t), intent(in) :: self'//new_line('a')// &
+            '    print *, 200'//new_line('a')// &
+            '  end subroutine ext_speak'//new_line('a')
+    end function hierarchy
+
+    logical function test_allocate_from_base_source()
+        ! A base source gives the allocatable the base dynamic type; the copied
+        ! value is readable through the declared type and deallocation ends the
+        ! lifetime.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  class(base_t), allocatable :: p'//new_line('a')// &
+            '  type(base_t) :: b'//new_line('a')// &
+            '  b%x = 41'//new_line('a')// &
+            '  allocate(p, source=b)'//new_line('a')// &
+            '  print *, p%x'//new_line('a')// &
+            '  deallocate(p)'//new_line('a')// &
+            'end program main'
+
+        test_allocate_from_base_source = expect_output(source, &
+            '          41'//new_line('a'), '/tmp/ffc_class_alloc_base')
+    end function test_allocate_from_base_source
+
+    logical function test_allocate_from_extension_source()
+        ! An extension source records the extension as the dynamic type, so
+        ! SELECT TYPE takes the TYPE IS (ext_t) arm and the extension component
+        ! survived the copy.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  class(base_t), allocatable :: p'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  e%x = 5'//new_line('a')// &
+            '  e%y = 7'//new_line('a')// &
+            '  allocate(p, source=e)'//new_line('a')// &
+            '  select type (q => p)'//new_line('a')// &
+            '  type is (ext_t)'//new_line('a')// &
+            '    print *, q%x * 10 + q%y'//new_line('a')// &
+            '  type is (base_t)'//new_line('a')// &
+            '    print *, -1'//new_line('a')// &
+            '  end select'//new_line('a')// &
+            '  deallocate(p)'//new_line('a')// &
+            'end program main'
+
+        test_allocate_from_extension_source = expect_output(source, &
+            '          57'//new_line('a'), '/tmp/ffc_class_alloc_ext')
+    end function test_allocate_from_extension_source
+
+    logical function test_extension_storage_is_exact()
+        ! Storage is the concrete extension layout, not the declared-type
+        ! prefix: writing the extension component through the SELECT TYPE arm
+        ! must not disturb the inherited component.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  class(base_t), allocatable :: p'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  e%x = 3'//new_line('a')// &
+            '  e%y = 4'//new_line('a')// &
+            '  allocate(p, source=e)'//new_line('a')// &
+            '  select type (q => p)'//new_line('a')// &
+            '  type is (ext_t)'//new_line('a')// &
+            '    q%y = 99'//new_line('a')// &
+            '    print *, q%x * 1000 + q%y'//new_line('a')// &
+            '  end select'//new_line('a')// &
+            '  print *, p%x'//new_line('a')// &
+            '  deallocate(p)'//new_line('a')// &
+            'end program main'
+
+        test_extension_storage_is_exact = expect_output(source, &
+            '        3099'//new_line('a')//'           3'//new_line('a'), &
+            '/tmp/ffc_class_alloc_exact')
+    end function test_extension_storage_is_exact
+
+    logical function test_dynamic_source_propagates_identity()
+        ! The source is itself polymorphic, so the dynamic type and the exact
+        ! storage size are only known at run time and must be taken from the
+        ! source's descriptor rather than from its declared type.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            '  subroutine clone_and_report(self)'//new_line('a')// &
+            '    class(base_t), intent(in) :: self'//new_line('a')// &
+            '    class(base_t), allocatable :: p'//new_line('a')// &
+            '    allocate(p, source=self)'//new_line('a')// &
+            '    select type (q => p)'//new_line('a')// &
+            '    type is (ext_t)'//new_line('a')// &
+            '      print *, 2000 + q%x'//new_line('a')// &
+            '    type is (base_t)'//new_line('a')// &
+            '      print *, 1000 + q%x'//new_line('a')// &
+            '    end select'//new_line('a')// &
+            '    deallocate(p)'//new_line('a')// &
+            '  end subroutine clone_and_report'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(base_t) :: b'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  b%x = 1'//new_line('a')// &
+            '  e%x = 2'//new_line('a')// &
+            '  e%y = 3'//new_line('a')// &
+            '  call clone_and_report(b)'//new_line('a')// &
+            '  call clone_and_report(e)'//new_line('a')// &
+            'end program main'
+
+        test_dynamic_source_propagates_identity = expect_output(source, &
+            '        1001'//new_line('a')//'        2002'//new_line('a'), &
+            '/tmp/ffc_class_alloc_dynsrc')
+    end function test_dynamic_source_propagates_identity
+
+    logical function test_typebound_dispatch_through_allocatable()
+        ! The allocatable's dynamic type drives type-bound dispatch, so the
+        ! override of the source's type is reached (#420 vtables consume the
+        ! same descriptor).
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  class(base_t), allocatable :: p'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  e%x = 1'//new_line('a')// &
+            '  e%y = 2'//new_line('a')// &
+            '  allocate(p, source=e)'//new_line('a')// &
+            '  call p%speak()'//new_line('a')// &
+            '  deallocate(p)'//new_line('a')// &
+            'end program main'
+
+        test_typebound_dispatch_through_allocatable = expect_output(source, &
+            '         200'//new_line('a'), '/tmp/ffc_class_alloc_dispatch')
+    end function test_typebound_dispatch_through_allocatable
+
+    logical function test_reallocate_changes_dynamic_type()
+        ! Deallocating and allocating again from a different source replaces
+        ! the recorded dynamic type; the second lifetime is independent.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  class(base_t), allocatable :: p'//new_line('a')// &
+            '  type(base_t) :: b'//new_line('a')// &
+            '  type(ext_t) :: e'//new_line('a')// &
+            '  b%x = 8'//new_line('a')// &
+            '  e%x = 9'//new_line('a')// &
+            '  e%y = 6'//new_line('a')// &
+            '  allocate(p, source=e)'//new_line('a')// &
+            '  call p%speak()'//new_line('a')// &
+            '  deallocate(p)'//new_line('a')// &
+            '  allocate(p, source=b)'//new_line('a')// &
+            '  call p%speak()'//new_line('a')// &
+            '  print *, p%x'//new_line('a')// &
+            '  deallocate(p)'//new_line('a')// &
+            'end program main'
+
+        test_reallocate_changes_dynamic_type = expect_output(source, &
+            '         200'//new_line('a')//'         100'//new_line('a')// &
+            '           8'//new_line('a'), '/tmp/ffc_class_alloc_realloc')
+    end function test_reallocate_changes_dynamic_type
+
+    logical function test_final_runs_once_on_deallocate()
+        ! Deallocation ends the value's lifetime exactly once, so the type's
+        ! FINAL procedure runs once and not again at scope exit.
+        character(len=:), allocatable :: source
+
+        source = 'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: base_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    final :: base_final'//new_line('a')// &
+            '  end type base_t'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine base_final(self)'//new_line('a')// &
+            '    type(base_t), intent(inout) :: self'//new_line('a')// &
+            '    print *, 777'//new_line('a')// &
+            '  end subroutine base_final'//new_line('a')// &
+            '  subroutine run()'//new_line('a')// &
+            '    class(base_t), allocatable :: p'//new_line('a')// &
+            '    type(base_t) :: b'//new_line('a')// &
+            '    b%x = 1'//new_line('a')// &
+            '    allocate(p, source=b)'//new_line('a')// &
+            '    deallocate(p)'//new_line('a')// &
+            '    print *, 5'//new_line('a')// &
+            '  end subroutine run'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  call run()'//new_line('a')// &
+            '  print *, 6'//new_line('a')// &
+            'end program main'
+
+        ! gfortran: 777 when the allocated value is released, 5, then 777 for
+        ! the local source at return, then 6. The deallocated value is not
+        ! finalized a second time at scope exit.
+        test_final_runs_once_on_deallocate = expect_output(source, &
+            '         777'//new_line('a')//'           5'//new_line('a')// &
+            '         777'//new_line('a')//'           6'//new_line('a'), &
+            '/tmp/ffc_class_alloc_final')
+    end function test_final_runs_once_on_deallocate
+
+    logical function test_incompatible_source_is_rejected()
+        ! F2018 C946: the source must be type compatible with the allocatable.
+        ! An unrelated type is neither the declared type nor an extension.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  class(base_t), allocatable :: p'//new_line('a')// &
+            '  type(other_t) :: o'//new_line('a')// &
+            '  o%z = 1'//new_line('a')// &
+            '  allocate(p, source=o)'//new_line('a')// &
+            '  deallocate(p)'//new_line('a')// &
+            'end program main'
+
+        test_incompatible_source_is_rejected = expect_error_contains(source, &
+            'not type compatible', '/tmp/ffc_class_alloc_badsource')
+    end function test_incompatible_source_is_rejected
+
+    logical function test_double_deallocate_is_rejected()
+        ! The second deallocation has no allocated value to release, so it is
+        ! rejected instead of freeing the same storage twice.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  class(base_t), allocatable :: p'//new_line('a')// &
+            '  type(base_t) :: b'//new_line('a')// &
+            '  b%x = 1'//new_line('a')// &
+            '  allocate(p, source=b)'//new_line('a')// &
+            '  deallocate(p)'//new_line('a')// &
+            '  deallocate(p)'//new_line('a')// &
+            'end program main'
+
+        test_double_deallocate_is_rejected = expect_error_contains(source, &
+            'not currently allocated', '/tmp/ffc_class_alloc_doublefree')
+    end function test_double_deallocate_is_rejected
+
+end program test_session_class_allocatable_source_compiler


### PR DESCRIPTION
Closes #421.

A `class(t), allocatable` scalar was lowered exactly like `type(t), allocatable`:
no dynamic type, and `ALLOCATE(p, SOURCE=y)` for a derived target fell through to
the integer-expression path and failed with `integer expression used non-integer
identifier`. `SELECT TYPE` on such an entity was refused outright.

## Design

The class allocatable now owns **the same 32-byte class descriptor** #400
defined and #417 passes — no second convention, no allocatable-specific ABI.
Unallocated is the null descriptor with `declared_type` already filled in.

`ALLOCATE` picks the concrete dynamic type — from `SOURCE=`, from an explicit
type-spec, or the declared type — allocates that type's exact layout, copies the
whole source value, and stores `data`, `dynamic_type`, `ownership = owned`.
`DEALLOCATE` finalizes, frees once, and resets the descriptor to null.

Because it is the *same* descriptor, `SELECT TYPE` (#419) and type-bound
dispatch (#420) light up for class allocatables with no path of their own: the
only change on those sides is that the SELECT TYPE refusal message no longer
claims allocatables are unsupported.

### Runtime size lookup

When the source is itself polymorphic (`allocate(p, source=self)` inside a
`class(base_t)` dummy) neither the dynamic type nor the exact size is known at
compile time. Following the id-indexed link-unit table convention #420
established, this adds `__ffc_type_size_table`: an `i64` array where entry `i`
is the byte size of the type whose id is `i`. A statically known dynamic type
still folds to an immediate; only the genuinely dynamic case pays a load. No
second descriptor and no second array shape were introduced.

## Invariants preserved

- Declared vs dynamic type: `declared_type` is written once at declaration and
  never changes; `dynamic_type` is set per allocation.
- Exact storage: an extension source allocates the extension's whole layout, not
  the declared-type prefix — covered by a fixture that writes the extension
  component and shows the inherited one is undisturbed.
- Lifetimes: `DEALLOCATE` finalizes before freeing and frees once; the
  descriptor is reset so the released address is unreachable and ownership is
  given up exactly once. Reallocation to a different dynamic type is covered.
  FINAL ordering matches gfortran (verified against gfortran directly).
- Aliasing: the descriptor holds a reference; the source value is copied, so the
  allocated value and the source are independent (the reallocate fixture depends
  on this).
- Type compatibility (F2018 C946) is enforced at compile time for both `SOURCE=`
  and the type-spec form; double deallocation keeps its existing diagnostic.

Fixing the derived `SOURCE=` path also fixes `type(t), allocatable` with
`SOURCE=`, which was silently broken in the same place — one path, both cases.

## Verification

`test/test_session_class_allocatable_source_compiler.f90`, 9 cases, recorded
failing on unmodified main (all 9, with the `integer expression used non-integer
identifier` diagnostic). Every expected output was validated against gfortran
before being asserted.

Corpus: measured back to back against the same corpus revision.
Baseline `PASS=447 XFAIL=94 XPASS=0 FAIL=12`, branch
`PASS=447 XFAIL=93 XPASS=1 FAIL=12` — identical FAIL sets, file for file. The
single XPASS is `issue_1324_if_inside_do_loop.f90`, whose own note says its
structure is nondeterministic; nothing was promoted out of any manifest.

`fo` is green apart from `test_fortfront_corpus_conformance`,
`test_parity_dashboard`, `test_session_real_parameter_compiler` and
`test_session_reject_result_01_compiler`, all four of which fail identically on
unmodified main (the last two from an upstream FortFront change).