### PR TITLE
[lf-defaults-02] lock lazy default real metadata against explicit declarations (closes #586)

### DIFF
--- a/test/test_session_lazy_defaults_compiler.f90
+++ b/test/test_session_lazy_defaults_compiler.f90
@@ -131,6 +131,38 @@ program test_session_lazy_defaults_compiler
         'end program p'//new_line('a'), 'lf', &
         '  0.33333333333333331', 'ffc_lf_dummy_real_kind_sub')) ok = .false.
 
+    ! An external (non-contained) subroutine whose dummy is explicitly
+    ! declared `real` must not gain a second, competing declaration record
+    ! from the lazy default policy (#586).
+    if (.not. runs( &
+        'subroutine show(x)'//new_line('a')// &
+        '    real :: x'//new_line('a')// &
+        '    print *, x'//new_line('a')// &
+        'end subroutine show'//new_line('a')// &
+        ''//new_line('a')// &
+        'call show(1.0d0/3.0d0)'//new_line('a'), 'lf', &
+        '  0.33333333333333331', 'ffc_lf_external_real_dummy')) ok = .false.
+
+    ! Same for an explicitly INTENT(IN) real dummy of an external unit.
+    if (.not. runs( &
+        'subroutine show(x)'//new_line('a')// &
+        '    real, intent(in) :: x'//new_line('a')// &
+        '    print *, x'//new_line('a')// &
+        'end subroutine show'//new_line('a')// &
+        ''//new_line('a')// &
+        'call show(1.0d0/3.0d0)'//new_line('a'), 'lf', &
+        '  0.33333333333333331', 'ffc_lf_external_intent_in_real_dummy')) ok = .false.
+
+    ! An implicitly typed function result gets its type from inference alone;
+    ! the lazy default must merge into that record, not duplicate it (#586).
+    if (.not. runs( &
+        'function twice(x) result(y)'//new_line('a')// &
+        '    y = 2.0*x'//new_line('a')// &
+        'end function twice'//new_line('a')// &
+        ''//new_line('a')// &
+        'print *, twice(1.0d0/6.0d0)'//new_line('a'), 'lf', &
+        '  0.33333333333333331', 'ffc_lf_inferred_real_result')) ok = .false.
+
     if (.not. ok) stop 1
     print *, 'PASS: lazy default real kind and default dummy intent apply'
 


### PR DESCRIPTION
Closes #586.

## Invariant preserved

A Lazy (.lf) unit whose dummy argument is explicitly declared `real` (with or
without `intent(in)`), and one whose function result type comes from inference,
must compile: the lazy default real(8) metadata has to merge into the existing
declaration record instead of registering a second, competing one.

## Red evidence (throwaway worktree at ab4d6fd, the commit that introduced the regression)

```
r1.lf:1:1: error: conflicting declaration metadata for x   ! real :: x dummy
r2.lf:1:1: error: conflicting declaration metadata for x   ! real, intent(in) :: x
d.lf:1:1:  error: duplicate real declaration: y            ! inferred real result
```

## Green evidence

The lowering-side fix already landed with c96811e (#571, "Apply the lazy
real-kind policy to every metadata source"); all nine corpus files named in
#586 now compile and none of them is XFAIL. What was missing was a behavioral
lock, so this PR adds three cases to `test_session_lazy_defaults_compiler`
that compile through the real ffc CLI, run the binary, and compare stdout:

```
test_session_lazy_defaults_compiler        PASS
```

The same three cases are red at ab4d6fd (above), so they are real oracles, not
state assertions.

## Frontend gap filed, not worked around

The literal reduction in the issue body (`y = 2*x` with an untyped result)
still misbehaves, but for a different reason: FortFront types the result
`integer` although `2*x` is real (gfortran oracle prints `0.333333343`). Filed
as lazy-fortran/fortfront#2980; the ffc test uses `y = 2.0*x`, which exercises
the same ffc declaration-record path without depending on that gap.

## Pipeline

Full local `fo` green apart from the two documented environmental failures:
`test_parity_dashboard` (resolves `../fortfront` and cannot run inside a `.wt/`
worktree) and `test_fortfront_corpus_conformance` (pre-existing corpus drift
against current fortfront main: 9 f90 FAILs and 3 lf XPASSes, all present on
unmodified main; this PR touches only one test file and cannot affect corpus
compilation).