### PR TITLE
[intrinsic-gap-01] lower RANDOM_SEED through the runtime (#588)

### DIFF
--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -661,6 +661,10 @@ The complete runtime ABI. Adding an entry point means editing
 | `_ffc_unit_rewind` | `int _ffc_unit_rewind(int unit)` | Repositions to the first record. |
 | `_ffc_unit_close` | `int _ffc_unit_close(int unit)` | Disconnects the unit. Succeeds on a unit that is not connected. |
 | `_ffc_unit_status` | `int _ffc_unit_status(void)` | Status of the most recent unit operation. |
+| `_ffc_random_seed_size` | `int _ffc_random_seed_size(void)` | Size of the seed array `RANDOM_SEED(SIZE=)` reports. The generator behind `RANDOM_NUMBER` has one integer of state, so this is 1. |
+| `_ffc_random_seed_put` | `void _ffc_random_seed_put(const int *seed)` | `RANDOM_SEED(PUT=)`. Restarts the generator from `seed[0]`, so an identical PUT replays an identical sequence. Null is ignored. |
+| `_ffc_random_seed_get` | `void _ffc_random_seed_get(int *seed)` | `RANDOM_SEED(GET=)`. Writes the current seed into `seed[0]`. Null is ignored. |
+| `_ffc_random_seed_default` | `void _ffc_random_seed_default(void)` | Argument-less `RANDOM_SEED()`. Resets the generator to the processor's default seed, which repeats across runs (permitted by F2018 16.9.155). |
 
 ### File-unit state (#396)
 

--- a/runtime/ffc_runtime.c
+++ b/runtime/ffc_runtime.c
@@ -47,6 +47,7 @@ int _ffc_runtime_probe(void) {
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #define FFC_UNIT_MIN 0
 #define FFC_UNIT_MAX 2048
@@ -222,4 +223,46 @@ int _ffc_unit_close(int unit) {
     }
     ffc_unit_last_status = 0;
     return 0;
+}
+
+/* ---- RANDOM_SEED (issue #588) ---------------------------- */
+
+/* RANDOM_NUMBER draws from glibc's random(), whose state is
+ * seeded by srandom(). That state is one integer, so the
+ * seed array RANDOM_SEED works with has size 1 and only its
+ * first element is read or written. The last seed put is
+ * kept here because srandom() offers no way to read it back,
+ * and RANDOM_SEED(GET=) must report it. */
+
+static int ffc_random_seed_state = 1;
+
+/* RANDOM_SEED(SIZE=n): the seed array size, always 1. */
+int _ffc_random_seed_size(void) {
+    return 1;
+}
+
+/* RANDOM_SEED(PUT=seed): restart the generator from seed[0],
+ * so an identical PUT replays an identical sequence. */
+void _ffc_random_seed_put(const int *seed) {
+    if (seed == NULL) {
+        return;
+    }
+    ffc_random_seed_state = seed[0];
+    srandom((unsigned int) seed[0]);
+}
+
+/* RANDOM_SEED(GET=seed): report the current seed. */
+void _ffc_random_seed_get(int *seed) {
+    if (seed == NULL) {
+        return;
+    }
+    seed[0] = ffc_random_seed_state;
+}
+
+/* RANDOM_SEED() with no arguments: reset to the processor's
+ * default seed, which is glibc's own initial random() state
+ * (srandom(1)). Repeatable across runs, as F2018 permits. */
+void _ffc_random_seed_default(void) {
+    ffc_random_seed_state = 1;
+    srandom(1u);
 }

--- a/src/ffc_runtime_link.f90
+++ b/src/ffc_runtime_link.f90
@@ -50,11 +50,13 @@ module ffc_runtime_link
     ! Every runtime entry point the lowerer is allowed to call. Each issue
     ! that moves compiler-emitted code behind the runtime ABI adds its symbols
     ! here and to docs/RUNTIME_ABI.md.
-    character(len=*), parameter :: FFC_RUNTIME_SYMBOLS(8) = &
+    character(len=*), parameter :: FFC_RUNTIME_SYMBOLS(12) = &
         [character(len=32) :: '_ffc_runtime_probe', &
          '_ffc_unit_status', '_ffc_unit_newunit', '_ffc_unit_open', &
          '_ffc_unit_is_open', '_ffc_unit_file', '_ffc_unit_rewind', &
-         '_ffc_unit_close']
+         '_ffc_unit_close', '_ffc_random_seed_size', &
+         '_ffc_random_seed_put', '_ffc_random_seed_get', &
+         '_ffc_random_seed_default']
 
 contains
 

