### PR TITLE
[proc-args-02] accept TARGET actual for INTENT(IN) POINTER dummy (#579)

### DIFF
--- a/src/session_program_lowering_reject_alloc.inc
+++ b/src/session_program_lowering_reject_alloc.inc
@@ -285,7 +285,8 @@
         integer, allocatable :: callee_params(:), callee_body(:)
         character(len=:), allocatable :: dummy_name
         logical :: found
-        logical :: dummy_alloc, dummy_ptr, dummy_definable
+        logical :: dummy_alloc, dummy_ptr, dummy_definable, dummy_ptr_intent_in
+        character(len=:), allocatable :: dummy_intent
         integer :: a, decl_index
 
         call set_empty(error_msg)
@@ -300,41 +301,45 @@
             dummy_alloc = .false.
             dummy_ptr = .false.
             dummy_definable = .false.
+            dummy_ptr_intent_in = .false.
+            dummy_intent = ''
             select type (decl => arena%entries(decl_index)%node)
             type is (declaration_node)
                 dummy_alloc = decl%is_allocatable
                 dummy_ptr = decl%is_pointer
                 if (decl%has_intent) then
                     if (allocated(decl%intent)) then
-                        dummy_definable = &
-                            trim(lowercase_text(decl%intent)) == 'out' .or. &
-                            trim(lowercase_text(decl%intent)) == 'inout'
+                        dummy_intent = trim(lowercase_text(decl%intent))
+                        dummy_definable = dummy_intent == 'out' .or. &
+                                          dummy_intent == 'inout'
                     end if
                 end if
             class default
                 cycle
             end select
+            if (dummy_ptr) dummy_ptr_intent_in = dummy_intent == 'in'
             call check_one_actual(arena, body_indices, arg_indices(a), &
-                dummy_name, dummy_alloc, dummy_ptr, dummy_definable, in_pure, &
-                error_msg)
+                dummy_name, dummy_alloc, dummy_ptr, dummy_definable, &
+                dummy_ptr_intent_in, in_pure, error_msg)
             if (len_trim(error_msg) > 0) return
         end do
     end subroutine check_call_actual_attributes
 
     subroutine check_one_actual(arena, body_indices, actual_index, dummy_name, &
                                 dummy_alloc, dummy_ptr, dummy_definable, &
-                                in_pure, error_msg)
+                                dummy_ptr_intent_in, in_pure, error_msg)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: body_indices(:)
         integer, intent(in) :: actual_index
         character(len=*), intent(in) :: dummy_name
         logical, intent(in) :: dummy_alloc, dummy_ptr, dummy_definable
+        logical, intent(in) :: dummy_ptr_intent_in
         logical, intent(in) :: in_pure
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: name
         character(len=64) :: location
         integer :: decl_index
-        logical :: actual_alloc, actual_ptr, is_literal
+        logical :: actual_alloc, actual_ptr, actual_target, is_literal
 
         call set_empty(error_msg)
         if (.not. node_exists(arena, actual_index)) return
@@ -369,10 +374,12 @@
         end if
         actual_alloc = .false.
         actual_ptr = .false.
+        actual_target = .false.
         select type (decl => arena%entries(decl_index)%node)
         type is (declaration_node)
             actual_alloc = decl%is_allocatable
             actual_ptr = decl%is_pointer
+            actual_target = decl%is_target
         class default
             return
         end select
@@ -384,6 +391,10 @@
             end if
         end if
         if (dummy_ptr) then
+            ! F2008 12.5.2.7: a POINTER dummy with INTENT(IN) also accepts a
+            ! non-pointer actual that has the TARGET attribute; the dummy is
+            ! then pointer-associated with that target.
+            if (dummy_ptr_intent_in .and. actual_target) return
             if (.not. actual_ptr) then
                 error_msg = 'actual argument for POINTER dummy '''// &
                     trim(dummy_name)//''' must be a pointer'//trim(location)

