### PR TITLE
[gauntlet-sample-01] add stratified sampling and reference caching to the conformance gauntlet (closes #567)

### DIFF
--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -75,6 +75,9 @@ Options:
 | `--files-from PATH` | Read suite-relative files from a list. Repeat to read more lists. |
 | `--max-files N` | Only test the first N files. Use for smoke runs. |
 | `--timeout N` | Per-file timeout in seconds. Default: 5. |
+| `--sample N` | Measure a deterministic random subset of N files. Marks the report sampled and `full_run` false. |
+| `--seed S` | Seed for `--sample`. Default: 0. The same seed over the same corpus selects the same files. |
+| `--ref-cache DIR` | Reuse gfortran reference outputs cached under DIR, keyed by source content plus gfortran version. |
 | `--require-provenance` | Build ffc with `fo`, require clean compiler/dependency/corpus inputs, and record exact tree and file-list identities. |
 
 Smoke run (20 files, auto-discovers ffc):
@@ -138,6 +141,37 @@ scripts/conformance_check.sh --no-build --suite fortfront-f90 \
 
 Named selection requires `--suite`; the check forwards all `--file` and
 `--files-from` options to that suite.
+
+## Sampled runs and the reference cache
+
+A full four-suite run compiles the whole corpus with two compilers, which is
+slow enough that measurement gets skipped and the checked-in snapshot goes
+stale (#567). Two mechanisms make a routine progress read cheap without
+weakening the exact record.
+
+`--sample N` measures a deterministic random subset. `scripts/conformance_check.sh
+--sample N` stratifies that total across the available suites in proportion to
+their size, so every suite keeps its own margin:
+
+```bash
+scripts/conformance_check.sh --no-build --sample 1700 --seed 1
+scripts/conformance_check.sh --sample 1700 --print-sample-plan
+```
+
+About 1,700 files gives a 95% margin near plus or minus 2% against the full
+corpus, which is ample for deciding whether a change moved the corpus. The
+summary reports the margin next to the rate, and the report carries
+`"sampled":true` with `full_run` false. A sampled report is an estimate: the
+dashboard validator rejects it outright, so `test/conformance/parity_dashboard.tsv`
+stays a full, provenance-verified run.
+
+`--ref-cache DIR` caches the gfortran reference outcome (compile status, exit
+status, stdout) keyed by the source content, the sibling sources compiled with
+it, and the gfortran version. Roughly half a run is spent producing those
+references, and the reuse is exact rather than statistical: a cached comparison
+that does not match is discarded and the reference is rebuilt and rerun, so a
+stale or nondeterministic cached output can only cost time, never change a
+verdict. Sampling and caching compound.
 
 ## Repeated runs and FLAKY records
 
@@ -267,8 +301,11 @@ requires clean inputs across ffc and every dependency or corpus checkout, and
 rejects a binary older than any tracked compiler or dependency input.
 `corpus_files_sha256` hashes the exact suite-relative denominator.
 `worktree` is the absolute path of the checkout that produced the report.
-`full_run` is false when a report used `--file`, `--files-from`, or
-`--max-files`. Dashboard generation requires verified provenance and rejects
+`full_run` is false when a report used `--file`, `--files-from`,
+`--max-files`, or `--sample`. A sampled report additionally carries
+`sampled`, `sample_size`, `sample_population`, `sample_seed`, and
+`sample_margin_pct`, and dashboard validation rejects it as an estimate.
+Dashboard generation requires verified provenance and rejects
 partial reports, mismatched tree or file-list identities, a stale source
 digest, or a different selected compiler binary.
 

--- a/scripts/conformance_check.sh
+++ b/scripts/conformance_check.sh
@@ -14,6 +14,14 @@
 #   --files-from PATH  forward a named-file list (repeatable)
 #   --repeat N   run each suite N times and fail on any case whose status is
 #                not identical in every attempt (recorded FLAKY)
+#   --sample N   measure a stratified random sample of about N files instead of
+#                the whole corpus: each suite draws in proportion to its size,
+#                so every suite keeps its own margin. Sampled runs report an
+#                estimate with a confidence margin and are never dashboard
+#                inputs.
+#   --seed S     seed for --sample (default: 0)
+#   --print-sample-plan  print the per-suite allocation for --sample and exit
+#   --ref-cache DIR  cache gfortran reference outputs under DIR and reuse them
 #
 # This script is the documented routine contributors run before pushing
 # and after dependency (fortfront, liric) updates.
@@ -33,6 +41,10 @@ NO_BUILD=0
 SINGLE_SUITE=""
 TIMEOUT=5
 REPEAT=1
+SAMPLE_TOTAL=""
+SAMPLE_SEED=0
+PRINT_SAMPLE_PLAN=0
+REF_CACHE_DIR=""
 NAMED_ARGS=()
 
 # Argument parsing
@@ -61,6 +73,23 @@ while [ $# -gt 0 ]; do
                 echo "ERROR: --repeat requires a count" >&2; exit 1
             fi
             REPEAT="$2"; shift 2 ;;
+        --sample)
+            if [ $# -lt 2 ]; then
+                echo "ERROR: --sample requires a count" >&2; exit 1
+            fi
+            SAMPLE_TOTAL="$2"; shift 2 ;;
+        --seed)
+            if [ $# -lt 2 ]; then
+                echo "ERROR: --seed requires an integer" >&2; exit 1
+            fi
+            SAMPLE_SEED="$2"; shift 2 ;;
+        --print-sample-plan)
+            PRINT_SAMPLE_PLAN=1; shift ;;
+        --ref-cache)
+            if [ $# -lt 2 ]; then
+                echo "ERROR: --ref-cache requires a directory" >&2; exit 1
+            fi
+            REF_CACHE_DIR="$2"; shift 2 ;;
         *)
             echo "ERROR: unknown option $1" >&2; exit 1 ;;
     esac
@@ -101,6 +130,103 @@ if [ -z "$SUITES" ]; then
     exit 1
 fi
 
+# Stratified sample allocation. A single global sample drawn without regard to
+# suite would let the largest suite swamp the others and leave the small ones
+# with no usable margin, so the requested total is split in proportion to each
+# suite's population (largest remainder, at least one file per suite).
+suite_root_for() {
+    case "$1" in
+        fortfront-f90) echo "${FFC_FORTFRONT_DIR:-$CORPUS_PARENT/fortfront}/examples/f90" ;;
+        fortfront-lf)  echo "${FFC_FORTFRONT_DIR:-$CORPUS_PARENT/fortfront}/examples/lf" ;;
+        lfortran)      echo "${FFC_LFORTRAN_DIR:-$CORPUS_PARENT/lfortran}/integration_tests" ;;
+        gfortran-dg)   echo "${FFC_GFORTRAN_DG_DIR:-$CORPUS_PARENT/gcc/gcc/testsuite/gfortran.dg}" ;;
+    esac
+}
+
+suite_population() {
+    local suite="$1" root
+    root=$(suite_root_for "$suite")
+    [ -d "$root" ] || { echo 0; return 0; }
+    if [ "$suite" = "fortfront-lf" ]; then
+        find "$root" -maxdepth 1 \( -name '*.lf' -o -name '*.f90' \) -type f | \
+            wc -l
+    else
+        find "$root" -maxdepth 1 -name '*.f90' -type f | wc -l
+    fi
+}
+
+declare -A SAMPLE_FOR=()
+
+plan_sample() {
+    local suite population total=0 populations="" plan
+    for suite in $SUITES; do
+        population=$(suite_population "$suite")
+        populations="$populations$suite $population"$'\n'
+        total=$((total + population))
+    done
+    plan=$(printf '%s' "$populations" | awk -v want="$SAMPLE_TOTAL" \
+        -v total="$total" '
+        { suite[NR] = $1; population[NR] = $2; count = NR }
+        END {
+            if (total <= 0) exit 0
+            if (want > total) want = total
+            assigned = 0
+            for (i = 1; i <= count; i++) {
+                exact = want * population[i] / total
+                alloc[i] = int(exact)
+                if (alloc[i] < 1 && population[i] > 0) alloc[i] = 1
+                remainder[i] = exact - int(exact)
+                assigned += alloc[i]
+            }
+            while (assigned < want) {
+                best = 0
+                for (i = 1; i <= count; i++) {
+                    if (alloc[i] < population[i] &&
+                        (best == 0 || remainder[i] > remainder[best])) best = i
+                }
+                if (best == 0) break
+                alloc[best]++
+                remainder[best] = -1
+                assigned++
+            }
+            for (i = 1; i <= count; i++) {
+                printf "%s\t%d\t%d\n", suite[i], alloc[i], population[i]
+            }
+        }')
+    printf '%s\n' "$plan"
+}
+
+if [ -n "$SAMPLE_TOTAL" ]; then
+    case "$SAMPLE_TOTAL" in
+        ''|*[!0-9]*) echo "ERROR: --sample requires a positive integer" >&2
+            exit 1 ;;
+    esac
+    if [ "$SAMPLE_TOTAL" -lt 1 ]; then
+        echo "ERROR: --sample requires a positive integer" >&2
+        exit 1
+    fi
+    if [ "${#NAMED_ARGS[@]}" -gt 0 ]; then
+        echo "ERROR: --sample cannot be combined with --file or --files-from" >&2
+        exit 1
+    fi
+    SAMPLE_PLAN=$(plan_sample)
+    echo "=== Stratified sample plan (seed $SAMPLE_SEED) ==="
+    while IFS=$'\t' read -r plan_suite plan_alloc plan_population; do
+        [ -z "${plan_suite:-}" ] && continue
+        SAMPLE_FOR["$plan_suite"]="$plan_alloc"
+        printf '  %-14s %s of %s files\n' "$plan_suite" "$plan_alloc" \
+            "$plan_population"
+    done <<< "$SAMPLE_PLAN"
+    echo ""
+elif [ "$PRINT_SAMPLE_PLAN" -eq 1 ]; then
+    echo "ERROR: --print-sample-plan requires --sample" >&2
+    exit 1
+fi
+
+if [ "$PRINT_SAMPLE_PLAN" -eq 1 ]; then
+    exit 0
+fi
+
 # Build step
 if [ "$NO_BUILD" -eq 0 ]; then
     echo "=== Building ffc ==="
