### PR TITLE
[lf-monomorph-01] refuse a call bound to no Lazy specialization (refs #437)

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -244,6 +244,7 @@ module session_program_lowering
         derived_type_info_t, &
         module_exports_t, &
         external_procedure_t, &
+        lazy_specialization_t, &
         generic_interface_t, &
         operator_interface_t, &
         MAX_PROC_ARGS, &
@@ -952,6 +953,7 @@ contains
     include 'session_program_lowering_data.inc'
     include 'session_program_lowering_declarations.inc'
     include 'session_program_lowering_inferred.inc'
+    include 'session_program_lowering_lazy_monomorph.inc'
     subroutine define_declared_symbol(context, node, name, value_kind, error_msg)
         type(lowering_context_t), intent(inout) :: context
         type(declaration_node), intent(in) :: node
@@ -1944,6 +1946,11 @@ contains
                     context)
             end do
         end if
+        call reject_monomorphized_call(context, trim(name), &
+                                       get_node_line(arena, node_index), &
+                                       get_node_column(arena, node_index), &
+                                       error_msg)
+        if (len_trim(error_msg) > 0) return
         call_name = degeneric_call_name(context, name, call_arg_count, call_arg_kinds, &
             call_arg_ranks)
         if (same_name(call_name, 'get_command_argument')) then

--- a/src/session_program_lowering_expr_lowering.inc
+++ b/src/session_program_lowering_expr_lowering.inc
@@ -179,6 +179,9 @@
                                 call_arg_count, call_arg_kinds)
         call call_argument_ranks(arena, node, context, call_arg_count, &
                                  call_arg_ranks)
+        call reject_monomorphized_call(context, trim(node%name), node%line, &
+                                       node%column, error_msg)
+        if (len_trim(error_msg) > 0) return
         call_name = degeneric_call_name(context, node%name, &
             call_arg_count, call_arg_kinds, call_arg_ranks)
         if (same_name(call_name, 'c_associated') .and. .not. &
@@ -554,6 +557,9 @@
                                 call_arg_count, call_arg_kinds)
         call call_argument_ranks(arena, node, context, call_arg_count, &
                                  call_arg_ranks)
+        call reject_monomorphized_call(context, trim(node%name), node%line, &
+                                       node%column, error_msg)
+        if (len_trim(error_msg) > 0) return
         call_name = degeneric_call_name(context, node%name, &
             call_arg_count, call_arg_kinds, call_arg_ranks)
 
@@ -913,6 +919,9 @@
                                 call_arg_count, call_arg_kinds)
         call call_argument_ranks(arena, node, context, call_arg_count, &
                                  call_arg_ranks)
+        call reject_monomorphized_call(context, trim(node%name), node%line, &
+                                       node%column, error_msg)
+        if (len_trim(error_msg) > 0) return
         call_name = degeneric_call_name(context, node%name, &
             call_arg_count, call_arg_kinds, call_arg_ranks)
 

--- a/src/session_program_lowering_integer.inc
+++ b/src/session_program_lowering_integer.inc
@@ -250,6 +250,9 @@
                                call_arg_count, call_arg_kinds)
        call call_argument_ranks(arena, node, context, call_arg_count, &
                                 call_arg_ranks)
+       call reject_monomorphized_call(context, trim(node%name), node%line, &
+                                      node%column, error_msg)
+       if (len_trim(error_msg) > 0) return
        call_name = degeneric_call_name(context, node%name, &
            call_arg_count, call_arg_kinds, call_arg_ranks)
 

