### PR TITLE
Record producing worktree in conformance reports; refuse cross-worktree comparison (#642)

### DIFF
--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -256,7 +256,7 @@ Fields:
 A final SUMMARY record closes the file:
 
 ```json
-{"suite":"fortfront-f90","status":"SUMMARY","pass":15,"xfail":3,"xpass":1,"fail":2,"noref":1,"skip":0,"warning_unchecked":0,"total":21,"schema_version":1,"full_run":true,"provenance_verified":true,"ffc_revision":"...","ffc_source_sha256":"...","ffc_binary_sha256":"...","fortfront_revision":"...","fortfront_tree":"...","liric_revision":"...","liric_tree":"...","corpus_revision":"...","corpus_tree":"...","corpus_files_sha256":"..."}
+{"suite":"fortfront-f90","status":"SUMMARY","pass":15,"xfail":3,"xpass":1,"fail":2,"noref":1,"skip":0,"warning_unchecked":0,"total":21,"schema_version":1,"full_run":true,"provenance_verified":true,"ffc_revision":"...","ffc_source_sha256":"...","ffc_binary_sha256":"...","fortfront_revision":"...","fortfront_tree":"...","liric_revision":"...","liric_tree":"...","corpus_revision":"...","corpus_tree":"...","corpus_files_sha256":"...","worktree":"/home/you/ffc"}
 ```
 
 The revision and tree fields are full Git hashes. `ffc_revision` identifies the
@@ -266,10 +266,23 @@ tested compiler commit. `ffc_source_sha256` hashes `src`, `app`, and `fpm.toml`;
 requires clean inputs across ffc and every dependency or corpus checkout, and
 rejects a binary older than any tracked compiler or dependency input.
 `corpus_files_sha256` hashes the exact suite-relative denominator.
+`worktree` is the absolute path of the checkout that produced the report.
 `full_run` is false when a report used `--file`, `--files-from`, or
 `--max-files`. Dashboard generation requires verified provenance and rejects
 partial reports, mismatched tree or file-list identities, a stale source
 digest, or a different selected compiler binary.
+
+## Comparing two reports
+
+Two clean worktrees at the same commit have been observed to disagree on corpus
+results (ffc #642), so a delta measured across worktrees carries unknown error.
+Sound A/B measurement is same-worktree before/after: measure the baseline,
+apply the change, rebuild, measure again, all in one checkout.
+
+`scripts/compare_conformance_reports.sh BASELINE.jsonl CANDIDATE.jsonl` enforces
+that. It exits 0 when no per-file status changed, 1 when some did (the changes
+are printed), and 2 when the pair is not comparable at all — different
+`worktree` values, a missing `worktree` field, or different suites.
 
 ## Disposition states
 

--- a/scripts/compare_conformance_reports.sh
+++ b/scripts/compare_conformance_reports.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# compare_conformance_reports.sh: A/B two conformance reports safely.
+#
+# Usage: scripts/compare_conformance_reports.sh BASELINE.jsonl CANDIDATE.jsonl
+#
+# ffc #642: two clean worktrees at the same commit have been observed to
+# disagree on corpus results, so a delta measured across worktrees carries
+# unknown error. This tool refuses such a pair outright rather than printing a
+# comparison that cannot be trusted. Sound A/B measurement is same-worktree
+# before/after: build and measure the baseline, apply the change, rebuild and
+# measure again, in one checkout.
+#
+# Exit status:
+#   0  reports comparable and identical per file
+#   1  reports comparable, per-file statuses differ (delta printed)
+#   2  reports not comparable (different worktrees, missing provenance,
+#       different suites, unreadable input)
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+    echo "usage: $0 BASELINE.jsonl CANDIDATE.jsonl" >&2
+    exit 2
+fi
+
+BASE="$1"
+CAND="$2"
+
+for path in "$BASE" "$CAND"; do
+    if [ ! -f "$path" ]; then
+        echo "ERROR: no such report: $path" >&2
+        exit 2
+    fi
+done
+
+summary_field() {
+    # $1 report path, $2 field name; empty when absent.
+    local summary
+    summary=$(grep '"status":"SUMMARY"' "$1" | tail -n 1 || true)
+    if [ -z "$summary" ]; then
+        return 0
+    fi
+    printf '%s\n' "$summary" |
+        grep -o "\"$2\":\"[^\"]*\"" |
+        tail -n 1 |
+        sed "s/\"$2\":\"//;s/\"$//" || true
+}
+
+base_worktree=$(summary_field "$BASE" worktree)
+cand_worktree=$(summary_field "$CAND" worktree)
+
+if [ -z "$base_worktree" ] || [ -z "$cand_worktree" ]; then
+    echo "ERROR: report without worktree provenance; cannot compare." >&2
+    echo "  baseline worktree:  ${base_worktree:-<missing>}" >&2
+    echo "  candidate worktree: ${cand_worktree:-<missing>}" >&2
+    echo "  Re-run both sides with the current runner in one worktree." >&2
+    exit 2
+fi
+
+if [ "$base_worktree" != "$cand_worktree" ]; then
+    echo "ERROR: reports were produced in different worktrees; refusing to" >&2
+    echo "  compare (ffc #642). Measure before and after in one checkout." >&2
+    echo "  baseline worktree:  $base_worktree" >&2
+    echo "  candidate worktree: $cand_worktree" >&2
+    exit 2
+fi
+
+base_suite=$(summary_field "$BASE" suite)
+cand_suite=$(summary_field "$CAND" suite)
+if [ "$base_suite" != "$cand_suite" ]; then
+    echo "ERROR: reports cover different suites: $base_suite vs $cand_suite" >&2
+    exit 2
+fi
+
+statuses() {
+    grep -v '"status":"SUMMARY"' "$1" |
+        sed -n 's/.*"file":"\([^"]*\)".*"status":"\([^"]*\)".*/\1\t\2/p' |
+        sort -u
+}
+
+base_table=$(mktemp)
+cand_table=$(mktemp)
+trap 'rm -f "$base_table" "$cand_table"' EXIT
+statuses "$BASE" > "$base_table"
+statuses "$CAND" > "$cand_table"
+
+delta=$(join -t "$(printf '\t')" -a 1 -a 2 -e '<absent>' -o '0,1.2,2.2' \
+    "$base_table" "$cand_table" |
+    awk -F '\t' '$2 != $3 { printf "  %s: %s -> %s\n", $1, $2, $3 }')
+
+echo "worktree: $base_worktree"
+echo "suite:    $base_suite"
+
+if [ -z "$delta" ]; then
+    echo "no per-file status changes"
+    exit 0
+fi
+
+echo "per-file status changes:"
+printf '%s\n' "$delta"
+exit 1

--- a/scripts/conformance_gauntlet.sh
+++ b/scripts/conformance_gauntlet.sh
@@ -371,6 +371,10 @@ FORTFRONT_TREE=$(git_tree_revision "${FFC_FORTFRONT_DIR:-$CORPUS_PARENT/fortfron
 LIRIC_TREE=$(git_tree_revision "${FFC_LIRIC_DIR:-$CORPUS_PARENT/liric}" || printf '%040d\n' 0)
 CORPUS_TREE=$(git_tree_revision "$SUITE_ROOT" || printf '%040d\n' 0)
 CORPUS_FILES_SHA256=$(printf '' | sha256sum | cut -d ' ' -f 1)
+# ffc #642: identical commits built in two worktrees have been observed to
+# disagree on corpus results. Every report names the checkout that produced it,
+# so a cross-worktree comparison is visibly invalid instead of silently wrong.
+WORKTREE_ID=$(readlink -f "$PROJECT_DIR")
 PROVENANCE_VERIFIED=false
 FULL_RUN=true
 if [ "${#SELECTOR_KINDS[@]}" -gt 0 ] || [ "${MAX_FILES:-0}" -gt 0 ] 2>/dev/null; then
@@ -382,14 +386,14 @@ write_summary() {
     if [ "$FLAKY_COUNT" -gt 0 ]; then
         flaky_json=$(printf ',"flaky":%d' "$FLAKY_COUNT")
     fi
-    printf '{"suite":"%s","status":"SUMMARY","pass":%d,"xfail":%d,"xpass":%d,"fail":%d,"noref":%d,"skip":%d,"warning_unchecked":%d,"total":%d,"schema_version":1,"full_run":%s,"provenance_verified":%s,"ffc_revision":"%s","ffc_source_sha256":"%s","ffc_binary_sha256":"%s","fortfront_revision":"%s","fortfront_tree":"%s","liric_revision":"%s","liric_tree":"%s","corpus_revision":"%s","corpus_tree":"%s","corpus_files_sha256":"%s"%s}\n' \
+    printf '{"suite":"%s","status":"SUMMARY","pass":%d,"xfail":%d,"xpass":%d,"fail":%d,"noref":%d,"skip":%d,"warning_unchecked":%d,"total":%d,"schema_version":1,"full_run":%s,"provenance_verified":%s,"ffc_revision":"%s","ffc_source_sha256":"%s","ffc_binary_sha256":"%s","fortfront_revision":"%s","fortfront_tree":"%s","liric_revision":"%s","liric_tree":"%s","corpus_revision":"%s","corpus_tree":"%s","corpus_files_sha256":"%s","worktree":"%s"%s}\n' \
         "$SUITE" "$PASS_COUNT" "$XFAIL_COUNT" "$XPASS_COUNT" "$FAIL_COUNT" \
         "$NOREF_COUNT" "$SKIP_COUNT" "$WARNING_UNCHECKED_COUNT" "$TOTAL_COUNT" \
         "$FULL_RUN" "$PROVENANCE_VERIFIED" "$FFC_REVISION" \
         "$FFC_SOURCE_SHA256" "$FFC_BINARY_SHA256" "$FORTFRONT_REVISION" \
         "$FORTFRONT_TREE" "$LIRIC_REVISION" "$LIRIC_TREE" \
         "$CORPUS_REVISION" "$CORPUS_TREE" "$CORPUS_FILES_SHA256" \
-        "$flaky_json" >> "$REPORT"
+        "$WORKTREE_ID" "$flaky_json" >> "$REPORT"
 }
 
 # Repeated runs: a single run cannot distinguish a stable result from a case

--- a/scripts/validate_parity_report.awk
+++ b/scripts/validate_parity_report.awk
@@ -170,7 +170,8 @@ function summary_field_allowed(key) {
         key == "ffc_binary_sha256" || key == "fortfront_revision" ||
         key == "fortfront_tree" || key == "liric_revision" ||
         key == "liric_tree" || key == "corpus_revision" ||
-        key == "corpus_tree" || key == "corpus_files_sha256"
+        key == "corpus_tree" || key == "corpus_files_sha256" ||
+        key == "worktree"
 }
 
 function validate_summary(    key, suite, pass_count, xfail_count, xpass_count,
@@ -212,6 +213,8 @@ function validate_summary(    key, suite, pass_count, xfail_count, xpass_count,
     corpus_revision = require_revision("corpus_revision")
     corpus_tree = require_revision("corpus_tree")
     corpus_files_digest = require_digest("corpus_files_sha256")
+    # ffc #642: a report must name the worktree that produced it.
+    require_string("worktree")
     if (row_count != total_count) report_error("SUMMARY total mismatch")
     if (counts["PASS"] != pass_count || counts["XFAIL"] != xfail_count ||
             counts["XPASS"] != xpass_count || counts["FAIL"] != fail_count ||

--- a/test/test_conformance_report_worktree.f90
+++ b/test/test_conformance_report_worktree.f90
@@ -1,0 +1,114 @@
+program test_conformance_report_worktree
+    ! ffc #642: identical commits built in different worktrees disagree on
+    ! corpus results, so a report from worktree A must never be compared
+    ! against a report from worktree B. The runner therefore records the
+    ! worktree that produced a report, and the comparison tool refuses any
+    ! cross-worktree pair instead of reporting a meaningless delta.
+    use conformance_temp_dir, only: make_temp_root, remove_temp_root
+    implicit none
+
+    character(len=*), parameter :: GAUNTLET = 'scripts/conformance_gauntlet.sh'
+    character(len=*), parameter :: COMPARE = 'scripts/compare_conformance_reports.sh'
+    character(len=:), allocatable :: root, report, base, cand
+    logical :: all_passed
+
+    print *, '=== conformance report worktree identity ==='
+
+    root = make_temp_root('report_worktree')
+    report = root//'/gauntlet.jsonl'
+    base = root//'/base.jsonl'
+    cand = root//'/cand.jsonl'
+    all_passed = .true.
+
+    ! The runner records the absolute path of the checkout it ran from.
+    call check('timeout 300 bash '//GAUNTLET// &
+        ' --suite fortfront-f90 --file ast_coverage_control_flow.f90'// &
+        ' --report '//report//' >/dev/null 2>&1', 0, &
+        'gauntlet single-file run', all_passed)
+    call check('grep -q ''"status":"SUMMARY"'' '//report// &
+        ' && grep -q "\"worktree\":\"$(readlink -f "$PWD")\"" '//report, 0, &
+        'summary records the producing worktree', all_passed)
+
+    ! Same worktree, identical results: comparison succeeds.
+    call write_report(base, '/home/x/ffc', 'PASS')
+    call write_report(cand, '/home/x/ffc', 'PASS')
+    call check('bash '//COMPARE//' '//base//' '//cand//' >/dev/null 2>&1', 0, &
+        'same worktree, no delta', all_passed)
+
+    ! Same worktree, changed result: comparison reports the regression.
+    call write_report(cand, '/home/x/ffc', 'FAIL')
+    call check('bash '//COMPARE//' '//base//' '//cand// &
+        ' 2>&1 | grep -q "a.f90: PASS -> FAIL"', 0, &
+        'same worktree delta is reported', all_passed)
+    call check('bash '//COMPARE//' '//base//' '//cand//' >/dev/null 2>&1', 1, &
+        'same worktree delta exits nonzero', all_passed)
+
+    ! Different worktrees: comparison must refuse rather than report a delta.
+    call write_report(cand, '/home/y/ffc-wt', 'PASS')
+    call check('bash '//COMPARE//' '//base//' '//cand//' >/dev/null 2>&1', 2, &
+        'cross-worktree comparison is refused', all_passed)
+    call check('bash '//COMPARE//' '//base//' '//cand// &
+        ' 2>&1 | grep -q "different worktrees"', 0, &
+        'refusal names the cause', all_passed)
+
+    ! A report without worktree provenance cannot be compared either.
+    call write_legacy_report(cand, 'PASS')
+    call check('bash '//COMPARE//' '//base//' '//cand//' >/dev/null 2>&1', 2, &
+        'report without worktree provenance is refused', all_passed)
+
+    if (all_passed) then
+        call remove_temp_root(root)
+        print *, 'ALL TESTS PASSED'
+    else
+        print *, 'FAILURES (scratch kept at '//root//')'
+        error stop 1
+    end if
+
+contains
+
+    subroutine check(command, expected_status, label, ok)
+        character(len=*), intent(in) :: command
+        integer, intent(in) :: expected_status
+        character(len=*), intent(in) :: label
+        logical, intent(inout) :: ok
+        integer :: exit_stat
+
+        exit_stat = -1
+        call execute_command_line(command, exitstat=exit_stat)
+        if (exit_stat == expected_status) then
+            print *, 'PASS: ', label
+        else
+            print *, 'FAIL: ', label, ' expected status ', expected_status, &
+                ' got ', exit_stat
+            ok = .false.
+        end if
+    end subroutine check
+
+    subroutine write_report(path, worktree, status)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: worktree
+        character(len=*), intent(in) :: status
+        integer :: unit
+
+        open (newunit=unit, file=path, status='replace', action='write')
+        write (unit, '(A)') '{"suite":"fortfront-f90","file":"a.f90",'// &
+            '"status":"'//status//'"}'
+        write (unit, '(A)') '{"suite":"fortfront-f90","status":"SUMMARY",'// &
+            '"total":1,"worktree":"'//worktree//'"}'
+        close (unit)
+    end subroutine write_report
+
+    subroutine write_legacy_report(path, status)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: status
+        integer :: unit
+
+        open (newunit=unit, file=path, status='replace', action='write')
+        write (unit, '(A)') '{"suite":"fortfront-f90","file":"a.f90",'// &
+            '"status":"'//status//'"}'
+        write (unit, '(A)') '{"suite":"fortfront-f90","status":"SUMMARY",'// &
+            '"total":1}'
+        close (unit)
+    end subroutine write_legacy_report
+
+end program test_conformance_report_worktree

--- a/test/test_parity_dashboard.f90
+++ b/test/test_parity_dashboard.f90
@@ -212,7 +212,8 @@ contains
             '","liric_tree":"'//repeat('5', 40)// &
             '","corpus_revision":"'//corpus_revision// &
             '","corpus_tree":"'//corpus_tree_value// &
-            '","corpus_files_sha256":"'//corpus_files_value//'"}'
+            '","corpus_files_sha256":"'//corpus_files_value// &
+            '","worktree":"/fixture/ffc"}'
     end function summary_record
 
     function integer_text(value) result(text)


### PR DESCRIPTION
Closes #642.

## Problem
Two clean worktrees at the same commit disagree on corpus results, so a branch-vs-main delta measured across worktrees carries unknown error. Nothing in the report made that visible, so the invalid comparison was silently wrong.

## Change
- `scripts/conformance_gauntlet.sh`: the SUMMARY record now carries `"worktree":"<abs checkout path>"`.
- `scripts/validate_parity_report.awk`: the field is allowed and required, so a report without worktree provenance cannot feed the dashboard.
- `scripts/compare_conformance_reports.sh` (new): A/B two reports. Exit 0 no per-file change, 1 changes printed, 2 not comparable (different `worktree`, missing `worktree`, different suites). Same-worktree before/after stays the only sound method, and it is now enforced rather than remembered.
- Docs: report schema + a "Comparing two reports" section.

## Preserved invariant
No `src/` or `app/` file is touched: compiler behavior and corpus dispositions are unchanged. Only report provenance and the comparison tool change.

## Red/green evidence
New behavioral test `test/test_conformance_report_worktree.f90` runs the real runner and the real script and checks observable exit status/output.

Red on unmodified main:
```
FAIL: gauntlet single-file run
FAIL: summary records the producing worktree (grep: no worktree field)
... compare script does not exist
```
Green after the change: all 7 assertions PASS (gauntlet emits `"worktree":"$(readlink -f $PWD)"`; same-worktree identical -> 0; same-worktree delta printed as `a.f90: PASS -> FAIL` -> 1; cross-worktree -> 2 with "different worktrees"; missing provenance -> 2).

Full `fo` pipeline: 322 tests, 3 failures, all pre-existing on `origin/main` and independent of this diff (no `src/` change): `test_session_lazy_monomorph_compiler` (frontend diagnostic), `test_fortfront_corpus_conformance` (corpus drift: fortfront-lf total 265 vs expected 264, plus 9 fortfront-f90 FAILs at base commit 8521e59), `test_parity_dashboard` (stale snapshot manifest digest / .wt sibling resolution).