--- a/src/ffc_runtime_source.f90
+++ b/src/ffc_runtime_source.f90
@@ -116,6 +116,8 @@ contains
         text = text//NL
         text = text// &
             '#include <stdio.h>'//NL
+        text = text// &
+            '#include <stdlib.h>'//NL
         text = text//NL
         text = text// &
             '#define FFC_UNIT_MIN 0'//NL
@@ -451,6 +453,83 @@ contains
             '    ffc_unit_last_status = 0;'//NL
         text = text// &
             '    return 0;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* ---- RANDOM_SEED (issue #588) ---------------------------- */'//NL
+        text = text//NL
+        text = text// &
+            '/* RANDOM_NUMBER draws from glibc''s random(), whose state is'//NL
+        text = text// &
+            ' * seeded by srandom(). That state is one integer, so the'//NL
+        text = text// &
+            ' * seed array RANDOM_SEED works with has size 1 and only its'//NL
+        text = text// &
+            ' * first element is read or written. The last seed put is'//NL
+        text = text// &
+            ' * kept here because srandom() offers no way to read it back,'//NL
+        text = text// &
+            ' * and RANDOM_SEED(GET=) must report it. */'//NL
+        text = text//NL
+        text = text// &
+            'static int ffc_random_seed_state = 1;'//NL
+        text = text//NL
+        text = text// &
+            '/* RANDOM_SEED(SIZE=n): the seed array size, always 1. */'//NL
+        text = text// &
+            'int _ffc_random_seed_size(void) {'//NL
+        text = text// &
+            '    return 1;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* RANDOM_SEED(PUT=seed): restart the generator from seed[0],'//NL
+        text = text// &
+            ' * so an identical PUT replays an identical sequence. */'//NL
+        text = text// &
+            'void _ffc_random_seed_put(const int *seed) {'//NL
+        text = text// &
+            '    if (seed == NULL) {'//NL
+        text = text// &
+            '        return;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    ffc_random_seed_state = seed[0];'//NL
+        text = text// &
+            '    srandom((unsigned int) seed[0]);'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* RANDOM_SEED(GET=seed): report the current seed. */'//NL
+        text = text// &
+            'void _ffc_random_seed_get(int *seed) {'//NL
+        text = text// &
+            '    if (seed == NULL) {'//NL
+        text = text// &
+            '        return;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    seed[0] = ffc_random_seed_state;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* RANDOM_SEED() with no arguments: reset to the processor''s'//NL
+        text = text// &
+            ' * default seed, which is glibc''s own initial random() state'//NL
+        text = text// &
+            ' * (srandom(1)). Repeatable across runs, as F2018 permits. */'//NL
+        text = text// &
+            'void _ffc_random_seed_default(void) {'//NL
+        text = text// &
+            '    ffc_random_seed_state = 1;'//NL
+        text = text// &
+            '    srandom(1u);'//NL
         text = text// &
             '}'//NL
     end subroutine ffc_runtime_source_text

--- a/src/liric_session_timing_bindings.f90
+++ b/src/liric_session_timing_bindings.f90
@@ -16,7 +16,7 @@ module liric_session_timing_bindings
         LR_OP_FMUL, LR_OP_KIND_VREG, &
         LR_OP_KIND_GLOBAL, LR_OP_KIND_IMM_I64, &
         lr_type_i32_s, lr_type_f32_s, &
-        lr_type_i64_s, lr_type_ptr_s, &
+        lr_type_i64_s, lr_type_ptr_s, lr_type_void_s, &
         lr_session_emit, lr_session_intern, &
         status_ok, clear_liric_error, set_empty, &
         require_open_session, to_c_chars
@@ -30,6 +30,10 @@ module liric_session_timing_bindings
     public :: emit_cpu_time_value
     public :: emit_system_clock_value
     public :: emit_random_number_value
+    public :: emit_random_seed_size
+    public :: emit_random_seed_put
+    public :: emit_random_seed_get
+    public :: emit_random_seed_default
 
     ! Scale from random()'s [0, 2^31-1] range into [0,1). 2**(-31) itself would
     ! round 2^31-1 up to exactly 1.0 in f32; the next representable value below
