### PR TITLE
[scope-06] keep a locally declared dummy out of host storage (#584)

### DIFF
--- a/src/session_program_lowering_functions.inc
+++ b/src/session_program_lowering_functions.inc
@@ -1551,6 +1551,12 @@
             call resolve_name_at_node(arena, i, name, binding, resolve_error)
             if (len_trim(resolve_error) > 0 .or. .not. binding%found) cycle
             if (binding%association /= ASSOCIATION_HOST) cycle
+            ! An entity declared by the internal procedure itself is local, not
+            ! host-associated, however the reference is labelled. Nested
+            ! ASSOCIATE constructs can report a local dummy as host-associated;
+            ! giving such a name host storage would shadow the genuine host
+            ! entity of the same spelling and reject its declaration (#584).
+            if (binding%scope_node_index == procedure_index) cycle
             if (binding_scope_is_module(arena, binding%scope_node_index)) cycle
             if (binding%binding_kind /= BINDING_DECLARATION .and. &
                 binding%binding_kind /= BINDING_FUNCTION_RESULT) cycle

--- a/test/test_session_host_shadowed_dummy_compiler.f90
+++ b/test/test_session_host_shadowed_dummy_compiler.f90
@@ -1,0 +1,71 @@
+program test_session_host_shadowed_dummy
+    !! A contained procedure whose scalar dummy shadows a host array must keep
+    !! the host array's declaration intact, however deeply the dummy is used
+    !! inside nested ASSOCIATE constructs (#584).
+    use ffc_test_support, only: expect_output
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session host-shadowed dummy compiler test ==='
+
+    all_passed = .true.
+    if (.not. test_nested_associate_shadowing_dummy()) all_passed = .false.
+    if (.not. test_single_associate_shadowing_dummy()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: shadowed dummies stay local to the contained procedure'
+
+contains
+
+    logical function test_nested_associate_shadowing_dummy()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'real :: x(4), y(4)'//new_line('a')// &
+            'integer :: i'//new_line('a')// &
+            'x = [1.0, 2.0, 3.0, 4.0]'//new_line('a')// &
+            'do i = 1, 4'//new_line('a')// &
+            '    y(i) = compute(x(i))'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'print *, y(4)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '    pure function compute(x) result(r)'//new_line('a')// &
+            '        real, intent(in) :: x'//new_line('a')// &
+            '        real :: r'//new_line('a')// &
+            '        associate (n => 1)'//new_line('a')// &
+            '            associate (z => x + real(n))'//new_line('a')// &
+            '                r = z'//new_line('a')// &
+            '            end associate'//new_line('a')// &
+            '        end associate'//new_line('a')// &
+            '    end function compute'//new_line('a')// &
+            'end program main'
+
+        test_nested_associate_shadowing_dummy = expect_output( &
+            source, '   5.00000000    '//new_line('a'), &
+            '/tmp/ffc_session_host_shadow_nested')
+    end function test_nested_associate_shadowing_dummy
+
+    logical function test_single_associate_shadowing_dummy()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'real :: x(4)'//new_line('a')// &
+            'x = [1.0, 2.0, 3.0, 4.0]'//new_line('a')// &
+            'print *, compute(x(2))'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '    pure function compute(x) result(r)'//new_line('a')// &
+            '        real, intent(in) :: x'//new_line('a')// &
+            '        real :: r'//new_line('a')// &
+            '        associate (z => x + 1.0)'//new_line('a')// &
+            '            r = z'//new_line('a')// &
+            '        end associate'//new_line('a')// &
+            '    end function compute'//new_line('a')// &
+            'end program main'
+
+        test_single_associate_shadowing_dummy = expect_output( &
+            source, '   3.00000000    '//new_line('a'), &
+            '/tmp/ffc_session_host_shadow_single')
+    end function test_single_associate_shadowing_dummy
+
+end program test_session_host_shadowed_dummy


### PR DESCRIPTION
Part of #584.

## Defect

`gpu_metal_145.f90`: a contained `pure function compute(x)` whose scalar dummy `x` shadows the host's `real :: x(4)`, with the dummy used inside two nested ASSOCIATE constructs, failed with `error: duplicate array declaration: x`. One ASSOCIATE level was not enough; two were.

Root cause: FortFront reports the reference to the procedure's *own* dummy as `ASSOCIATION_HOST` once two ASSOCIATE levels are nested (filed as lazy-fortran/fortfront#2975; the binding it resolves to is correct, only the label is wrong). ffc's host-association pre-pass then created host storage under the name `x`, which the host's genuine `x(4)` declaration later hit as a duplicate symbol.

## Change

`collect_host_associated_symbols` now skips any binding whose `scope_node_index` is the internal procedure being scanned. An entity declared by the procedure itself is local by definition, so this holds independently of the frontend label — it is an invariant, not a label workaround.

## Preserved invariant

Host storage is materialised only for entities declared outside the internal procedure. Names declared inside it never gain host globals, so a shadowing dummy can no longer displace the host entity of the same spelling.

## Red evidence (unmodified main)

```
error: duplicate array declaration: x
```
for the reduced program now in `test/test_session_host_shadowed_dummy_compiler.f90` (first case), and for the corpus file `gpu_metal_145.f90`.

## Green evidence

- `fo test test_session_host_shadowed_dummy_compiler` PASS (new test: nested-ASSOCIATE case prints `5.00000000`, single-ASSOCIATE control prints `3.00000000`).
- `gpu_metal_145.f90` compiles and runs, printing `PASS`, exit 0.
- Corpus: fortfront-f90 goes from PASS=447 FAIL=13 on origin/main to PASS=448 FAIL=12 on this branch; no case regresses.
- Full `fo` pipeline: the same four failures as unmodified origin/main, verified in a separate baseline worktree — `test_session_real_parameter_compiler`, `test_session_reject_result_01_compiler` (both FortFront-main diagnostic drift), `test_fortfront_corpus_conformance` (pre-existing corpus FAILs), `test_parity_dashboard` (resolves `../fortfront` from a worktree). No new failure.

## Remaining #584 symptoms (issue stays open)

- `legacy_array_sections_03.f90`: FortFront drops the trailing entities of a multi-entity declaration when an earlier entity has a non-constant array spec — lazy-fortran/fortfront#2974.
- `class_is_1_ok.f90` / `type_is_1_ok.f90`: SELECT TYPE on a host-associated `class(t), allocatable` needs host storage for a polymorphic scalar, which the direct-session ABI does not yet have.
- `associate_18.f90`: the `.fmod` omits a procedure with a derived-type dummy because derived dummies are deliberately not exportable across separate compilation yet (#284/#415).
- `expr_11.f90` already compiles on current main.