--- a/src/session_program_lowering_lazy_monomorph.inc
+++ b/src/session_program_lowering_lazy_monomorph.inc
@@ -1,0 +1,153 @@
+    subroutine collect_lazy_specializations(arena, root_index, context, error_msg)
+        ! Lazy Fortran lets a procedure leave its dummies untyped and take their
+        ! types from use. When every call site agrees on one concrete type,
+        ! FortFront resolves the dummies in place and the ordinary path lowers a
+        ! single body. When call sites disagree there is no one type to give the
+        ! dummies, so FortFront monomorphizes: it leaves the written procedure
+        ! untyped and adds one fully typed copy per concrete signature.
+        !
+        ! This pass records which procedures were monomorphized. It does not
+        ! name, key, or emit specializations: FortFront owns all of that. What
+        ! it establishes is that the untyped original is not a callable body,
+        ! so a call that still names it is refused instead of bound to whichever
+        ! instance happened to be emitted (#437).
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: root_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: i
+
+        call set_empty(error_msg)
+        if (.not. context%lazy_mode) return
+        do i = 1, arena%size
+            if (.not. node_exists(arena, i)) cycle
+            call record_monomorphized_procedure(arena, i, context, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine collect_lazy_specializations
+
+    subroutine record_monomorphized_procedure(arena, node_index, context, &
+                                              error_msg)
+        ! Record one Lazy procedure that FortFront replaced with typed copies.
+        ! The presence of copies is the fact that matters: FortFront makes them
+        ! only when the written procedure cannot serve every call site, so the
+        ! written name no longer denotes a callable body.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(function_def_node), pointer :: fn_node
+        integer :: arg_count
+
+        call set_empty(error_msg)
+        fn_node => get_node_as_function_def(arena, node_index)
+        if (.not. associated(fn_node)) return
+        if (.not. allocated(fn_node%name)) return
+        if (.not. allocated(fn_node%param_indices)) return
+        arg_count = size(fn_node%param_indices)
+        if (arg_count < 1 .or. arg_count > MAX_PROC_ARGS) return
+        if (.not. has_monomorphic_copies(arena, trim(fn_node%name), arg_count)) &
+            return
+        call add_monomorphized_name(context, trim(fn_node%name))
+    end subroutine record_monomorphized_procedure
+
+    logical function has_monomorphic_copies(arena, proc_name, arg_count) &
+            result(has_copies)
+        ! Whether FortFront added typed copies of this procedure. A copy is a
+        ! procedure of the same dummy count whose name FortFront derived from
+        ! this one; the name only associates copy with original, and no type
+        ! fact is read from it.
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: proc_name
+        integer, intent(in) :: arg_count
+        type(function_def_node), pointer :: copy_node
+        integer :: i
+
+        has_copies = .false.
+        do i = 1, arena%size
+            if (.not. node_exists(arena, i)) cycle
+            copy_node => get_node_as_function_def(arena, i)
+            if (.not. associated(copy_node)) cycle
+            if (.not. allocated(copy_node%name)) cycle
+            if (.not. name_is_monomorphic_copy(copy_node%name, proc_name)) cycle
+            if (.not. allocated(copy_node%param_indices)) cycle
+            if (size(copy_node%param_indices) /= arg_count) cycle
+            has_copies = .true.
+            return
+        end do
+    end function has_monomorphic_copies
+
+    logical function name_is_monomorphic_copy(candidate, proc_name) result(is_copy)
+        ! FortFront names a monomorphic copy <procedure>__<kind tokens>.
+        character(len=*), intent(in) :: candidate
+        character(len=*), intent(in) :: proc_name
+        character(len=:), allocatable :: prefix, lowered
+
+        is_copy = .false.
+        prefix = lowercase_text(trim(proc_name))//'__'
+        lowered = lowercase_text(trim(candidate))
+        if (len(lowered) <= len(prefix)) return
+        is_copy = lowered(1:len(prefix)) == prefix
+    end function name_is_monomorphic_copy
+
+    subroutine add_monomorphized_name(context, proc_name)
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: proc_name
+        type(lazy_specialization_t), allocatable :: bigger(:)
+        integer :: current, next
+
+        if (lazy_procedure_is_monomorphized(context, proc_name)) return
+        if (.not. allocated(context%lazy_specializations)) then
+            allocate (context%lazy_specializations(8))
+        else
+            current = size(context%lazy_specializations)
+            if (context%lazy_specialization_count >= current) then
+                allocate (bigger(2 * current))
+                bigger(1:current) = context%lazy_specializations
+                call move_alloc(bigger, context%lazy_specializations)
+            end if
+        end if
+        next = context%lazy_specialization_count + 1
+        context%lazy_specializations(next)%procedure_name = trim(proc_name)
+        context%lazy_specialization_count = next
+    end subroutine add_monomorphized_name
+
+    logical function lazy_procedure_is_monomorphized(context, proc_name) &
+            result(is_mono)
+        ! Whether the written name is an untyped original that FortFront
+        ! replaced with typed copies.
+        type(lowering_context_t), intent(in) :: context
+        character(len=*), intent(in) :: proc_name
+        integer :: i
+
+        is_mono = .false.
+        do i = 1, context%lazy_specialization_count
+            if (same_name(context%lazy_specializations(i)%procedure_name, &
+                          proc_name)) then
+                is_mono = .true.
+                return
+            end if
+        end do
+    end function lazy_procedure_is_monomorphized
+
+    subroutine reject_monomorphized_call(context, call_name, line, column, &
+                                         error_msg)
+        ! A call that still names a monomorphized original names no callable
+        ! body: the original was left untyped and each concrete signature lives
+        ! in its own copy. Which copy this call means is FortFront's mapping to
+        ! make, so binding one here would be a guess -- and binding the wrong
+        ! one silently returns a wrong value. Refuse it instead (#437,
+        ! FortFront #2971).
+        type(lowering_context_t), intent(in) :: context
+        character(len=*), intent(in) :: call_name
+        integer, intent(in) :: line, column
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call set_empty(error_msg)
+        if (.not. lazy_procedure_is_monomorphized(context, call_name)) return
+        call unsupported_feature_error('Lazy procedure call', line, column, &
+            'call to '//trim(call_name)//' was not bound to one of its '// &
+            'monomorphic specializations; the procedure leaves its dummy '// &
+            'arguments untyped and is used at more than one concrete '// &
+            'signature', error_msg)
+    end subroutine reject_monomorphized_call

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -220,6 +220,13 @@
             call destroy(context%session)
             return
         end if
+        ! Record which Lazy procedures FortFront monomorphized, before any call
+        ! is lowered against the untyped original they left behind (#437).
+        call collect_lazy_specializations(arena, root_index, context, error_msg)
+        if (len_trim(error_msg) > 0) then
+            call destroy(context%session)
+            return
+        end if
         call lower_internal_functions(arena, root_index, context, error_msg)
         if (len_trim(error_msg) > 0) then
             call destroy(context%session)

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -537,6 +537,14 @@ module session_program_lowering_types
     integer, parameter, public :: ARG_INTENT_OUT = 2
     integer, parameter, public :: ARG_INTENT_INOUT = 3
 
+    ! A Lazy procedure whose untyped dummies FortFront could not resolve to one
+    ! concrete type, so it monomorphized instead: the written name is not a
+    ! callable body, and each concrete signature lives in its own typed copy
+    ! (#437).
+    type, public :: lazy_specialization_t
+        character(len=64) :: procedure_name = ''
+    end type lazy_specialization_t
+
     type, public :: external_procedure_t
         character(len=64) :: fortran_name = ''
         character(len=64) :: c_name = ''
@@ -737,6 +745,8 @@ module session_program_lowering_types
         ! A call to such a name inlines the body with actuals bound to dummies.
         type(statement_function_t), allocatable :: statement_functions(:)
         integer :: statement_function_count = 0
+        type(lazy_specialization_t), allocatable :: lazy_specializations(:)
+        integer :: lazy_specialization_count = 0
         ! OPEN(unit=6, sign='plus') reconfigures the preconnected stdout
         ! connection's sign mode (#280): PRINT and WRITE(*,...) share that
         ! connection, so a forced-plus mode applies to their F editing too.

--- a/test/test_session_lazy_monomorph_compiler.f90
+++ b/test/test_session_lazy_monomorph_compiler.f90
@@ -1,0 +1,194 @@
+program test_session_lazy_monomorph_compiler
+    !! A Lazy procedure may leave its dummies untyped and take their types from
+    !! use. When every call site agrees on one concrete type, FortFront resolves
+    !! the dummies in place and one body lowers. When call sites disagree there
+    !! is no one type for the dummies, so FortFront monomorphizes: it leaves the
+    !! written procedure untyped and adds one typed copy per signature, but the
+    !! call sites still name the written procedure (FortFront #2971).
+    !!
+    !! ffc must not pick a copy for them. Binding one is a guess, and binding
+    !! the wrong one returns a wrong value with no diagnostic: before this
+    !! change the two-signature program below printed 6 and 0, and swapping the
+    !! two calls printed 0.0 and 6.0. The boundary is now diagnosed (#437).
+    implicit none
+
+    logical :: ok
+
+    print *, '=== direct session lazy monomorphization compiler test ==='
+
+    ok = .true.
+
+    ! Every call site agrees on one concrete type: FortFront resolves the dummy
+    ! and the single body lowers. This is the path monomorphization must not
+    ! disturb.
+    if (.not. lazy_first_line( &
+        'function twice(x)'//new_line('a')// &
+        '  twice = 2 * x'//new_line('a')// &
+        'end function'//new_line('a')// &
+        'program main'//new_line('a')// &
+        '  print *, twice(3)'//new_line('a')// &
+        '  print *, twice(4)'//new_line('a')// &
+        'end program'//new_line('a'), &
+        '           6', 'ffc_lazy_mono_same_signature')) ok = .false.
+
+    ! One real call site resolves the dummy to real just as well.
+    if (.not. lazy_first_line( &
+        'function twice(x)'//new_line('a')// &
+        '  twice = 2 * x'//new_line('a')// &
+        'end function'//new_line('a')// &
+        'program main'//new_line('a')// &
+        '  print *, twice(2.5)'//new_line('a')// &
+        'end program'//new_line('a'), &
+        '   5.0000000000000000', 'ffc_lazy_mono_real_signature')) ok = .false.
+
+    ! Two call sites of different concrete types. The written name denotes no
+    ! callable body, so the call is refused rather than bound to whichever copy
+    ! happened to be emitted.
+    if (.not. lazy_rejected( &
+        'function twice(x)'//new_line('a')// &
+        '  twice = 2 * x'//new_line('a')// &
+        'end function'//new_line('a')// &
+        'program main'//new_line('a')// &
+        '  print *, twice(3)'//new_line('a')// &
+        '  print *, twice(2.5)'//new_line('a')// &
+        'end program'//new_line('a'), &
+        'monomorphic specializations', &
+        'ffc_lazy_mono_conflicting')) ok = .false.
+
+    ! The same program with the calls in the other order is refused the same
+    ! way: which call is wrong must not depend on emission order.
+    if (.not. lazy_rejected( &
+        'function twice(x)'//new_line('a')// &
+        '  twice = 2 * x'//new_line('a')// &
+        'end function'//new_line('a')// &
+        'program main'//new_line('a')// &
+        '  print *, twice(2.5)'//new_line('a')// &
+        '  print *, twice(3)'//new_line('a')// &
+        'end program'//new_line('a'), &
+        'monomorphic specializations', &
+        'ffc_lazy_mono_conflicting_reversed')) ok = .false.
+
+    if (.not. ok) stop 1
+    print *, 'PASS: lazy monomorphization boundary'
+
+contains
+
+    logical function lazy_first_line(source, expected, stem) result(ok)
+        ! Compile and run a lazy fragment, comparing its first output line.
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        character(len=*), intent(in) :: stem
+        character(len=:), allocatable :: dir, src_path, exe_path, out_path
+        character(len=:), allocatable :: actual
+        integer :: unit, exit_stat, cmd_stat
+
+        ok = .false.
+        call scratch_dir(stem, dir)
+        src_path = dir//'/'//stem//'.lf'
+        exe_path = dir//'/'//stem//'.exe'
+        out_path = dir//'/'//stem//'.out'
+        open (newunit=unit, file=src_path, status='replace', action='write')
+        write (unit, '(A)', advance='no') source
+        close (unit)
+
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; '// &
+            '"$exe" '//src_path//' -o '//exe_path//" >"//dir//"/log 2>&1'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0 .or. exit_stat /= 0) then
+            print *, 'FAIL: ffc rejected lazy source ', stem, ' exit=', exit_stat
+            call execute_command_line('cat '//dir//'/log')
+            return
+        end if
+
+        call execute_command_line(exe_path//' > '//out_path, &
+                                  exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0 .or. exit_stat /= 0) then
+            print *, 'FAIL: lazy executable did not run cleanly: ', stem
+            return
+        end if
+        actual = read_first_line(out_path)
+        if (trim(actual) /= trim(expected)) then
+            print *, 'FAIL: ', stem, ' expected [', trim(expected), &
+                '] got [', trim(actual), ']'
+            return
+        end if
+        call execute_command_line('rm -rf '//dir)
+        ok = .true.
+    end function lazy_first_line
+
+    logical function lazy_rejected(source, fragment, stem) result(ok)
+        ! Compiling this lazy fragment must fail with a diagnostic naming the
+        ! given fragment. A clean compile would mean ffc bound the call to one
+        ! specialization and silently returned a wrong value for the others.
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: fragment
+        character(len=*), intent(in) :: stem
+        character(len=:), allocatable :: dir, src_path, exe_path
+        integer :: unit, exit_stat, cmd_stat, grep_stat
+
+        ok = .false.
+        call scratch_dir(stem, dir)
+        src_path = dir//'/'//stem//'.lf'
+        exe_path = dir//'/'//stem//'.exe'
+        open (newunit=unit, file=src_path, status='replace', action='write')
+        write (unit, '(A)', advance='no') source
+        close (unit)
+
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; '// &
+            '"$exe" '//src_path//' -o '//exe_path//" >"//dir//"/log 2>&1'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) then
+            print *, 'FAIL: could not run ffc for ', stem
+            return
+        end if
+        if (exit_stat == 0) then
+            print *, 'FAIL: ', stem, ' compiled instead of being diagnosed'
+            call execute_command_line('cat '//dir//'/log')
+            return
+        end if
+        call execute_command_line('grep -q "'//fragment//'" '//dir//'/log', &
+                                  exitstat=grep_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0 .or. grep_stat /= 0) then
+            print *, 'FAIL: ', stem, ' diagnostic did not mention: ', fragment
+            call execute_command_line('cat '//dir//'/log')
+            return
+        end if
+        call execute_command_line('rm -rf '//dir)
+        ok = .true.
+    end function lazy_rejected
+
+    subroutine scratch_dir(stem, dir)
+        ! A scratch directory of this run's own, so concurrent builds of other
+        ! worktrees never share it (ffc #547).
+        character(len=*), intent(in) :: stem
+        character(len=:), allocatable, intent(out) :: dir
+        character(len=32) :: stamp
+        integer :: values(8)
+
+        call date_and_time(values=values)
+        write (stamp, '(I0,A,I0)') values(6)*60000 + values(7)*1000 + &
+            values(8), '_', values(5)
+        dir = '/tmp/'//stem//'_'//trim(stamp)
+        call execute_command_line('rm -rf '//dir//'; mkdir -p '//dir)
+    end subroutine scratch_dir
+
+    function read_first_line(path) result(text)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable :: text
+        character(len=512) :: buffer
+        integer :: unit, io_stat
+
+        text = ''
+        open (newunit=unit, file=path, status='old', action='read', &
+              iostat=io_stat)
+        if (io_stat /= 0) return
+        read (unit, '(A)', iostat=io_stat) buffer
+        if (io_stat == 0) text = trim(buffer)
+        close (unit)
+    end function read_first_line
+
+end program test_session_lazy_monomorph_compiler


### PR DESCRIPTION
Refs #437. Lands the half that is correct today; the positive oracle needs
FortFront #2971.

## The silent miscompile this removes

A Lazy procedure may leave its dummies untyped. When every call site agrees on
one concrete type FortFront resolves them in place and one body lowers — that
already worked. When call sites disagree FortFront monomorphizes: it leaves the
written procedure untyped and adds one typed copy per signature.

FortFront does not rename the call sites, so they still name the written
procedure, which now denotes no callable body. ffc bound them to whichever copy
happened to be emitted:

```
print *, twice(3)     ->  6      correct
print *, twice(2.5)   ->  0      wrong, no diagnostic
```

Swap the two calls and it prints `0.0` and `6.0` — *which* call is wrong
followed emission order. That is the exact failure mode this chunk exists to
prevent, and it is silent.

Such a call is now diagnosed.

## Why ffc does not pick a copy

Which copy a call means is FortFront's mapping to make. It already visits every
call site (`update_call_result_type`) and holds the mangled callee there
(`type_signature_t` carries `param_kinds` and `param_type_strings`, which is
what `mangle_procedure_name` consumes). Choosing here would mean re-inferring
argument kinds and re-parsing FortFront's mangling — a second copy of
information FortFront owns, and a wrong guess is silent rather than loud.

Filed as **FortFront #2971**. Once call sites name their specialization, these
programs compile and run, and the copies lower as the ordinary typed procedures
they are — at which point this diagnostic becomes unreachable and the positive
oracle goes in.

## What this does and does not add

- ffc invents **no** specialization keys, names, kinds, or emission.
- The pass records only *which procedures FortFront replaced with copies*.
- A copy's name associates it with its original and nothing else; **no type
  fact is read from the mangled name**.
- I deliberately did **not** build the generic-table routing step. It would be
  compensation for a transformation FortFront should finish, exactly as the
  steer said to check for.

## Oracles

New `test/test_session_lazy_monomorph_compiler.f90`:

- same-signature Lazy call still works (integer) — regression guard
- single real signature still works — regression guard
- two conflicting signatures are diagnosed — negative control
- the same program with calls reversed is diagnosed the same way, so the
  boundary does not depend on emission order

## Corpus delta

Same-commit branch vs `origin/main`, both with FortFront `e520b05e`. The only
difference is `issue_1324_if_inside_do_loop.f90`, which is a `random_number`
fixture: re-run with `--repeat 3` (ffc #599 tooling) it is **FAIL 3/3 on both
branch and main**, so it is corpus flake in the full run, not a regression.
No case moved PASS→FAIL. No xfail manifest entries moved.

## Pre-existing failures, not from this PR

`fo` reports 4 failures; all 4 reproduce on an unmodified `origin/main`
worktree built against the same FortFront:

- `test_session_real_parameter_compiler`
- `test_session_reject_result_01_compiler`
- `test_fortfront_corpus_conformance`
- `test_parity_dashboard`

The first two are new: the shared FortFront checkout was behind and I
fast-forwarded it to pick up the #2958 clone fix, which also brought
`Enforce explicit-interface declaration rules` (#2883) and `Reject statements
placed in forbidden program sections` (#2896). Both tests assert on ffc
diagnostic text that FortFront now emits differently. They need an owner —
flagging rather than touching, since they are outside this chain.