@@ -122,6 +126,86 @@ contains
         call set_empty(error_msg)
         emit_random_number_value = .true.
     end function emit_random_number_value
+
+    logical function emit_random_seed_size(session, result, error_msg)
+        ! result (i32) = _ffc_random_seed_size(), the seed array size the
+        ! runtime works with. It is a runtime call rather than a compiled-in
+        ! constant so the compiler and its runtime can never disagree on it.
+        type(liric_session_t), intent(inout) :: session
+        type(lr_operand_desc_t), intent(out) :: result
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: args(0)
+
+        emit_random_seed_size = .false.
+        if (.not. require_open_session(session, error_msg)) return
+        if (.not. declare_extern(session, '_ffc_random_seed_size', &
+            lr_type_i32_s(session%handle), error_msg)) return
+        if (.not. call_extern(session, '_ffc_random_seed_size', args, &
+            lr_type_i32_s(session%handle), 0_c_int32_t, result, &
+            error_msg)) return
+        call set_empty(error_msg)
+        emit_random_seed_size = .true.
+    end function emit_random_seed_size
+
+    logical function emit_random_seed_put(session, address, error_msg)
+        ! _ffc_random_seed_put(address): restart the generator from the seed
+        ! array whose first element `address` points at.
+        type(liric_session_t), intent(inout) :: session
+        type(lr_operand_desc_t), intent(in) :: address
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        emit_random_seed_put = emit_random_seed_call(session, &
+            '_ffc_random_seed_put', address, error_msg)
+    end function emit_random_seed_put
+
+    logical function emit_random_seed_get(session, address, error_msg)
+        ! _ffc_random_seed_get(address): write the current seed into the seed
+        ! array whose first element `address` points at.
+        type(liric_session_t), intent(inout) :: session
+        type(lr_operand_desc_t), intent(in) :: address
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        emit_random_seed_get = emit_random_seed_call(session, &
+            '_ffc_random_seed_get', address, error_msg)
+    end function emit_random_seed_get
+
+    logical function emit_random_seed_call(session, name, address, error_msg)
+        ! Shared shape of the PUT and GET runtime calls: void f(int *).
+        type(liric_session_t), intent(inout) :: session
+        character(len=*), intent(in) :: name
+        type(lr_operand_desc_t), intent(in) :: address
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: args(1), ignored
+
+        emit_random_seed_call = .false.
+        if (.not. require_open_session(session, error_msg)) return
+        if (.not. declare_extern_ptr_arg(session, name, &
+            lr_type_void_s(session%handle), error_msg)) return
+        args(1) = address
+        if (.not. call_extern(session, name, args, &
+            lr_type_void_s(session%handle), 1_c_int32_t, ignored, &
+            error_msg)) return
+        call set_empty(error_msg)
+        emit_random_seed_call = .true.
+    end function emit_random_seed_call
+
+    logical function emit_random_seed_default(session, error_msg)
+        ! _ffc_random_seed_default(): argument-less RANDOM_SEED, which resets
+        ! the generator to the processor's default seed.
+        type(liric_session_t), intent(inout) :: session
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: args(0), ignored
+
+        emit_random_seed_default = .false.
+        if (.not. require_open_session(session, error_msg)) return
+        if (.not. declare_extern(session, '_ffc_random_seed_default', &
+            lr_type_void_s(session%handle), error_msg)) return
+        if (.not. call_extern(session, '_ffc_random_seed_default', args, &
+            lr_type_void_s(session%handle), 0_c_int32_t, ignored, &
+            error_msg)) return
+        call set_empty(error_msg)
+        emit_random_seed_default = .true.
+    end function emit_random_seed_default
 
     function i64_null_ptr(session) result(operand)
         ! A null pointer immediate for the time(NULL) argument.

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -206,7 +206,9 @@ module session_program_lowering
         emit_liric_f64_load, &
         emit_liric_f64_store
     use liric_session_timing_bindings, only: emit_cpu_time_value, &
-        emit_system_clock_value, emit_random_number_value
+        emit_system_clock_value, emit_random_number_value, &
+        emit_random_seed_size, emit_random_seed_put, emit_random_seed_get, &
+        emit_random_seed_default
     use session_lowering_ops, only: integer_compare_predicate, &
         integer_opcode, parse_i32_literal
     use ffc_strings, only: set_empty
