### PR TITLE
[reject-620] stop the generic/USE rejection heuristics rejecting valid programs

### DIFF
--- a/src/ffc_test_support.f90
+++ b/src/ffc_test_support.f90
@@ -26,6 +26,7 @@ module ffc_test_support
     public :: expect_stderr_and_exit
     public :: expect_eof_stderr_and_exit
     public :: expect_no_leaks
+    public :: expect_error_lacks
     ! Lets a test keep the emitted executable and inspect it (#565).
     public :: compile_to_exe
 
@@ -367,6 +368,27 @@ contains
         end if
         ok = .true.
     end function expect_error_contains
+
+    ! Compiles source and checks that no diagnostic containing fragment is
+    ! emitted. Used where a rejection rule must stop firing but the program
+    ! still exercises unrelated unimplemented lowering (#620).
+    logical function expect_error_lacks(source, fragment, exe_path) result(ok)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: fragment
+        character(len=*), intent(in) :: exe_path
+        character(len=:), allocatable :: error_msg
+
+        ok = .false.
+        call compile_to_exe(source, exe_path, error_msg)
+        call execute_command_line('rm -f '//exe_path)
+        if (len_trim(error_msg) > 0) then
+            if (index(error_msg, fragment) > 0) then
+                print *, 'FAIL: unexpected diagnostic: ', trim(error_msg)
+                return
+            end if
+        end if
+        ok = .true.
+    end function expect_error_lacks
 
     logical function expect_cli_error_contains(source, fragment, stem) result(ok)
         ! Tests the CLI binary (ffc) directly for unsupported-source diagnostics.

--- a/src/session_program_lowering_reject_generic.inc
+++ b/src/session_program_lowering_reject_generic.inc
@@ -701,9 +701,9 @@
                 unit_name = ''
             end do
             if (len_trim(unit_name) == 0) cycle
-            if (use_renames_name(text, unit_name)) cycle
             if (.not. owned_name_present(names, owner, nname, unit_name, midx)) &
                 cycle
+            if (.not. use_makes_name_accessible(text, unit_name)) cycle
             write (location, '(" at line ",I0)') i
             error_msg = trim(unit_name)//' from module '//trim(mods(midx))// &
                 ' is also the name of the current program unit'//trim(location)
@@ -711,25 +711,52 @@
         end do
     end subroutine check_use_shadows_program_unit
 
-    ! True when the USE statement renames the module entity called name, so
-    ! that name is not made accessible under its own spelling.
-    logical function use_renames_name(text, name) result(yes)
+    ! Whether a USE statement makes name accessible under that same name. A
+    ! rename moves the module entity to a different local name, and an ONLY
+    ! clause admits nothing that it does not list, so in both cases the name
+    ! itself never enters the local scope (F2018 14.2.2).
+    logical function use_makes_name_accessible(text, name) result(yes)
         character(len=*), intent(in) :: text
         character(len=*), intent(in) :: name
-        integer :: p, base
+        character(len=:), allocatable :: tail, item, use_name
+        logical :: only_form
+        integer :: comma, p, start, i
 
-        yes = .false.
-        base = 0
-        do
-            p = index(text(base + 1:), '=>')
-            if (p == 0) return
-            base = base + p + 1
-            if (identifier_after(text, base) == trim(name)) then
-                yes = .true.
-                return
+        yes = .true.
+        comma = index(text, ',')
+        if (comma == 0) return
+        tail = text(comma + 1:)
+        only_form = .false.
+        p = index(tail, 'only')
+        if (p > 0) then
+            p = index(tail, ':')
+            if (p > 0) then
+                only_form = .true.
+                tail = tail(p + 1:)
             end if
+        end if
+        if (only_form) yes = .false.
+        start = 1
+        do i = 1, len(tail) + 1
+            if (i <= len(tail)) then
+                if (tail(i:i) /= ',') cycle
+            end if
+            item = trim(adjustl(tail(start:i - 1)))
+            start = i + 1
+            if (len_trim(item) == 0) cycle
+            p = index(item, '=>')
+            if (p > 0) then
+                use_name = trim(adjustl(item(p + 2:)))
+                if (use_name == trim(name)) then
+                    yes = .false.
+                    return
+                end if
+                cycle
+            end if
+            if (.not. only_form) cycle
+            if (item == trim(name)) yes = .true.
         end do
-    end function use_renames_name
+    end function use_makes_name_accessible
 
     ! True when name occurs as a whole word on the line.
     logical function line_references_name(line, name) result(yes)
@@ -750,6 +777,10 @@
                 ! object, never the use associated entity of that name.
                 if (line(p - 1:p - 1) == '%') cycle
             end if
+            ! A component or type-bound name after % resolves through the
+            ! declared type, not through use association, so it never makes
+            ! an ambiguous use-associated name referenced.
+            if (preceded_by_component_selector(line, p)) cycle
             if (p + len_trim(name) <= len(line)) then
                 if (is_fortran_identifier_char(line(p + len_trim(name): &
                                                     p + len_trim(name)))) cycle
@@ -758,6 +789,20 @@
             return
         end do
     end function line_references_name
+
+    ! Whether the identifier starting at pos is preceded by a % selector.
+    logical function preceded_by_component_selector(line, pos) result(yes)
+        character(len=*), intent(in) :: line
+        integer, intent(in) :: pos
+        integer :: i
+
+        yes = .false.
+        do i = pos - 1, 1, -1
+            if (line(i:i) == ' ') cycle
+            yes = line(i:i) == '%'
+            return
+        end do
+    end function preceded_by_component_selector
 
     ! Two modules that make the same name accessible to one scoping unit leave
     ! that name ambiguous; referencing it is an error (F2018 19.5.1.4).
@@ -1186,7 +1231,7 @@
         character(len=64) :: specs(MAXN), actuals(MAXN)
         character(len=:), allocatable :: text, callee
         character(len=64) :: location
-        integer :: i, j, nspec, nactual, header
+        integer :: i, nspec, nactual
         logical :: matched, resolvable
 
         call set_empty(error_msg)
@@ -1195,11 +1240,9 @@
             if (.not. stmt_starts(text, 'call')) cycle
             callee = identifier_after(text, 5)
             if (len_trim(callee) == 0) cycle
-            call generic_header_line(lines, count, callee, header)
-            if (header == 0) cycle
             call literal_actual_types(text, actuals, nactual)
             if (nactual <= 0) cycle
-            call generic_block_specifics(lines, count, header, specs, nspec)
+            call generic_union_specifics(lines, count, callee, specs, nspec)
             if (nspec == 0) cycle
             call generic_call_matches(arena, specs, nspec, actuals, nactual, &
                                       matched, resolvable)
@@ -1212,23 +1255,43 @@
         end do
     end subroutine check_generic_call_resolves
 
-    subroutine generic_header_line(lines, count, name, header)
+    ! The union of the specific procedures of every generic interface block
+    ! that declares name. One reference may see several of them at once: a
+    ! generic can be extended by host association and by USE association in
+    ! the same scope (F2018 15.4.3.4.1), so judging a call against a single
+    ! block would reject valid references.
+    subroutine generic_union_specifics(lines, count, name, specs, nspec)
         character(len=512), intent(in) :: lines(:)
         integer, intent(in) :: count
         character(len=*), intent(in) :: name
-        integer, intent(out) :: header
+        character(len=64), intent(inout) :: specs(:)
+        integer, intent(out) :: nspec
+        character(len=64) :: block_specs(64)
         character(len=:), allocatable :: text
-        integer :: i
+        integer :: i, j, k, nblock
 
-        header = 0
+        nspec = 0
         do i = 1, count
             text = trim(lines(i))
             if (.not. stmt_starts(text, 'interface')) cycle
             if (identifier_after(text, 10) /= trim(name)) cycle
-            header = i
-            return
+            call generic_block_specifics(lines, count, i, block_specs, nblock)
+            do k = 1, nblock
+                if (nspec >= size(specs)) exit
+                ! One specific name declared by two blocks names two distinct
+                ! procedures, which a name lookup cannot tell apart. Judge
+                ! nothing rather than judge the wrong signature.
+                do j = 1, nspec
+                    if (trim(specs(j)) == trim(block_specs(k))) then
+                        nspec = 0
+                        return
+                    end if
+                end do
+                nspec = nspec + 1
+                specs(nspec) = block_specs(k)
+            end do
         end do
-    end subroutine generic_header_line
+    end subroutine generic_union_specifics
 
     ! Base types of a call's actual arguments when every one is a literal
     ! constant; nactual is -1 otherwise.

--- a/test/test_session_accept_use_generic_heuristics_compiler.f90
+++ b/test/test_session_accept_use_generic_heuristics_compiler.f90
@@ -1,0 +1,210 @@
+program test_session_accept_use_generic_heuristics_compiler
+    ! ffc #620: the line-based generic/USE rejection heuristics must not
+    ! reject valid programs. The accepted-side cases are reduced from
+    ! gfortran.dg/generic_6.f90, use_14.f90 and use_26.f90, all of which
+    ! gfortran -fsyntax-only accepts. The rejected-side cases are negative
+    ! controls: the heuristics must still catch the real violations.
+    use ffc_test_support, only: expect_error_contains, expect_error_lacks, &
+                                expect_no_error
+    implicit none
+
+    logical :: all_passed
+    character(len=*), parameter :: nl = new_line('a')
+
+    print *, '=== USE/generic rejection heuristic accept tests ==='
+
+    all_passed = .true.
+    if (.not. test_host_and_local_generic_accepted()) all_passed = .false.
+    if (.not. test_renamed_use_accepted()) all_passed = .false.
+    if (.not. test_type_bound_ambiguity_accepted()) all_passed = .false.
+    if (.not. test_unmatched_generic_still_rejected()) all_passed = .false.
+    if (.not. test_use_shadow_still_rejected()) all_passed = .false.
+    if (.not. test_ambiguous_use_still_rejected()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: USE/generic heuristics accept valid programs'
+
+contains
+
+    ! gfortran.dg/generic_6.f90: the generic CREATE visible in useCreate is the
+    ! union of the host-associated one from A and the locally use-associated
+    ! one from B.
+    logical function test_host_and_local_generic_accepted()
+        character(len=:), allocatable :: source
+
+        source = 'module a_mod'//nl// &
+                 '  interface create'//nl// &
+                 '    module procedure create1'//nl// &
+                 '  end interface'//nl// &
+                 'contains'//nl// &
+                 '  subroutine create1'//nl// &
+                 '    print *, "module A"'//nl// &
+                 '  end subroutine'//nl// &
+                 'end module a_mod'//nl// &
+                 'module b_mod'//nl// &
+                 '  interface create'//nl// &
+                 '    module procedure create1'//nl// &
+                 '  end interface'//nl// &
+                 'contains'//nl// &
+                 '  subroutine create1(a)'//nl// &
+                 '    integer a'//nl// &
+                 '    print *, "module B"'//nl// &
+                 '  end subroutine'//nl// &
+                 'end module b_mod'//nl// &
+                 'module c_mod'//nl// &
+                 '  use a_mod'//nl// &
+                 'contains'//nl// &
+                 '  subroutine usecreate'//nl// &
+                 '    use b_mod'//nl// &
+                 '    call create()'//nl// &
+                 '    call create(1)'//nl// &
+                 '  end subroutine'//nl// &
+                 'end module c_mod'//nl// &
+                 'program main'//nl// &
+                 '  use c_mod'//nl// &
+                 '  call usecreate'//nl// &
+                 'end program main'
+        ! Lowering a generic dispatched across modules is a separate gap;
+        ! what must hold here is that the resolution rule does not fire.
+        test_host_and_local_generic_accepted = expect_error_lacks(source, &
+            'matches this reference', '/tmp/ffc620_generic_union')
+    end function test_host_and_local_generic_accepted
+
+    ! gfortran.dg/use_14.f90: the rename moves the clashing name away.
+    logical function test_renamed_use_accepted()
+        character(len=:), allocatable :: source
+
+        source = 'module test_mod'//nl// &
+                 '  interface'//nl// &
+                 '    subroutine my_sub(a)'//nl// &
+                 '      real a'//nl// &
+                 '    end subroutine'//nl// &
+                 '  end interface'//nl// &
+                 'end module test_mod'//nl// &
+                 'subroutine my_sub(a)'//nl// &
+                 '  use test_mod, gugu => my_sub'//nl// &
+                 '  real a'//nl// &
+                 '  print *, a'//nl// &
+                 'end subroutine'//nl// &
+                 'program main'//nl// &
+                 'end program main'
+        test_renamed_use_accepted = expect_no_error(source, &
+            '/tmp/ffc620_use_rename')
+    end function test_renamed_use_accepted
+
+    ! gfortran.dg/use_26.f90: sizereturn is ambiguous as a name, but every
+    ! reference is a type-bound call resolved through the declared type.
+    logical function test_type_bound_ambiguity_accepted()
+        character(len=:), allocatable :: source
+
+        source = 'module a_mod'//nl// &
+                 '  implicit none'//nl// &
+                 '  type :: a_type'//nl// &
+                 '    integer :: isize = 1'//nl// &
+                 '  contains'//nl// &
+                 '    procedure :: sizereturn'//nl// &
+                 '  end type a_type'//nl// &
+                 'contains'//nl// &
+                 '  function sizereturn(self)'//nl// &
+                 '    integer :: sizereturn'//nl// &
+                 '    class(a_type) :: self'//nl// &
+                 '    sizereturn = self%isize'//nl// &
+                 '  end function sizereturn'//nl// &
+                 'end module a_mod'//nl// &
+                 'module b_mod'//nl// &
+                 '  implicit none'//nl// &
+                 '  type :: b_type'//nl// &
+                 '    integer :: isize = 2'//nl// &
+                 '  contains'//nl// &
+                 '    procedure :: sizereturn'//nl// &
+                 '  end type b_type'//nl// &
+                 'contains'//nl// &
+                 '  function sizereturn(self)'//nl// &
+                 '    integer :: sizereturn'//nl// &
+                 '    class(b_type) :: self'//nl// &
+                 '    sizereturn = self%isize'//nl// &
+                 '  end function sizereturn'//nl// &
+                 'end module b_mod'//nl// &
+                 'program main'//nl// &
+                 '  use a_mod'//nl// &
+                 '  use b_mod'//nl// &
+                 '  implicit none'//nl// &
+                 '  type(a_type) :: ai'//nl// &
+                 '  type(b_type) :: bi'//nl// &
+                 '  print *, ai%sizereturn()'//nl// &
+                 '  print *, bi%sizereturn()'//nl// &
+                 'end program main'
+        test_type_bound_ambiguity_accepted = expect_error_lacks(source, &
+            'use associated from more than one module', &
+            '/tmp/ffc620_type_bound')
+    end function test_type_bound_ambiguity_accepted
+
+    logical function test_unmatched_generic_still_rejected()
+        character(len=:), allocatable :: source
+
+        source = 'module g_mod'//nl// &
+                 '  interface create'//nl// &
+                 '    module procedure create1'//nl// &
+                 '  end interface'//nl// &
+                 'contains'//nl// &
+                 '  subroutine create1(a)'//nl// &
+                 '    integer a'//nl// &
+                 '    print *, a'//nl// &
+                 '  end subroutine'//nl// &
+                 'end module g_mod'//nl// &
+                 'program main'//nl// &
+                 '  use g_mod'//nl// &
+                 '  call create(.true.)'//nl// &
+                 'end program main'
+        test_unmatched_generic_still_rejected = expect_error_contains(source, &
+            'matches this reference', '/tmp/ffc620_generic_bad')
+    end function test_unmatched_generic_still_rejected
+
+    logical function test_use_shadow_still_rejected()
+        character(len=:), allocatable :: source
+
+        source = 'module test_mod'//nl// &
+                 '  interface'//nl// &
+                 '    subroutine my_sub(a)'//nl// &
+                 '      real a'//nl// &
+                 '    end subroutine'//nl// &
+                 '  end interface'//nl// &
+                 'end module test_mod'//nl// &
+                 'subroutine my_sub(a)'//nl// &
+                 '  use test_mod'//nl// &
+                 '  real a'//nl// &
+                 '  print *, a'//nl// &
+                 'end subroutine'//nl// &
+                 'program main'//nl// &
+                 'end program main'
+        test_use_shadow_still_rejected = expect_error_contains(source, &
+            'is also the name of the current program unit', &
+            '/tmp/ffc620_use_shadow')
+    end function test_use_shadow_still_rejected
+
+    logical function test_ambiguous_use_still_rejected()
+        character(len=:), allocatable :: source
+
+        source = 'module m1'//nl// &
+                 'contains'//nl// &
+                 '  subroutine shared_thing()'//nl// &
+                 '    print *, 1'//nl// &
+                 '  end subroutine shared_thing'//nl// &
+                 'end module m1'//nl// &
+                 'module m2'//nl// &
+                 'contains'//nl// &
+                 '  subroutine shared_thing()'//nl// &
+                 '    print *, 2'//nl// &
+                 '  end subroutine shared_thing'//nl// &
+                 'end module m2'//nl// &
+                 'program main'//nl// &
+                 '  use m1'//nl// &
+                 '  use m2'//nl// &
+                 '  call shared_thing()'//nl// &
+                 'end program main'
+        test_ambiguous_use_still_rejected = expect_error_contains(source, &
+            'use associated from more than one module', &
+            '/tmp/ffc620_ambiguous')
+    end function test_ambiguous_use_still_rejected
+
+end program test_session_accept_use_generic_heuristics_compiler


### PR DESCRIPTION
Closes #620.

## Invariant preserved
A rejection rule may only fire where the program is genuinely invalid. All
three rules keep rejecting their real violations (negative controls in the new
test); they now stand down where the language makes the construct legal.

## Change
`src/session_program_lowering_reject_generic.inc`:

- **generic resolution** (`generic_6.f90`): a call is judged against the union
  of every generic interface block declaring that name, because host
  association and USE association can extend one generic in a single scope
  (F2018 15.4.3.4.1). `generic_header_line` (first block wins) is retired in
  favour of `generic_union_specifics`; when two blocks declare the same
  specific name, a bare name lookup cannot tell the two procedures apart, so
  the rule judges nothing.
- **program-unit shadowing** (`use_14.f90`): `use_makes_name_accessible`
  honours rename lists and ONLY lists. This replaces the narrower
  `use_renames_name` added in #630-adjacent work; exactly one helper survives.
- **ambiguous use association** (`use_26.f90`): occurrences preceded by `%`
  no longer count as references, since a component or type-bound name resolves
  through the declared type.

`expect_error_lacks` is added to `ffc_test_support` for cases where a rule must
stop firing while the program still hits unrelated unimplemented lowering.

## Red evidence (unmodified main, new test)
```
FAIL: expected no error, got: no specific subroutine of the generic interface create matches this reference at line 26
FAIL: expected no error, got: my_sub from module test_mod is also the name of the current program unit at line 9
FAIL: expected no error, got: ambiguous reference to sizereturn: it is use associated from more than one module at line 35
```

## Green evidence
`fo test test_session_accept_use_generic_heuristics_compiler`: PASS (3 accept
cases reduced from the corpus files + 3 negative controls).

Driving the real corpus files through `ffc` after the change: `use_14.f90`
compiles clean; `use_26.f90` no longer reports ambiguity (it now hits a
type-bound resolution gap, separate work); `generic_6.f90` no longer reports
the generic mismatch (it now hits a cross-module generic linking gap).

## Rejection gate
The change only relaxes rejections, so no valid file can become newly rejected.
`test_fortfront_corpus_conformance` is unchanged against origin/main
(PASS=448 XFAIL=93 XPASS=0 FAIL=12); the intermittent
`issue_1324_if_inside_do_loop` output mismatch reproduces as the known corpus
flake and passes on re-run.

Pre-existing failures unrelated to this change, verified identical on a
throwaway origin/main worktree: `test_session_real_parameter_compiler`,
`test_session_reject_result_01_compiler` (both FortFront-main drift),
`test_parity_dashboard` (resolves `../fortfront` outside a `.wt` worktree).