--- a/test/test_session_pointer_intent_in_target_arg_compiler.f90
+++ b/test/test_session_pointer_intent_in_target_arg_compiler.f90
@@ -1,0 +1,71 @@
+program test_session_pointer_intent_in_target_arg
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    print *, '=== direct session TARGET actual for INTENT(IN) POINTER dummy ==='
+
+    ! F2008 12.5.2.7: a POINTER dummy declared INTENT(IN) may be associated
+    ! with a non-pointer actual that has the TARGET attribute. The callee
+    ! reads through the dummy and reports the target's value.
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'integer, target :: t'//new_line('a')// &
+        't = 42'//new_line('a')// &
+        'call show(t)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        'subroutine show(p)'//new_line('a')// &
+        'integer, pointer, intent(in) :: p'//new_line('a')// &
+        'stop p'//new_line('a')// &
+        'end subroutine show'//new_line('a')// &
+        'end program main', 42, &
+        '/tmp/ffc_pointer_intent_in_target_arg')) stop 1
+
+    ! Same rule for a derived-type TARGET actual (lfortran class_22.f90).
+    if (.not. expect_exit_status( &
+        'program main'//new_line('a')// &
+        'type :: inner_t'//new_line('a')// &
+        'integer :: value'//new_line('a')// &
+        'end type inner_t'//new_line('a')// &
+        'type(inner_t), target :: x'//new_line('a')// &
+        'x%value = 50'//new_line('a')// &
+        'call expect_pointer(x)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        'subroutine expect_pointer(p)'//new_line('a')// &
+        'type(inner_t), pointer, intent(in) :: p'//new_line('a')// &
+        'stop p%value'//new_line('a')// &
+        'end subroutine expect_pointer'//new_line('a')// &
+        'end program main', 50, &
+        '/tmp/ffc_pointer_intent_in_target_derived')) stop 1
+
+    ! Negative control: without the TARGET attribute the actual still cannot
+    ! associate with a POINTER dummy.
+    if (.not. expect_error_contains( &
+        'program main'//new_line('a')// &
+        'integer :: t'//new_line('a')// &
+        't = 1'//new_line('a')// &
+        'call show(t)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        'subroutine show(p)'//new_line('a')// &
+        'integer, pointer, intent(in) :: p'//new_line('a')// &
+        'stop p'//new_line('a')// &
+        'end subroutine show'//new_line('a')// &
+        'end program main', 'must be a pointer', &
+        '/tmp/ffc_pointer_intent_in_no_target')) stop 1
+
+    ! Negative control: INTENT(OUT)/INTENT(INOUT) POINTER dummies still
+    ! require a pointer actual, TARGET attribute notwithstanding.
+    if (.not. expect_error_contains( &
+        'program main'//new_line('a')// &
+        'integer, target :: t'//new_line('a')// &
+        't = 1'//new_line('a')// &
+        'call reset(t)'//new_line('a')// &
+        'contains'//new_line('a')// &
+        'subroutine reset(p)'//new_line('a')// &
+        'integer, pointer, intent(inout) :: p'//new_line('a')// &
+        'nullify(p)'//new_line('a')// &
+        'end subroutine reset'//new_line('a')// &
+        'end program main', 'must be a pointer', &
+        '/tmp/ffc_pointer_intent_inout_target')) stop 1
+
+    print *, 'PASS: TARGET actual accepted for INTENT(IN) POINTER dummy'
+end program test_session_pointer_intent_in_target_arg


### PR DESCRIPTION
Fixes part of #579.

## Change

`check_one_actual` in `src/session_program_lowering_reject_alloc.inc` rejected every non-pointer actual passed to a POINTER dummy. F2008 12.5.2.7 allows a POINTER dummy declared INTENT(IN) to be associated with a non-pointer actual that has the TARGET attribute; the dummy is then pointer-associated with that target. The check now carries the dummy's intent and the actual's TARGET attribute and accepts exactly that combination.

## Preserved invariant

The relaxation is narrow and the rejection rule is otherwise untouched:
- non-TARGET actual to an INTENT(IN) POINTER dummy: still rejected
- TARGET actual to an INTENT(INOUT)/INTENT(OUT) POINTER dummy: still rejected
- ALLOCATABLE dummy rule, literal-in-definition-context rule, PURE locality rule: unchanged

Both negative controls are asserted in the new test.

## Red/green evidence

New behavioural test `test/test_session_pointer_intent_in_target_arg_compiler.f90` compiles and runs programs through ffc and checks the exit status / diagnostic text.

Red on unmodified main:
```
test_session_pointer_intent_in_target_arg_ FAIL
  FAIL: actual argument for POINTER dummy 'p' must be a pointer at line 4, column 11
```

Green with the change: `test_session_pointer_intent_in_target_arg_ PASS`.

Corpus files from the issue, previously rejected, now compile and run to exit 0:
- `lfortran/integration_tests/class_22.f90`
- `gfortran.dg/pointer_intent_8.f90`

Corpus conformance unchanged: baseline on unmodified main `PASS=448 XFAIL=93 XPASS=0 FAIL=12`; with the change the only delta is `issue_1324_if_inside_do_loop.f90 (output mismatch)`, a `random_number`-driven flake unrelated to argument handling.

## Not fixed here

- `interface_48.f90`: blocked by FortFront — the `external :: foo` statement inside a module-contained procedure is dropped from the AST, so ffc cannot see that the call has an implicit interface. Filed as lazy-fortran/fortfront#2977 with a reduced case.
- `interface_14.f90`: no longer hits the argument check at all; it now fails in array element-expression lowering, already tracked as xfail under ffc#342.

## Pre-existing failures (present on unmodified main, verified by reverting the change and re-running)

`test_session_real_parameter_compiler`, `test_session_reject_result_01_compiler`, `test_fortfront_corpus_conformance` — all FortFront-main diagnostic drift. `test_parity_dashboard` is the known worktree-environment failure.