### PR TITLE
[generic-rank-01] rank distinguishes generic specifics (closes #595)

### DIFF
--- a/src/session_program_lowering_reject_checks.inc
+++ b/src/session_program_lowering_reject_checks.inc
@@ -195,6 +195,12 @@
                             rank = size(pn%dimension_indices)
                         end if
                     end if
+                    ! The dummy's own declaration in the specification part
+                    ! carries the rank when the parameter node does not
+                    ! (#595): differing rank distinguishes two specifics.
+                    if (rank == 0) then
+                        rank = dummy_declared_rank(arena, body_indices, name)
+                    end if
                     if (pn%has_kind) then
                         kind_value = pn%kind_value
                         if (pn%kind_value <= 0) return
@@ -216,6 +222,36 @@
         base_name = implicit_base_type(name)
         known = len_trim(base_name) > 0
     end subroutine dummy_signature_at
+
+    ! The rank a dummy is given by its own declaration in the specification
+    ! part, or 0 when no declaration in body_indices names it as an array of
+    ! statically known rank. Used where the parameter node itself carries no
+    ! shape, so that a rank-1 and a rank-2 specific of the same element kind
+    ! stay distinguishable (F2018 C1514, #595).
+    integer function dummy_declared_rank(arena, body_indices, param_name) &
+            result(rank)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: param_name
+        integer :: i
+
+        rank = 0
+        if (.not. allocated(body_indices)) return
+        do i = 1, size(body_indices)
+            if (.not. node_exists(arena, body_indices(i))) cycle
+            select type (decl => arena%entries(body_indices(i))%node)
+            type is (declaration_node)
+                if (.not. decl%is_array) cycle
+                if (.not. declaration_declares_name(decl, &
+                                        trim(lowercase_text(param_name)))) cycle
+                if (allocated(decl%dimension_indices)) then
+                    rank = max(rank, size(decl%dimension_indices))
+                else
+                    rank = max(rank, 1)
+                end if
+            end select
+        end do
+    end function dummy_declared_rank
 
     ! unresolved reports a KIND selector that is not a literal - the declared
     ! kind is then unknown, and no distinguishability claim may rest on it.

--- a/test/test_session_reject_generic_01_compiler.f90
+++ b/test/test_session_reject_generic_01_compiler.f90
@@ -28,6 +28,7 @@ program test_session_reject_generic_01_compiler
     if (.not. test_derived_type_assignment_accepted()) all_passed = .false.
     if (.not. test_generic_call_with_specific()) all_passed = .false.
     if (.not. test_kind_distinguishable_specifics()) all_passed = .false.
+    if (.not. test_same_rank_array_specifics_ambiguous()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: malformed and ambiguous generic interfaces rejected'
@@ -576,5 +577,38 @@ contains
         test_kind_distinguishable_specifics = expect_exit_status( &
             source, 0, '/tmp/ffc_reject_generic_01_q10')
     end function test_kind_distinguishable_specifics
+
+    logical function test_same_rank_array_specifics_ambiguous()
+        !! Negative control for #595: rank distinguishes specifics only when it
+        !! differs. Two rank-1 integer array specifics stay ambiguous.
+        character(len=*), parameter :: source = &
+            'module m'//new_line('a')// &
+            '   implicit none'//new_line('a')// &
+            '   interface gen'//new_line('a')// &
+            '      module procedure one_vec'//new_line('a')// &
+            '      module procedure other_vec'//new_line('a')// &
+            '   end interface'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine one_vec(a)'//new_line('a')// &
+            '      integer, intent(in) :: a(3)'//new_line('a')// &
+            '      print *, a(1)'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            '   subroutine other_vec(a)'//new_line('a')// &
+            '      integer, intent(in) :: a(4)'//new_line('a')// &
+            '      print *, a(1)'//new_line('a')// &
+            '   end subroutine'//new_line('a')// &
+            'end module'//new_line('a')// &
+            ''//new_line('a')// &
+            'program p'//new_line('a')// &
+            '   use m'//new_line('a')// &
+            '   integer :: v(3)'//new_line('a')// &
+            '   v = 1'//new_line('a')// &
+            '   call gen(v)'//new_line('a')// &
+            'end program'
+
+        test_same_rank_array_specifics_ambiguous = expect_error_contains( &
+            source, 'ambiguous interfaces', &
+            '/tmp/ffc_reject_generic_01_r595')
+    end function test_same_rank_array_specifics_ambiguous
 
 end program test_session_reject_generic_01_compiler

--- a/test/test_session_reject_generic_01_compiler.f90
+++ b/test/test_session_reject_generic_01_compiler.f90
@@ -590,11 +590,11 @@ contains
             '   end interface'//new_line('a')// &
             'contains'//new_line('a')// &
             '   subroutine one_vec(a)'//new_line('a')// &
-            '      integer, intent(in) :: a(3)'//new_line('a')// &
+            '      integer, intent(in) :: a(:)'//new_line('a')// &
             '      print *, a(1)'//new_line('a')// &
             '   end subroutine'//new_line('a')// &
             '   subroutine other_vec(a)'//new_line('a')// &
-            '      integer, intent(in) :: a(4)'//new_line('a')// &
+            '      integer, intent(in) :: a(:)'//new_line('a')// &
             '      print *, a(1)'//new_line('a')// &
             '   end subroutine'//new_line('a')// &
             'end module'//new_line('a')// &

--- a/test/test_session_separate_generic_compiler.f90
+++ b/test/test_session_separate_generic_compiler.f90
@@ -55,6 +55,7 @@ program test_session_separate_generic_compiler
     if (.not. test_rank_aware_specifics_resolve()) all_passed = .false.
     if (.not. test_no_matching_rank_is_diagnosed()) all_passed = .false.
     if (.not. test_rank_only_specifics_share_one_generic()) all_passed = .false.
+    if (.not. test_assumed_shape_rank_specifics_accepted()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: separate-compilation generic interface'
@@ -259,6 +260,53 @@ contains
         call remove_scratch_dir(dir)
         ok = .true.
     end function test_rank_only_specifics_share_one_generic
+
+    logical function test_assumed_shape_rank_specifics_accepted() result(ok)
+        ! Assumed-shape specifics that differ only in rank are distinguishable
+        ! too, and their dummies carry no shape on the parameter node - the
+        ! rank has to come from the dummy's own declaration. gfortran
+        ! -fsyntax-only accepts this source (#595).
+        character(len=:), allocatable :: dir
+        integer :: same_status
+        character(len=*), parameter :: module_source = &
+            'module fmod595_assumed'//new_line('a')// &
+            '    implicit none'//new_line('a')// &
+            '    interface pick'//new_line('a')// &
+            '        module procedure pick_vec'//new_line('a')// &
+            '        module procedure pick_mat'//new_line('a')// &
+            '    end interface pick'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '    integer function pick_vec(z) result(r)'//new_line('a')// &
+            '        integer, intent(in) :: z(:)'//new_line('a')// &
+            '        r = z(1)'//new_line('a')// &
+            '    end function pick_vec'//new_line('a')// &
+            '    integer function pick_mat(z) result(r)'//new_line('a')// &
+            '        integer, intent(in) :: z(:,:)'//new_line('a')// &
+            '        r = z(1,1)'//new_line('a')// &
+            '    end function pick_mat'//new_line('a')// &
+            'end module fmod595_assumed'
+        character(len=*), parameter :: program_source = &
+            'program main'//new_line('a')// &
+            '    use fmod595_assumed, only: pick'//new_line('a')// &
+            '    integer :: v(3)'//new_line('a')// &
+            '    integer :: m(2,2)'//new_line('a')// &
+            '    v = 1'//new_line('a')// &
+            '    m = 2'//new_line('a')// &
+            '    stop pick(v) + pick(m)'//new_line('a')// &
+            'end program main'
+
+        ok = .false.
+        call make_scratch_dir('ffc595_assumed', dir)
+        same_status = run_same_unit_compilation(dir, module_source, &
+                                                program_source)
+        if (same_status /= 103) then
+            print *, 'FAIL: assumed-shape rank specifics status ', same_status
+            call show_log(dir)
+            return
+        end if
+        call remove_scratch_dir(dir)
+        ok = .true.
+    end function test_assumed_shape_rank_specifics_accepted
 
     integer function run_separate_compilation(dir, mod_source, prog_source) &
             result(status)

--- a/test/test_session_separate_generic_compiler.f90
+++ b/test/test_session_separate_generic_compiler.f90
@@ -13,6 +13,10 @@ program test_session_separate_generic_compiler
         '        module procedure total_scalar'//new_line('a')// &
         '        module procedure total_vec'//new_line('a')// &
         '    end interface total'//new_line('a')// &
+        '    interface merged'//new_line('a')// &
+        '        module procedure merged_vec'//new_line('a')// &
+        '        module procedure merged_mat'//new_line('a')// &
+        '    end interface merged'//new_line('a')// &
         '    interface grid_total'//new_line('a')// &
         '        module procedure grid_scalar'//new_line('a')// &
         '        module procedure grid_mat'//new_line('a')// &
@@ -34,6 +38,14 @@ program test_session_separate_generic_compiler
         '        integer, intent(in) :: y(2,2)'//new_line('a')// &
         '        r = y(1,1) + y(2,2)'//new_line('a')// &
         '    end function grid_mat'//new_line('a')// &
+        '    integer function merged_vec(z) result(r)'//new_line('a')// &
+        '        integer, intent(in) :: z(3)'//new_line('a')// &
+        '        r = z(1)'//new_line('a')// &
+        '    end function merged_vec'//new_line('a')// &
+        '    integer function merged_mat(z) result(r)'//new_line('a')// &
+        '        integer, intent(in) :: z(2,2)'//new_line('a')// &
+        '        r = z(1,1)'//new_line('a')// &
+        '    end function merged_mat'//new_line('a')// &
         'end module fmod415_generic'
 
     print *, '=== separate-compilation generic interface tests ==='
@@ -42,6 +54,7 @@ program test_session_separate_generic_compiler
     if (.not. test_use_associated_generic_resolves()) all_passed = .false.
     if (.not. test_rank_aware_specifics_resolve()) all_passed = .false.
     if (.not. test_no_matching_rank_is_diagnosed()) all_passed = .false.
+    if (.not. test_rank_only_specifics_share_one_generic()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: separate-compilation generic interface'
@@ -203,6 +216,49 @@ contains
         call remove_scratch_dir(dir)
         ok = .true.
     end function test_no_matching_rank_is_diagnosed
+
+    logical function test_rank_only_specifics_share_one_generic() result(ok)
+        ! Two specifics of the same element kind that differ only in rank are
+        ! distinguishable (F2018 C1514), so one generic may hold both. The
+        ! source is valid - gfortran -fsyntax-only accepts it - and must
+        ! compile both same-unit and through the .fmod (#595).
+        character(len=:), allocatable :: dir
+        integer :: separate_status, same_status
+        character(len=*), parameter :: program_source = &
+            'program main'//new_line('a')// &
+            '    use fmod415_generic, only: merged'//new_line('a')// &
+            '    integer :: v(3)'//new_line('a')// &
+            '    integer :: m(2,2)'//new_line('a')// &
+            '    v(1) = 1'//new_line('a')// &
+            '    v(2) = 2'//new_line('a')// &
+            '    v(3) = 3'//new_line('a')// &
+            '    m(1,1) = 10'//new_line('a')// &
+            '    m(2,1) = 0'//new_line('a')// &
+            '    m(1,2) = 0'//new_line('a')// &
+            '    m(2,2) = 20'//new_line('a')// &
+            '    stop merged(v) + merged(m)'//new_line('a')// &
+            'end program main'
+
+        ok = .false.
+        call make_scratch_dir('ffc595_rank_only', dir)
+        same_status = run_same_unit_compilation(dir, rank_module_source, &
+                                                program_source)
+        separate_status = run_separate_compilation(dir, rank_module_source, &
+                                                   program_source)
+        if (same_status /= 111) then
+            print *, 'FAIL: same-unit rank-only generic status ', same_status
+            call show_log(dir)
+            return
+        end if
+        if (separate_status /= 111) then
+            print *, 'FAIL: use-associated rank-only generic status ', &
+                separate_status
+            call show_log(dir)
+            return
+        end if
+        call remove_scratch_dir(dir)
+        ok = .true.
+    end function test_rank_only_specifics_share_one_generic
 
     integer function run_separate_compilation(dir, mod_source, prog_source) &
             result(status)


### PR DESCRIPTION
## Problem

ffc's source-text ambiguity pre-check read a dummy's rank only from the
parameter node. An assumed-shape dummy (`z(:)`, `z(:,:)`) carries no shape
there, so both a rank-1 and a rank-2 specific looked like rank 0 and the
pre-check called them indistinguishable — rejecting a valid program that
`gfortran -fsyntax-only` accepts. Differing rank is sufficient under
F2018 C1514.

## Change

When the parameter node carries no shape, fall back to the dummy's own
declaration in the specification part for the rank
(`dummy_declared_rank` in `src/session_program_lowering_reject_checks.inc`).
Nothing else in the distinguishability rule changes; this only loosens
rejection where the rank was previously unknown.

## Preserved invariant

Genuinely ambiguous pairs are still rejected. New negative control: two
specifics both taking `integer, intent(in) :: a(:)` still produce
`ambiguous interfaces` (test_session_reject_generic_01_compiler).

## Red evidence (origin/main)

```
$ ffc t595.f90 -o t595
t595.f90:1:1: error: ambiguous interfaces gen_vec and gen_mat in generic interface gen
$ gfortran -fsyntax-only t595.f90   # accepts
```
(module with `gen_vec(a(:))` / `gen_mat(a(:,:))` under one generic)

## Green evidence

- `test_session_separate_generic_compiler` PASS — new
  `test_assumed_shape_rank_specifics_accepted` (same-unit, assumed shape:
  red on main, green here) and
  `test_rank_only_specifics_share_one_generic` (rank-1/rank-2 explicit-shape
  specifics in one generic, same-unit and use-associated through the `.fmod`).
- `test_session_reject_generic_01_compiler` PASS — including the new
  same-rank negative control.
- Full `fo` pipeline: build OK, static OK. Three failures, all reproduced
  identically with the source change reverted to origin/main, so all
  pre-existing/environmental: `test_parity_dashboard` (resolves `../fortfront`
  from `.wt/`), `test_session_lazy_monomorph_compiler`, and
  `test_fortfront_corpus_conformance` (same 9 fortfront-f90 FAILs, same 3 lf
  XPASS, same total drift on main).

Assumed-shape dummies remain non-exportable across `.fmod` (an existing
#284/#415 boundary), so the use-associated fixture uses explicit shape.