### PR TITLE
[data-init-core-01] lower DATA array sections and derived initializers (closes #463)

### DIFF
--- a/src/session_program_lowering_common.inc
+++ b/src/session_program_lowering_common.inc
@@ -800,8 +800,10 @@
         type(common_slot_t), intent(inout) :: slots(:)
         integer, intent(in) :: slot_count
         character(len=:), allocatable, intent(out) :: error_msg
-        character(len=:), allocatable :: name, value_text
+        character(len=:), allocatable :: name, value_text, base_name
         integer :: i, s, k, value_cursor
+        integer :: lo, hi, st, e
+        logical :: is_section
 
         call set_empty(error_msg)
         if (.not. node_exists(arena, idx)) return
@@ -811,6 +813,42 @@
                 .not. allocated(data%value_indices)) return
             value_cursor = 0
             do i = 1, size(data%object_indices)
+                call block_data_section_range(arena, data%object_indices(i), &
+                                              base_name, lo, hi, st, is_section, &
+                                              error_msg)
+                if (len_trim(error_msg) > 0) return
+                if (is_section) then
+                    s = find_common_slot(slots, slot_count, base_name)
+                    if (s <= 0) then
+                        error_msg = 'BLOCK DATA section target is not in a '// &
+                                    'COMMON block: '//trim(base_name)
+                        return
+                    end if
+                    if (.not. slots(s)%is_array) then
+                        error_msg = 'BLOCK DATA section target is not an '// &
+                                    'array: '//trim(base_name)
+                        return
+                    end if
+                    if (hi <= 0) hi = slots(s)%array_size
+                    e = lo
+                    do while ((st > 0 .and. e <= hi) .or. (st < 0 .and. e >= hi))
+                        value_cursor = value_cursor + 1
+                        if (value_cursor > size(data%value_indices)) then
+                            error_msg = 'BLOCK DATA value count does not '// &
+                                        'match variable count'
+                            return
+                        end if
+                        call data_value_literal_text(arena, &
+                            data%value_indices(value_cursor), value_text, &
+                            error_msg)
+                        if (len_trim(error_msg) > 0) return
+                        call add_array_element_init(slots(s), e, value_text, &
+                                                    error_msg)
+                        if (len_trim(error_msg) > 0) return
+                        e = e + st
+                    end do
+                    cycle
+                end if
                 call data_object_name_and_index(arena, data%object_indices(i), &
                                                 name, error_msg)
                 if (len_trim(error_msg) > 0) return
@@ -857,6 +895,103 @@
             end if
         end select
     end subroutine apply_block_data_statement