@@ -1974,6 +1976,10 @@ contains
             call lower_random_number(arena, arg_indices, context, error_msg)
             return
         end if
+        if (same_name(call_name, 'random_seed')) then
+            call lower_random_seed(arena, arg_indices, context, error_msg)
+            return
+        end if
         if (is_method_subroutine_call(call_name)) then
             call lower_method_subroutine_call(arena, call_name, arg_indices, &
                 context, error_msg)
@@ -2084,6 +2090,101 @@ contains
         if (.not. emit_random_number_value(context%session, value, error_msg)) return
         call store_intrinsic_scalar_result(context, symbol_index, value, error_msg)
     end subroutine lower_random_number
+
+    subroutine lower_random_seed(arena, arg_indices, context, error_msg)
+        ! random_seed([size=n] | [put=seed] | [get=seed]): control the
+        ! generator RANDOM_NUMBER draws from. The runtime owns the seed state
+        ! (_ffc_random_seed_*), so the size and the PUT/GET semantics live in
+        ! one place instead of being duplicated in emitted code. Exactly one
+        ! keyword per call is supported, which covers every corpus use.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: arg_indices(:)
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: value, address
+        character(len=:), allocatable :: kw_name
+        integer :: kw_value, symbol_index
+
+        call set_empty(error_msg)
+        if (size(arg_indices) == 0) then
+            if (.not. emit_random_seed_default(context%session, error_msg)) return
+            return
+        end if
+        if (size(arg_indices) /= 1) then
+            error_msg = 'random_seed supports one of size=, put= or get= per call'
+            return
+        end if
+        call reshape_keyword_arg(arena, arg_indices(1), kw_name, kw_value)
+        if (kw_name == 'size') then
+            call intrinsic_out_scalar(arena, [kw_value], context, 'random_seed', &
+                VALUE_I32, symbol_index, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (.not. emit_random_seed_size(context%session, value, error_msg)) return
+            call store_intrinsic_scalar_result(context, symbol_index, value, &
+                error_msg)
+            return
+        end if
+        if (kw_name /= 'put') then
+            if (kw_name /= 'get') then
+                error_msg = 'random_seed argument must be size=, put= or get='
+                return
+            end if
+        end if
+        call random_seed_array_address(arena, kw_value, context, address, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (kw_name == 'put') then
+            if (.not. emit_random_seed_put(context%session, address, error_msg)) &
+                return
+        else
+            if (.not. emit_random_seed_get(context%session, address, error_msg)) &
+                return
+        end if
+    end subroutine lower_random_seed
+
+    subroutine random_seed_array_address(arena, node_index, context, address, &
+            error_msg)
+        ! Base address of the integer seed array a PUT/GET actual names. An
+        ! allocatable's storage is behind its descriptor, so load the data
+        ! pointer; an explicit-shape array is its own storage.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(out) :: address
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: id_name
+        integer :: symbol_index
+
+        if (.not. is_identifier(arena, node_index)) then
+            error_msg = 'random_seed put=/get= argument must be an integer array'
+            return
+        end if
+        call get_identifier_name(arena, node_index, id_name, error_msg)
+        if (len_trim(error_msg) > 0) return
+        symbol_index = resolve_symbol_at_node(context, node_index, id_name)
+        if (symbol_index <= 0) then
+            error_msg = 'random_seed argument is not declared: '//trim(id_name)
+            return
+        end if
+        if (.not. context%symbols(symbol_index)%is_array) then
+            error_msg = 'random_seed put=/get= argument must be an array: '// &
+                        trim(id_name)
+            return
+        end if
+        if (context%symbols(symbol_index)%value_kind /= VALUE_I32) then
+            error_msg = 'random_seed put=/get= argument must be a default '// &
+                        'integer array: '//trim(id_name)
+            return
+        end if
+        if (context%symbols(symbol_index)%is_allocatable) then
+            if (.not. emit_ptr_load(context%session, &
+                context%symbols(symbol_index)%allocatable_descriptor_address, &
+                address, error_msg)) return
+            call set_empty(error_msg)
+            return
+        end if
+        address = context%symbols(symbol_index)%element_address
+        call set_empty(error_msg)
+    end subroutine random_seed_array_address
 
     subroutine intrinsic_out_scalar(arena, arg_indices, context, name, kind, &
             symbol_index, error_msg)

--- a/test/conformance/xfail_lfortran.txt
+++ b/test/conformance/xfail_lfortran.txt
@@ -2668,7 +2668,6 @@ random_init_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar 
 random_init_02.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 random_number_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 random_number_complex_part_01.f90 # owner=lazy-fortran/ffc#449; reason=lower plain scalar derived values
-random_seed_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 read_01.f90 # owner=lazy-fortran/ffc#352; reason=register POINTER-statement entities
 read_02.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
 read_03.f90 # owner=lazy-fortran/ffc#451; reason=lower scalar formatted input

--- a/test/test_session_random_seed_compiler.f90
+++ b/test/test_session_random_seed_compiler.f90
@@ -1,0 +1,114 @@
+program test_session_random_seed
+    ! RANDOM_SEED intrinsic subroutine (#588). Before this support existed,
+    ! `call random_seed(...)` fell through to the generic external-call path
+    ! and emitted a call to an undeclared symbol: the link failed with
+    ! "undefined reference to `random_seed'", so no executable was produced.
+    ! The oracles are observable invariants of the generated program: the
+    ! reported seed size is positive, PUT/GET round-trips, and re-seeding
+    ! with the same value replays the same draw.
+    use ffc_test_support, only: expect_output
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session random_seed compiler test ==='
+
+    all_passed = .true.
+    if (.not. test_default_seed_runs()) all_passed = .false.
+    if (.not. test_size_is_positive()) all_passed = .false.
+    if (.not. test_put_get_round_trip()) all_passed = .false.
+    if (.not. test_put_replays_sequence()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: random_seed lowers through LIRIC and runs'
+
+contains
+
+    logical function test_default_seed_runs()
+        ! `call random_seed()` with no arguments must run and leave the
+        ! generator usable: the next draw still lies in [0,1).
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  real :: x'//new_line('a')// &
+            '  call random_seed()'//new_line('a')// &
+            '  call random_number(x)'//new_line('a')// &
+            '  if (x < 0.0) then'//new_line('a')// &
+            '    print *, "LOW"'//new_line('a')// &
+            '  else if (x >= 1.0) then'//new_line('a')// &
+            '    print *, "HIGH"'//new_line('a')// &
+            '  else'//new_line('a')// &
+            '    print *, "INRANGE"'//new_line('a')// &
+            '  end if'//new_line('a')// &
+            'end program main'
+
+        test_default_seed_runs = expect_output( &
+            source, ' INRANGE'//new_line('a'), '/tmp/ffc_random_seed_default')
+    end function test_default_seed_runs
+
+    logical function test_size_is_positive()
+        ! random_seed_01.f90's oracle: the size the processor reports must be
+        ! positive, so a caller can allocate a seed array of that size.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: n'//new_line('a')// &
+            '  n = -1'//new_line('a')// &
+            '  call random_seed(size=n)'//new_line('a')// &
+            '  if (n > 0) then'//new_line('a')// &
+            '    print *, "POSITIVE"'//new_line('a')// &
+            '  else'//new_line('a')// &
+            '    print *, "NONPOSITIVE"'//new_line('a')// &
+            '  end if'//new_line('a')// &
+            'end program main'
+
+        test_size_is_positive = expect_output( &
+            source, ' POSITIVE'//new_line('a'), '/tmp/ffc_random_seed_size')
+    end function test_size_is_positive
+
+    logical function test_put_get_round_trip()
+        ! What was PUT comes back out of GET.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: seed(1), got(1)'//new_line('a')// &
+            '  seed(1) = 4711'//new_line('a')// &
+            '  got(1) = 0'//new_line('a')// &
+            '  call random_seed(put=seed)'//new_line('a')// &
+            '  call random_seed(get=got)'//new_line('a')// &
+            '  if (got(1) == 4711) then'//new_line('a')// &
+            '    print *, "ROUNDTRIP"'//new_line('a')// &
+            '  else'//new_line('a')// &
+            '    print *, "LOST"'//new_line('a')// &
+            '  end if'//new_line('a')// &
+            'end program main'
+
+        test_put_get_round_trip = expect_output( &
+            source, ' ROUNDTRIP'//new_line('a'), '/tmp/ffc_random_seed_roundtrip')
+    end function test_put_get_round_trip
+
+    logical function test_put_replays_sequence()
+        ! intrinsics_429.f90's oracle: PUT of the same seed restarts the same
+        ! sequence, so two draws taken after identical PUTs are equal, while a
+        ! draw taken without re-seeding differs from them.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: seed(1)'//new_line('a')// &
+            '  real :: a, b, c'//new_line('a')// &
+            '  seed(1) = 12345'//new_line('a')// &
+            '  call random_seed(put=seed)'//new_line('a')// &
+            '  call random_number(a)'//new_line('a')// &
+            '  call random_seed(put=seed)'//new_line('a')// &
+            '  call random_number(b)'//new_line('a')// &
+            '  call random_number(c)'//new_line('a')// &
+            '  if (a /= b) then'//new_line('a')// &
+            '    print *, "NOTREPLAYED"'//new_line('a')// &
+            '  else if (b == c) then'//new_line('a')// &
+            '    print *, "STUCK"'//new_line('a')// &
+            '  else'//new_line('a')// &
+            '    print *, "REPLAYED"'//new_line('a')// &
+            '  end if'//new_line('a')// &
+            'end program main'
+
+        test_put_replays_sequence = expect_output( &
+            source, ' REPLAYED'//new_line('a'), '/tmp/ffc_random_seed_replay')
+    end function test_put_replays_sequence
+
+end program test_session_random_seed


### PR DESCRIPTION
Closes #588 (RANDOM_SEED half).

## Problem

`call random_seed(...)` was not recognised as an intrinsic, so it fell through
to the generic external-call path: the emitted object referenced an undefined
symbol `random_seed` and the link failed. The keyword forms
(`size=`/`put=`/`get=`) were additionally rejected earlier with "keyword
argument in call to random_seed requires a visible explicit interface".

## Change

- `runtime/ffc_runtime.c`: four new entry points that own the seed state —
  `_ffc_random_seed_size/put/get/default`. RANDOM_NUMBER draws from glibc
  `random()`, whose state is one integer, so the seed array size is 1 and
  `PUT=`/`GET=` read/write its first element. `PUT=` calls `srandom()`, so an
  identical PUT replays an identical sequence; the runtime also remembers the
  value because `srandom()` cannot be read back and `GET=` must report it.
- `src/ffc_runtime_link.f90` + `docs/RUNTIME_ABI.md`: symbols registered and
  documented, so `test_runtime_link_compiler` guards them.
- `src/liric_session_timing_bindings.f90`: emitters for the four calls.
- `src/session_program_lowering.f90`: `lower_random_seed` intercepts the call
  before the external-call path and accepts exactly one of `size=`, `put=`,
  `get=` (or no argument). Anything else is a named compile-time diagnostic
  rather than an undefined symbol.

Preserved invariant: the compiler never emits a call to a symbol no runtime
archive defines. Every new symbol is in `FFC_RUNTIME_SYMBOLS`, and unsupported
argument forms are diagnosed at compile time.

## Red / green

Red on unmodified main (`fo test test_session_random_seed_compiler`):

    /usr/bin/ld: undefined reference to `random_seed'
    FAIL: linker failed with status=1
    FAIL: keyword argument in call to random_seed requires a visible explicit interface  (x3)

Green after the change: 4/4 oracles pass — the draw after `random_seed()` stays
in [0,1), `SIZE=` reports a positive size, `PUT=`/`GET=` round-trip, and two
draws after identical PUTs are equal while a third unseeded draw differs.

Corpus: `lfortran/random_seed_01.f90` XPASSed 3/3 consecutive runs and is
promoted out of `test/conformance/xfail_lfortran.txt` (PASS afterwards).

No rejection rule is added or tightened, so the rejection gate does not apply.

## Note on the issue's second bullet

The ISO_FORTRAN_ENV LOGICAL kinds already import and run on current main
(verified with `lfortran/intrinsics_404.f90` and a program declaring
`logical(logical8/16/32/64)`), as does the `do_concurrent_3_valid.f90` shape
(RANDOM_NUMBER landed in #608). No change was needed there.

## Pre-existing failures (not from this change)

`test_session_real_parameter_compiler`, `test_session_reject_result_01_compiler`
and `test_fortfront_corpus_conformance` fail identically on an unmodified
origin/main worktree (FortFront main tightened declaration/interface
diagnostics). `test_parity_dashboard` is the known worktree-path failure.