### PR TITLE
[lex-bom-01] skip byte-order marks in source files (#583)

### DIFF
--- a/src/ffc_include_expansion.f90
+++ b/src/ffc_include_expansion.f90
@@ -60,6 +60,7 @@ contains
         character(len=:), allocatable :: resolved
         character(len=:), allocatable :: nested
         integer :: pos, nl, line_no, i
+        logical :: terminated
 
         call read_whole_file(path, text)
         if (.not. allocated(text)) return
@@ -84,14 +85,24 @@ contains
             if (nl == 0) then
                 line = text(pos:)
                 pos = len(text) + 1
+                terminated = .false.
             else
                 line = text(pos:pos + nl - 2)
                 pos = pos + nl
+                terminated = .true.
             end if
             line_no = line_no + 1
 
             if (.not. include_name(line, name)) then
-                source = source//line//new_line('a')
+                ! A final fragment with no newline of its own must not gain
+                ! one: a wide-encoded file (UTF-16/UTF-32 BOM) ends in the
+                ! zero bytes that pad its last line terminator, and adding a
+                ! byte there breaks the byte count its decoder requires.
+                if (terminated) then
+                    source = source//line//new_line('a')
+                else
+                    source = source//line
+                end if
                 cycle
             end if
 

--- a/test/test_session_include_compiler.f90
+++ b/test/test_session_include_compiler.f90
@@ -20,6 +20,8 @@ program test_session_include_compiler
     if (.not. check_bom_in_both_files()) ok = .false.
     if (.not. check_interior_bom_still_rejected()) ok = .false.
     if (.not. check_utf16le_included_file()) ok = .false.
+    if (.not. check_utf16le_source_file()) ok = .false.
+    if (.not. check_utf32le_source_file()) ok = .false.
     if (.not. ok) stop 1
 
     print *, 'PASS: include lines expand and report missing files and cycles'
@@ -312,6 +314,72 @@ contains
         end if
         ok = .true.
     end function check_utf16le_included_file
+
+    logical function check_utf16le_source_file() result(ok)
+        ! The compiled file itself may carry a UTF-16LE BOM
+        ! (gfortran.dg/bom_UTF16-LE.f90). Its wide line terminator leaves a
+        ! trailing zero byte after the final newline, so expansion must hand
+        ! the frontend the file's bytes unchanged rather than terminating that
+        ! remainder with a newline of its own.
+        character(len=:), allocatable :: output
+
+        ok = .false.
+        call reset_work()
+        call write_bytes(WORK//'/main.f90', &
+                         achar(255)//achar(254)//widen(plain_source(), 2))
+        if (.not. compile_ok(WORK//'/main.f90', '')) return
+        call run_exe(output)
+        if (first_line(output) /= '42') then
+            print *, 'FAIL: UTF-16LE source output was ', first_line(output)
+            return
+        end if
+        ok = .true.
+    end function check_utf16le_source_file
+
+    logical function check_utf32le_source_file() result(ok)
+        ! Same for a UTF-32LE BOM (gfortran.dg/bom_UTF-32.f90), where three
+        ! zero bytes trail the final newline.
+        character(len=:), allocatable :: output
+
+        ok = .false.
+        call reset_work()
+        call write_bytes(WORK//'/main.f90', &
+                         achar(255)//achar(254)//achar(0)//achar(0)// &
+                         widen(plain_source(), 4))
+        if (.not. compile_ok(WORK//'/main.f90', '')) return
+        call run_exe(output)
+        if (first_line(output) /= '42') then
+            print *, 'FAIL: UTF-32LE source output was ', first_line(output)
+            return
+        end if
+        ok = .true.
+    end function check_utf32le_source_file
+
+    function plain_source() result(text)
+        character(len=:), allocatable :: text
+
+        text = 'program main'//new_line('a')// &
+               'implicit none'//new_line('a')// &
+               "print '(I0)', 42"//new_line('a')// &
+               'end program main'//new_line('a')
+    end function plain_source
+
+    ! Little-endian wide encoding of ASCII text: each character followed by
+    ! width-1 zero bytes.
+    function widen(text, width) result(wide)
+        character(len=*), intent(in) :: text
+        integer, intent(in) :: width
+        character(len=:), allocatable :: wide
+        integer :: i, j
+
+        allocate (character(len=len(text)*width) :: wide)
+        do i = 1, len(text)
+            wide((i - 1)*width + 1:(i - 1)*width + 1) = text(i:i)
+            do j = 2, width
+                wide((i - 1)*width + j:(i - 1)*width + j) = achar(0)
+            end do
+        end do
+    end function widen
 
     subroutine write_bytes(path, contents)
         ! Writes exactly the given bytes, with no record terminator, so a


### PR DESCRIPTION
Fixes #583.

## Problem

`gfortran.dg/bom_UTF16-LE.f90` and `gfortran.dg/bom_UTF-32.f90` were rejected at
their first byte with `Invalid character 0xFF at line 1, column 1`, although
gfortran accepts both (`dg-do compile`, no `dg-error`).

The frontend already decodes a leading BOM (`source_bom`). The damage was done
before it: ffc expands INCLUDE lines textually, and that pass split the file at
newline bytes and re-terminated *every* fragment with a newline. A little-endian
wide encoding pads its line terminator with zero bytes, so the file ends
`0A 00` (UTF-16LE) or `0A 00 00 00` (UTF-32LE). The trailing zero bytes form a
final fragment with no newline of its own, and the pass appended one. The extra
byte broke the byte count the decoder requires (`mod(n-2,2)`, `mod(n-4,4)`), the
decode fell through, and the raw `0xFF` reached character validation.

Big-endian marks were unaffected: their terminator ends on the newline byte, so
nothing trailed it.

## Change

`expand_file` now re-terminates a line only when it was terminated in the file.
Include expansion is therefore byte-exact for a source with no INCLUDE line —
the invariant it always needed for wide-encoded input, and the preserved
compiler invariant here: what the frontend decodes is what the file contains.

## Red / green evidence

Red, before the change (worktree at origin/main):

```
$ ffc -c bom_UTF16-LE.f90 -o out.o
bom_UTF16-LE.f90:1:1: error: Invalid character 0xFF at line 1, column 1
$ ffc -c bom_UTF-32.f90 -o out.o
bom_UTF-32.f90:1:1: error: Invalid character 0xFF at line 1, column 1
$ fo test test_session_include_compiler
test_session_include_compiler   FAIL
  FAIL: ffc rejected /tmp/ffc_include_test/main.f90
    stderr: ...: error: Invalid character 0xFF at line 1, column 1
```

Green, after:

```
$ ffc -c bom_UTF16-LE.f90 -o out.o   # exit 0, no diagnostic
$ ffc -c bom_UTF-32.f90  -o out.o    # exit 0, no diagnostic
$ fo test test_session_include_compiler
test_session_include_compiler   PASS
```

Two new behavioural cases in `test/test_session_include_compiler.f90` compile a
UTF-16LE and a UTF-32LE encoded program through the CLI and check the compiled
program prints `42`. The existing `check_interior_bom_still_rejected` negative
control (a BOM in the middle of a file stays an invalid character) still passes,
as do the UTF-8 and included-file BOM cases.

## Full pipeline

`fo` was run in full. Four tests fail, all of them identically on unmodified
main with these two files reverted to `origin/main` (verified in the same
worktree): `test_session_real_parameter_compiler`,
`test_session_reject_result_01_compiler`, `test_fortfront_corpus_conformance`
(fortfront-f90 FAIL=12, XPASS=0) and `test_parity_dashboard` (the known
`.wt/` sibling-path failure). No case regressed from PASS. This change adds no
rejection rule.