+
+    subroutine block_data_section_range(arena, idx, base_name, lo, hi, st, &
+                                        is_section, error_msg)
+        !! Bounds of a rank-1 array-section DATA object in a BLOCK DATA unit,
+        !! arr(lo:hi[:st]). is_section stays false for any other object form.
+        !! COMMON array slots are rank-1 and one-based, so an omitted bound
+        !! spans 1..array_size, resolved by the caller through slot bounds
+        !! checking on each element index.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        character(len=:), allocatable, intent(out) :: base_name
+        integer, intent(out) :: lo, hi, st
+        logical, intent(out) :: is_section
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: bounds_index
+
+        is_section = .false.
+        base_name = ''
+        lo = 0
+        hi = 0
+        st = 1
+        call set_empty(error_msg)
+        if (.not. node_exists(arena, idx)) return
+        select type (obj => arena%entries(idx)%node)
+        type is (array_slice_node)
+            is_section = .true.
+            if (obj%num_dimensions /= 1) then
+                error_msg = 'BLOCK DATA section must be rank one'
+                return
+            end if
+            call common_identifier_text(arena, obj%array_index, base_name)
+            if (len_trim(base_name) == 0) then
+                error_msg = 'BLOCK DATA section target is not a name'
+                return
+            end if
+            bounds_index = obj%bounds_indices(1)
+            if (.not. node_exists(arena, bounds_index)) then
+                error_msg = 'BLOCK DATA section subscript is missing'
+                return
+            end if
+            select type (bnode => arena%entries(bounds_index)%node)
+            type is (range_expression_node)
+                call block_data_bound_const(arena, bnode%start_index, 1, lo, &
+                                            error_msg)
+                if (len_trim(error_msg) > 0) return
+                call block_data_bound_const(arena, bnode%end_index, 0, hi, &
+                                            error_msg)
+                if (len_trim(error_msg) > 0) return
+                call block_data_bound_const(arena, bnode%stride_index, 1, st, &
+                                            error_msg)
+                if (len_trim(error_msg) > 0) return
+                if (st == 0) error_msg = 'BLOCK DATA section stride is zero'
+            class default
+                error_msg = 'BLOCK DATA section bound is not a constant'
+            end select
+        end select
+    end subroutine block_data_section_range
+
+    subroutine block_data_bound_const(arena, node_index, default_value, value, &
+                                      error_msg)
+        !! Fold one section bound to an integer literal, or take the default
+        !! when the bound is omitted.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        integer, intent(in) :: default_value
+        integer, intent(out) :: value
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: io_stat
+
+        call set_empty(error_msg)
+        value = default_value
+        if (node_index <= 0) return
+        if (.not. node_exists(arena, node_index)) return
+        select type (bn => arena%entries(node_index)%node)
+        type is (literal_node)
+            read (bn%value, *, iostat=io_stat) value
+            if (io_stat /= 0) then
+                error_msg = 'BLOCK DATA section bound is not a constant'
+            end if
+        class default
+            error_msg = 'BLOCK DATA section bound is not a constant'
+        end select
+    end subroutine block_data_bound_const
+
+    subroutine common_identifier_text(arena, idx, name)
+        !! The identifier name at idx, or an empty string.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        character(len=:), allocatable, intent(out) :: name
+
+        name = ''
+        if (.not. node_exists(arena, idx)) return
+        select type (nd => arena%entries(idx)%node)
+        type is (identifier_node)
+            if (allocated(nd%name)) name = trim(nd%name)
+        end select
+    end subroutine common_identifier_text
 
     subroutine data_object_name_and_index(arena, idx, name, error_msg)
         ! Extract the name and index from a DATA object. Handles both scalar

--- a/src/session_program_lowering_data.inc
+++ b/src/session_program_lowering_data.inc
@@ -120,6 +120,11 @@
                                                  context, error_msg)
             return
         end if
+        if (is_data_section_object(arena, obj_index)) then
+            call lower_data_section_object(arena, node, obj_index, cursor, &
+                                           context, error_msg)
+            return
+        end if
         call identifier_name(arena, obj_index, name, error_msg)
         if (len_trim(error_msg) > 0) return
         sym = find_symbol_compat(context, name)
@@ -134,7 +139,10 @@
                                          error_msg)
             return
         end if
-        if (context%symbols(sym)%is_array) then
+        if (context%symbols(sym)%is_derived) then
+            call store_next_data_value_to_derived(arena, node, cursor, sym, &
+                                                  name, context, error_msg)
+        else if (context%symbols(sym)%is_array) then
             asz = context%symbols(sym)%array_size
             do k = 0, asz - 1
                 call store_next_data_value_to_element(arena, node, cursor, sym, &
@@ -147,6 +155,200 @@
                                                   context, error_msg)
         end if
     end subroutine lower_data_object
