### PR TITLE
[io-status-01] return stable IOSTAT and IOMSG values (closes #427)

### DIFF
--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -725,8 +725,61 @@ They are never opened as `fort.<N>` and never closed, and `OPEN` on one of
 them without `FILE=` reconfigures the existing connection rather than
 replacing it, so `open(6, sign='plus')` keeps writing to standard output.
 
-Runtime entry points for IOSTAT/IOMSG and descriptor allocation are added by
-their own issues (#427, #428).
+### IOSTAT= and IOMSG= (#427)
+
+Fortran reports I/O outcome through `IOSTAT=` and `IOMSG=`. The classes are
+fixed by the standard and by what programs test for:
+
+| IOSTAT | Meaning |
+|---|---|
+| 0 | success |
+| -1 | end of file (gfortran's `IOSTAT_END`) |
+| -2 | end of record (gfortran's `IOSTAT_EOR`) |
+| > 0 | an error; the unit status codes above |
+
+| Symbol | Signature | Contract |
+|---|---|---|
+| `_ffc_iostat` | `int _ffc_iostat(void)` | Fortran status of the most recent I/O operation. |
+| `_ffc_iostat_set_end` | `void _ffc_iostat_set_end(void)` | Record an end-of-file condition. |
+| `_ffc_iostat_clear` | `void _ffc_iostat_clear(void)` | Record success. |
+| `_ffc_iomsg` | `void _ffc_iomsg(char *dest, int len)` | Message for the recorded status. |
+
+`_ffc_iomsg` writes with Fortran character assignment semantics: the text is
+truncated to `len` and the remainder blank filled. It writes exactly `len`
+characters plus a terminating NUL, so `dest` must have room for `len + 1` —
+the compiler's character values are NUL-terminated buffers of the declared
+length. After a successful operation the destination is left all blanks rather
+than untouched, so it is always defined; the standard defines `IOMSG=` only
+when an error or end-of-file condition occurs.
+
+`OPEN`'s own return value is its `IOSTAT=`. A file `WRITE` and a `READ` report
+the runtime's record of the operation. A `READ` that reaches end of file
+records it in the runtime as well, so `IOSTAT=` and `IOMSG=` describe the same
+condition rather than being derived independently.
+
+`IOSTAT=` targets must be default integers and `IOMSG=` targets character
+variables with a declared length; both are rejected with a named diagnostic
+otherwise.
+
+Runtime entry points for descriptor allocation are added by their own issue
+(#428).
+
+## Building the runtime
+
+`runtime/ffc_runtime.c` is compiled by whichever C driver links an emitted
+executable, and by clang in `runtime/CMakeLists.txt`. It states its own
+language level and feature set — `#define _XOPEN_SOURCE 700` before any
+include — instead of inheriting the invoking driver's defaults, because
+`random`/`srandom` are POSIX rather than ISO C and a strict driver would
+otherwise reach them only through an implicit declaration: a warning on a
+lenient toolchain, a hard error elsewhere.
+
+It is C, and only C flags apply to it. It lives in `runtime/`, never under
+`src/`, where fpm would compile it with the Fortran flag set (`-J`,
+`-ffree-form`, `-fimplicit-none`). `runtime/CMakeLists.txt` spells its clang
+flags out rather than inheriting them. `test_runtime_link_compiler` enforces
+both: it fails if any C source appears under `src/`, and it fails unless the
+runtime builds under `cc -std=c11 -Wall -Wextra -Werror -pedantic`.
 
 ### Dependencies
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -68,7 +68,13 @@ file(MAKE_DIRECTORY "${FFC_RUNTIME_ARTIFACT_DIR}")
 set(FFC_RUNTIME_BC "${CMAKE_CURRENT_BINARY_DIR}/ffc_runtime.bc")
 add_custom_command(
     OUTPUT "${FFC_RUNTIME_BC}"
-    COMMAND "${FFC_RUNTIME_CLANG}" -emit-llvm -c -O1
+    # C flags only, spelled out here rather than inherited. This project
+    # produces a C artifact, and a Fortran-only flag reaching this command
+    # (-J, -ffree-form, -fimplicit-none) is a hard error from clang rather
+    # than something to discover later. The language level matches the one
+    # the runtime source states for itself.
+    COMMAND "${FFC_RUNTIME_CLANG}" -x c -std=c11 -emit-llvm -c -O1
+            -Wall -Wextra -Werror
             -o "${FFC_RUNTIME_BC}"
             "${CMAKE_CURRENT_SOURCE_DIR}/ffc_runtime.c"
     DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/ffc_runtime.c"

--- a/runtime/ffc_runtime.c
+++ b/runtime/ffc_runtime.c
@@ -1,3 +1,17 @@
+/* The runtime states the language level and the feature set it
+ * needs, before any include, instead of inheriting whatever the
+ * invoking driver happens to default to.
+ *
+ * Three drivers compile this file: the system C compiler that
+ * links every emitted executable, clang in
+ * runtime/CMakeLists.txt, and any packager's. random() and
+ * srandom() are POSIX, not ISO C, so without this a strict
+ * driver reaches them only through an implicit declaration: a
+ * warning on a lenient toolchain, a hard error on a strict one
+ * or on a C23 default. Declaring the macro makes every driver
+ * agree. */
+#define _XOPEN_SOURCE 700
+
 /* ffc runtime support library.
  *
  * Single source of truth for the ffc runtime. Two consumers
@@ -382,4 +396,96 @@ int _ffc_write_text(int unit, const char *text) {
         return ffc_unit_last_status;
     }
     return ffc_write_failed(fputs(text, fp));
+}
+
+/* ---- IOSTAT and IOMSG (issue #427) ------------------------ */
+
+/* Fortran reports I/O status through IOSTAT= and IOMSG=. The
+ * classes are fixed by the standard and by what programs test
+ * for:
+ *
+ *   0    success
+ *   -1   end of file      (gfortran's IOSTAT_END)
+ *   -2   end of record    (gfortran's IOSTAT_EOR)
+ *   > 0  an error
+ *
+ * The runtime already records an internal status per unit
+ * operation. These map that to the Fortran class and to the
+ * message text, in one place, so every statement reports the
+ * same value for the same condition. */
+
+#define FFC_IOSTAT_END (-1)
+#define FFC_IOSTAT_EOR (-2)
+
+/* Fortran status of the most recent I/O operation. Internal
+ * codes are already positive error numbers, and the end-of-file
+ * and end-of-record classes are stored as themselves, so this
+ * is the recorded status unchanged. It exists so lowering has
+ * one name to call rather than knowing the mapping. */
+int _ffc_iostat(void) {
+    return ffc_unit_last_status;
+}
+
+/* Records an end-of-file condition, so a READ that hits it
+ * reports the same -1 every other statement reports. */
+void _ffc_iostat_set_end(void) {
+    ffc_unit_last_status = FFC_IOSTAT_END;
+}
+
+void _ffc_iostat_clear(void) {
+    ffc_unit_last_status = 0;
+}
+
+static const char *ffc_iostat_text(int status) {
+    switch (status) {
+    case 0:
+        return "";
+    case FFC_IOSTAT_END:
+        return "End of file";
+    case FFC_IOSTAT_EOR:
+        return "End of record";
+    case FFC_IOSTAT_BADUNIT:
+        return "Unit number is out of range";
+    case FFC_IOSTAT_NOUNIT:
+        return "Unit is not connected";
+    case FFC_IOSTAT_INUSE:
+        return "Unit is already connected";
+    case FFC_IOSTAT_OPEN:
+        return "Cannot open file";
+    case FFC_IOSTAT_NOSPACE:
+        return "No free unit for NEWUNIT";
+    case FFC_IOSTAT_WRITE:
+        return "Write failed";
+    default:
+        return "I/O error";
+    }
+}
+
+/* IOMSG= for the most recent operation, written with Fortran
+ * character assignment semantics: the text is truncated to len
+ * and the remainder is blank filled, never NUL terminated.
+ *
+ * The standard defines IOMSG only when an error or end-of-file
+ * condition occurs. After a successful operation this leaves the
+ * variable all blanks rather than untouched, so the destination
+ * is always defined and a program never reads whatever the
+ * buffer happened to hold.
+ *
+ * Writes exactly len characters and a terminating NUL, so dest
+ * must have room for len + 1: the compiler's character values
+ * are NUL-terminated buffers of the declared length. */
+void _ffc_iomsg(char *dest, int len) {
+    const char *text;
+    int i;
+    if (dest == NULL || len <= 0) {
+        return;
+    }
+    text = ffc_iostat_text(ffc_unit_last_status);
+    for (i = 0; i < len && text[i] != '\0'; i++) {
+        dest[i] = text[i];
+    }
+    for (; i < len; i++) {
+        dest[i] = ' ';
+    }
+    dest[len] = '\0';
 }

--- a/src/ffc_runtime_link.f90
+++ b/src/ffc_runtime_link.f90
@@ -50,7 +50,7 @@ module ffc_runtime_link
     ! Every runtime entry point the lowerer is allowed to call. Each issue
     ! that moves compiler-emitted code behind the runtime ABI adds its symbols
     ! here and to docs/RUNTIME_ABI.md.
-    character(len=*), parameter :: FFC_RUNTIME_SYMBOLS(17) = &
+    character(len=*), parameter :: FFC_RUNTIME_SYMBOLS(21) = &
         [character(len=32) :: '_ffc_runtime_probe', &
          '_ffc_unit_status', '_ffc_unit_newunit', '_ffc_unit_open', &
          '_ffc_unit_is_open', '_ffc_unit_file', '_ffc_unit_rewind', &
@@ -58,7 +58,9 @@ module ffc_runtime_link
          '_ffc_write_i32', '_ffc_write_i64', '_ffc_write_f64', &
          '_ffc_write_str', '_ffc_write_text', &
          '_ffc_random_seed_size', '_ffc_random_seed_put', &
-         '_ffc_random_seed_get', '_ffc_random_seed_default']
+         '_ffc_random_seed_get', '_ffc_random_seed_default', &
+         '_ffc_iostat', '_ffc_iostat_set_end', '_ffc_iostat_clear', &
+         '_ffc_iomsg']
 
 contains
 

--- a/src/ffc_runtime_source.f90
+++ b/src/ffc_runtime_source.f90
@@ -23,6 +23,33 @@ contains
 
         text = ''
         text = text// &
+            '/* The runtime states the language level and the feature set it'//NL
+        text = text// &
+            ' * needs, before any include, instead of inheriting whatever the'//NL
+        text = text// &
+            ' * invoking driver happens to default to.'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' * Three drivers compile this file: the system C compiler that'//NL
+        text = text// &
+            ' * links every emitted executable, clang in'//NL
+        text = text// &
+            ' * runtime/CMakeLists.txt, and any packager''s. random() and'//NL
+        text = text// &
+            ' * srandom() are POSIX, not ISO C, so without this a strict'//NL
+        text = text// &
+            ' * driver reaches them only through an implicit declaration: a'//NL
+        text = text// &
+            ' * warning on a lenient toolchain, a hard error on a strict one'//NL
+        text = text// &
+            ' * or on a C23 default. Declaring the macro makes every driver'//NL
+        text = text// &
+            ' * agree. */'//NL
+        text = text// &
+            '#define _XOPEN_SOURCE 700'//NL
+        text = text//NL
+        text = text// &
             '/* ffc runtime support library.'//NL
         text = text// &
             ' *'//NL
@@ -754,6 +781,182 @@ contains
             '    }'//NL
         text = text// &
             '    return ffc_write_failed(fputs(text, fp));'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* ---- IOSTAT and IOMSG (issue #427) ------------------------ */'//NL
+        text = text//NL
+        text = text// &
+            '/* Fortran reports I/O status through IOSTAT= and IOMSG=. The'//NL
+        text = text// &
+            ' * classes are fixed by the standard and by what programs test'//NL
+        text = text// &
+            ' * for:'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' *   0    success'//NL
+        text = text// &
+            ' *   -1   end of file      (gfortran''s IOSTAT_END)'//NL
+        text = text// &
+            ' *   -2   end of record    (gfortran''s IOSTAT_EOR)'//NL
+        text = text// &
+            ' *   > 0  an error'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' * The runtime already records an internal status per unit'//NL
+        text = text// &
+            ' * operation. These map that to the Fortran class and to the'//NL
+        text = text// &
+            ' * message text, in one place, so every statement reports the'//NL
+        text = text// &
+            ' * same value for the same condition. */'//NL
+        text = text//NL
+        text = text// &
+            '#define FFC_IOSTAT_END (-1)'//NL
+        text = text// &
+            '#define FFC_IOSTAT_EOR (-2)'//NL
+        text = text//NL
+        text = text// &
+            '/* Fortran status of the most recent I/O operation. Internal'//NL
+        text = text// &
+            ' * codes are already positive error numbers, and the end-of-file'//NL
+        text = text// &
+            ' * and end-of-record classes are stored as themselves, so this'//NL
+        text = text// &
+            ' * is the recorded status unchanged. It exists so lowering has'//NL
+        text = text// &
+            ' * one name to call rather than knowing the mapping. */'//NL
+        text = text// &
+            'int _ffc_iostat(void) {'//NL
+        text = text// &
+            '    return ffc_unit_last_status;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Records an end-of-file condition, so a READ that hits it'//NL
+        text = text// &
+            ' * reports the same -1 every other statement reports. */'//NL
+        text = text// &
+            'void _ffc_iostat_set_end(void) {'//NL
+        text = text// &
+            '    ffc_unit_last_status = FFC_IOSTAT_END;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            'void _ffc_iostat_clear(void) {'//NL
+        text = text// &
+            '    ffc_unit_last_status = 0;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            'static const char *ffc_iostat_text(int status) {'//NL
+        text = text// &
+            '    switch (status) {'//NL
+        text = text// &
+            '    case 0:'//NL
+        text = text// &
+            '        return "";'//NL
+        text = text// &
+            '    case FFC_IOSTAT_END:'//NL
+        text = text// &
+            '        return "End of file";'//NL
+        text = text// &
+            '    case FFC_IOSTAT_EOR:'//NL
+        text = text// &
+            '        return "End of record";'//NL
+        text = text// &
+            '    case FFC_IOSTAT_BADUNIT:'//NL
+        text = text// &
+            '        return "Unit number is out of range";'//NL
+        text = text// &
+            '    case FFC_IOSTAT_NOUNIT:'//NL
+        text = text// &
+            '        return "Unit is not connected";'//NL
+        text = text// &
+            '    case FFC_IOSTAT_INUSE:'//NL
+        text = text// &
+            '        return "Unit is already connected";'//NL
+        text = text// &
+            '    case FFC_IOSTAT_OPEN:'//NL
+        text = text// &
+            '        return "Cannot open file";'//NL
+        text = text// &
+            '    case FFC_IOSTAT_NOSPACE:'//NL
+        text = text// &
+            '        return "No free unit for NEWUNIT";'//NL
+        text = text// &
+            '    case FFC_IOSTAT_WRITE:'//NL
+        text = text// &
+            '        return "Write failed";'//NL
+        text = text// &
+            '    default:'//NL
+        text = text// &
+            '        return "I/O error";'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* IOMSG= for the most recent operation, written with Fortran'//NL
+        text = text// &
+            ' * character assignment semantics: the text is truncated to len'//NL
+        text = text// &
+            ' * and the remainder is blank filled, never NUL terminated.'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' * The standard defines IOMSG only when an error or end-of-file'//NL
+        text = text// &
+            ' * condition occurs. After a successful operation this leaves the'//NL
+        text = text// &
+            ' * variable all blanks rather than untouched, so the destination'//NL
+        text = text// &
+            ' * is always defined and a program never reads whatever the'//NL
+        text = text// &
+            ' * buffer happened to hold.'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' * Writes exactly len characters and a terminating NUL, so dest'//NL
+        text = text// &
+            ' * must have room for len + 1: the compiler''s character values'//NL
+        text = text// &
+            ' * are NUL-terminated buffers of the declared length. */'//NL
+        text = text// &
+            'void _ffc_iomsg(char *dest, int len) {'//NL
+        text = text// &
+            '    const char *text;'//NL
+        text = text// &
+            '    int i;'//NL
+        text = text// &
+            '    if (dest == NULL || len <= 0) {'//NL
+        text = text// &
+            '        return;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    text = ffc_iostat_text(ffc_unit_last_status);'//NL
+        text = text// &
+            '    for (i = 0; i < len && text[i] != ''\0''; i++) {'//NL
+        text = text// &
+            '        dest[i] = text[i];'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    for (; i < len; i++) {'//NL
+        text = text// &
+            '        dest[i] = '' '';'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    dest[len] = ''\0'';'//NL
         text = text// &
             '}'//NL
     end subroutine ffc_runtime_source_text

--- a/src/session_program_lowering_open_close.inc
+++ b/src/session_program_lowering_open_close.inc
@@ -8,7 +8,8 @@
     ! --- spec-text helpers ---------------------------------------------------
 
     subroutine parse_open_spec(spec, unit_str, newunit_var, file_path, &
-                                file_quoted, status_str, sign_str, error_msg)
+                                file_quoted, status_str, sign_str, &
+                                iostat_var, iomsg_var, error_msg)
         ! Extract keyword values from an OPEN specifier-list text.
         ! spec is the raw text inside the OPEN(...) parentheses.
         character(len=*), intent(in) :: spec
@@ -18,6 +19,8 @@
         logical, intent(out) :: file_quoted
         character(len=:), allocatable, intent(out) :: status_str
         character(len=:), allocatable, intent(out) :: sign_str
+        character(len=:), allocatable, intent(out) :: iostat_var
+        character(len=:), allocatable, intent(out) :: iomsg_var
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: text, kw, val
         integer :: p, eq_pos, cp, qend, arg_end
@@ -31,6 +34,8 @@
         file_quoted = .false.
         status_str = ''
         sign_str = ''
+        iostat_var = ''
+        iomsg_var = ''
         text = trim(adjustl(spec))
         p = 1
         first_arg = .true.
@@ -101,6 +106,10 @@
                 status_str = spec_lower(trim(val))
             case ('sign')
                 sign_str = spec_lower(trim(val))
+            case ('iostat')
+                iostat_var = trim(val)
+            case ('iomsg')
+                iomsg_var = trim(val)
             end select
         end do
     end subroutine parse_open_spec
@@ -133,7 +142,8 @@
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: ustr, nuvar, fpath, sstr, signstr
-        type(lr_operand_desc_t) :: unit_op, args(4), unused
+        character(len=:), allocatable :: iostat_var, iomsg_var
+        type(lr_operand_desc_t) :: unit_op, args(4), status_op
         integer :: sym, ios, unit_number
         logical :: file_quoted
 
@@ -145,7 +155,7 @@
         end if
 
         call parse_open_spec(node%unit_spec, ustr, nuvar, fpath, file_quoted, &
-                              sstr, signstr, error_msg)
+                              sstr, signstr, iostat_var, iomsg_var, error_msg)
         if (len_trim(error_msg) > 0) return
 
         ! F2018 12.5.6.12: OPEN with NEWUNIT= must also give FILE= or
@@ -206,7 +216,12 @@
                                  error_msg)
         if (len_trim(error_msg) > 0) return
         if (.not. emit_i32_call(context%session, '_ffc_unit_open', args, &
-                                unused, error_msg)) return
+                                status_op, error_msg)) return
+        ! The OPEN's own return value is its IOSTAT=, so a failed connection
+        ! reports the runtime's code instead of being lost (#427).
+        call store_io_status(context, iostat_var, iomsg_var, status_op, &
+                             error_msg)
+        if (len_trim(error_msg) > 0) return
         call set_empty(error_msg)
     end subroutine lower_open
 
@@ -319,6 +334,115 @@
 
 
 
+
+
+    ! --- IOSTAT= and IOMSG= (#427) -------------------------------------------
+
+    subroutine store_io_status(context, iostat_name, iomsg_name, status_op, &
+                               error_msg)
+        ! Report one I/O statement's outcome. status_op is the value the
+        ! runtime returned for the operation; when it is absent the caller
+        ! wants the runtime's record of the last operation instead, which is
+        ! the same number reached by a different route.
+        !
+        ! Both specifiers are optional and independent, and each is left
+        ! alone when its specifier is absent.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: iostat_name
+        character(len=*), intent(in) :: iomsg_name
+        type(lr_operand_desc_t), intent(in) :: status_op
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call set_empty(error_msg)
+        if (len_trim(iostat_name) > 0) then
+            call store_iostat_value(context, iostat_name, status_op, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end if
+        if (len_trim(iomsg_name) > 0) then
+            call store_iomsg_text(context, iomsg_name, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end if
+    end subroutine store_io_status
+
+    subroutine store_iostat_value(context, name, status_op, error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: name
+        type(lr_operand_desc_t), intent(in) :: status_op
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: sym
+
+        call set_empty(error_msg)
+        sym = find_symbol_compat(context, trim(name))
+        if (sym <= 0) then
+            error_msg = 'iostat target was not declared: '//trim(name)
+            return
+        end if
+        if (context%symbols(sym)%value_kind /= VALUE_I32) then
+            error_msg = 'iostat target must be a default integer: '//trim(name)
+            return
+        end if
+        call assign_i32_to_symbol(context, sym, status_op, error_msg)
+    end subroutine store_iostat_value
+
+    subroutine store_iomsg_text(context, name, error_msg)
+        ! _ffc_iomsg(buffer, len) fills a fresh buffer of the variable's
+        ! declared length with the message for the recorded status, truncated
+        ! or blank padded to that length by Fortran character assignment
+        ! rules. The symbol is rebound to the buffer, the same way a runtime
+        ! character assignment rebinds it.
+        use liric_session_memory_bindings, only: emit_malloc
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: buffer, args(2), unused
+        integer :: sym, length
+
+        call set_empty(error_msg)
+        sym = find_symbol_compat(context, trim(name))
+        if (sym <= 0) then
+            error_msg = 'iomsg target was not declared: '//trim(name)
+            return
+        end if
+        if (context%symbols(sym)%value_kind /= VALUE_CHARACTER) then
+            error_msg = 'iomsg target must be a character variable: '// &
+                trim(name)
+            return
+        end if
+        length = context%symbols(sym)%character_length
+        if (length <= 0) then
+            error_msg = 'iomsg target must have a declared length: '//trim(name)
+            return
+        end if
+        ! One byte more than the declared length: _ffc_iomsg writes len
+        ! characters and a terminating NUL, matching the NUL-terminated
+        ! buffers the compiler's character values point at.
+        if (.not. emit_malloc(context%session, &
+                              i64_immediate(context%session, &
+                                            int(length + 1, c_int64_t)), &
+                              buffer, error_msg)) return
+        args(1) = buffer
+        args(2) = i32_immediate(context%session, int(length, c_int64_t))
+        if (.not. emit_void_call(context%session, '_ffc_iomsg', args, &
+                                 error_msg)) return
+        context%symbols(sym)%value = buffer
+        context%symbols(sym)%has_character_value = .true.
+    end subroutine store_iomsg_text
+
+    function runtime_iostat_operand(context, error_msg) result(status_op)
+        ! The runtime's record of the last I/O operation, for statements that
+        ! do not have a single call whose return value is the status.
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: status_op
+        type(lr_operand_desc_t), allocatable :: noargs(:)
+
+        allocate (noargs(0))
+        if (.not. emit_i32_call(context%session, '_ffc_iostat', noargs, &
+                                status_op, error_msg)) return
+        call set_empty(error_msg)
+    end function runtime_iostat_operand
 
     ! --- CLOSE ---------------------------------------------------------------
 
@@ -496,30 +620,25 @@
     end subroutine lower_write_file
 
     subroutine store_write_iostat_success(node, context, error_msg)
-        ! Populate a WRITE's iostat= target with 0 (success). The variable name
-        ! lives in the io_control_list text (iostat=<name>).
+        ! Report a file WRITE's outcome. The status comes from the runtime's
+        ! record of the operation rather than an assumed 0, so a write to an
+        ! unusable unit is visible to the program (#427). The specifier names
+        ! live in the io_control_list text (iostat=<name>, iomsg=<name>).
         type(write_statement_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
-        character(len=:), allocatable :: var_name
-        integer :: sym
+        character(len=:), allocatable :: iostat_name, iomsg_name
+        type(lr_operand_desc_t) :: status_op
 
         call set_empty(error_msg)
         if (.not. allocated(node%io_control_list)) return
-        call io_control_value(node%io_control_list, 'iostat', var_name)
-        if (len_trim(var_name) == 0) return
-        sym = find_symbol_compat(context, var_name)
-        if (sym <= 0) then
-            error_msg = 'iostat target was not declared: '//trim(var_name)
-            return
-        end if
-        if (context%symbols(sym)%value_kind /= VALUE_I32) then
-            error_msg = 'iostat target must be a default integer: '//trim(var_name)
-            return
-        end if
-        call assign_i32_to_symbol(context, sym, &
-                                  i32_immediate(context%session, 0_c_int64_t), &
-                                  error_msg)
+        call io_control_value(node%io_control_list, 'iostat', iostat_name)
+        call io_control_value(node%io_control_list, 'iomsg', iomsg_name)
+        if (len_trim(iostat_name) == 0 .and. len_trim(iomsg_name) == 0) return
+        status_op = runtime_iostat_operand(context, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call store_io_status(context, iostat_name, iomsg_name, status_op, &
+                             error_msg)
     end subroutine store_write_iostat_success
 
     integer function file_write_value_kind(arena, node_index, context)

--- a/src/session_program_lowering_read_ops.inc
+++ b/src/session_program_lowering_read_ops.inc
@@ -165,12 +165,19 @@
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t), intent(in), optional :: ok_value
         type(lr_operand_desc_t) :: ok, eof_flag, fp_arg(1), success_code
+        type(lr_operand_desc_t), allocatable :: noargs(:)
+        character(len=:), allocatable :: iomsg_name
         integer(c_int32_t) :: ok_blk, eof_blk, done_blk
         integer :: sym
 
         call set_empty(error_msg)
         call read_iostat_symbol(node, context, sym, error_msg)
-        if (len_trim(error_msg) > 0 .or. sym <= 0) return
+        if (len_trim(error_msg) > 0) return
+        iomsg_name = ''
+        if (allocated(node%io_control_list)) &
+            call io_control_value(node%io_control_list, 'iomsg', iomsg_name)
+        if (sym <= 0 .and. len_trim(iomsg_name) == 0) return
+        allocate (noargs(0))
 
         ! feof(fp) is set only once a read hits end-of-file. The vararg fscanf
         ! return is not reliably captured by the backend, so use feof to detect
@@ -187,23 +194,38 @@
                                      error_msg)) return
 
         if (.not. set_liric_block(context%session, ok_blk, error_msg)) return
+        ! Tell the runtime which condition this was, so IOMSG= reports the
+        ! same thing IOSTAT= does and both come from one place (#427).
+        if (.not. emit_void_call(context%session, '_ffc_iostat_clear', noargs, &
+                                 error_msg)) return
         success_code = i32_immediate(context%session, 0_c_int64_t)
         if (present(ok_value)) success_code = ok_value
-        call assign_i32_to_symbol(context, sym, success_code, error_msg)
-        if (len_trim(error_msg) > 0) return
+        if (sym > 0) then
+            call assign_i32_to_symbol(context, sym, success_code, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end if
         if (.not. emit_liric_br(context%session, done_blk, error_msg)) return
 
         if (.not. set_liric_block(context%session, eof_blk, error_msg)) return
-        call assign_i32_to_symbol(context, sym, &
-                                  i32_immediate(context%session, -1_c_int64_t), &
-                                  error_msg)
-        if (len_trim(error_msg) > 0) return
+        if (.not. emit_void_call(context%session, '_ffc_iostat_set_end', &
+                                 noargs, error_msg)) return
+        if (sym > 0) then
+            call assign_i32_to_symbol(context, sym, &
+                                      i32_immediate(context%session, &
+                                                    -1_c_int64_t), error_msg)
+            if (len_trim(error_msg) > 0) return
+        end if
         if (.not. emit_liric_br(context%session, done_blk, error_msg)) return
 
         if (.not. set_liric_block(context%session, done_blk, error_msg)) return
         ! Both branches stored to the same slot; reload so later uses of the
         ! iostat variable see the merged value rather than a per-branch register.
-        call reload_i32_symbol(context, sym, error_msg)
+        if (sym > 0) then
+            call reload_i32_symbol(context, sym, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end if
+        if (len_trim(iomsg_name) > 0) &
+            call store_iomsg_text(context, iomsg_name, error_msg)
     end subroutine store_read_iostat_from_eof
 
     subroutine reload_i32_symbol(context, sym, error_msg)

--- a/test/test_runtime_link_compiler.f90
+++ b/test/test_runtime_link_compiler.f90
@@ -44,6 +44,7 @@ program test_runtime_link_compiler
 
     call check_embedded_source_matches_file(failures)
     call check_runtime_c_is_out_of_the_fpm_tree(failures)
+    call check_runtime_builds_under_a_strict_c_driver(failures)
     call check_declared_symbols_are_defined(failures)
     call check_probe_runs_with_runtime(failures)
     call check_probe_fails_without_runtime(failures)
@@ -149,6 +150,34 @@ contains
             nfail = nfail + 1
         end if
     end subroutine check_runtime_c_is_out_of_the_fpm_tree
+
+    ! The runtime is compiled by whichever C driver is on the machine that
+    ! links an executable, and by clang in runtime/CMakeLists.txt. Building
+    ! only under a lenient driver is how a runtime that works here fails on
+    ! someone else's machine, so this pins the strict case: C11, pedantic,
+    ! warnings as errors. An implicit declaration of a POSIX function is the
+    ! failure this catches; the runtime declares its own feature-test macro
+    ! rather than inheriting the driver's default.
+    subroutine check_runtime_builds_under_a_strict_c_driver(nfail)
+        integer, intent(inout) :: nfail
+        character(len=*), parameter :: obj = WORK//'/strict.o'
+        character(len=:), allocatable :: link_input, error_msg
+        integer :: status
+
+        call ffc_runtime_link_input(link_input, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: runtime link input: ', trim(error_msg)
+            nfail = nfail + 1
+            return
+        end if
+        status = status_of('cc -std=c11 -Wall -Wextra -Werror -pedantic '// &
+                           '-c -o '//obj//' '//link_input)
+        if (status /= 0) then
+            print *, 'FAIL: the runtime does not build under a strict C ', &
+                'driver (C11, pedantic, warnings as errors)'
+            nfail = nfail + 1
+        end if
+    end subroutine check_runtime_builds_under_a_strict_c_driver
 
     ! Guards the lowerer: a symbol it is allowed to call must exist.
     subroutine check_declared_symbols_are_defined(nfail)

--- a/test/test_session_iostat_iomsg_compiler.f90
+++ b/test/test_session_iostat_iomsg_compiler.f90
@@ -1,0 +1,135 @@
+! Issue #427: IOSTAT= and IOMSG= report stable, documented values.
+!
+! Behavioral oracle. Before #427 a WRITE's IOSTAT= was assigned a literal 0
+! whatever happened, OPEN had no IOSTAT= or IOMSG= at all, and IOMSG= was
+! never written by any statement. The status classes and the message text
+! now come from one place in the runtime, so every statement reports the
+! same value for the same condition.
+!
+!   1. OPEN on a file that cannot be opened reports a nonzero status and a
+!      message; the same OPEN on a usable file reports 0 and blanks. Both
+!      fail on the pre-#427 compiler, which ignored the specifiers.
+!   2. READ reports 0 with a blank message, then -1 with "End of file",
+!      distinguishing end of file from an error.
+!   3. IOMSG= obeys Fortran character assignment: truncated to the
+!      destination length, blank padded when shorter.
+!   4. A noninteger IOSTAT= and a noncharacter IOMSG= are still rejected.
+program test_session_iostat_iomsg_compiler
+    use ffc_test_support, only: expect_output, expect_error_contains
+    implicit none
+
+    character(len=*), parameter :: Q = achar(39)
+    logical :: all_passed
+
+    print *, '=== IOSTAT and IOMSG tests (#427) ==='
+
+    all_passed = .true.
+    if (.not. test_open_failure_and_success()) all_passed = .false.
+    if (.not. test_read_end_of_file()) all_passed = .false.
+    if (.not. test_iomsg_is_truncated()) all_passed = .false.
+    if (.not. test_noninteger_iostat_is_rejected()) all_passed = .false.
+    if (.not. test_noncharacter_iomsg_is_rejected()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: IOSTAT and IOMSG are stable'
+
+contains
+
+    ! A missing file is an error with a message; a usable file is not.
+    logical function test_open_failure_and_success() result(ok)
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: ios'//new_line('a')// &
+            '  character(len=20) :: msg'//new_line('a')// &
+            '  open(unit=11, file='//Q//'/nonexistent-427/x.dat'//Q// &
+            ', status='//Q//'old'//Q//', iostat=ios, iomsg=msg)'// &
+            new_line('a')// &
+            '  print *, ios'//new_line('a')// &
+            '  print *, msg'//new_line('a')// &
+            '  open(unit=12, file='//Q//'/tmp/ffc_427_ok.dat'//Q// &
+            ', status='//Q//'replace'//Q//', iostat=ios, iomsg=msg)'// &
+            new_line('a')// &
+            '  print *, ios'//new_line('a')// &
+            '  print *, msg'//new_line('a')// &
+            '  close(12)'//new_line('a')// &
+            'end program main'
+
+        ok = expect_output(source, &
+            '        5004'//new_line('a')// &
+            ' Cannot open file    '//new_line('a')// &
+            '           0'//new_line('a')// &
+            '                     '//new_line('a'), &
+            '/tmp/ffc_iostat_open')
+    end function test_open_failure_and_success
+
+    ! End of file is its own class, not a generic error and not success.
+    logical function test_read_end_of_file() result(ok)
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: u, ios, n'//new_line('a')// &
+            '  character(len=15) :: msg'//new_line('a')// &
+            '  open(newunit=u, file='//Q//'/tmp/ffc_427_eof.dat'//Q// &
+            ', status='//Q//'replace'//Q//')'//new_line('a')// &
+            '  write(u, *) 7'//new_line('a')// &
+            '  rewind(u)'//new_line('a')// &
+            '  read(u, *, iostat=ios, iomsg=msg) n'//new_line('a')// &
+            '  print *, ios, n'//new_line('a')// &
+            '  print *, msg'//new_line('a')// &
+            '  read(u, *, iostat=ios, iomsg=msg) n'//new_line('a')// &
+            '  print *, ios'//new_line('a')// &
+            '  print *, msg'//new_line('a')// &
+            '  close(u)'//new_line('a')// &
+            'end program main'
+
+        ok = expect_output(source, &
+            '           0           7'//new_line('a')// &
+            '                '//new_line('a')// &
+            '          -1'//new_line('a')// &
+            ' End of file    '//new_line('a'), &
+            '/tmp/ffc_iostat_eof')
+    end function test_read_end_of_file
+
+    ! Fortran character assignment, not a C string: too long is truncated.
+    logical function test_iomsg_is_truncated() result(ok)
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: ios'//new_line('a')// &
+            '  character(len=6) :: msg'//new_line('a')// &
+            '  open(unit=13, file='//Q//'/nonexistent-427/y.dat'//Q// &
+            ', status='//Q//'old'//Q//', iostat=ios, iomsg=msg)'// &
+            new_line('a')// &
+            '  print *, msg'//new_line('a')// &
+            'end program main'
+
+        ok = expect_output(source, ' Cannot'//new_line('a'), &
+                           '/tmp/ffc_iostat_trunc')
+    end function test_iomsg_is_truncated
+
+    logical function test_noninteger_iostat_is_rejected() result(ok)
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  real :: ios'//new_line('a')// &
+            '  open(unit=14, file='//Q//'/tmp/ffc_427_r.dat'//Q// &
+            ', iostat=ios)'//new_line('a')// &
+            'end program main'
+
+        ok = expect_error_contains(source, 'default integer', &
+                                   '/tmp/ffc_iostat_badtype')
+    end function test_noninteger_iostat_is_rejected
+
+    logical function test_noncharacter_iomsg_is_rejected() result(ok)
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: ios'//new_line('a')// &
+            '  integer :: msg'//new_line('a')// &
+            '  open(unit=15, file='//Q//'/tmp/ffc_427_m.dat'//Q// &
+            ', iostat=ios, iomsg=msg)'//new_line('a')// &
+            'end program main'
+
+        ! FortFront rejects this before lowering sees it; the compiler's own
+        ! check on the IOMSG target is the backstop behind that.
+        ok = expect_error_contains(source, 'type CHARACTER', &
+                                   '/tmp/ffc_iomsg_badtype')
+    end function test_noncharacter_iomsg_is_rejected
+
+end program test_session_iostat_iomsg_compiler


### PR DESCRIPTION
Closes #427. Follows #396 (#624), #423 (#645) and #565 (#603).

## What moved

`IOSTAT=` and `IOMSG=` now report documented values that come from one place.
Before this a file `WRITE`'s `IOSTAT=` was assigned a literal `0` whatever
happened, `OPEN` accepted neither specifier, and `IOMSG=` was never written by
any statement.

New entry points: `_ffc_iostat`, `_ffc_iostat_set_end`, `_ffc_iostat_clear`,
`_ffc_iomsg`.

- `OPEN`'s own return value is its `IOSTAT=`, so a connection that fails
  reports the runtime's code instead of losing it.
- A file `WRITE` and a `READ` report the runtime's record of the operation.
- A `READ` that reaches end of file records that condition in the runtime as
  well, so `IOSTAT=` and `IOMSG=` describe the same condition instead of being
  derived independently on two paths.

## Status classes

| IOSTAT | Meaning |
|---|---|
| 0 | success |
| -1 | end of file (gfortran's `IOSTAT_END`) |
| -2 | end of record (gfortran's `IOSTAT_EOR`) |
| > 0 | an error; the unit status codes from #396 |

## Invariants preserved and stated

- **Versioned public interfaces.** No LIRIC ABI declaration changed.
- **Verified ABI declarations.** The four new symbols are in
  `FFC_RUNTIME_SYMBOLS`, so `test_runtime_link_compiler` fails unless the
  runtime defines each one.
- **Matching runtime.** Unchanged from #565: the runtime linked into a program
  is the one compiled into the compiler that produced it. A missing runtime is
  a loud error; no inline fallback exists on any migrated path.
- **Stable IOSTAT/IOMSG contract.** The class table above is fixed and
  documented. `IOMSG=` follows Fortran character assignment: truncated to the
  destination length, blank padded when shorter. It writes exactly `len`
  characters plus a terminating NUL, so the buffer is `len + 1` — matching the
  NUL-terminated buffers the compiler's character values point at. After a
  successful operation the destination is left all blanks rather than
  untouched, so it is always defined.
- **Ownership and view lifetimes.** `_ffc_iomsg` writes into a buffer the
  caller owns and the symbol is rebound to it, the same way a runtime
  character assignment rebinds.
- **Rejections kept.** A noninteger `IOSTAT=` and a noncharacter `IOMSG=` are
  still rejected, each with a named diagnostic.

## Runtime build contract (the reported flag-routing problem)

Investigating the report that `runtime/ffc_runtime.c` was being handed `-J`,
`-ffree-form` and `-fimplicit-none` turned up a real defect underneath it.

`fo` compiles C sources with `gcc -c -I …` and never with the Fortran flag
set, and the runtime C file is not in the fpm source tree at all, so no
Fortran flag reaches it today — `test_runtime_link_compiler` has enforced that
since #423 by failing if any C source appears under `src/`.

But the runtime **did not build under a strict C driver**. It calls POSIX
`random`/`srandom` while declaring no feature-test macro, so
`cc -std=c11 -pedantic -Werror` reached them only through an implicit
declaration. That is a warning on a lenient toolchain and a hard error on a
strict one or on a C23 default: exactly the "works here, fails on someone
else's machine" failure the report was pointing at.

- The runtime now states its own language level and feature set
  (`#define _XOPEN_SOURCE 700` before any include) instead of inheriting the
  invoking driver's defaults. Three drivers compile this file and they now
  agree.
- `runtime/CMakeLists.txt` spells its clang flags out (`-x c -std=c11 -Wall
  -Wextra -Werror`) rather than inheriting them, so a Fortran-only flag
  reaching that command is a hard error rather than something to discover
  later.
- `test_runtime_link_compiler` now fails unless the runtime builds under
  `cc -std=c11 -Wall -Wextra -Werror -pedantic`.

## Behavioral oracle

`test/test_session_iostat_iomsg_compiler.f90` (new):

- `OPEN` on a file that cannot be opened reports 5004 and `Cannot open file`;
  the same `OPEN` on a usable file reports 0 and blanks. Both halves fail on
  the pre-#427 compiler, which ignored the specifiers.
- `READ` reports `0` with a blank message, then `-1` with `End of file`,
  distinguishing end of file from success and from an error.
- `IOMSG=` into a `character(len=6)` is truncated to `Cannot`.
- A `real` `IOSTAT=` and an `integer` `IOMSG=` are still rejected.

## Corpus delta

Measured **before and after in the same worktree** at the same commit, per
#642: two clean worktrees at the same commit disagree, so cross-worktree
numbers would not be trustworthy.

| suite | pass | xfail | xpass | fail | noref | skip |
|---|---|---|---|---|---|---|
| lfortran, base | 875 | 3287 | 110 | 7 | 165 | 1 |
| lfortran, this PR | 875 | 3287 | 110 | 7 | 165 | 1 |
| gfortran-dg, base | 1355 | 2072 | 57 | 155 | 20 | 2299 |
| gfortran-dg, this PR | 1355 | 2072 | 57 | 155 | 20 | 2299 |

lfortran is identical file for file. gfortran-dg needed a second full run to
say so: the first showed `bind_c_char_8.f90` PASS→FAIL and `minmaxloc_11.f90`
XFAIL→XPASS. Neither reproduces. Run in isolation in the same worktree,
`bind_c_char_8.f90` is PASS three times on `main` and three times on this
branch, with the compiler's own diagnostics byte-identical on both; the repeat
full run is identical to base across all 5938 cases. Both were the run-to-run
nondeterminism #642 describes, not this change. Nothing is promoted out of the
xfail manifests.

`test_session_lazy_monomorph_compiler`, `test_fortfront_corpus_conformance`
and `test_parity_dashboard` fail on this branch and fail identically on `main`
at the same commit in the same worktree.
