### PR TITLE
[poly-06] stride polymorphic array dummies by the dynamic element size (refs #422)

### DIFF
--- a/docs/ARRAY_DESCRIPTOR_ABI.md
+++ b/docs/ARRAY_DESCRIPTOR_ABI.md
@@ -93,6 +93,21 @@ size, and element type zero. Failed initialization also leaves this state.
 The code names the type only. The kind lives in `element_size`, so
 `real(real64)` is code 2 with element size 8.
 
+## Polymorphic array dummies
+
+A `class(t)` array dummy may be associated with an actual whose dynamic element
+type extends `t`, so its elements are wider than `t`'s own layout. No extra
+field is needed for this: `element_size` and the per-dimension `stride_bytes`
+already describe the actual's concrete elements, because the caller builds the
+descriptor from the actual, not from the dummy's declared type.
+
+The callee therefore must not stride by its declared type's size. At entry a
+`class(t)` array dummy reads `element_size` from the descriptor and uses it as
+its element stride for the whole call; a `type(t)` dummy is monomorphic and
+keeps its compile-time stride. The declared type still governs which components
+are nameable — a `class(t)` dummy sees only `t`'s prefix of each element — so
+the declared and dynamic types stay distinct exactly as for a scalar.
+
 ## Ownership and lifetime
 
 Exactly one descriptor owns any given allocation. `ARRAY_FLAG_OWNS_DATA`

--- a/src/session_program_lowering_assumed_shape_descriptor.inc
+++ b/src/session_program_lowering_assumed_shape_descriptor.inc
@@ -359,6 +359,9 @@
             if (.not. emit_ptr_load(context%session, descriptor, base, &
                                     error_msg)) return
             context%symbols(sym_index)%address = base
+            call bind_polymorphic_array_element_stride(arena, context, &
+                callee_name, i, sym_index, descriptor, error_msg)
+            if (len_trim(error_msg) > 0) return
             do dim = 1, rank
                 if (.not. emit_i64_load_at(context%session, descriptor, &
                         assumed_shape_dim_field_offset(dim, &
@@ -371,6 +374,46 @@
             end do
         end do
     end subroutine bind_assumed_shape_descriptor_params
+
+    subroutine bind_polymorphic_array_element_stride(arena, context, callee_name, &
+                                                     param_pos, sym_index, &
+                                                     descriptor, error_msg)
+        ! A class(t) array dummy accepts actuals whose dynamic element type
+        ! extends t, and those elements are wider than t's own layout. The
+        ! concrete element size is already in the descriptor the caller built,
+        ! so read it once at entry and keep it as the element stride in i32
+        ! slots (#422). A type(t) dummy is monomorphic: its element size is its
+        ! declared type's size by definition, so it keeps the compile-time
+        ! stride and emits nothing here.
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: callee_name
+        integer, intent(in) :: param_pos
+        integer, intent(in) :: sym_index
+        type(lr_operand_desc_t), intent(in) :: descriptor
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: declared_type_index
+        type(lr_operand_desc_t) :: elem_bytes, elem_slots, slots_i32
+
+        call set_empty(error_msg)
+        call class_dummy_declared_type_index(context, arena, callee_name, &
+                                             param_pos, declared_type_index)
+        if (declared_type_index <= 0) return
+
+        if (.not. emit_i64_load_at(context%session, descriptor, &
+                int(ARRAY_DESCRIPTOR_ELEMENT_SIZE_OFFSET, c_int64_t), &
+                elem_bytes, error_msg)) return
+        ! Derived storage is a flat block of 4-byte i32 slots, so the stride in
+        ! slots is the element size in bytes divided by four; the size is a
+        ! positive multiple of four, so the shift and the division agree.
+        if (.not. emit_i64_binary(context%session, LR_OP_LSHR, elem_bytes, &
+                i64_immediate(context%session, 2_c_int64_t), elem_slots, &
+                error_msg)) return
+        if (.not. emit_liric_i64_to_i32(context%session, elem_slots, slots_i32, &
+                                        error_msg)) return
+        context%symbols(sym_index)%has_runtime_element_slots = .true.
+        context%symbols(sym_index)%runtime_element_slots = slots_i32
+    end subroutine bind_polymorphic_array_element_stride
 
     subroutine bind_optional_assumed_shape_descriptor(context, sym_index, rank, &
                                                        error_msg)

--- a/src/session_program_lowering_derived_type_ops.inc
+++ b/src/session_program_lowering_derived_type_ops.inc
@@ -818,6 +818,16 @@
                 stride = stride * context%symbols(symbol_index)%array_dim_sizes(i)
             end if
         end do
+        ! A polymorphic array dummy strides by the dynamic element type's size,
+        ! which is only known at run time; every other derived array strides by
+        ! its declared type's compile-time slot count (#422).
+        if (context%symbols(symbol_index)%has_runtime_element_slots) then
+            if (.not. emit_i32_binary(context%session, LR_OP_MUL, acc, &
+                    context%symbols(symbol_index)%runtime_element_slots, offset, &
+                    error_msg)) return
+            call set_empty(error_msg)
+            return
+        end if
         if (.not. emit_i32_binary(context%session, LR_OP_MUL, acc, &
                 i32_immediate(context%session, int(slots, c_int64_t)), offset, &
                 error_msg)) return

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -271,6 +271,15 @@ module session_program_lowering_types
         ! per-dimension count lives in this i32 operand instead.
         logical, dimension(2) :: has_runtime_dim_size = .false.
         type(lr_operand_desc_t), dimension(2) :: runtime_dim_size
+        ! Element stride, in i32 slots, of a polymorphic array dummy (#422).
+        ! A class(t) array dummy may receive an actual whose dynamic element
+        ! type is an extension of t, so its elements are wider than the
+        ! declared type's layout. The concrete element size travels in the
+        ! canonical array descriptor's element_size field and is loaded here at
+        ! procedure entry; element addressing scales by this operand instead of
+        ! the declared type's compile-time slot count.
+        logical :: has_runtime_element_slots = .false.
+        type(lr_operand_desc_t) :: runtime_element_slots
         ! A rank-1 local automatic array whose element count is only known at
         ! runtime (integer :: a(n) with n a dummy/host value). Its storage is
         ! a dynamic alloca reached through element_address; the compile-time

--- a/test/test_session_polymorphic_array_compiler.f90
+++ b/test/test_session_polymorphic_array_compiler.f90
@@ -1,0 +1,203 @@
+program test_session_polymorphic_array_compiler
+    use ffc_test_support, only: expect_output, expect_error_contains
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== polymorphic array passing tests ==='
+
+    all_passed = .true.
+    if (.not. test_base_actual_unchanged()) all_passed = .false.
+    if (.not. test_extension_actual_uses_concrete_stride()) all_passed = .false.
+    if (.not. test_extension_components_are_addressable()) all_passed = .false.
+    if (.not. test_rank2_extension_actual()) all_passed = .false.
+    if (.not. test_monomorphic_dummy_is_unaffected()) all_passed = .false.
+    if (.not. test_rank_mismatch_is_rejected()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: polymorphic array passing'
+
+contains
+
+    character(len=:) function hierarchy() result(text)
+        allocatable :: text
+        text = 'module m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type :: base_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  end type base_t'//new_line('a')// &
+            '  type, extends(base_t) :: ext_t'//new_line('a')// &
+            '    integer :: y'//new_line('a')// &
+            '  end type ext_t'//new_line('a')// &
+            'contains'//new_line('a')
+    end function hierarchy
+
+    logical function test_base_actual_unchanged()
+        ! Negative control: a base actual already worked and must keep working.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            '  subroutine show(a)'//new_line('a')// &
+            '    class(base_t), intent(in) :: a(:)'//new_line('a')// &
+            '    print *, size(a), a(1)%x, a(2)%x, a(3)%x'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(base_t) :: b(3)'//new_line('a')// &
+            '  b(1)%x = 1'//new_line('a')// &
+            '  b(2)%x = 2'//new_line('a')// &
+            '  b(3)%x = 3'//new_line('a')// &
+            '  call show(b)'//new_line('a')// &
+            'end program main'
+
+        test_base_actual_unchanged = expect_output(source, &
+            '           3           1           2           3'// &
+            new_line('a'), '/tmp/ffc_polyarr_base')
+    end function test_base_actual_unchanged
+
+    logical function test_extension_actual_uses_concrete_stride()
+        ! The heart of the slice: an extension actual has a wider element than
+        ! the dummy's declared type, so the callee must step by the dynamic
+        ! element size. Stepping by the declared size reads the extension's
+        ! own component of element 1 as element 2's inherited component.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            '  subroutine show(a)'//new_line('a')// &
+            '    class(base_t), intent(in) :: a(:)'//new_line('a')// &
+            '    print *, size(a), a(1)%x, a(2)%x, a(3)%x'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(ext_t) :: e(3)'//new_line('a')// &
+            '  e(1)%x = 10'//new_line('a')// &
+            '  e(1)%y = 11'//new_line('a')// &
+            '  e(2)%x = 20'//new_line('a')// &
+            '  e(2)%y = 21'//new_line('a')// &
+            '  e(3)%x = 30'//new_line('a')// &
+            '  e(3)%y = 31'//new_line('a')// &
+            '  call show(e)'//new_line('a')// &
+            'end program main'
+
+        test_extension_actual_uses_concrete_stride = expect_output(source, &
+            '           3          10          20          30'// &
+            new_line('a'), '/tmp/ffc_polyarr_stride')
+    end function test_extension_actual_uses_concrete_stride
+
+    logical function test_extension_components_are_addressable()
+        ! Writing through the declared-type prefix of one element must not
+        ! touch the neighbouring element or the extension's own component.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            '  subroutine bump(a)'//new_line('a')// &
+            '    class(base_t), intent(inout) :: a(:)'//new_line('a')// &
+            '    a(2)%x = a(2)%x + 100'//new_line('a')// &
+            '  end subroutine bump'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(ext_t) :: e(3)'//new_line('a')// &
+            '  e(1)%x = 1'//new_line('a')// &
+            '  e(1)%y = 2'//new_line('a')// &
+            '  e(2)%x = 3'//new_line('a')// &
+            '  e(2)%y = 4'//new_line('a')// &
+            '  e(3)%x = 5'//new_line('a')// &
+            '  e(3)%y = 6'//new_line('a')// &
+            '  call bump(e)'//new_line('a')// &
+            '  print *, e(1)%x, e(1)%y, e(2)%x, e(2)%y, e(3)%x, e(3)%y'// &
+            new_line('a')// &
+            'end program main'
+
+        test_extension_components_are_addressable = expect_output(source, &
+            '           1           2         103           4           5'// &
+            '           6'//new_line('a'), '/tmp/ffc_polyarr_write')
+    end function test_extension_components_are_addressable
+
+    logical function test_rank2_extension_actual()
+        ! Column-major addressing scales by the dynamic element size in every
+        ! dimension, not only the first.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            '  subroutine show(a)'//new_line('a')// &
+            '    class(base_t), intent(in) :: a(:,:)'//new_line('a')// &
+            '    print *, a(1,1)%x, a(2,1)%x, a(1,2)%x, a(2,2)%x'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(ext_t) :: e(2,2)'//new_line('a')// &
+            '  e(1,1)%x = 11'//new_line('a')// &
+            '  e(1,1)%y = 1'//new_line('a')// &
+            '  e(2,1)%x = 21'//new_line('a')// &
+            '  e(2,1)%y = 2'//new_line('a')// &
+            '  e(1,2)%x = 12'//new_line('a')// &
+            '  e(1,2)%y = 3'//new_line('a')// &
+            '  e(2,2)%x = 22'//new_line('a')// &
+            '  e(2,2)%y = 4'//new_line('a')// &
+            '  call show(e)'//new_line('a')// &
+            'end program main'
+
+        test_rank2_extension_actual = expect_output(source, &
+            '          11          21          12          22'// &
+            new_line('a'), '/tmp/ffc_polyarr_rank2')
+    end function test_rank2_extension_actual
+
+    logical function test_monomorphic_dummy_is_unaffected()
+        ! Negative control: a type(t) assumed-shape dummy is not polymorphic,
+        ! keeps its compile-time element size, and is unchanged by this slice.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            '  subroutine show(a)'//new_line('a')// &
+            '    type(ext_t), intent(in) :: a(:)'//new_line('a')// &
+            '    print *, size(a), a(1)%x, a(2)%y'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(ext_t) :: e(2)'//new_line('a')// &
+            '  e(1)%x = 4'//new_line('a')// &
+            '  e(1)%y = 5'//new_line('a')// &
+            '  e(2)%x = 6'//new_line('a')// &
+            '  e(2)%y = 7'//new_line('a')// &
+            '  call show(e)'//new_line('a')// &
+            'end program main'
+
+        test_monomorphic_dummy_is_unaffected = expect_output(source, &
+            '           2           4           7'//new_line('a'), &
+            '/tmp/ffc_polyarr_mono')
+    end function test_monomorphic_dummy_is_unaffected
+
+    logical function test_rank_mismatch_is_rejected()
+        ! A rank-2 actual for a rank-1 polymorphic dummy is rejected rather
+        ! than miscompiled into a wrong stride.
+        character(len=:), allocatable :: source
+
+        source = hierarchy()// &
+            '  subroutine show(a)'//new_line('a')// &
+            '    class(base_t), intent(in) :: a(:)'//new_line('a')// &
+            '    print *, size(a)'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program main'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  type(ext_t) :: e(2,2)'//new_line('a')// &
+            '  e(1,1)%x = 1'//new_line('a')// &
+            '  call show(e)'//new_line('a')// &
+            'end program main'
+
+        test_rank_mismatch_is_rejected = expect_error_contains(source, &
+            'assumed-shape derived', '/tmp/ffc_polyarr_rankmismatch')
+    end function test_rank_mismatch_is_rejected
+
+end program test_session_polymorphic_array_compiler


### PR DESCRIPTION
First green step of #422. Does not close it — see "What is left" below.

## The bug

A `class(base_t) :: a(:)` dummy given a `type(ext_t)` actual read the wrong
memory. The caller already built a correct canonical array descriptor — its
`element_size` and `stride_bytes` come from the *actual*, so they describe
`ext_t` elements — but the callee ignored them and strided by its *declared*
type's compile-time slot count. `a(2)%x` returned `ext_t`'s `y` component of
element 1:

```
gfortran:  3  10  20  30
ffc (was): 3  10  11  20
```

## Fix

At procedure entry a `class(t)` array dummy loads `element_size` from the
descriptor it was passed and keeps it as its element stride for the call.
Element addressing scales the linearised subscript by that operand instead of
the declared type's slot count.

**No new descriptor and no new descriptor field.** The canonical 200-byte
`array_descriptor_t` from #333/#334 already carries everything needed: the
concrete element size and the concrete strides. The defect was purely on the
consuming side. Adding declared/dynamic element-type ids would have been
speculative here — nothing in this step could consume them — so the descriptor
is unchanged.

A `type(t)` dummy is monomorphic by definition and keeps its compile-time
stride, emitting nothing new; that is not a fallback path but the same rule
applied to a type whose dynamic element type is fixed.

## Invariants preserved

- Declared vs dynamic type: the dummy still sees only the declared type's
  prefix of each element; only the stride between elements changes.
- Aliasing: the dummy still borrows the actual's storage. The write fixture
  shows a store through one element touches neither its neighbour nor the
  extension component.
- Column-major addressing holds in both dimensions (rank-2 fixture).
- SIZE is unchanged and still comes from the descriptor extents.
- Ownership and lifetimes are untouched: no allocation is involved.

## Verification

`test/test_session_polymorphic_array_compiler.f90`, 6 cases, recorded failing on
unmodified main: 3 wrong-output failures with exactly the off-by-one-element
reads above, plus 1 diagnostic case. Two cases (base actual, `type(t)` dummy)
passed before and after as negative controls. Every expected output was checked
against gfortran first.

Corpus, measured back to back on the same corpus revision: baseline
`PASS=447 XFAIL=93 XPASS=0 FAIL=13 NOREF=173` and branch identical, FAIL sets
byte for byte the same. Nothing promoted out of any manifest.

`fo` is green apart from `test_fortfront_corpus_conformance`,
`test_parity_dashboard`, `test_session_real_parameter_compiler` and
`test_session_reject_result_01_compiler`, all four failing identically on
unmodified main.

## What is left on #422

Two parts of the issue are blocked on prerequisites outside polymorphism and
are deliberately not attempted here:

- **`ALLOCATE(p(n), SOURCE=...)` for a `class(t), allocatable :: p(:)`.**
  Allocatable derived array *variables* do not exist in ffc at all — the
  declaration is rejected by `lower_derived_array_declaration` and
  `docs/SUPPORT_CONTRACT.md` records allocatable derived arrays as unsupported.
  Polymorphic allocation cannot be built on a form that has no monomorphic
  version yet.
- **`SELECT TYPE` narrowing a whole array**, which needs the associate name to
  bind as an array of the concrete type; the runtime guard machinery from #419
  binds scalars only.
- **Re-passing a `class(t)` array dummy onward** hits a pre-existing,
  non-polymorphic limitation: an assumed-shape derived dummy's extent must be
  recoverable from a compile-time-sized whole-array actual, so an assumed-shape
  actual is refused with "assumed-shape derived dummy extent must come from a
  whole-array actual of compile-time size". That is an extent-resolution gap,
  not a stride gap.

Each is a separate, independently green step.