### PR TITLE
[test-drift-01] realign two diagnostic assertions with current FortFront (#635)

### DIFF
--- a/test/test_session_real_parameter_compiler.f90
+++ b/test/test_session_real_parameter_compiler.f90
@@ -46,7 +46,6 @@ program test_session_real_parameter_compiler
     if (.not. expect_error_contains( &
         'program main'//nl// &
         '  integer :: k'//nl// &
-        '  k = 3'//nl// &
         '  parameter (ialen = k)'//nl// &
         '  integer :: myarray(ialen)'//nl// &
         '  print *, size(myarray)'//nl// &

--- a/test/test_session_reject_result_01_compiler.f90
+++ b/test/test_session_reject_result_01_compiler.f90
@@ -116,7 +116,8 @@ contains
             'end function'
 
         test_self_named_interface_rejected = expect_error_contains( &
-            source, 'cannot have a type', '/tmp/ffc_reject_result_self_iface')
+            source, 'outside its INTERFACE body', &
+            '/tmp/ffc_reject_result_self_iface')
     end function test_self_named_interface_rejected
 
     logical function test_function_name_attribute_rejected()


### PR DESCRIPTION
Fixes #635.

Both tests were red on unmodified origin/main.

Red evidence:
- test_session_real_parameter_compiler: `FAIL: diagnostic did not contain "compile-time integer parameter was not declared" / actual: data declaration statement at (1) cannot appear after executable statements` (FortFront #2896).
- test_session_reject_result_01_compiler: `FAIL: diagnostic did not contain "cannot have a type" / actual: Attribute of 'g' is declared outside its INTERFACE body` (FortFront #2883).

Change:
- The PARAMETER case had `k = 3` before a later declaration, so the unit was invalid for two reasons and the ordering error fired first. Removing the stray assignment leaves exactly the intended defect; gfortran -fsyntax-only still rejects it (nonconstant parameter), and ffc reports the constant-expression diagnostic again.
- The self-named-interface case is still rejected; the assertion now matches the stable substring `outside its INTERFACE body` rather than the old prose.

Preserved invariant: each case must still be rejected with a source diagnostic; neither test was weakened to an exit-status check, and both still fail if the rejection disappears.

Green evidence: both tests PASS. Full `fo` pipeline otherwise green apart from the two known environmental/corpus-drift failures (test_parity_dashboard in .wt worktrees, test_fortfront_corpus_conformance corpus drift), both pre-existing on main and untouched by this two-file test-only diff.