### PR TITLE
[lazy-kind-01] read a Lazy specialization's dummy kind from its parameter entry (closes #651)

### DIFF
--- a/src/session_program_lowering_functions_tail.inc
+++ b/src/session_program_lowering_functions_tail.inc
@@ -863,7 +863,14 @@
             if (.not. node_exists(arena, body_indices(i))) cycle
             select type (decl => arena%entries(body_indices(i))%node)
             type is (declaration_node)
-                if (decl%is_array) cycle
+                ! An array declaration names a shape, not a scalar kind: the
+                ! caller reads the rank separately, and reporting a scalar kind
+                ! here would hide it. Say "no scalar kind" and stop looking, so
+                ! the parameter-entry fallback below cannot answer for it.
+                if (decl%is_array) then
+                    if (declaration_names_entity(decl, name)) return
+                    cycle
+                end if
                 if (allocated(decl%var_name)) then
                     if (trim(decl%var_name) == trim(name)) then
                         call declaration_value_kind(decl, value_kind, kind_err, &
@@ -884,7 +891,69 @@
                 end if
             end select
         end do
+        ! No specification-part declaration names this dummy. A Lazy unit's
+        ! monomorphized specialization carries the dummy's resolved type on
+        ! the parameter-list entry itself and adds no declaration node, so
+        ! read the kind from there rather than defaulting to i32 (#651).
+        value_kind = parameter_entry_value_kind(arena, param_indices(param_pos), &
+                                                context)
     end function param_at_value_kind
+
+    logical function declaration_names_entity(decl, name) result(names_it)
+        ! Whether this declaration declares the named entity, single or multi.
+        type(declaration_node), intent(in) :: decl
+        character(len=*), intent(in) :: name
+        integer :: k
+
+        names_it = .false.
+        if (allocated(decl%var_name)) then
+            if (trim(decl%var_name) == trim(name)) then
+                names_it = .true.
+                return
+            end if
+        end if
+        if (.not. decl%is_multi_declaration) return
+        if (.not. allocated(decl%var_names)) return
+        do k = 1, size(decl%var_names)
+            if (trim(decl%var_names(k)) == trim(name)) then
+                names_it = .true.
+                return
+            end if
+        end do
+    end function declaration_names_entity
+
+    integer function parameter_entry_value_kind(arena, param_index, context) &
+        result(value_kind)
+        ! The value kind recorded on a parameter-list entry itself. The dialect
+        ! decides what a kind-less `real` dummy means, so a Lazy unit's
+        ! kind-less real dummy is 8 bytes like every other kind-less real
+        ! there (#438, #651).
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: param_index
+        type(lowering_context_t), intent(in), optional :: context
+        integer :: kind_value
+        character(len=:), allocatable :: type_text
+
+        value_kind = 0
+        if (.not. node_exists(arena, param_index)) return
+        select type (entry => arena%entries(param_index)%node)
+        type is (parameter_declaration_node)
+            if (entry%is_array) return
+            if (entry%resolved_rank > 0) return
+            if (allocated(entry%dimension_indices)) then
+                if (size(entry%dimension_indices) > 0) return
+            end if
+            if (entry%resolved_type_kind <= 0) return
+            kind_value = entry%resolved_kind_value
+            if (present(context)) &
+                call apply_lazy_real_kind(context, entry%resolved_type_kind, &
+                                          entry%has_kind, kind_value)
+            type_text = ''
+            if (allocated(entry%type_name)) type_text = trim(entry%type_name)
+            value_kind = declaration_metadata_value_kind( &
+                entry%resolved_type_kind, kind_value, type_text)
+        end select
+    end function parameter_entry_value_kind
 
     function procedure_emit_name(fortran_name, bind_c_clause) result(emit_name)
         ! The LIRIC symbol a contained procedure is emitted under: its

--- a/test/test_session_lazy_monomorph_compiler.f90
+++ b/test/test_session_lazy_monomorph_compiler.f90
@@ -6,10 +6,14 @@ program test_session_lazy_monomorph_compiler
     !! written procedure untyped and adds one typed copy per signature, but the
     !! call sites still name the written procedure (FortFront #2971).
     !!
-    !! ffc must not pick a copy for them. Binding one is a guess, and binding
-    !! the wrong one returns a wrong value with no diagnostic: before this
-    !! change the two-signature program below printed 6 and 0, and swapping the
-    !! two calls printed 0.0 and 6.0. The boundary is now diagnosed (#437).
+    !! Where FortFront does rename the call sites, both copies must lower at
+    !! the kinds the Lazy dialect gives them: a kind-less real dummy is 8 bytes
+    !! there (#438), whatever the copy's mangled name says. Reading it as a
+    !! 4-byte default made the real copy return 0.0 with no diagnostic (#651).
+    !!
+    !! Where a call still names the untyped original, ffc must not pick a copy
+    !! for it. Binding one is a guess, and binding the wrong one returns a
+    !! wrong value with no diagnostic, so that boundary stays diagnosed (#437).
     implicit none
 
     logical :: ok
@@ -41,10 +45,13 @@ program test_session_lazy_monomorph_compiler
         'end program'//new_line('a'), &
         '   5.0000000000000000', 'ffc_lazy_mono_real_signature')) ok = .false.
 
-    ! Two call sites of different concrete types. The written name denotes no
-    ! callable body, so the call is refused rather than bound to whichever copy
-    ! happened to be emitted.
-    if (.not. lazy_rejected( &
+    ! Two call sites of different concrete types. FortFront renames each call
+    ! to its own specialization, so both bodies lower and both calls must
+    ! return the value gfortran returns: 2*3 is 6 and 2*2.5 is 5.0, printed at
+    ! the Lazy default real kind of 8 bytes. Before #651 the real
+    ! specialization read its kind-less real dummy as a 4-byte default and the
+    ! second line printed 0.0 with no diagnostic.
+    if (.not. lazy_two_lines( &
         'function twice(x)'//new_line('a')// &
         '  twice = 2 * x'//new_line('a')// &
         'end function'//new_line('a')// &
@@ -52,12 +59,12 @@ program test_session_lazy_monomorph_compiler
         '  print *, twice(3)'//new_line('a')// &
         '  print *, twice(2.5)'//new_line('a')// &
         'end program'//new_line('a'), &
-        'monomorphic specializations', &
+        '           6', '   5.0000000000000000', &
         'ffc_lazy_mono_conflicting')) ok = .false.
 
-    ! The same program with the calls in the other order is refused the same
-    ! way: which call is wrong must not depend on emission order.
-    if (.not. lazy_rejected( &
+    ! The same program with the calls in the other order: which specialization
+    ! a call binds to must not depend on emission order.
+    if (.not. lazy_two_lines( &
         'function twice(x)'//new_line('a')// &
         '  twice = 2 * x'//new_line('a')// &
         'end function'//new_line('a')// &
@@ -65,8 +72,23 @@ program test_session_lazy_monomorph_compiler
         '  print *, twice(2.5)'//new_line('a')// &
         '  print *, twice(3)'//new_line('a')// &
         'end program'//new_line('a'), &
-        'monomorphic specializations', &
+        '   5.0000000000000000', '           6', &
         'ffc_lazy_mono_conflicting_reversed')) ok = .false.
+
+    ! FortFront does not always rename every call site. When a call still names
+    ! the untyped original, that name denotes no callable body and the call is
+    ! refused rather than bound to whichever copy happened to be emitted (#437).
+    if (.not. lazy_rejected( &
+        'function half(x)'//new_line('a')// &
+        '  half = x / 2'//new_line('a')// &
+        'end function'//new_line('a')// &
+        'program main'//new_line('a')// &
+        '  print *, half(2.5)'//new_line('a')// &
+        '  print *, half(4)'//new_line('a')// &
+        '  print *, half(1.0)'//new_line('a')// &
+        'end program'//new_line('a'), &
+        'monomorphic specializations', &
+        'ffc_lazy_mono_unbound_call')) ok = .false.
 
     if (.not. ok) stop 1
     print *, 'PASS: lazy monomorphization boundary'
@@ -117,6 +139,57 @@ contains
         call execute_command_line('rm -rf '//dir)
         ok = .true.
     end function lazy_first_line
+
+    logical function lazy_two_lines(source, first, second, stem) result(ok)
+        ! Compile and run a lazy fragment, comparing its first two output
+        ! lines against the values gfortran prints for the same program.
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: first, second
+        character(len=*), intent(in) :: stem
+        character(len=:), allocatable :: dir, src_path, exe_path, out_path
+        character(len=:), allocatable :: got_first, got_second
+        integer :: unit, exit_stat, cmd_stat
+
+        ok = .false.
+        call scratch_dir(stem, dir)
+        src_path = dir//'/'//stem//'.lf'
+        exe_path = dir//'/'//stem//'.exe'
+        out_path = dir//'/'//stem//'.out'
+        open (newunit=unit, file=src_path, status='replace', action='write')
+        write (unit, '(A)', advance='no') source
+        close (unit)
+
+        call execute_command_line( &
+            "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc 2>/dev/null | "// &
+            'head -n 1); test -n "$exe" || exit 90; '// &
+            '"$exe" '//src_path//' -o '//exe_path//" >"//dir//"/log 2>&1'", &
+            exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0 .or. exit_stat /= 0) then
+            print *, 'FAIL: ffc rejected lazy source ', stem, ' exit=', exit_stat
+            call execute_command_line('cat '//dir//'/log')
+            return
+        end if
+
+        call execute_command_line(exe_path//' > '//out_path, &
+                                  exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0 .or. exit_stat /= 0) then
+            print *, 'FAIL: lazy executable did not run cleanly: ', stem
+            return
+        end if
+        call read_two_lines(out_path, got_first, got_second)
+        if (trim(got_first) /= trim(first)) then
+            print *, 'FAIL: ', stem, ' line 1 expected [', trim(first), &
+                '] got [', trim(got_first), ']'
+            return
+        end if
+        if (trim(got_second) /= trim(second)) then
+            print *, 'FAIL: ', stem, ' line 2 expected [', trim(second), &
+                '] got [', trim(got_second), ']'
+            return
+        end if
+        call execute_command_line('rm -rf '//dir)
+        ok = .true.
+    end function lazy_two_lines
 
     logical function lazy_rejected(source, fragment, stem) result(ok)
         ! Compiling this lazy fragment must fail with a diagnostic naming the
@@ -175,6 +248,24 @@ contains
         dir = '/tmp/'//stem//'_'//trim(stamp)
         call execute_command_line('rm -rf '//dir//'; mkdir -p '//dir)
     end subroutine scratch_dir
+
+    subroutine read_two_lines(path, first, second)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: first, second
+        character(len=512) :: buffer
+        integer :: unit, io_stat
+
+        first = ''
+        second = ''
+        open (newunit=unit, file=path, status='old', action='read', &
+              iostat=io_stat)
+        if (io_stat /= 0) return
+        read (unit, '(A)', iostat=io_stat) buffer
+        if (io_stat == 0) first = trim(buffer)
+        read (unit, '(A)', iostat=io_stat) buffer
+        if (io_stat == 0) second = trim(buffer)
+        close (unit)
+    end subroutine read_two_lines
 
     function read_first_line(path) result(text)
         character(len=*), intent(in) :: path


### PR DESCRIPTION
## The defect

A Lazy unit calling one untyped procedure at two concrete types compiled clean and printed a wrong number:

```
print *, twice(3)     ->  6                      correct
print *, twice(2.5)   ->  0.0000000000000000     wrong, should be 5.0
```

## The exact branch at fault

Not the result kind. `function_value_kind` does reach its Lazy branch for `twice__r32` and returns `VALUE_F64`. The `vk=2` in the issue's trace *is* `VALUE_F64`: the constants are `VALUE_F64 = 2` and `VALUE_F32 = 10`, so the reported evidence for a wrong result kind was a misread.

The dummy was wrong. `param_at_value_kind` (`src/session_program_lowering_functions_tail.inc`) resolves a dummy's kind by scanning the procedure body for a `declaration_node` naming it. A monomorphized Lazy specialization has none: FortFront records the dummy's resolved type on the `parameter_declaration_node` itself and synthesizes the `real, intent(in) :: x` line only in a later codegen stage ffc never consumes. With no match, `define_reference_parameters` took the `value_kind = VALUE_I32` default. The disassembly showed it plainly - the f64 callee loaded its argument as a 32-bit integer and `cvtsi2sd`'d it.

## The fix

When no body declaration names the dummy, read the kind off the parameter-list entry, applying `apply_lazy_real_kind` exactly as `make_parameter_record` and `make_declaration_record` already do, so a kind-less `real` dummy in a Lazy unit is 8 bytes whatever the mangled `__r32` name says. An array dummy still answers "no scalar kind" (the callers read rank separately, and the .fmod signature writer depends on that), which the array guard in the declaration scan now also enforces when the declaration is found but skipped.

## Oracle

`test/test_session_lazy_monomorph_compiler.f90` now compiles and runs the two-signature program in both call orders and compares both output lines against the values gfortran prints for the equivalent explicit program (`6` and `5.0000000000000000`). The integer line is checked in both cases as a regression guard. Recorded failing before the fix, same worktree:

```
FAIL: ffc_lazy_mono_conflicting line 2 expected [   5.0000000000000000] got [   0.0000000000000000]
FAIL: ffc_lazy_mono_conflicting_reversed line 1 expected [   5.0000000000000000] got [   0.0000000000000000]
```

## The interim refusal (#437, 18e1164) is KEPT

It is not redundant. It still fires, and it is still the only thing standing between a user and a silent wrong answer:

```
function half(x)
  half = x / 2
end function
print *, half(2.5)
print *, half(4)
print *, half(1.0)
```

FortFront does not rename every call site here, so a call still names the untyped original, and ffc refuses it rather than guessing a copy. That shape is now covered by its own case in the test, replacing the two cases the rename made obsolete. Removing the guard would have re-opened exactly this class.

Note that the two `lazy_rejected` cases this PR converts were **already failing on `main`** - the guard stopped firing for them when FortFront #2971 landed, so `test_session_lazy_monomorph_compiler` was red at `8521e59`. This PR turns them green by making the shape compile *correctly*, not by weakening them.

## Width-mismatch backstop: not added, and why

Caller and callee never disagreed on the *result* width here - both read it from the same `function_value_kinds` registry entry, so by construction they cannot. The disagreement was on an *argument* width. A general argument-width check at every call site would have to reconstruct callee dummy kinds for cross-unit calls from `.fmod` signature tokens and for procedure dummies from interface bodies, on a path where "kind unknown" is a normal answer, so it would either be noisy or vacuous. That is not cheap, and the honest fix is the one made: both sides now read the dummy kind from the same source.

## Siblings of the #571 class

Checked every path that decides a Lazy unit's default real kind: `function_value_kind`, `inferred_type_to_value_kind`, `declaration_value_kind`/`make_declaration_record`/`make_parameter_record` (all honour `lazy_mode`), and the contained-procedure context inheritance #571 fixed (`context%lazy_mode = parent_context%lazy_mode`, present in both places that build a child context). The gap fixed here was a path that consulted *neither*.

Two remaining siblings, reported not fixed (adjacent, separate change): `implicit_result_kind` (`session_program_lowering_functions.inc`) and `implicit_parameter_value_kind` (`session_program_lowering_derived_types.inc`) apply the i-n implicit-typing letter rule and hardcode `VALUE_F32` for the real half. Neither takes a context, so neither can honour the Lazy default; plumbing one through is its own change.

## Corpus delta

Measured same-worktree, reverting `src/` to `origin/main`, rebuilding, measuring, restoring (ffc #642 makes cross-worktree A/B untrustworthy).

| suite | before | after |
|---|---|---|
| fortfront-f90 | PASS=451 FAIL=9 | PASS=452 FAIL=8 |
| fortfront-lf | pass=211 xfail=51 xpass=3 | pass=211 xfail=51 xpass=3 |

One f90 file gained, none lost. No manifest was promoted.

`test_fortfront_corpus_conformance` and `test_parity_dashboard` fail identically at clean `origin/main` (the lf corpus grew to 265 files against an expected 264, plus 3 pre-existing XPASS entries) - pre-existing, untouched by this PR. Everything else in `fo` is green.

## FortFront naming

`twice__r32` for a unit whose default real is real64 is a misleading name and ffc now ignores it entirely rather than compensating for it. Worth a FortFront issue; no ffc change made for it.

Closes #651.