+
+    logical function is_data_section_object(arena, idx)
+        !! A DATA object written as an array section, arr(lo:hi[:step]) or
+        !! arr(:,j). FortFront represents it as an array_slice_node.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+
+        is_data_section_object = .false.
+        if (.not. node_exists(arena, idx)) return
+        select type (n => arena%entries(idx)%node)
+        type is (array_slice_node)
+            is_data_section_object = .true.
+        end select
+    end function is_data_section_object
+
+    subroutine lower_data_section_object(arena, node, obj_index, cursor, &
+                                         context, error_msg)
+        !! Expand an array-section DATA object into its elements in Fortran
+        !! array element order (leftmost subscript varies fastest) and consume
+        !! one value per element. Every subscript must fold to a compile-time
+        !! constant, matching the constant-expression rule for DATA.
+        type(ast_arena_t), intent(in) :: arena
+        type(data_statement_node), intent(in) :: node
+        integer, intent(in) :: obj_index
+        type(data_value_cursor_t), intent(inout) :: cursor
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer, parameter :: max_rank = 7
+        integer(c_int64_t) :: lowers(max_rank), extents(max_rank)
+        integer(c_int64_t) :: first(max_rank), step(max_rank), count(max_rank)
+        integer(c_int64_t) :: cur(max_rank), linear, stride
+        character(len=:), allocatable :: name
+        integer :: sym, rank, d
+        integer(c_int64_t) :: total, k
+        logical :: ok
+
+        call set_empty(error_msg)
+        select type (slice => arena%entries(obj_index)%node)
+        type is (array_slice_node)
+            call identifier_name(arena, slice%array_index, name, error_msg)
+            if (len_trim(error_msg) > 0) return
+            sym = find_symbol_compat(context, name)
+            if (sym <= 0) then
+                error_msg = 'data statement target was not declared: '//trim(name)
+                return
+            end if
+            if (.not. context%symbols(sym)%is_array) then
+                error_msg = 'data statement section target is not an array: '// &
+                            trim(name)
+                return
+            end if
+            call base_array_decl_shape(context, name, max_rank, rank, lowers, &
+                                       extents, ok)
+            if (.not. ok) then
+                error_msg = 'data statement section target has no '// &
+                            'compile-time shape: '//trim(name)
+                return
+            end if
+            call data_section_ranges(arena, context, slice, rank, lowers, &
+                                     extents, first, step, count, error_msg)
+            if (len_trim(error_msg) > 0) return
+        class default
+            error_msg = 'data statement object form not supported'
+            return
+        end select
+
+        total = 1_c_int64_t
+        do d = 1, rank
+            total = total*count(d)
+            cur(d) = first(d)
+        end do
+        do k = 1, total
+            linear = 0_c_int64_t
+            stride = 1_c_int64_t
+            do d = 1, rank
+                linear = linear + (cur(d) - lowers(d))*stride
+                stride = stride*extents(d)
+            end do
+            call store_next_data_value_to_element(arena, node, cursor, sym, &
+                                                  linear, context, error_msg)
+            if (len_trim(error_msg) > 0) return
+            do d = 1, rank
+                cur(d) = cur(d) + step(d)
+                if ((cur(d) - first(d))/step(d) < count(d)) exit
+                cur(d) = first(d)
+            end do
+        end do
+    end subroutine lower_data_section_object
+
+    subroutine data_section_ranges(arena, context, slice, rank, lowers, extents, &
+                                   first, step, count, error_msg)
+        !! Per-dimension first index, stride, and element count of a section.
+        !! An omitted dimension or a bare colon spans the declared bounds; a
+        !! scalar subscript selects one element.
+        type(ast_arena_t), intent(in) :: arena
+        type(lowering_context_t), intent(in) :: context
+        type(array_slice_node), intent(in) :: slice
+        integer, intent(in) :: rank
+        integer(c_int64_t), intent(in) :: lowers(:), extents(:)
+        integer(c_int64_t), intent(out) :: first(:), step(:), count(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer(c_int64_t) :: lo, hi, st, scalar_value
+        integer :: d, bounds_index
+        logical :: ok
+
+        call set_empty(error_msg)
+        if (slice%num_dimensions > rank) then
+            error_msg = 'data statement section has too many subscripts'
+            return
+        end if
+        do d = 1, rank
+            bounds_index = 0
+            if (d <= slice%num_dimensions) bounds_index = slice%bounds_indices(d)
+            first(d) = lowers(d)
+            step(d) = 1_c_int64_t
+            count(d) = extents(d)
+            if (bounds_index <= 0) cycle
+            if (.not. node_exists(arena, bounds_index)) then
+                error_msg = 'data statement section subscript is missing'
+                return
+            end if
+            select type (bnode => arena%entries(bounds_index)%node)
+            type is (range_expression_node)
+                call section_bound_const(arena, context, bnode%start_index, &
+                                         lowers(d), lo, ok)
+                if (ok) then
+                    call section_bound_const(arena, context, bnode%end_index, &
+                                        lowers(d) + extents(d) - 1_c_int64_t, &
+                                        hi, ok)
+                end if
+                if (ok) then
+                    call section_bound_const(arena, context, bnode%stride_index, &
+                                             1_c_int64_t, st, ok)
+                end if
+                if (.not. ok) then
+                    error_msg = 'data statement section bound is not a constant'
+                    return
+                end if
+                if (st == 0_c_int64_t) then
+                    error_msg = 'data statement section stride is zero'
+                    return
+                end if
+                first(d) = lo
+                step(d) = st
+                count(d) = (hi - lo)/st + 1_c_int64_t
+                if (count(d) < 0_c_int64_t) count(d) = 0_c_int64_t
+            class default
+                call eval_i32_constant(arena, bounds_index, context, &
+                                       scalar_value, error_msg)
+                if (len_trim(error_msg) > 0) then
+                    error_msg = 'data statement section subscript is not a '// &
+                                'constant'
+                    return
+                end if
+                first(d) = scalar_value
+                step(d) = 1_c_int64_t
+                count(d) = 1_c_int64_t
+            end select
+        end do
+    end subroutine data_section_ranges
+
+    subroutine store_next_data_value_to_derived(arena, node, cursor, sym, name, &
+                                                context, error_msg)
+        !! A derived-type DATA object takes one structure-constructor value,
+        !! stored component-by-component through the same slot layout the
+        !! constructor assignment path uses, so nested constructors keep the
+        !! declared component layout.
+        type(ast_arena_t), intent(in) :: arena
+        type(data_statement_node), intent(in) :: node
+        type(data_value_cursor_t), intent(inout) :: cursor
+        integer, intent(in) :: sym
+        character(len=*), intent(in) :: name
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: vidx, type_index
+        logical :: handled
+
+        call next_data_value(arena, node, cursor, context, vidx, error_msg)
+        if (len_trim(error_msg) > 0) return
+        type_index = context%symbols(sym)%derived_type_index
+        handled = .false.
+        if (type_index > 0 .and. .not. context%symbols(sym)%is_array) then
+            if (is_derived_constructor_call(arena, vidx, context, type_index)) then
+                call lower_derived_constructor_assignment(arena, vidx, context, &
+                                                          sym, type_index, &
+                                                          handled, error_msg)
+                if (len_trim(error_msg) > 0) return
+            end if
+        end if
+        if (.not. handled) then
+            error_msg = 'unsupported DATA initializer for derived-type '// &
+                        'object '''//trim(name)//''''
+        end if
+    end subroutine store_next_data_value_to_derived
 
     subroutine skip_static_data_values(arena, node, cursor, sym, context, &
                                        error_msg)

--- a/test/test_session_block_data_compiler.f90
+++ b/test/test_session_block_data_compiler.f90
@@ -15,6 +15,7 @@ program test_session_block_data_compiler
     if (.not. test_zero_size_common_array()) all_passed = .false.
     if (.not. test_do_loop_over_common_variable()) all_passed = .false.
     if (.not. test_whole_array_data_statement()) all_passed = .false.
+    if (.not. test_array_section_data_statement()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: block data initializes shared common storage'
@@ -214,5 +215,35 @@ contains
         test_whole_array_data_statement = expect_output( &
             source, expected, '/tmp/ffc_session_block_data_whole_array')
     end function test_whole_array_data_statement
+
+    logical function test_array_section_data_statement()
+        ! A BLOCK DATA array-section object initialises exactly its selected
+        ! COMMON elements, including a repeated value, and a real member
+        ! section keeps its declared kind.
+        character(len=*), parameter :: source = &
+            'program p'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer :: v(4)'//new_line('a')// &
+            '  real :: w(2)'//new_line('a')// &
+            '  common /blk/ v, w'//new_line('a')// &
+            '  print *, v(1), v(2), v(3), v(4)'//new_line('a')// &
+            '  print *, w(1), w(2)'//new_line('a')// &
+            'end program p'//new_line('a')// &
+            'block data bd'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer :: v(4)'//new_line('a')// &
+            '  real :: w(2)'//new_line('a')// &
+            '  common /blk/ v, w'//new_line('a')// &
+            '  data v(1:2) /5, 6/'//new_line('a')// &
+            '  data v(3:4) /2*9/'//new_line('a')// &
+            '  data w(1:2) /1.5, 2.5/'//new_line('a')// &
+            'end block data bd'
+        character(len=*), parameter :: expected = &
+            '           5           6           9           9'//new_line('a')// &
+            '   1.50000000       2.50000000    '//new_line('a')
+
+        test_array_section_data_statement = expect_output( &
+            source, expected, '/tmp/ffc_session_block_data_section')
+    end function test_array_section_data_statement
 
 end program test_session_block_data_compiler

--- a/test/test_session_data_statement_compiler.f90
+++ b/test/test_session_data_statement_compiler.f90
@@ -17,6 +17,10 @@ program test_session_data_statement
     if (.not. test_assignment_overrides_data()) all_passed = .false.
     if (.not. test_real_array_implied_do()) all_passed = .false.
     if (.not. test_boz_constant()) all_passed = .false.
+    if (.not. test_strided_section_init()) all_passed = .false.
+    if (.not. test_rank_two_section_and_repeat()) all_passed = .false.
+    if (.not. test_repeated_value_init()) all_passed = .false.
+    if (.not. test_nested_derived_constructor()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: DATA statements lower through direct LIRIC session'
@@ -99,5 +103,80 @@ contains
             source, '          16'//new_line('a'), &
             '/tmp/ffc_data_boz')
     end function test_boz_constant
+
+    logical function test_strided_section_init()
+        ! Array-section objects with a stride consume one value per selected
+        ! element in element order; two sections interleave in one array.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: arr(6)'//new_line('a')// &
+            '  data arr(1:5:2) /1, 2, 3/'//new_line('a')// &
+            '  data arr(2:4:2) /7, 8/'//new_line('a')// &
+            '  print *, arr(1), arr(2), arr(3), arr(4), arr(5)'//new_line('a')// &
+            'end program main'
+
+        test_strided_section_init = expect_output( &
+            source, &
+            '           1           7           2           8           3'// &
+            new_line('a'), &
+            '/tmp/ffc_data_section_stride')
+    end function test_strided_section_init
+
+    logical function test_rank_two_section_and_repeat()
+        ! A section of a rank-2 array walks the declared column-major layout,
+        ! and a repeated value expands over a real section.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: m(2,3)'//new_line('a')// &
+            '  real :: r(4)'//new_line('a')// &
+            '  data m(1,1:3) /10, 20, 30/'//new_line('a')// &
+            '  data r(2:3) /2*1.5/'//new_line('a')// &
+            '  print *, m(1,1), m(1,2), m(1,3)'//new_line('a')// &
+            '  print *, r(2), r(3)'//new_line('a')// &
+            'end program main'
+
+        test_rank_two_section_and_repeat = expect_output( &
+            source, &
+            '          10          20          30'//new_line('a')// &
+            '   1.50000000       1.50000000    '//new_line('a'), &
+            '/tmp/ffc_data_section_rank2')
+    end function test_rank_two_section_and_repeat
+
+    logical function test_repeated_value_init()
+        ! A repeat count supplies the same value to every element once.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(4)'//new_line('a')// &
+            '  data a /4*3/'//new_line('a')// &
+            '  print *, a(1), a(2), a(3), a(4)'//new_line('a')// &
+            'end program main'
+
+        test_repeated_value_init = expect_output( &
+            source, &
+            '           3           3           3           3'//new_line('a'), &
+            '/tmp/ffc_data_repeat')
+    end function test_repeated_value_init
+
+    logical function test_nested_derived_constructor()
+        ! A nested structure constructor initialises the derived object's
+        ! component layout instead of reaching the scalar store path.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type :: inner_t'//new_line('a')// &
+            '    integer :: k'//new_line('a')// &
+            '  end type inner_t'//new_line('a')// &
+            '  type :: outer_t'//new_line('a')// &
+            '    type(inner_t) :: i'//new_line('a')// &
+            '    integer :: j'//new_line('a')// &
+            '  end type outer_t'//new_line('a')// &
+            '  type(outer_t) :: o'//new_line('a')// &
+            '  data o /outer_t(inner_t(3), 4)/'//new_line('a')// &
+            '  print *, o%i%k, o%j'//new_line('a')// &
+            'end program main'
+
+        test_nested_derived_constructor = expect_output( &
+            source, '           3           4'//new_line('a'), &
+            '/tmp/ffc_data_derived_ctor')
+    end function test_nested_derived_constructor
 
 end program test_session_data_statement


### PR DESCRIPTION
Closes #463.

## What changed

- `src/session_program_lowering_data.inc`: an array-section DATA object
  (`array_slice_node`) is now expanded into its elements in Fortran array
  element order (leftmost subscript fastest), folding each dimension's
  start/end/stride to a compile-time constant against the declared shape.
  Covers `arr(lo:hi)`, strides (`arr(1:5:2)`), scalar subscripts mixed with
  ranges (`m(1,1:3)`), and omitted bounds. A derived-type DATA object now
  consumes one structure-constructor value and stores it through the same
  component-slot path used by constructor assignment, so nested constructors
  keep the declared component layout.
- `src/session_program_lowering_common.inc`: the BLOCK DATA folding path
  expands rank-1 COMMON array sections into per-element static initialisers
  instead of miscounting them as one value.
- Tests: section (strided, rank-2), repeated-value, nested derived
  constructor, and a BLOCK DATA COMMON section case.

## Preserved invariant

DATA remains static initialisation applied before execution: each value is
consumed exactly once in element order, kinds and COMMON storage offsets are
unchanged, and no valid initializer becomes an executable assignment.

## Red evidence (unmodified main)

- `data arr(2:4) /1,2,3/` -> `error: expected identifier assignment target`
- `data m(1,1:3) /1,2,3/` -> same error
- BLOCK DATA `data v(1:2) /5,6/` -> `error: BLOCK DATA value count does not match variable count`
- `data o /outer_t(inner_t(3), 4)/` -> compiled but printed garbage
  (`564331712 32764` instead of `3 4`)

## Green evidence

`fo test test_session_data_statement_compiler` and
`fo test test_session_block_data_compiler` both PASS; outputs match
`gfortran` on every new case.

Full `fo` pipeline: the only failures are the three pre-existing ones,
verified identical on an unmodified `origin/main` worktree in the same
session: `test_session_lazy_monomorph_compiler` (same two diagnostics on
baseline), `test_fortfront_corpus_conformance` (baseline and branch both
PASS=451 XFAIL=93 XPASS=0 FAIL=9 with the identical file list; lf suite
identical XPASS trio), and `test_parity_dashboard` (known `.wt/` sibling-repo
resolution failure). No corpus case regressed from PASS and no valid file is
newly rejected.