### PR TITLE
[use-rename-02] stop reporting non-conflicting USE associations as ambiguous (#587)

### DIFF
--- a/src/ffc_test_support.f90
+++ b/src/ffc_test_support.f90
@@ -20,6 +20,7 @@ module ffc_test_support
     public :: expect_cli_no_error
     public :: expect_object_exists
     public :: expect_no_error
+    public :: expect_error_absent
     public :: expect_exe_has_symbol
     public :: expect_output_with_stdin
     public :: expect_stderr_and_exit
@@ -655,6 +656,25 @@ contains
         end if
         ok = .true.
     end function expect_no_error
+
+    logical function expect_error_absent(source, fragment, exe_path) result(ok)
+        ! Compiles source and checks that no diagnostic mentions fragment.
+        ! Unrelated diagnostics are tolerated, so the check stays a targeted
+        ! oracle for one rejection rule.
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: fragment
+        character(len=*), intent(in) :: exe_path
+        character(len=:), allocatable :: error_msg
+
+        ok = .true.
+        call compile_to_exe(source, exe_path, error_msg)
+        call execute_command_line('rm -f '//exe_path)
+        if (len_trim(error_msg) == 0) return
+        if (index(error_msg, fragment) == 0) return
+        print *, 'FAIL: diagnostic wrongly reported "', fragment, '"'
+        print *, '  actual: ', trim(error_msg)
+        ok = .false.
+    end function expect_error_absent
 
     logical function write_source_file(path, source)
         character(len=*), intent(in) :: path

--- a/src/session_program_lowering_reject_generic.inc
+++ b/src/session_program_lowering_reject_generic.inc
@@ -584,16 +584,33 @@
         integer, intent(out) :: nname
         integer, allocatable :: depth(:)
         character(len=64), allocatable :: iface_name(:)
-        character(len=:), allocatable :: text, name, signature
+        character(len=:), allocatable :: text, name, signature, word
         integer :: i, current
-        logical :: ok
+        logical :: ok, in_proc
 
         call interface_regions(lines, count, depth, iface_name)
         nmod = 0
         nname = 0
         current = 0
+        in_proc = .false.
         do i = 1, count
             text = trim(lines(i))
+            ! Everything inside a module procedure body, an interface block of
+            ! its own included, is local to that procedure and exports nothing.
+            if (in_proc) then
+                if (depth(i) == 0) then
+                    if (stmt_starts(text, 'end')) then
+                        word = identifier_after(text, 4)
+                        if (len_trim(word) == 0 .or. word == 'subroutine' .or. &
+                            word == 'function') in_proc = .false.
+                        if (word == 'module') then
+                            in_proc = .false.
+                            current = 0
+                        end if
+                    end if
+                end if
+                cycle
+            end if
             if (stmt_starts(text, 'end')) then
                 if (identifier_after(text, 4) == 'module') current = 0
                 cycle
@@ -619,7 +636,10 @@
                 cycle
             end if
             call interface_body_header(text, name, signature, ok)
-            if (ok) call append_owned_name(names, owner, nname, name, current)
+            if (ok) then
+                call append_owned_name(names, owner, nname, name, current)
+                if (depth(i) == 0) in_proc = .true.
+            end if
         end do
     end subroutine module_export_table
 
@@ -681,6 +701,7 @@
                 unit_name = ''
             end do
             if (len_trim(unit_name) == 0) cycle
+            if (use_renames_name(text, unit_name)) cycle
             if (.not. owned_name_present(names, owner, nname, unit_name, midx)) &
                 cycle
             write (location, '(" at line ",I0)') i
@@ -689,6 +710,26 @@
             return
         end do
     end subroutine check_use_shadows_program_unit
+
+    ! True when the USE statement renames the module entity called name, so
+    ! that name is not made accessible under its own spelling.
+    logical function use_renames_name(text, name) result(yes)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: name
+        integer :: p, base
+
+        yes = .false.
+        base = 0
+        do
+            p = index(text(base + 1:), '=>')
+            if (p == 0) return
+            base = base + p + 1
+            if (identifier_after(text, base) == trim(name)) then
+                yes = .true.
+                return
+            end if
+        end do
+    end function use_renames_name
 
     ! True when name occurs as a whole word on the line.
     logical function line_references_name(line, name) result(yes)
@@ -705,6 +746,9 @@
             base = p
             if (p > 1) then
                 if (is_fortran_identifier_char(line(p - 1:p - 1))) cycle
+                ! A component or type-bound reference names a part of an
+                ! object, never the use associated entity of that name.
+                if (line(p - 1:p - 1) == '%') cycle
             end if
             if (p + len_trim(name) <= len(line)) then
                 if (is_fortran_identifier_char(line(p + len_trim(name): &
@@ -764,6 +808,10 @@
                         if (trim(names(k)) /= trim(names(j))) cycle
                         if (owner(k) == owner(j)) cycle
                         if (.not. any(used(1:nused) == owner(k))) cycle
+                        if (generic_extends_own_name(lines, count, mods, &
+                                                     owner(j), names(j))) cycle
+                        if (generic_extends_own_name(lines, count, mods, &
+                                                     owner(k), names(k))) cycle
                         call ambiguous_reference_line(lines, first, last, &
                                                       names(j), i)
                         if (i == 0) cycle
@@ -778,6 +826,48 @@
             first = last + 1
         end do
     end subroutine check_ambiguous_use_association
+
+    ! True when the module makes name generic through an interface block that
+    ! lists name itself as a specific. The generic then extends the very entity
+    ! of that name it inherits, so USE of both modules names one generic
+    ! (F2018 15.4.3.4.1) rather than two conflicting entities.
+    logical function generic_extends_own_name(lines, count, mods, midx, name) &
+        result(yes)
+        character(len=512), intent(in) :: lines(:)
+        integer, intent(in) :: count
+        character(len=64), intent(in) :: mods(:)
+        integer, intent(in) :: midx
+        character(len=*), intent(in) :: name
+        character(len=64) :: specs(128)
+        character(len=:), allocatable :: text, word
+        integer :: i, k, nspec
+        logical :: inside
+
+        yes = .false.
+        inside = .false.
+        do i = 1, count
+            text = trim(lines(i))
+            if (stmt_starts(text, 'end')) then
+                if (identifier_after(text, 4) == 'module') inside = .false.
+                cycle
+            end if
+            if (stmt_starts(text, 'module')) then
+                word = identifier_after(text, 7)
+                inside = word == trim(mods(midx))
+                cycle
+            end if
+            if (.not. inside) cycle
+            if (.not. stmt_starts(text, 'interface')) cycle
+            if (identifier_after(text, 10) /= trim(name)) cycle
+            call generic_block_specifics(lines, count, i, specs, nspec)
+            do k = 1, nspec
+                if (trim(specs(k)) == trim(name)) then
+                    yes = .true.
+                    return
+                end if
+            end do
+        end do
+    end function generic_extends_own_name
 
     ! The first line of the region that references name outside a USE
     ! statement, or 0.

--- a/test/test_session_use_association_valid_compiler.f90
+++ b/test/test_session_use_association_valid_compiler.f90
@@ -1,0 +1,173 @@
+program test_session_use_association_valid_compiler
+    !! Valid USE associations must not be reported as ambiguous (#587).
+    use ffc_test_support, only: expect_error_absent
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== valid USE associations accepted ==='
+
+    all_passed = .true.
+    if (.not. test_generic_extends_module_procedure()) all_passed = .false.
+    if (.not. test_local_interface_is_not_export()) all_passed = .false.
+    if (.not. test_typebound_component_reference()) all_passed = .false.
+    if (.not. test_renamed_use_of_own_name()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: valid USE associations accepted'
+
+contains
+
+    logical function test_generic_extends_module_procedure()
+        !! gfortran.dg/generic_19.f90: mod2 extends mod1's SUB into a generic
+        !! that lists SUB itself, so USE of both modules names one generic.
+        character(len=*), parameter :: source = &
+            'module mod1'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine sub(x)'//new_line('a')// &
+            '      real x'//new_line('a')// &
+            '      print *, x'//new_line('a')// &
+            '   end subroutine sub'//new_line('a')// &
+            'end module mod1'//new_line('a')// &
+            ''//new_line('a')// &
+            'module mod2'//new_line('a')// &
+            '   use mod1'//new_line('a')// &
+            '   interface sub'//new_line('a')// &
+            '      module procedure sub, sub_int'//new_line('a')// &
+            '   end interface sub'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine sub_int(i)'//new_line('a')// &
+            '      integer i'//new_line('a')// &
+            '      print *, i'//new_line('a')// &
+            '   end subroutine sub_int'//new_line('a')// &
+            'end module mod2'//new_line('a')// &
+            ''//new_line('a')// &
+            'program prog'//new_line('a')// &
+            '   use mod1'//new_line('a')// &
+            '   use mod2'//new_line('a')// &
+            '   call sub(1)'//new_line('a')// &
+            'end program prog'
+
+        test_generic_extends_module_procedure = expect_error_absent( &
+            source, 'ambiguous reference', &
+            '/tmp/ffc_use_assoc_valid_1')
+    end function test_generic_extends_module_procedure
+
+    logical function test_local_interface_is_not_export()
+        !! gfortran.dg/generic_13.f90: the interface block inside a contained
+        !! procedure is local to it and exports nothing from its module.
+        character(len=*), parameter :: source = &
+            'module test'//new_line('a')// &
+            '   interface xx'//new_line('a')// &
+            '      module procedure xx'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            '   public :: xx'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine xx(i)'//new_line('a')// &
+            '      integer :: i'//new_line('a')// &
+            '      i = 7'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module test'//new_line('a')// &
+            ''//new_line('a')// &
+            'module too'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine sub(i)'//new_line('a')// &
+            '      interface'//new_line('a')// &
+            '         subroutine xx(i)'//new_line('a')// &
+            '            integer :: i'//new_line('a')// &
+            '         end subroutine'//new_line('a')// &
+            '      end interface'//new_line('a')// &
+            '      integer :: i'//new_line('a')// &
+            '      i = 1'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module too'//new_line('a')// &
+            ''//new_line('a')// &
+            'program tt'//new_line('a')// &
+            '   use test'//new_line('a')// &
+            '   use too'//new_line('a')// &
+            '   integer :: i'//new_line('a')// &
+            '   call xx(i)'//new_line('a')// &
+            'end program tt'
+
+        test_local_interface_is_not_export = expect_error_absent( &
+            source, 'ambiguous reference', &
+            '/tmp/ffc_use_assoc_valid_2')
+    end function test_local_interface_is_not_export
+
+    logical function test_typebound_component_reference()
+        !! gfortran.dg/use_26.f90: a %sizereturn() type-bound reference names a
+        !! binding, not the use associated module procedure of that name.
+        character(len=*), parameter :: source = &
+            'module a'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   type :: a_type'//new_line('a')// &
+            '      integer :: isize = 1'//new_line('a')// &
+            '   contains'//new_line('a')// &
+            '      procedure :: sizereturn'//new_line('a')// &
+            '   end type a_type'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   function sizereturn(self)'//new_line('a')// &
+            '      integer :: sizereturn'//new_line('a')// &
+            '      class(a_type) :: self'//new_line('a')// &
+            '      sizereturn = self%isize'//new_line('a')// &
+            '   end function sizereturn'//new_line('a')// &
+            'end module a'//new_line('a')// &
+            ''//new_line('a')// &
+            'module b'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   type :: b_type'//new_line('a')// &
+            '      integer :: isize = 2'//new_line('a')// &
+            '   contains'//new_line('a')// &
+            '      procedure :: sizereturn'//new_line('a')// &
+            '   end type b_type'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   function sizereturn(self)'//new_line('a')// &
+            '      integer :: sizereturn'//new_line('a')// &
+            '      class(b_type) :: self'//new_line('a')// &
+            '      sizereturn = self%isize'//new_line('a')// &
+            '   end function sizereturn'//new_line('a')// &
+            'end module b'//new_line('a')// &
+            ''//new_line('a')// &
+            'program main'//new_line('a')// &
+            '   use a'//new_line('a')// &
+            '   use b'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   type(a_type) :: ai'//new_line('a')// &
+            '   type(b_type) :: bi'//new_line('a')// &
+            '   print *, ai%sizereturn()'//new_line('a')// &
+            '   print *, bi%sizereturn()'//new_line('a')// &
+            'end program main'
+
+        test_typebound_component_reference = expect_error_absent( &
+            source, 'ambiguous reference', &
+            '/tmp/ffc_use_assoc_valid_3')
+    end function test_typebound_component_reference
+
+    logical function test_renamed_use_of_own_name()
+        !! gfortran.dg/use_14.f90: the module entity is renamed, so the local
+        !! name of the program unit stays free.
+        character(len=*), parameter :: source = &
+            'module test_mod'//new_line('a')// &
+            '   interface'//new_line('a')// &
+            '      subroutine my_sub(a)'//new_line('a')// &
+            '         real a'//new_line('a')// &
+            '      end subroutine'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'subroutine my_sub(a)'//new_line('a')// &
+            '   use test_mod, gugu => my_sub'//new_line('a')// &
+            '   real a'//new_line('a')// &
+            '   print *, a'//new_line('a')// &
+            'end subroutine'//new_line('a')// &
+            ''//new_line('a')// &
+            'program p'//new_line('a')// &
+            '   call my_sub(1.0)'//new_line('a')// &
+            'end program p'
+
+        test_renamed_use_of_own_name = expect_error_absent( &
+            source, 'name of the current program unit', &
+            '/tmp/ffc_use_assoc_valid_4')
+    end function test_renamed_use_of_own_name
+
+end program test_session_use_association_valid_compiler


### PR DESCRIPTION
Fixes #587.

Four valid programs that gfortran compiles were rejected by ffc's text-level
generic/USE checks. Each rejection came from a different over-approximation:

- `module_export_table` treated an interface block inside a module-contained
  procedure as a module export (`generic_13.f90`). Such a block is local to
  the procedure; the body of a contained procedure now exports nothing.
- A generic interface that lists its own name as a specific extends the entity
  it inherits, so USE of both modules names one generic, not two conflicting
  entities (`generic_19.f90`).
- `a%sizereturn()` names a type-bound binding, not the use associated procedure
  of that name, so a `%`-prefixed occurrence is no longer a reference
  (`use_26.f90`).
- `use test_mod, gugu => my_sub` does not make `my_sub` accessible, so the
  program unit may still be called `my_sub` (`use_14.f90`).

Preserved invariant: the genuine conflicts stay rejected. The negative controls
in `test_session_reject_generic_01_compiler` (generic_11-shaped ambiguity, and
interface_3-shaped program-unit shadowing without a rename) still fail to
compile with the same diagnostics.

Red evidence (before the fix, new test):
```
FAIL: diagnostic wrongly reported "ambiguous reference"
  actual: ambiguous reference to sub: ... at line 24
  actual: ambiguous reference to xx: ... at line 30
  actual: ambiguous reference to sizereturn: ... at line 37
FAIL: diagnostic wrongly reported "name of the current program unit"
  actual: my_sub from module test_mod is also the name ... at line 10
```

Green evidence:
- `fo test test_session_use_association_valid_compiler` PASS (4/4)
- `fo test test_session_reject_generic_01_compiler` PASS (all 21 checks)
- Full `fo` pipeline: 310/314 tests pass. The four failures
  (`test_session_real_parameter_compiler`, `test_session_reject_result_01_compiler`,
  `test_fortfront_corpus_conformance`, `test_parity_dashboard`) reproduce
  identically in a clean `origin/main` worktree, with the same corpus FAIL list
  and the same FortFront diagnostics, so they are pre-existing/environmental.