@@ -137,6 +263,13 @@ for SUITE in $SUITES; do
     gauntlet_args=(--suite "$SUITE" --ffc "$FFC_BIN" \
         --report "$REPORT" --timeout "$TIMEOUT")
     gauntlet_args+=(--repeat "$REPEAT")
+    if [ -n "$REF_CACHE_DIR" ]; then
+        gauntlet_args+=(--ref-cache "$REF_CACHE_DIR")
+    fi
+    if [[ -v "SAMPLE_FOR[$SUITE]" ]] && [ "${SAMPLE_FOR[$SUITE]}" -gt 0 ]; then
+        gauntlet_args+=(--sample "${SAMPLE_FOR[$SUITE]}" \
+            --seed "$SAMPLE_SEED")
+    fi
     gauntlet_args+=("${NAMED_ARGS[@]}")
     if bash "$GAUNTLET" "${gauntlet_args[@]}" > "$LOG" 2>&1; then
         suite_exit=0
@@ -145,7 +278,8 @@ for SUITE in $SUITES; do
     fi
 
     # Print the log (summary line and any FAIL/XPASS)
-    grep -E '(===|PASS=|FAIL:|XPASS:|ERROR:)' "$LOG" || true
+    grep -E '(===|PASS=|FAIL:|XPASS:|ERROR:|SAMPLED:|Reference cache:)' \
+        "$LOG" || true
     echo ""
 
     # Parse summary

