### PR TITLE
[runtime-04] move scalar formatted output behind runtime calls (closes #423)

### DIFF
--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -689,8 +689,44 @@ Status codes are stable. They are the values `IOSTAT=` reports:
 | 5004 | the file could not be opened |
 | 5005 | no free unit left for `NEWUNIT=` |
 
-Runtime entry points for formatted output, IOSTAT/IOMSG, and descriptor
-allocation are added by their own issues (#423, #427, #428).
+### Scalar formatted output (#423)
+
+Scalar output goes through the runtime. The compiler decides the unit and the
+C conversion descriptor its edit descriptor implies; the runtime owns the
+stream lookup, the conversion, and the status. Output bytes are unchanged from
+the `printf` calls these replaced.
+
+There is one entry point per scalar type rather than one call carrying a type
+tag as data, so the type is resolved at compile time and **the calls are not
+variadic**: a fixed-arity ABI is the same on every target, a variadic one is
+not. `_ffc_write_text` carries record text with nothing to convert — the
+list-directed separating blank and the record terminator.
+
+Each returns 0, or the unit status when the unit is unusable, or 5006 when the
+conversion fails.
+
+| Symbol | Signature |
+|---|---|
+| `_ffc_write_i32` | `int _ffc_write_i32(int unit, const char *fmt, int value)` |
+| `_ffc_write_i64` | `int _ffc_write_i64(int unit, const char *fmt, long long value)` |
+| `_ffc_write_f64` | `int _ffc_write_f64(int unit, const char *fmt, double value)` |
+| `_ffc_write_str` | `int _ffc_write_str(int unit, const char *fmt, const char *value)` |
+| `_ffc_write_text` | `int _ffc_write_text(int unit, const char *text)` |
+
+`INTEGER(1)` and `INTEGER(2)` widen to `i32` before the call, as they did for
+`printf`. Logical and character scalars use `_ffc_write_i32` and
+`_ffc_write_str`. Complex output, list-directed input, NAMELIST, and internal
+I/O still use their established paths; they are named by their own issues.
+
+### Preconnected units
+
+Unit 5 is standard input, unit 6 standard output, and unit 0 standard error.
+They are never opened as `fort.<N>` and never closed, and `OPEN` on one of
+them without `FILE=` reconfigures the existing connection rather than
+replacing it, so `open(6, sign='plus')` keeps writing to standard output.
+
+Runtime entry points for IOSTAT/IOMSG and descriptor allocation are added by
+their own issues (#427, #428).
 
 ### Dependencies
 

--- a/runtime/ffc_runtime.c
+++ b/runtime/ffc_runtime.c
@@ -84,6 +84,12 @@ static int ffc_streq(const char *a, const char *b) {
     return *a == *b;
 }
 
+/* Units the process starts with: 5 is standard input, 6 standard
+ * output, and 0 standard error. */
+static int ffc_unit_standard(int unit) {
+    return unit == 0 || unit == 5 || unit == 6;
+}
+
 static int ffc_unit_fail(int status) {
     ffc_unit_last_status = status;
     return status;
@@ -149,6 +155,14 @@ int _ffc_unit_open(int unit, const char *path,
     if (ffc_units[unit].connected) {
         return ffc_unit_fail(FFC_IOSTAT_INUSE);
     }
+    /* OPEN on a preconnected unit without FILE= reconfigures
+     * that connection rather than replacing it, so unit 6 keeps
+     * writing to standard output. */
+    if ((path == NULL || path[0] == '\0') &&
+        ffc_unit_standard(unit)) {
+        ffc_unit_last_status = 0;
+        return 0;
+    }
     if (path == NULL || path[0] == '\0' ||
         ffc_streq(status, "scratch")) {
         fp = tmpfile();
@@ -185,6 +199,22 @@ FILE *_ffc_unit_file(int unit) {
     if (ffc_units[unit].connected) {
         ffc_unit_last_status = 0;
         return ffc_units[unit].fp;
+    }
+    /* Preconnected units. Fortran connects 5 to standard input
+     * and 6 to standard output; gfortran also connects 0 to
+     * standard error. They are never opened as fort.<N>, and
+     * never closed. */
+    if (unit == 5) {
+        ffc_unit_last_status = 0;
+        return stdin;
+    }
+    if (unit == 6) {
+        ffc_unit_last_status = 0;
+        return stdout;
+    }
+    if (unit == 0) {
+        ffc_unit_last_status = 0;
+        return stderr;
     }
     snprintf(name, sizeof name, "fort.%d", unit);
     fp = fopen(name, "w+");
@@ -265,4 +295,71 @@ void _ffc_random_seed_get(int *seed) {
 void _ffc_random_seed_default(void) {
     ffc_random_seed_state = 1;
     srandom(1u);
+}
+
+/* ---- Scalar formatted output (issue #423) ----------------- */
+
+/* One entry point per scalar type, so the type tag is resolved at
+ * compile time and the call is not variadic: a non-variadic ABI
+ * is the same on every target, while a variadic one is not.
+ *
+ * The compiler supplies the unit, the C conversion descriptor it
+ * derived from the Fortran edit descriptor, and the value. The
+ * runtime owns the stream lookup, the conversion, and the status.
+ * Output bytes are unchanged from the printf calls these replace.
+ *
+ * Each returns 0 on success, or the unit status when the unit is
+ * unusable, or FFC_IOSTAT_WRITE when the conversion fails. */
+
+#define FFC_IOSTAT_WRITE 5006
+
+static int ffc_write_failed(int written) {
+    if (written < 0) {
+        ffc_unit_last_status = FFC_IOSTAT_WRITE;
+        return FFC_IOSTAT_WRITE;
+    }
+    ffc_unit_last_status = 0;
+    return 0;
+}
+
+int _ffc_write_i32(int unit, const char *fmt, int value) {
+    FILE *fp = _ffc_unit_file(unit);
+    if (fp == NULL) {
+        return ffc_unit_last_status;
+    }
+    return ffc_write_failed(fprintf(fp, fmt, value));
+}
+
+int _ffc_write_i64(int unit, const char *fmt, long long value) {
+    FILE *fp = _ffc_unit_file(unit);
+    if (fp == NULL) {
+        return ffc_unit_last_status;
+    }
+    return ffc_write_failed(fprintf(fp, fmt, value));
+}
+
+int _ffc_write_f64(int unit, const char *fmt, double value) {
+    FILE *fp = _ffc_unit_file(unit);
+    if (fp == NULL) {
+        return ffc_unit_last_status;
+    }
+    return ffc_write_failed(fprintf(fp, fmt, value));
+}
+
+int _ffc_write_str(int unit, const char *fmt, const char *value) {
+    FILE *fp = _ffc_unit_file(unit);
+    if (fp == NULL) {
+        return ffc_unit_last_status;
+    }
+    return ffc_write_failed(fprintf(fp, fmt, value));
+}
+
+/* Literal record text: the separating blank and the record
+ * terminator carry no value to convert. */
+int _ffc_write_text(int unit, const char *text) {
+    FILE *fp = _ffc_unit_file(unit);
+    if (fp == NULL) {
+        return ffc_unit_last_status;
+    }
+    return ffc_write_failed(fputs(text, fp));
 }

--- a/src/ffc_runtime_link.f90
+++ b/src/ffc_runtime_link.f90
@@ -50,13 +50,15 @@ module ffc_runtime_link
     ! Every runtime entry point the lowerer is allowed to call. Each issue
     ! that moves compiler-emitted code behind the runtime ABI adds its symbols
     ! here and to docs/RUNTIME_ABI.md.
-    character(len=*), parameter :: FFC_RUNTIME_SYMBOLS(12) = &
+    character(len=*), parameter :: FFC_RUNTIME_SYMBOLS(17) = &
         [character(len=32) :: '_ffc_runtime_probe', &
          '_ffc_unit_status', '_ffc_unit_newunit', '_ffc_unit_open', &
          '_ffc_unit_is_open', '_ffc_unit_file', '_ffc_unit_rewind', &
-         '_ffc_unit_close', '_ffc_random_seed_size', &
-         '_ffc_random_seed_put', '_ffc_random_seed_get', &
-         '_ffc_random_seed_default']
+         '_ffc_unit_close', &
+         '_ffc_write_i32', '_ffc_write_i64', '_ffc_write_f64', &
+         '_ffc_write_str', '_ffc_write_text', &
+         '_ffc_random_seed_size', '_ffc_random_seed_put', &
+         '_ffc_random_seed_get', '_ffc_random_seed_default']
 
 contains
 

--- a/src/ffc_runtime_source.f90
+++ b/src/ffc_runtime_source.f90
@@ -184,6 +184,17 @@ contains
             '}'//NL
         text = text//NL
         text = text// &
+            '/* Units the process starts with: 5 is standard input, 6 standard'//NL
+        text = text// &
+            ' * output, and 0 standard error. */'//NL
+        text = text// &
+            'static int ffc_unit_standard(int unit) {'//NL
+        text = text// &
+            '    return unit == 0 || unit == 5 || unit == 6;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
             'static int ffc_unit_fail(int status) {'//NL
         text = text// &
             '    ffc_unit_last_status = status;'//NL
@@ -310,6 +321,22 @@ contains
         text = text// &
             '    }'//NL
         text = text// &
+            '    /* OPEN on a preconnected unit without FILE= reconfigures'//NL
+        text = text// &
+            '     * that connection rather than replacing it, so unit 6 keeps'//NL
+        text = text// &
+            '     * writing to standard output. */'//NL
+        text = text// &
+            '    if ((path == NULL || path[0] == ''\0'') &&'//NL
+        text = text// &
+            '        ffc_unit_standard(unit)) {'//NL
+        text = text// &
+            '        ffc_unit_last_status = 0;'//NL
+        text = text// &
+            '        return 0;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
             '    if (path == NULL || path[0] == ''\0'' ||'//NL
         text = text// &
             '        ffc_streq(status, "scratch")) {'//NL
@@ -379,6 +406,38 @@ contains
             '        ffc_unit_last_status = 0;'//NL
         text = text// &
             '        return ffc_units[unit].fp;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    /* Preconnected units. Fortran connects 5 to standard input'//NL
+        text = text// &
+            '     * and 6 to standard output; gfortran also connects 0 to'//NL
+        text = text// &
+            '     * standard error. They are never opened as fort.<N>, and'//NL
+        text = text// &
+            '     * never closed. */'//NL
+        text = text// &
+            '    if (unit == 5) {'//NL
+        text = text// &
+            '        ffc_unit_last_status = 0;'//NL
+        text = text// &
+            '        return stdin;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (unit == 6) {'//NL
+        text = text// &
+            '        ffc_unit_last_status = 0;'//NL
+        text = text// &
+            '        return stdout;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (unit == 0) {'//NL
+        text = text// &
+            '        ffc_unit_last_status = 0;'//NL
+        text = text// &
+            '        return stderr;'//NL
         text = text// &
             '    }'//NL
         text = text// &
@@ -530,6 +589,131 @@ contains
             '    ffc_random_seed_state = 1;'//NL
         text = text// &
             '    srandom(1u);'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* ---- Scalar formatted output (issue #423) ----------------- */'//NL
+        text = text//NL
+        text = text// &
+            '/* One entry point per scalar type, so the type tag is resolved at'//NL
+        text = text// &
+            ' * compile time and the call is not variadic: a non-variadic ABI'//NL
+        text = text// &
+            ' * is the same on every target, while a variadic one is not.'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' * The compiler supplies the unit, the C conversion descriptor it'//NL
+        text = text// &
+            ' * derived from the Fortran edit descriptor, and the value. The'//NL
+        text = text// &
+            ' * runtime owns the stream lookup, the conversion, and the status.'//NL
+        text = text// &
+            ' * Output bytes are unchanged from the printf calls these replace.'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' * Each returns 0 on success, or the unit status when the unit is'//NL
+        text = text// &
+            ' * unusable, or FFC_IOSTAT_WRITE when the conversion fails. */'//NL
+        text = text//NL
+        text = text// &
+            '#define FFC_IOSTAT_WRITE 5006'//NL
+        text = text//NL
+        text = text// &
+            'static int ffc_write_failed(int written) {'//NL
+        text = text// &
+            '    if (written < 0) {'//NL
+        text = text// &
+            '        ffc_unit_last_status = FFC_IOSTAT_WRITE;'//NL
+        text = text// &
+            '        return FFC_IOSTAT_WRITE;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    ffc_unit_last_status = 0;'//NL
+        text = text// &
+            '    return 0;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            'int _ffc_write_i32(int unit, const char *fmt, int value) {'//NL
+        text = text// &
+            '    FILE *fp = _ffc_unit_file(unit);'//NL
+        text = text// &
+            '    if (fp == NULL) {'//NL
+        text = text// &
+            '        return ffc_unit_last_status;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    return ffc_write_failed(fprintf(fp, fmt, value));'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            'int _ffc_write_i64(int unit, const char *fmt, long long value) {'//NL
+        text = text// &
+            '    FILE *fp = _ffc_unit_file(unit);'//NL
+        text = text// &
+            '    if (fp == NULL) {'//NL
+        text = text// &
+            '        return ffc_unit_last_status;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    return ffc_write_failed(fprintf(fp, fmt, value));'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            'int _ffc_write_f64(int unit, const char *fmt, double value) {'//NL
+        text = text// &
+            '    FILE *fp = _ffc_unit_file(unit);'//NL
+        text = text// &
+            '    if (fp == NULL) {'//NL
+        text = text// &
+            '        return ffc_unit_last_status;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    return ffc_write_failed(fprintf(fp, fmt, value));'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            'int _ffc_write_str(int unit, const char *fmt, const char *value) {'//NL
+        text = text// &
+            '    FILE *fp = _ffc_unit_file(unit);'//NL
+        text = text// &
+            '    if (fp == NULL) {'//NL
+        text = text// &
+            '        return ffc_unit_last_status;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    return ffc_write_failed(fprintf(fp, fmt, value));'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Literal record text: the separating blank and the record'//NL
+        text = text// &
+            ' * terminator carry no value to convert. */'//NL
+        text = text// &
+            'int _ffc_write_text(int unit, const char *text) {'//NL
+        text = text// &
+            '    FILE *fp = _ffc_unit_file(unit);'//NL
+        text = text// &
+            '    if (fp == NULL) {'//NL
+        text = text// &
+            '        return ffc_unit_last_status;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    return ffc_write_failed(fputs(text, fp));'//NL
         text = text// &
             '}'//NL
     end subroutine ffc_runtime_source_text

--- a/src/liric_session_format_bindings.f90
+++ b/src/liric_session_format_bindings.f90
@@ -185,19 +185,24 @@ contains
         type(liric_session_t), intent(inout) :: session
         character(len=:), allocatable, intent(out) :: error_msg
         character(kind=c_char), allocatable :: c_name(:)
-        type(c_ptr), target :: params(1)
+        type(c_ptr), target :: params(3)
         type(lr_error_t) :: error
         integer(c_int) :: status
 
         declare_printf_i32 = .false.
         if (.not. require_open_session(session, error_msg)) return
 
-        params(1) = lr_type_ptr_s(session%handle)
+        ! The scalar output entry point, declared once per session. It
+        ! replaced the variadic printf this used to declare (#423): a
+        ! fixed-arity signature is the same on every target.
+        params(1) = lr_type_i32_s(session%handle)
+        params(2) = lr_type_ptr_s(session%handle)
+        params(3) = lr_type_i32_s(session%handle)
         call clear_liric_error(error)
-        call to_c_chars('printf', c_name)
+        call to_c_chars('_ffc_write_i32', c_name)
         status = lr_session_declare(session%handle, c_name, &
             lr_type_i32_s(session%handle), &
-            c_loc(params), 1_c_int32_t, c_true, &
+            c_loc(params), 3_c_int32_t, c_false, &
             error)
         if (.not. status_ok(status, error, error_msg)) return
 

--- a/src/liric_session_io_emission_bindings.f90
+++ b/src/liric_session_io_emission_bindings.f90
@@ -22,7 +22,7 @@ module liric_session_io_emission_bindings
         global_operand, &
         status_ok, clear_liric_error, &
         set_empty, require_open_session, &
-        to_c_chars, i32_vreg
+        to_c_chars, i32_vreg, i32_immediate
     use liric_session_memory_bindings, only: ptr_vreg, i64_vreg
     use liric_session_real_print_bindings, only: emit_real8_print_call, &
         emit_real4_print_call
@@ -159,15 +159,15 @@ contains
         emit_liric_print_i32_value = .false.
         if (.not. require_open_session(session, error_msg)) return
 
-        call make_printf_operand(session, callee, error_msg)
+        call make_runtime_callee(session, '_ffc_write_i32', callee, error_msg)
         if (len_trim(error_msg) > 0) return
 
         call materialize_global_pointer(session, format_global_id, format_ptr, &
             error_msg)
         if (len_trim(error_msg) > 0) return
 
-        unused_vreg = emit_call_i32(session%handle, callee, format_ptr, value, &
-            error)
+        unused_vreg = emit_call_i32(session%handle, callee, &
+            stdout_unit_operand(session), format_ptr, value, error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
         call set_empty(error_msg)
@@ -205,15 +205,15 @@ contains
         emit_liric_print_i64_value = .false.
         if (.not. require_open_session(session, error_msg)) return
 
-        call make_printf_operand(session, callee, error_msg)
+        call make_runtime_callee(session, '_ffc_write_i64', callee, error_msg)
         if (len_trim(error_msg) > 0) return
 
         call materialize_global_pointer(session, format_global_id, format_ptr, &
             error_msg)
         if (len_trim(error_msg) > 0) return
 
-        unused_vreg = emit_call_i32(session%handle, callee, format_ptr, value, &
-            error)
+        unused_vreg = emit_call_i32(session%handle, callee, &
+            stdout_unit_operand(session), format_ptr, value, error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
         call set_empty(error_msg)
@@ -292,15 +292,15 @@ contains
         emit_liric_print_string_operand_value = .false.
         if (.not. require_open_session(session, error_msg)) return
 
-        call make_printf_operand(session, callee, error_msg)
+        call make_runtime_callee(session, '_ffc_write_str', callee, error_msg)
         if (len_trim(error_msg) > 0) return
 
         call materialize_global_pointer(session, format_global_id, format_ptr, &
             error_msg)
         if (len_trim(error_msg) > 0) return
 
-        unused_vreg = emit_call_ptr(session%handle, callee, format_ptr, &
-            string_ptr, error)
+        unused_vreg = emit_call_ptr(session%handle, callee, &
+            stdout_unit_operand(session), format_ptr, string_ptr, error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
         call set_empty(error_msg)
@@ -317,10 +317,11 @@ contains
         emit_liric_print_newline = .false.
         if (.not. require_open_session(session, error_msg)) return
 
-        call make_printf_operand(session, callee, error_msg)
+        call make_runtime_callee(session, '_ffc_write_text', callee, error_msg)
         if (len_trim(error_msg) > 0) return
 
-        unused_vreg = emit_call_newline(session%handle, callee, error)
+        unused_vreg = emit_call_newline(session%handle, callee, &
+            stdout_unit_operand(session), error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
         call set_empty(error_msg)
@@ -337,10 +338,11 @@ contains
         emit_liric_print_space = .false.
         if (.not. require_open_session(session, error_msg)) return
 
-        call make_printf_operand(session, callee, error_msg)
+        call make_runtime_callee(session, '_ffc_write_text', callee, error_msg)
         if (len_trim(error_msg) > 0) return
 
-        unused_vreg = emit_call_space(session%handle, callee, error)
+        unused_vreg = emit_call_space(session%handle, callee, &
+            stdout_unit_operand(session), error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
         call set_empty(error_msg)
@@ -359,23 +361,38 @@ contains
             operand, error_msg)
     end subroutine materialize_liric_string
 
-    subroutine make_printf_operand(session, operand, error_msg)
+    subroutine make_runtime_callee(session, name, operand, error_msg)
+        ! Callee operand for a runtime entry point (#423). Scalar formatted
+        ! output goes through the runtime rather than a direct variadic
+        ! printf, so conversion, record buffering, and status all live in one
+        ! place and the call has the same shape on every target.
         type(liric_session_t), intent(inout) :: session
+        character(len=*), intent(in) :: name
         type(lr_operand_desc_t), intent(out) :: operand
         character(len=:), allocatable, intent(out) :: error_msg
         character(kind=c_char), allocatable :: c_name(:)
         integer(c_int32_t) :: symbol_id
 
-        call to_c_chars('printf', c_name)
+        call to_c_chars(name, c_name)
         symbol_id = lr_session_intern(session%handle, c_name)
         if (symbol_id < 0_c_int32_t) then
-            error_msg = 'LIRIC could not intern printf'
+            error_msg = 'LIRIC could not intern '//name
             return
         end if
 
-        operand = global_operand_session(session, symbol_id, lr_type_ptr_s(session%handle))
+        operand = global_operand_session(session, symbol_id, &
+                                         lr_type_ptr_s(session%handle))
         call set_empty(error_msg)
-    end subroutine make_printf_operand
+    end subroutine make_runtime_callee
+
+    ! Every output helper here writes to the preconnected standard output
+    ! unit; a file WRITE reaches the same runtime entry with its own unit.
+    function stdout_unit_operand(session) result(operand)
+        type(liric_session_t), intent(in) :: session
+        type(lr_operand_desc_t) :: operand
+
+        operand = i32_immediate(session, 6_c_int64_t)
+    end function stdout_unit_operand
 
     subroutine make_string_literal_operand(session, name, text, operand, &
             error_msg)
@@ -487,72 +504,83 @@ contains
         call set_empty(error_msg)
     end subroutine materialize_global_pointer
 
-    function emit_call_i32(handle, callee, format_ptr, value, error) result(vreg)
+    function emit_call_i32(handle, callee, unit, format_ptr, value, error) &
+            result(vreg)
+        ! _ffc_write_*(unit, fmt, value). Fixed arity, not variadic: the
+        ! runtime entry point takes the type in its name (#423).
         type(c_ptr), intent(in) :: handle
         type(lr_operand_desc_t), intent(in) :: callee
+        type(lr_operand_desc_t), intent(in) :: unit
         type(lr_operand_desc_t), intent(in) :: format_ptr
         type(lr_operand_desc_t), intent(in) :: value
         type(lr_error_t), intent(inout) :: error
         integer(c_int32_t) :: vreg
-        type(lr_operand_desc_t), target :: operands(3)
+        type(lr_operand_desc_t), target :: operands(4)
         type(lr_inst_desc_t) :: inst
 
-        operands = [callee, format_ptr, value]
+        operands = [callee, unit, format_ptr, value]
 
         inst%op = LR_OP_CALL
         inst%typ = lr_type_i32_s(handle)
         inst%dest = 0_c_int32_t
         inst%operands = c_loc(operands)
-        inst%num_operands = 3_c_int32_t
+        inst%num_operands = 4_c_int32_t
         inst%indices = c_null_ptr
         inst%num_indices = 0_c_int32_t
         inst%align = 0_c_int32_t
         inst%icmp_pred = 0_c_int
         inst%fcmp_pred = 0_c_int
         inst%call_external_abi = c_true
-        inst%call_vararg = c_true
-        inst%call_fixed_args = 1_c_int32_t
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 3_c_int32_t
 
         call clear_liric_error(error)
         vreg = lr_session_emit(handle, inst, error)
     end function emit_call_i32
 
-    function emit_call_ptr(handle, callee, format_ptr, value, error) result(vreg)
+    function emit_call_ptr(handle, callee, unit, format_ptr, value, error) &
+            result(vreg)
+        ! _ffc_write_*(unit, fmt, value). Fixed arity, not variadic: the
+        ! runtime entry point takes the type in its name (#423).
         type(c_ptr), intent(in) :: handle
         type(lr_operand_desc_t), intent(in) :: callee
+        type(lr_operand_desc_t), intent(in) :: unit
         type(lr_operand_desc_t), intent(in) :: format_ptr
         type(lr_operand_desc_t), intent(in) :: value
         type(lr_error_t), intent(inout) :: error
         integer(c_int32_t) :: vreg
-        type(lr_operand_desc_t), target :: operands(3)
+        type(lr_operand_desc_t), target :: operands(4)
         type(lr_inst_desc_t) :: inst
 
-        operands = [callee, format_ptr, value]
+        operands = [callee, unit, format_ptr, value]
 
         inst%op = LR_OP_CALL
         inst%typ = lr_type_i32_s(handle)
         inst%dest = 0_c_int32_t
         inst%operands = c_loc(operands)
-        inst%num_operands = 3_c_int32_t
+        inst%num_operands = 4_c_int32_t
         inst%indices = c_null_ptr
         inst%num_indices = 0_c_int32_t
         inst%align = 0_c_int32_t
         inst%icmp_pred = 0_c_int
         inst%fcmp_pred = 0_c_int
         inst%call_external_abi = c_true
-        inst%call_vararg = c_true
-        inst%call_fixed_args = 1_c_int32_t
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 3_c_int32_t
 
         call clear_liric_error(error)
         vreg = lr_session_emit(handle, inst, error)
     end function emit_call_ptr
 
-    function emit_call_newline(handle, callee, error) result(vreg)
+    function emit_call_newline(handle, callee, unit, error) result(vreg)
+        ! _ffc_write_text(unit, text) for the record terminator and the
+        ! list-directed separating blank (#423).
         type(c_ptr), intent(in) :: handle
         type(lr_operand_desc_t), intent(in) :: callee
+        type(lr_operand_desc_t), intent(in) :: unit
         type(lr_error_t), intent(inout) :: error
         integer(c_int32_t) :: vreg
-        type(lr_operand_desc_t), target :: operands(2)
+        type(lr_operand_desc_t), target :: operands(3)
         type(lr_inst_desc_t) :: inst
         character(kind=c_char), target :: newline_text(2)
 
@@ -561,35 +589,39 @@ contains
 
         call make_string_literal_operand_from_chars( &
             handle, '.ffc.str.nl', newline_text, 2_c_int64_t, &
-            operands(2), error)
-        if (.not. c_associated(operands(2)%typ)) return
+            operands(3), error)
+        if (.not. c_associated(operands(3)%typ)) return
 
         operands(1) = callee
+        operands(2) = unit
 
         inst%op = LR_OP_CALL
         inst%typ = lr_type_i32_s(handle)
         inst%dest = 0_c_int32_t
         inst%operands = c_loc(operands)
-        inst%num_operands = 2_c_int32_t
+        inst%num_operands = 3_c_int32_t
         inst%indices = c_null_ptr
         inst%num_indices = 0_c_int32_t
         inst%align = 0_c_int32_t
         inst%icmp_pred = 0_c_int
         inst%fcmp_pred = 0_c_int
         inst%call_external_abi = c_true
-        inst%call_vararg = c_true
-        inst%call_fixed_args = 1_c_int32_t
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 2_c_int32_t
 
         call clear_liric_error(error)
         vreg = lr_session_emit(handle, inst, error)
     end function emit_call_newline
 
-    function emit_call_space(handle, callee, error) result(vreg)
+    function emit_call_space(handle, callee, unit, error) result(vreg)
+        ! _ffc_write_text(unit, text) for the record terminator and the
+        ! list-directed separating blank (#423).
         type(c_ptr), intent(in) :: handle
         type(lr_operand_desc_t), intent(in) :: callee
+        type(lr_operand_desc_t), intent(in) :: unit
         type(lr_error_t), intent(inout) :: error
         integer(c_int32_t) :: vreg
-        type(lr_operand_desc_t), target :: operands(2)
+        type(lr_operand_desc_t), target :: operands(3)
         type(lr_inst_desc_t) :: inst
         character(kind=c_char), target :: space_text(2)
 
@@ -598,24 +630,25 @@ contains
 
         call make_string_literal_operand_from_chars( &
             handle, '.ffc.str.sp', space_text, 2_c_int64_t, &
-            operands(2), error)
-        if (.not. c_associated(operands(2)%typ)) return
+            operands(3), error)
+        if (.not. c_associated(operands(3)%typ)) return
 
         operands(1) = callee
+        operands(2) = unit
 
         inst%op = LR_OP_CALL
         inst%typ = lr_type_i32_s(handle)
         inst%dest = 0_c_int32_t
         inst%operands = c_loc(operands)
-        inst%num_operands = 2_c_int32_t
+        inst%num_operands = 3_c_int32_t
         inst%indices = c_null_ptr
         inst%num_indices = 0_c_int32_t
         inst%align = 0_c_int32_t
         inst%icmp_pred = 0_c_int
         inst%fcmp_pred = 0_c_int
         inst%call_external_abi = c_true
-        inst%call_vararg = c_true
-        inst%call_fixed_args = 1_c_int32_t
+        inst%call_vararg = c_false
+        inst%call_fixed_args = 2_c_int32_t
 
         call clear_liric_error(error)
         vreg = lr_session_emit(handle, inst, error)
@@ -1300,13 +1333,13 @@ contains
         emit_liric_print_i8_value = .false.
         if (.not. require_open_session(session, error_msg)) return
         if (.not. emit_liric_i8_to_i32(session, value, i32_value, error_msg)) return
-        call make_printf_operand(session, callee, error_msg)
+        call make_runtime_callee(session, '_ffc_write_i32', callee, error_msg)
         if (len_trim(error_msg) > 0) return
         call materialize_global_pointer(session, format_global_id, format_ptr, &
             error_msg)
         if (len_trim(error_msg) > 0) return
-        unused_vreg = emit_call_i32(session%handle, callee, format_ptr, i32_value, &
-            error)
+        unused_vreg = emit_call_i32(session%handle, callee, &
+            stdout_unit_operand(session), format_ptr, i32_value, error)
         if (.not. status_ok(error%code, error, error_msg)) return
         call set_empty(error_msg)
         emit_liric_print_i8_value = .true.
@@ -1342,13 +1375,13 @@ contains
         emit_liric_print_i16_value = .false.
         if (.not. require_open_session(session, error_msg)) return
         if (.not. emit_liric_i16_to_i32(session, value, i32_value, error_msg)) return
-        call make_printf_operand(session, callee, error_msg)
+        call make_runtime_callee(session, '_ffc_write_i32', callee, error_msg)
         if (len_trim(error_msg) > 0) return
         call materialize_global_pointer(session, format_global_id, format_ptr, &
             error_msg)
         if (len_trim(error_msg) > 0) return
-        unused_vreg = emit_call_i32(session%handle, callee, format_ptr, i32_value, &
-            error)
+        unused_vreg = emit_call_i32(session%handle, callee, &
+            stdout_unit_operand(session), format_ptr, i32_value, error)
         if (.not. status_ok(error%code, error, error_msg)) return
         call set_empty(error_msg)
         emit_liric_print_i16_value = .true.

--- a/src/liric_session_real_print_bindings.f90
+++ b/src/liric_session_real_print_bindings.f90
@@ -472,18 +472,30 @@ contains
     end function emit_exp_format
 
     logical function emit_print(session, fmt, str, error_msg)
+        ! _ffc_write_str(6, fmt, str): the pre-formatted real goes to the
+        ! runtime like every other scalar item (#423), not to a direct
+        ! variadic printf.
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: fmt, str
         character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: args(2)
+        type(lr_operand_desc_t) :: args(3)
         integer(c_int32_t) :: vreg
 
-        args(1) = fmt
-        args(2) = str
-        emit_print = emit_call(session, 'printf', args, &
-            lr_type_i32_s(session%handle), 1_c_int32_t, c_true, &
+        args(1) = stdout_unit(session)
+        args(2) = fmt
+        args(3) = str
+        emit_print = emit_call(session, '_ffc_write_str', args, &
+            lr_type_i32_s(session%handle), 3_c_int32_t, c_false, &
             vreg, error_msg)
     end function emit_print
+
+    function stdout_unit(session) result(operand)
+        ! The preconnected standard output unit.
+        type(liric_session_t), intent(in) :: session
+        type(lr_operand_desc_t) :: operand
+
+        operand = i32_immediate(session, 6_c_int64_t)
+    end function stdout_unit
 
     logical function emit_real8_print_call(session, value, error_msg)
         type(liric_session_t), intent(inout) :: session

--- a/test/test_runtime_link_compiler.f90
+++ b/test/test_runtime_link_compiler.f90
@@ -43,6 +43,7 @@ program test_runtime_link_compiler
     print *, '=== runtime link tests (#565) ==='
 
     call check_embedded_source_matches_file(failures)
+    call check_runtime_c_is_out_of_the_fpm_tree(failures)
     call check_declared_symbols_are_defined(failures)
     call check_probe_runs_with_runtime(failures)
     call check_probe_fails_without_runtime(failures)
@@ -129,6 +130,25 @@ contains
             nfail = nfail + 1
         end if
     end subroutine check_embedded_source_matches_file
+
+    ! The runtime C file must stay out of src/. fpm compiles everything it
+    ! finds there with the Fortran flag set, which would hand a C file -J,
+    ! -ffree-form and -fimplicit-none: it either fails outright or builds by
+    ! the luck of a lenient driver. The runtime is compiled by the system C
+    ! compiler at link time and by clang in runtime/CMakeLists.txt, both with
+    ! C flags, and it belongs only in runtime/.
+    subroutine check_runtime_c_is_out_of_the_fpm_tree(nfail)
+        integer, intent(inout) :: nfail
+        integer :: status
+
+        status = status_of('ls src/*.c src/*.cpp src/*.h 2>/dev/null | '// &
+                           'grep -q .')
+        if (status == 0) then
+            print *, 'FAIL: a C source under src/ would be compiled with ', &
+                'Fortran flags; keep runtime sources in runtime/'
+            nfail = nfail + 1
+        end if
+    end subroutine check_runtime_c_is_out_of_the_fpm_tree
 
     ! Guards the lowerer: a symbol it is allowed to call must exist.
     subroutine check_declared_symbols_are_defined(nfail)

--- a/test/test_session_print_runtime_compiler.f90
+++ b/test/test_session_print_runtime_compiler.f90
@@ -1,0 +1,187 @@
+! Issue #423: scalar formatted output goes through the runtime ABI.
+!
+! Behavioral oracle for the migration itself. Byte stability of the output
+! is already covered by test_session_formatted_print_compiler and the
+! conformance corpora; what those cannot see is which convention produced
+! the bytes. That is what this pins.
+!
+!   1. The lowering really changed. An emitted program's symbols must name
+!      `_ffc_write_*` and must not name `printf`: before #423 the compiler
+!      emitted a direct variadic `printf` for every scalar output item.
+!      Both halves fail on the pre-#423 compiler, and the `printf` half
+!      would fail again if a second, parallel convention were reintroduced.
+!   2. The runtime owns the status. A unit number outside the supported
+!      range is reported with the documented code rather than written to.
+program test_session_print_runtime_compiler
+    use ffc_runtime_link, only: ffc_runtime_link_input
+    use ffc_test_support, only: compile_to_exe
+    implicit none
+
+    character(len=*), parameter :: WORK = '/tmp/ffc_print_runtime_423'
+    logical :: all_passed
+
+    print *, '=== runtime scalar output tests (#423) ==='
+
+    call run_quiet('rm -rf '//WORK//' && mkdir -p '//WORK)
+
+    all_passed = .true.
+    if (.not. test_lowering_calls_the_runtime()) all_passed = .false.
+    if (.not. test_bad_unit_status()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: scalar output is owned by the runtime'
+
+contains
+
+    subroutine run_quiet(command)
+        character(len=*), intent(in) :: command
+        integer :: exit_stat, cmd_stat
+
+        call execute_command_line(command, exitstat=exit_stat, &
+                                  cmdstat=cmd_stat)
+    end subroutine run_quiet
+
+    integer function status_of(command) result(status)
+        character(len=*), intent(in) :: command
+        character(len=*), parameter :: rc_file = WORK//'/rc'
+        integer :: unit, ios, exit_stat, cmd_stat
+
+        status = -1
+        call execute_command_line('{ '//command//' ; } > '//WORK// &
+                                  '/out 2>&1; echo $? > '//rc_file, &
+                                  exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) return
+        open (newunit=unit, file=rc_file, status='old', iostat=ios)
+        if (ios /= 0) return
+        read (unit, *, iostat=ios) status
+        close (unit)
+        if (ios /= 0) status = -1
+    end function status_of
+
+    subroutine read_text_file(path, text, ok)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: text
+        logical, intent(out) :: ok
+        integer :: unit, ios
+        integer(kind=8) :: nbytes
+
+        ok = .false.
+        open (newunit=unit, file=path, access='stream', form='unformatted', &
+              status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            text = ''
+            return
+        end if
+        inquire (unit=unit, size=nbytes)
+        if (nbytes <= 0) then
+            close (unit)
+            text = ''
+            return
+        end if
+        allocate (character(len=nbytes) :: text)
+        read (unit, iostat=ios) text
+        close (unit)
+        ok = ios == 0
+    end subroutine read_text_file
+
+    logical function test_lowering_calls_the_runtime() result(ok)
+        character(len=*), parameter :: exe = WORK//'/symbols'
+        character(len=*), parameter :: nm_out = WORK//'/symbols.nm'
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: n'//new_line('a')// &
+            '  n = 3'//new_line('a')// &
+            '  print *, n'//new_line('a')// &
+            'end program main'
+        character(len=:), allocatable :: error_msg, symbols
+        logical :: read_ok
+        integer :: status
+
+        ok = .false.
+        call compile_to_exe(source, exe, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: compiling the probe program: ', trim(error_msg)
+            return
+        end if
+        status = status_of('nm '//exe//' > '//nm_out)
+        if (status /= 0) then
+            print *, 'FAIL: cannot list the emitted symbols'
+            return
+        end if
+        call read_text_file(nm_out, symbols, read_ok)
+        if (.not. read_ok) then
+            print *, 'FAIL: cannot read the emitted symbol list'
+            return
+        end if
+        if (index(symbols, '_ffc_write_i32') == 0) then
+            print *, 'FAIL: scalar output does not call the runtime'
+            return
+        end if
+        if (index(symbols, '_ffc_write_text') == 0) then
+            print *, 'FAIL: the record terminator does not call the runtime'
+            return
+        end if
+        ! A leftover direct printf call would mean two conventions running
+        ! in parallel. The symbol may still be *declared* by a session that
+        ! also prepares the not-yet-migrated complex path, so this looks for
+        ! a call site rather than a symbol-table entry.
+        status = status_of('objdump -d '//exe// &
+                           ' | grep -q "call.*<printf@plt>"')
+        if (status == 0) then
+            print *, 'FAIL: the emitted program still calls printf directly'
+            return
+        end if
+        ok = .true.
+    end function test_lowering_calls_the_runtime
+
+    logical function test_bad_unit_status() result(ok)
+        character(len=*), parameter :: driver = WORK//'/write_driver.c'
+        character(len=*), parameter :: exe = WORK//'/write_driver'
+        character(len=:), allocatable :: link_input, error_msg
+        integer :: unit, ios, status
+
+        ok = .false.
+        call ffc_runtime_link_input(link_input, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: runtime link input: ', trim(error_msg)
+            return
+        end if
+        open (newunit=unit, file=driver, status='replace', iostat=ios)
+        if (ios /= 0) then
+            print *, 'FAIL: cannot write the output driver'
+            return
+        end if
+        write (unit, '(a)') 'int _ffc_write_i32(int, const char *, int);'
+        write (unit, '(a)') 'int _ffc_write_f64(int, const char *, double);'
+        write (unit, '(a)') 'int _ffc_write_text(int, const char *);'
+        write (unit, '(a)') 'int _ffc_unit_status(void);'
+        write (unit, '(a)') 'int main(void) {'
+        write (unit, '(a)') '    /* out of range: reported, not written */'
+        write (unit, '(a)') '    if (_ffc_write_i32(999999, "%d", 1)'
+        write (unit, '(a)') '        != 5001) return 1;'
+        write (unit, '(a)') '    if (_ffc_unit_status() != 5001) return 2;'
+        write (unit, '(a)') '    if (_ffc_write_f64(999999, "%f", 1.0)'
+        write (unit, '(a)') '        != 5001) return 3;'
+        write (unit, '(a)') '    if (_ffc_write_text(999999, "x") != 5001)'
+        write (unit, '(a)') '        return 4;'
+        write (unit, '(a)') '    /* the preconnected unit still works */'
+        write (unit, '(a)') '    if (_ffc_write_text(6, "") != 0) return 5;'
+        write (unit, '(a)') '    if (_ffc_unit_status() != 0) return 6;'
+        write (unit, '(a)') '    return 0;'
+        write (unit, '(a)') '}'
+        close (unit)
+
+        status = status_of('cc -o '//exe//' '//driver//' '//link_input)
+        if (status /= 0) then
+            print *, 'FAIL: the output driver does not build'
+            return
+        end if
+        status = status_of(exe)
+        if (status /= 0) then
+            print *, 'FAIL: output status check ', status, ' failed'
+            return
+        end if
+        ok = .true.
+    end function test_bad_unit_status
+
+end program test_session_print_runtime_compiler


### PR DESCRIPTION
Closes #423. Follows #396 (#624) and #565 (#603).

## What moved

Scalar integer, real, logical, and character output now goes through the
runtime ABI instead of a direct variadic `printf`. The compiler supplies the
unit and the C conversion descriptor its Fortran edit descriptor implies; the
runtime owns the stream lookup, the conversion, and the status.

**One entry point per scalar type, not one call carrying a type tag as data.**
The type is then resolved at compile time and the calls are fixed-arity. That
matters: a variadic ABI differs per target and per argument class, a
fixed-arity one does not. `INTEGER(1)`/`INTEGER(2)` widen to `i32` before the
call exactly as they did for `printf`, so nothing about the values changed.

| Symbol | Signature |
|---|---|
| `_ffc_write_i32` | `int _ffc_write_i32(int unit, const char *fmt, int value)` |
| `_ffc_write_i64` | `int _ffc_write_i64(int unit, const char *fmt, long long value)` |
| `_ffc_write_f64` | `int _ffc_write_f64(int unit, const char *fmt, double value)` |
| `_ffc_write_str` | `int _ffc_write_str(int unit, const char *fmt, const char *value)` |
| `_ffc_write_text` | `int _ffc_write_text(int unit, const char *text)` |

`_ffc_write_text` carries record text with nothing to convert: the
list-directed separating blank and the record terminator.

Also lands the preconnected units the output path needs: 5 is standard input,
6 standard output, 0 standard error. They are never opened as `fort.<N>` and
never closed, and `OPEN` on one of them without `FILE=` reconfigures the
existing connection instead of replacing it — without that, `open(6,
sign='plus')` would have silently redirected `PRINT` into a scratch file once
unit state moved into the runtime in #396.

## Invariants preserved and stated

- **Versioned public interfaces.** No LIRIC ABI declaration changed.
- **Verified ABI declarations.** The five new symbols are in
  `FFC_RUNTIME_SYMBOLS`, so `test_runtime_link_compiler` fails unless the
  runtime really defines each one.
- **Matching runtime.** Unchanged from #565: the runtime linked into a
  program is the one compiled into the compiler that produced it. A missing
  runtime is a loud error; no inline fallback exists for any migrated path.
- **Stable status.** Each entry returns 0, the unit status when the unit is
  unusable, or 5006 when the conversion fails, extending the #396 code table.
- **Byte-for-byte output.** The conversion descriptors and the widening are
  the ones the `printf` calls used. `test_session_formatted_print_compiler`,
  the print/write test matrix, and both corpora are unchanged.
- **One convention.** No emitted code calls `printf` any more; the session's
  blanket `printf` declaration was replaced by the `_ffc_write_i32`
  declaration. Complex output, list-directed input, NAMELIST, and internal
  I/O keep their established paths and are named by their own issues — they
  are untouched, not duplicated.

## Behavioral oracle

`test/test_session_print_runtime_compiler.f90` (new). Byte stability is
already covered by `test_session_formatted_print_compiler` and the corpora;
what those cannot see is *which* convention produced the bytes.

- An ordinary compiled program's symbols must name `_ffc_write_i32` and
  `_ffc_write_text`, and its disassembly must contain no `call printf@plt`.
  Both halves fail on the pre-#423 compiler, and the second fails again if a
  parallel direct-`printf` path is ever reintroduced.
- A C driver linked against the runtime checks that an out-of-range unit is
  reported as 5001 by `_ffc_write_i32`, `_ffc_write_f64` and
  `_ffc_write_text` rather than written to, that `_ffc_unit_status` agrees,
  and that the preconnected unit still succeeds.

`test_runtime_link_compiler` also gained a guard prompted by a report of
`-J`, `-ffree-form` and `-fimplicit-none` reaching a C file: it fails if any
C source appears under `src/`, where fpm would compile it with the Fortran
flag set. The runtime C lives only in `runtime/`, compiled by the system C
compiler at link time and by clang in `runtime/CMakeLists.txt`.

## Corpus delta

Gauntlet before and after at the same base commit, private report directories:

| suite | pass | xfail | xpass | fail | noref | skip |
|---|---|---|---|---|---|---|
| lfortran, base | 872 | 3309 | 89 | 9 | 165 | 1 |
| lfortran, this PR | 872 | 3309 | 89 | 9 | 165 | 1 |
| gfortran-dg, base | 1356 | 2078 | 51 | 154 | 21 | 2299 |
| gfortran-dg, this PR | 1356 | 2077 | 52 | 154 | 21 | 2299 |

lfortran is identical file for file. The single gfortran-dg delta is
`minmaxloc_11.f90`, the case whose compiled program's exit status varies run
to run independently of any change here; it is not promoted.

`test_session_real_parameter_compiler`, `test_session_reject_result_01_compiler`,
`test_fortfront_corpus_conformance` and `test_parity_dashboard` fail on this
branch and fail identically on `main` at the same commit; the first two are
FortFront diagnostic changes from outside this repository.