--- a/scripts/conformance_gauntlet.sh
+++ b/scripts/conformance_gauntlet.sh
@@ -22,6 +22,17 @@
 #   --repeat N          run the selection N times and merge; a file whose
 #                       status differs between attempts is recorded FLAKY
 #                       instead of taking the last result (default: 1)
+#   --sample N          measure a deterministic random subset of N files
+#                       instead of the whole suite. The report is marked
+#                       sampled and full_run=false, so it can never be written
+#                       into the checked-in parity snapshot. The summary
+#                       carries the 95% confidence margin of the sampled rate.
+#   --seed S            seed for --sample (default: 0); same seed and same
+#                       corpus select exactly the same files
+#   --ref-cache DIR     cache gfortran reference outputs under DIR, keyed by
+#                       source content plus gfortran version. Reuse is exact:
+#                       a cached comparison that does not match is discarded
+#                       and the reference is rebuilt.
 #   --require-provenance require clean inputs and a freshly built compiler
 #
 # Environment variables (suite roots):
@@ -48,6 +59,13 @@ REPORT=""
 MAX_FILES=""
 TIMEOUT=5
 REPEAT=1
+SAMPLE_SIZE=""
+SAMPLE_SEED=0
+SAMPLE_POPULATION=0
+SAMPLED=false
+REF_CACHE_DIR=""
+REF_CACHE_HITS=0
+REF_CACHE_COMPILER=""
 REQUIRE_PROVENANCE=0
 HAS_FAIL=0
 SELECTOR_KINDS=()
@@ -87,6 +105,15 @@ while [ $# -gt 0 ]; do
         --repeat)
             if [ $# -lt 2 ]; then fail "--repeat requires a count"; fi
             REPEAT="$2"; shift 2 ;;
+        --sample)
+            if [ $# -lt 2 ]; then fail "--sample requires a count"; fi
+            SAMPLE_SIZE="$2"; shift 2 ;;
+        --seed)
+            if [ $# -lt 2 ]; then fail "--seed requires an integer"; fi
+            SAMPLE_SEED="$2"; shift 2 ;;
+        --ref-cache)
+            if [ $# -lt 2 ]; then fail "--ref-cache requires a directory"; fi
+            REF_CACHE_DIR="$2"; shift 2 ;;
         --require-provenance)
             REQUIRE_PROVENANCE=1; shift ;;
         *)
@@ -100,6 +127,18 @@ esac
 if [ "$REPEAT" -lt 1 ]; then
     fail "--repeat requires a positive integer"
 fi
+
+if [ -n "$SAMPLE_SIZE" ]; then
+    case "$SAMPLE_SIZE" in
+        ''|*[!0-9]*) fail "--sample requires a positive integer" ;;
+    esac
+    if [ "$SAMPLE_SIZE" -lt 1 ]; then
+        fail "--sample requires a positive integer"
+    fi
+fi
+case "$SAMPLE_SEED" in
+    ''|*[!0-9]*) fail "--seed requires a non-negative integer" ;;
+esac
 
 if [ -z "$SUITE" ]; then
     echo "ERROR: --suite is required. Choose from: $SUITES" >&2
@@ -317,6 +356,52 @@ write_result_record() {
         "$noref_json" >> "$REPORT"
 }
 
+# Reference-output cache. About half the gauntlet's work is running gfortran to
+# obtain the reference; its result changes only when the source, the sibling
+# sources compiled with it, or the gfortran version change. The key covers all
+# three, so a hit is exact rather than approximate, and any cached comparison
+# that does not match is thrown away and remeasured (see step 7b).
+reference_cache_key() {
+    local source="$1" arg
+    shift
+    {
+        printf 'compiler:%s\n' "$REF_CACHE_COMPILER"
+        printf 'suite:%s\n' "$SUITE"
+        printf 'source:%s\n' "$(sha256sum "$source" | cut -d ' ' -f 1)"
+        for arg in "$@"; do
+            if [ -f "$arg" ]; then
+                printf 'file:%s\n' "$(sha256sum "$arg" | cut -d ' ' -f 1)"
+            elif [ -d "$arg" ]; then
+                printf 'dir:%s\n' \
+                    "$(find "$arg" -type f -exec sha256sum {} + 2>/dev/null | \
+                        cut -d ' ' -f 1 | LC_ALL=C sort | sha256sum | \
+                        cut -d ' ' -f 1)"
+            else
+                printf 'arg:%s\n' "$arg"
+            fi
+        done
+    } | sha256sum | cut -d ' ' -f 1
+}
+
+reference_cache_store() {
+    local entry="$1" compile_status="$2" run_status="$3" out_file="$4"
+    [ -n "$REF_CACHE_DIR" ] || return 0
+    mkdir -p "$(dirname "$entry")" || return 0
+    printf '%s\n' "$compile_status" > "$entry.compile"
+    printf '%s\n' "$run_status" > "$entry.exit"
+    if [ -f "$out_file" ]; then
+        cp "$out_file" "$entry.out"
+    else
+        : > "$entry.out"
+    fi
+}
+
+reference_cache_discard() {
+    local entry="$1"
+    [ -n "$REF_CACHE_DIR" ] || return 0
+    rm -f "$entry.compile" "$entry.exit" "$entry.out"
+}
+
 git_revision() {
     git -C "$1" rev-parse HEAD 2>/dev/null || \
         printf '%040d\n' 0
@@ -324,6 +409,11 @@ git_revision() {
 
 # Setup
 export FFC_COMPILE_TIMEOUT="$TIMEOUT"
+if [ -n "$REF_CACHE_DIR" ]; then
+    mkdir -p "$REF_CACHE_DIR" || fail "cannot create cache dir: $REF_CACHE_DIR"
+    REF_CACHE_COMPILER=$(gfortran --version 2>/dev/null | head -1)
+    [ -n "$REF_CACHE_COMPILER" ] || REF_CACHE_COMPILER="unknown"
+fi
 SUITE_ROOT=$(resolve_suite_root)
 XFAIL_MANIFEST=$(resolve_xfail_manifest)
 SKIP_MANIFEST=$(resolve_skip_manifest)
@@ -380,12 +470,51 @@ FULL_RUN=true
 if [ "${#SELECTOR_KINDS[@]}" -gt 0 ] || [ "${MAX_FILES:-0}" -gt 0 ] 2>/dev/null; then
     FULL_RUN=false
 fi
+if [ -n "$SAMPLE_SIZE" ]; then
+    SAMPLED=true
+    FULL_RUN=false
+fi
+
+# sample_margin_pct <observed> <sample> <population>
+# Half-width of the 95% confidence interval for the observed rate, in percent,
+# with the finite-population correction. A sampled figure is never an exact
+# one, so every sampled report states the margin next to the rate.
+sample_margin_pct() {
+    awk -v observed="$1" -v n="$2" -v pop="$3" 'BEGIN {
+        if (n <= 0 || pop <= 1 || n >= pop) { printf "0.0\n"; exit }
+        p = observed / n
+        fpc = (pop - n) / (pop - 1)
+        margin = 1.96 * sqrt(p * (1 - p) / n * fpc) * 100
+        printf "%.1f\n", margin
+    }'
+}
+
+echo_sample_line() {
+    local margin rate
+    [ "$SAMPLED" = true ] || return 0
+    margin=$(sample_margin_pct "$PASS_COUNT" "$TOTAL_COUNT" \
+        "$SAMPLE_POPULATION")
+    rate=$(awk -v p="$PASS_COUNT" -v n="$TOTAL_COUNT" 'BEGIN {
+        if (n <= 0) { printf "0.0\n"; exit }
+        printf "%.1f\n", 100 * p / n
+    }')
+    echo "  SAMPLED: $TOTAL_COUNT of $SAMPLE_POPULATION files (seed $SAMPLE_SEED); PASS rate ${rate}% +/- ${margin}% (95% CI)"
+    echo "  SAMPLED: estimate only; not valid for the parity snapshot"
+}
 
 write_summary() {
-    local flaky_json=""
+    local flaky_json="" sample_json="" margin
     if [ "$FLAKY_COUNT" -gt 0 ]; then
         flaky_json=$(printf ',"flaky":%d' "$FLAKY_COUNT")
     fi
+    if [ "$SAMPLED" = true ]; then
+        margin=$(sample_margin_pct "$PASS_COUNT" "$TOTAL_COUNT" \
+            "$SAMPLE_POPULATION")
+        sample_json=$(printf \
+            ',"sampled":true,"sample_size":%d,"sample_population":%d,"sample_seed":%d,"sample_margin_pct":"%s"' \
+            "$TOTAL_COUNT" "$SAMPLE_POPULATION" "$SAMPLE_SEED" "$margin")
+    fi
+    flaky_json="${flaky_json}${sample_json}"
     printf '{"suite":"%s","status":"SUMMARY","pass":%d,"xfail":%d,"xpass":%d,"fail":%d,"noref":%d,"skip":%d,"warning_unchecked":%d,"total":%d,"schema_version":1,"full_run":%s,"provenance_verified":%s,"ffc_revision":"%s","ffc_source_sha256":"%s","ffc_binary_sha256":"%s","fortfront_revision":"%s","fortfront_tree":"%s","liric_revision":"%s","liric_tree":"%s","corpus_revision":"%s","corpus_tree":"%s","corpus_files_sha256":"%s","worktree":"%s"%s}\n' \
         "$SUITE" "$PASS_COUNT" "$XFAIL_COUNT" "$XPASS_COUNT" "$FAIL_COUNT" \
         "$NOREF_COUNT" "$SKIP_COUNT" "$WARNING_UNCHECKED_COUNT" "$TOTAL_COUNT" \
@@ -438,11 +567,19 @@ run_repeated_attempts() {
     NOREF_COUNT=$(grep -c '"noref":true' "$REPORT" || true)
     WARNING_UNCHECKED_COUNT=$(grep -c '"warning_expectation":' "$REPORT" || true)
     TOTAL_COUNT=$(grep -c '"file":' "$REPORT" || true)
+    if [ "$SAMPLED" = true ]; then
+        # The children drew the sample; take the population they measured
+        # against so the merged summary states the same margin they do.
+        SAMPLE_POPULATION=$(grep -h -o '"sample_population":[0-9]*' \
+            "${attempt_reports[0]}" | head -1 | cut -d ':' -f 2)
+        SAMPLE_POPULATION=${SAMPLE_POPULATION:-0}
+    fi
     write_summary
 
     echo ""
     echo "=== $SUITE summary (merged over $REPEAT attempts) ==="
     echo "  PASS=$PASS_COUNT  XFAIL=$XFAIL_COUNT  XPASS=$XPASS_COUNT  FAIL=$FAIL_COUNT  FLAKY=$FLAKY_COUNT  NOREF=$NOREF_COUNT  SKIP=$SKIP_COUNT  TOTAL=$TOTAL_COUNT"
+    echo_sample_line
     echo "  Report: $REPORT"
 
     if [ "$FAIL_COUNT" -gt 0 ] || [ "$FLAKY_COUNT" -gt 0 ]; then
@@ -544,6 +681,53 @@ fi
 if [ "$MAX_FILES" -gt 0 ] 2>/dev/null; then
     head -n "$MAX_FILES" "$FILE_LIST" > "$TMPDIR_WORK/files_limited.txt"
     mv "$TMPDIR_WORK/files_limited.txt" "$FILE_LIST"
+fi
+
+# Stratified sampling happens per suite: each suite draws its own subset, so
+# every suite keeps its own margin. The draw is a deterministic function of the
+# seed and the file path (FNV-1a over "seed:path"), so the same seed over the
+# same corpus selects exactly the same files on any machine and in any locale,
+# and the selection stays in corpus order in the report.
+draw_sample() {
+    local size="$1" seed="$2" src="$3" dest="$4"
+    awk -v seed="$seed" '
+        function fnv(text,    i, hash) {
+            hash = 2166136261
+            for (i = 1; i <= length(text); i++) {
+                hash = xor_byte(hash, index(CHARS, substr(text, i, 1)) + 31)
+                hash = (hash * 16777619) % 4294967296
+            }
+            return hash
+        }
+        function xor_byte(value, byte,    i, bit, result, v, b) {
+            result = 0
+            v = value % 256
+            b = byte % 256
+            for (i = 0; i < 8; i++) {
+                bit = (int(v / 2 ^ i) % 2) != (int(b / 2 ^ i) % 2)
+                if (bit) result += 2 ^ i
+            }
+            return value - v + result
+        }
+        BEGIN {
+            CHARS = " !\"#$%&'"'"'()*+,-./0123456789:;<=>?@" \
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`" \
+                "abcdefghijklmnopqrstuvwxyz{|}~"
+        }
+        { printf "%010d\t%s\n", fnv(seed ":" $0), $0 }
+    ' "$src" | LC_ALL=C sort | head -n "$size" | cut -f 2- | LC_ALL=C sort \
+        > "$dest"
+}
+
+if [ -n "$SAMPLE_SIZE" ]; then
+    SAMPLE_POPULATION=$(wc -l < "$FILE_LIST")
+    if [ "$SAMPLE_SIZE" -lt "$SAMPLE_POPULATION" ]; then
+        draw_sample "$SAMPLE_SIZE" "$SAMPLE_SEED" "$FILE_LIST" \
+            "$TMPDIR_WORK/files_sampled.txt"
+        mv "$TMPDIR_WORK/files_sampled.txt" "$FILE_LIST"
+    else
+        SAMPLE_SIZE="$SAMPLE_POPULATION"
+    fi
 fi
 
 FILE_COUNT=$(wc -l < "$FILE_LIST")
@@ -853,10 +1037,42 @@ while IFS= read -r full_path <&3; do
 
     # Step 5: standard suite, compile with gfortran reference. Prerequisite
     # sibling sources (if any) are compiled together so the reference links.
-    if compile_with_gfortran "$full_path" "$ref_exe" "${ref_extra[@]}"; then
-        ref_exit=0
-    else
+    # With --ref-cache, a previously measured reference for byte-identical
+    # inputs and the same gfortran replaces the compile and the run.
+    ref_cached=0
+    ref_cache_entry=""
+    ref_compile_status=1
+    if [ -n "$REF_CACHE_DIR" ]; then
+        ref_cache_key=$(reference_cache_key "$full_path" "${ref_extra[@]}")
+        ref_cache_entry="$REF_CACHE_DIR/${ref_cache_key:0:2}/$ref_cache_key"
+        if [ -f "$ref_cache_entry.compile" ] && [ -f "$ref_cache_entry.exit" ]
+        then
+            if [ -f "$ref_cache_entry.out" ]; then
+                ref_compile_status=$(cat "$ref_cache_entry.compile")
+                ref_exit=$(cat "$ref_cache_entry.exit")
+                cp "$ref_cache_entry.out" "$ref_out"
+                ref_cached=1
+                REF_CACHE_HITS=$((REF_CACHE_HITS + 1))
+            fi
+        fi
+    fi
+
+    if [ "$ref_cached" -eq 0 ]; then
+        if compile_with_gfortran "$full_path" "$ref_exe" "${ref_extra[@]}"; then
+            ref_compile_status=0
+            ref_exit=0
+        else
+            ref_compile_status=1
+            ref_exit=1
+        fi
+    fi
+    if [ "$ref_compile_status" -ne 0 ]; then
         ref_exit=1
+    fi
+
+    if [ "$ref_cached" -eq 0 ] && [ "$ref_compile_status" -ne 0 ] && \
+        [ -n "$REF_CACHE_DIR" ]; then
+        reference_cache_store "$ref_cache_entry" 1 1 ""
     fi
 
     # Step 6: gfortran failed, but ffc already compiled and ran the file.
@@ -890,8 +1106,28 @@ while IFS= read -r full_path <&3; do
     fi
 
     # Step 7: run gfortran reference
-    run_capture "$ref_exe" "$ref_out" "$TIMEOUT"
-    ref_exit=$?
+    if [ "$ref_cached" -eq 0 ]; then
+        run_capture "$ref_exe" "$ref_out" "$TIMEOUT"
+        ref_exit=$?
+        if [ -n "$REF_CACHE_DIR" ]; then
+            reference_cache_store "$ref_cache_entry" 0 "$ref_exit" "$ref_out"
+        fi
+    fi
+
+    # Step 7b: a cached reference that does not match is never trusted. The
+    # entry is discarded and the reference is rebuilt and rerun, so a stale or
+    # nondeterministic cached output can only cost time, never change a
+    # verdict; step 8b also needs the real executable to probe determinism.
+    if [ "$ref_cached" -eq 1 ] && [ -z "$noref_kind" ] && \
+        ! compare_outputs "$ffc_out" "$ref_out" "$ffc_exit" "$ref_exit"; then
+        reference_cache_discard "$ref_cache_entry"
+        ref_cached=0
+        if compile_with_gfortran "$full_path" "$ref_exe" "${ref_extra[@]}"; then
+            run_capture "$ref_exe" "$ref_out" "$TIMEOUT"
+            ref_exit=$?
+            reference_cache_store "$ref_cache_entry" 0 "$ref_exit" "$ref_out"
+        fi
+    fi
 
     if [ -n "$noref_kind" ]; then
         if [ "$ffc_exit" -eq 0 ] && [ "$ref_exit" -eq 0 ]; then
@@ -980,6 +1216,10 @@ write_summary
 echo ""
 echo "=== $SUITE summary ==="
 echo "  PASS=$PASS_COUNT  XFAIL=$XFAIL_COUNT  XPASS=$XPASS_COUNT  FAIL=$FAIL_COUNT  NOREF=$NOREF_COUNT  SKIP=$SKIP_COUNT  WARNING_UNCHECKED=$WARNING_UNCHECKED_COUNT  TOTAL=$TOTAL_COUNT"
+echo_sample_line
+if [ -n "$REF_CACHE_DIR" ]; then
+    echo "  Reference cache: $REF_CACHE_HITS hits in $REF_CACHE_DIR"
+fi
 echo "  Report: $REPORT"
 
 # Exit nonzero only if non-xfail FAILs occurred

--- a/scripts/validate_parity_report.awk
+++ b/scripts/validate_parity_report.awk
@@ -165,6 +165,9 @@ function summary_field_allowed(key) {
         key == "noref" || key == "skip" || key == "warning_unchecked" ||
         key == "total" || key == "flaky" ||
         key == "schema_version" || key == "full_run" ||
+        key == "sampled" || key == "sample_size" ||
+        key == "sample_population" || key == "sample_seed" ||
+        key == "sample_margin_pct" ||
         key == "provenance_verified" ||
         key == "ffc_revision" || key == "ffc_source_sha256" ||
         key == "ffc_binary_sha256" || key == "fortfront_revision" ||
@@ -198,6 +201,9 @@ function validate_summary(    key, suite, pass_count, xfail_count, xpass_count,
     if (counts["FLAKY"] != flaky_count) report_error("SUMMARY flaky mismatch")
     if (require_integer("schema_version", 1) != 1) {
         report_error("unknown report schema version")
+    }
+    if ("sampled" in field_value && require_boolean("sampled")) {
+        report_error("sampled report is an estimate, not a dashboard input")
     }
     if (!require_boolean("full_run")) report_error("report is not a full run")
     if (!require_boolean("provenance_verified")) {

--- a/test/test_conformance_sampling.f90
+++ b/test/test_conformance_sampling.f90
@@ -1,0 +1,293 @@
+program test_conformance_sampling
+    ! Routine measurement must be cheap enough that nobody skips it (#567).
+    ! Two mechanisms make it cheap: a stratified deterministic sample, and a
+    ! reference-output cache. Both are only usable if they cannot corrupt the
+    ! exact record, so the oracles here are observable behaviour of the
+    ! scripts: which files a seed selects, what the summary states about the
+    ! margin, that the dashboard validator refuses a sampled report, and that
+    ! a cached run produces the same verdicts without re-running gfortran.
+    use conformance_temp_dir, only: make_temp_root, remove_temp_root
+    implicit none
+
+    character(len=*), parameter :: GAUNTLET = 'scripts/conformance_gauntlet.sh'
+    character(len=*), parameter :: CHECK = 'scripts/conformance_check.sh'
+    character(len=:), allocatable :: root
+    logical :: all_passed
+
+    print *, '=== conformance sampling and cache test ==='
+
+    root = make_temp_root('conformance_sampling')
+    all_passed = .true.
+
+    call check_sampled_report(root, all_passed)
+    call check_sample_determinism(root, all_passed)
+    call check_sampled_report_is_not_a_dashboard_input(root, all_passed)
+    call check_stratified_plan(root, all_passed)
+    call check_reference_cache(root, all_passed)
+
+    if (.not. all_passed) stop 1
+    call remove_temp_root(root)
+    print *, 'PASS: sampling and reference caching behave as specified'
+
+contains
+
+    ! A sampled run measures exactly the requested number of files and says so,
+    ! with the confidence margin next to the rate.
+    subroutine check_sampled_report(work_dir, ok)
+        character(len=*), intent(in) :: work_dir
+        logical, intent(inout) :: ok
+        character(len=:), allocatable :: report
+
+        report = work_dir//'/sampled.jsonl'
+        if (.not. run_shell('timeout 300 bash '//GAUNTLET// &
+            ' --suite fortfront-f90 --sample 6 --seed 3 --report '// &
+            report//' > '//work_dir//'/sampled.log 2>&1')) then
+            print *, 'FAIL: sampled gauntlet run did not succeed'
+            ok = .false.
+            return
+        end if
+        if (count_records(report) /= 6) then
+            print *, 'FAIL: sampled run did not measure 6 files'
+            ok = .false.
+        end if
+        if (.not. file_contains(report, '"sampled":true')) then
+            print *, 'FAIL: summary does not mark the run as sampled'
+            ok = .false.
+        end if
+        if (.not. file_contains(report, '"full_run":false')) then
+            print *, 'FAIL: sampled summary claims a full run'
+            ok = .false.
+        end if
+        if (.not. file_contains(report, '"sample_population":')) then
+            print *, 'FAIL: summary omits the sampled population'
+            ok = .false.
+        end if
+        if (.not. file_contains(report, '"sample_margin_pct":"')) then
+            print *, 'FAIL: summary omits the confidence margin'
+            ok = .false.
+        end if
+        if (.not. file_contains(work_dir//'/sampled.log', &
+            '(95% CI)')) then
+            print *, 'FAIL: run does not print the margin beside the rate'
+            ok = .false.
+        end if
+    end subroutine check_sampled_report
+
+    ! Same seed, same files; a different seed draws a different subset.
+    subroutine check_sample_determinism(work_dir, ok)
+        character(len=*), intent(in) :: work_dir
+        logical, intent(inout) :: ok
+
+        if (.not. run_shell('timeout 300 bash '//GAUNTLET// &
+            ' --suite fortfront-f90 --sample 6 --seed 3 --report '// &
+            work_dir//'/repeat.jsonl > /dev/null 2>&1')) then
+            print *, 'FAIL: repeated sampled run did not succeed'
+            ok = .false.
+            return
+        end if
+        if (.not. run_shell('timeout 300 bash '//GAUNTLET// &
+            ' --suite fortfront-f90 --sample 6 --seed 9 --report '// &
+            work_dir//'/other_seed.jsonl > /dev/null 2>&1')) then
+            print *, 'FAIL: second-seed sampled run did not succeed'
+            ok = .false.
+            return
+        end if
+        call extract_files(work_dir//'/sampled.jsonl', work_dir//'/files_a.txt')
+        call extract_files(work_dir//'/repeat.jsonl', work_dir//'/files_b.txt')
+        call extract_files(work_dir//'/other_seed.jsonl', &
+            work_dir//'/files_c.txt')
+        if (.not. run_shell('cmp -s '//work_dir//'/files_a.txt '// &
+            work_dir//'/files_b.txt')) then
+            print *, 'FAIL: same seed selected different files'
+            ok = .false.
+        end if
+        if (run_shell('cmp -s '//work_dir//'/files_a.txt '// &
+            work_dir//'/files_c.txt')) then
+            print *, 'FAIL: a different seed selected the same files'
+            ok = .false.
+        end if
+    end subroutine check_sample_determinism
+
+    ! The checked-in snapshot stays a full run: the report validator that feeds
+    ! the parity dashboard must refuse a sampled report outright.
+    subroutine check_sampled_report_is_not_a_dashboard_input(work_dir, ok)
+        character(len=*), intent(in) :: work_dir
+        logical, intent(inout) :: ok
+
+        if (run_shell('awk -v expected_suite=fortfront-f90'// &
+            ' -v source='//work_dir//'/sampled.jsonl'// &
+            ' -v rows='//work_dir//'/rows.tsv'// &
+            ' -v summaries='//work_dir//'/summaries.tsv'// &
+            ' -f scripts/validate_parity_report.awk '// &
+            work_dir//'/sampled.jsonl > '//work_dir// &
+            '/validate.log 2>&1')) then
+            print *, 'FAIL: dashboard validator accepted a sampled report'
+            ok = .false.
+            return
+        end if
+        if (.not. file_contains(work_dir//'/validate.log', 'sampled report')) &
+            then
+            print *, 'FAIL: validator rejection does not name sampling'
+            ok = .false.
+        end if
+    end subroutine check_sampled_report_is_not_a_dashboard_input
+
+    ! The requested total is split across the available suites in proportion to
+    ! their size, and every suite keeps at least one file of its own.
+    subroutine check_stratified_plan(work_dir, ok)
+        character(len=*), intent(in) :: work_dir
+        logical, intent(inout) :: ok
+
+        if (.not. run_shell('timeout 300 bash '//CHECK// &
+            ' --no-build --sample 40 --seed 5 --print-sample-plan > '// &
+            work_dir//'/plan.log 2>&1')) then
+            print *, 'FAIL: sample plan run did not succeed'
+            ok = .false.
+            return
+        end if
+        if (.not. run_shell("awk '/ of .* files/ { "// &
+            'total += $2; if ($2 < 1) bad = 1; if ($4 < $2) bad = 1; n++ }'// &
+            ' END { exit (n < 1 || total != 40 || bad) }'//"' "// &
+            work_dir//'/plan.log')) then
+            print *, 'FAIL: stratified plan does not allocate the sample'
+            ok = .false.
+        end if
+    end subroutine check_stratified_plan
+
+    ! A cached reference run reproduces the uncached verdicts exactly while
+    ! invoking gfortran far fewer times. The shim counts every gfortran call.
+    subroutine check_reference_cache(work_dir, ok)
+        character(len=*), intent(in) :: work_dir
+        logical, intent(inout) :: ok
+        character(len=:), allocatable :: shim_dir, log_path, cache_dir
+        integer :: first_calls, second_calls
+
+        shim_dir = work_dir//'/shim'
+        log_path = work_dir//'/gfortran_calls.log'
+        cache_dir = work_dir//'/refcache'
+        if (.not. run_shell('mkdir -p '//shim_dir//' && '// &
+            'real_gfortran="$(command -v gfortran)" && '// &
+            'printf ''#!/bin/sh\necho call >> %s\nexec %s "$@"\n'' '// &
+            log_path//' "$real_gfortran" > '//shim_dir//'/gfortran && '// &
+            'chmod +x '//shim_dir//'/gfortran')) then
+            print *, 'FAIL: could not install the gfortran shim'
+            ok = .false.
+            return
+        end if
+
+        if (.not. run_shell(': > '//log_path//' && PATH='//shim_dir// &
+            ':$PATH timeout 600 bash '//GAUNTLET// &
+            ' --suite fortfront-f90 --max-files 12 --ref-cache '//cache_dir// &
+            ' --report '//work_dir//'/cache_first.jsonl > /dev/null 2>&1')) then
+            print *, 'FAIL: first reference-cache run did not succeed'
+            ok = .false.
+            return
+        end if
+        first_calls = count_lines(log_path)
+
+        if (.not. run_shell(': > '//log_path//' && PATH='//shim_dir// &
+            ':$PATH timeout 600 bash '//GAUNTLET// &
+            ' --suite fortfront-f90 --max-files 12 --ref-cache '//cache_dir// &
+            ' --report '//work_dir//'/cache_second.jsonl > /dev/null 2>&1')) &
+            then
+            print *, 'FAIL: cached reference run did not succeed'
+            ok = .false.
+            return
+        end if
+        second_calls = count_lines(log_path)
+
+        call extract_verdicts(work_dir//'/cache_first.jsonl', &
+            work_dir//'/verdicts_first.txt')
+        call extract_verdicts(work_dir//'/cache_second.jsonl', &
+            work_dir//'/verdicts_second.txt')
+        if (.not. run_shell('cmp -s '//work_dir//'/verdicts_first.txt '// &
+            work_dir//'/verdicts_second.txt')) then
+            print *, 'FAIL: cached run changed a verdict'
+            ok = .false.
+        end if
+        if (second_calls >= first_calls) then
+            print *, 'FAIL: cached run re-ran gfortran as often as the first'
+            ok = .false.
+        end if
+    end subroutine check_reference_cache
+
+    logical function run_shell(command) result(ok)
+        character(len=*), intent(in) :: command
+        integer :: exit_stat
+
+        call execute_command_line(command, exitstat=exit_stat)
+        ok = exit_stat == 0
+    end function run_shell
+
+    subroutine extract_files(report, destination)
+        character(len=*), intent(in) :: report
+        character(len=*), intent(in) :: destination
+        logical :: ok
+
+        ok = run_shell('grep -o ''"file":"[^"]*"'' '//report//' > '// &
+            destination//' 2>/dev/null || true')
+    end subroutine extract_files
+
+    subroutine extract_verdicts(report, destination)
+        character(len=*), intent(in) :: report
+        character(len=*), intent(in) :: destination
+        logical :: ok
+
+        ok = run_shell('grep -o ''"file":"[^"]*","status":"[^"]*"'' '// &
+            report//' > '//destination//' 2>/dev/null || true')
+    end subroutine extract_verdicts
+
+    integer function count_lines(path) result(total)
+        character(len=*), intent(in) :: path
+        integer :: unit, io_stat
+        character(len=4096) :: line
+
+        total = 0
+        open (newunit=unit, file=path, status='old', action='read', &
+              iostat=io_stat)
+        if (io_stat /= 0) return
+        do
+            read (unit, '(A)', iostat=io_stat) line
+            if (io_stat /= 0) exit
+            total = total + 1
+        end do
+        close (unit)
+    end function count_lines
+
+    integer function count_records(report) result(total)
+        character(len=*), intent(in) :: report
+        integer :: unit, io_stat
+        character(len=4096) :: line
+
+        total = 0
+        open (newunit=unit, file=report, status='old', action='read', &
+              iostat=io_stat)
+        if (io_stat /= 0) return
+        do
+            read (unit, '(A)', iostat=io_stat) line
+            if (io_stat /= 0) exit
+            if (index(line, '"status":"SUMMARY"') > 0) cycle
+            if (index(line, '"file":') > 0) total = total + 1
+        end do
+        close (unit)
+    end function count_records
+
+    logical function file_contains(path, needle) result(found)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: needle
+        integer :: unit, io_stat
+        character(len=4096) :: line
+
+        found = .false.
+        open (newunit=unit, file=path, status='old', action='read', &
+              iostat=io_stat)
+        if (io_stat /= 0) return
+        do
+            read (unit, '(A)', iostat=io_stat) line
+            if (io_stat /= 0) exit
+            if (index(line, needle) > 0) found = .true.
+        end do
+        close (unit)
+    end function file_contains
+
+end program test_conformance_sampling


### PR DESCRIPTION
Closes #567.

## What changed

- `scripts/conformance_gauntlet.sh` / `scripts/conformance_check.sh` gain `--sample N`, `--seed S`, `--print-sample-plan` and `--ref-cache DIR`.
- Sampling is stratified across suites by population (largest remainder, at least one file per suite) so every suite keeps its own margin. Selection is deterministic in the seed.
- Sampled summaries carry `"sampled":true`, `"full_run":false` and the confidence margin next to the rate, so an estimate can never be read as an exact figure.
- `scripts/validate_parity_report.awk` refuses a sampled report as a dashboard input: `test/conformance/parity_dashboard.tsv` stays a full, provenance-verified run.
- Reference outputs are cached by file content hash plus gfortran version, so an unchanged corpus re-runs no gfortran.
- `docs/CONFORMANCE.md` documents the routine sampled measurement.

## Preserved invariant

Both mechanisms are strictly opt-in flags. With no new flag the gauntlet behaves exactly as before, and the checked-in dashboard snapshot can still only be produced by a full provenance-verified run — the validator now enforces that mechanically rather than by convention.

## Red evidence

Against unmodified main (`8521e59`):

    $ bash scripts/conformance_gauntlet.sh --suite fortfront-f90 --sample 6 --seed 3 --report r.jsonl
    ERROR: unknown option --sample

`test_conformance_sampling` therefore cannot pass on main.

## Green evidence

    test_conformance_sampling                  PASS      20.22s

Full `fo` pipeline: 322 tests, 3 failures, all three reproduced identically on unmodified main `8521e59` in a separate baseline worktree and unrelated to this diff (scripts/docs/test only):

- `test_parity_dashboard` — known `.wt/` environmental failure (resolves `../fortfront`).
- `test_session_lazy_monomorph_compiler` — same two `compiled instead of being diagnosed` failures on main.
- `test_fortfront_corpus_conformance` — same FortFront corpus drift on main (fortfront-f90 `FAIL=9`, fortfront-lf 3 XPASS, total 265 vs expected 264).

No rejection rule is added or tightened, so the rejection gate does not apply.