### PR TITLE
[concat-nested-01] lower concatenation of any operand count into a deferred destination

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -355,6 +355,10 @@ module session_program_lowering
     integer(c_int64_t), parameter :: LOWERING_CHARACTER_STORAGE_OWNED = &
         int(CHARACTER_STORAGE_OWNED, c_int64_t)
 
+    ! Passed as emit_concat_copies' dest_len when the destination has no
+    ! declared width to clamp to, which is every deferred-length destination.
+    integer, parameter :: CONCAT_NO_CLAMP = -1
+
     ! Reduction kinds for dim-wise whole-array reductions (sum/product/count/
     ! any/all along one dimension). See lower_dim_reduction_assignment.
     ! An argument-less call still goes through prepare_reference_args so that

--- a/src/session_program_lowering_deferred_char.inc
+++ b/src/session_program_lowering_deferred_char.inc
@@ -73,289 +73,104 @@ integer function resolve_concat_operand(arena, node_index, context, &
         end select
     end function resolve_concat_operand
 
- subroutine lower_deferred_concat_assignment(arena, node, context, &
-                                                  dest_symbol_index, error_msg)
+    subroutine lower_deferred_concat_assignment(arena, node, context, &
+                                                dest_symbol_index, error_msg)
+        ! str = <a // b // ...> for a deferred-length allocatable destination.
+        !
+        ! The concatenation tree is flattened to its leaf operands first, so an
+        ! arbitrary operand count works and every leaf kind char_expr_operands
+        ! understands - variable, literal, substring, function result,
+        ! trim()/adjustl()/repeat() - is an operand here. This is the same
+        ! flattening the fixed-length destination uses, so the two destinations
+        ! agree on what a concatenation is instead of each carrying its own
+        ! idea of one.
+        !
+        ! The result is heap storage the destination owns. Every operand is
+        ! copied into it before the destination releases the block it currently
+        ! holds, so an operand that aliases that block - `s = s // t`, or
+        ! `s = s // s` - still reads valid bytes.
         use, intrinsic :: iso_c_binding, only: c_int64_t
         type(ast_arena_t), intent(in) :: arena
         type(assignment_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: dest_symbol_index
         character(len=:), allocatable, intent(out) :: error_msg
-        character(len=:), allocatable :: bin_op
-        integer :: bin_line, bin_col
-        integer :: left_idx
-        integer :: right_idx
-        type(lr_operand_desc_t) :: left_data
-        type(lr_operand_desc_t) :: left_len
-        type(lr_operand_desc_t) :: right_data
-        type(lr_operand_desc_t) :: right_len
-        type(lr_operand_desc_t) :: total_len
-        type(lr_operand_desc_t) :: new_ptr
-        type(lr_operand_desc_t) :: zero_i64
-        type(lr_operand_desc_t) :: one_i64
-        type(lr_operand_desc_t) :: running_offset
-        type(lr_operand_desc_t) :: old_data
-        type(lr_operand_desc_t) :: old_len_val
-        character(len=:), allocatable :: left_name
-        character(len=:), allocatable :: right_name
-        character(len=:), allocatable :: left_text
-        character(len=:), allocatable :: right_text
-        integer :: left_sym_idx
-        integer :: right_sym_idx
-        logical :: is_self_alias
-        logical :: left_is_literal
-        logical :: right_is_literal
-        logical :: left_is_call
-        logical :: right_is_call
-        logical :: left_is_view
-        logical :: right_is_view
-        type(lr_operand_desc_t) :: call_len_i32
-        character(len=:), allocatable :: literal_text
-        character(len=64) :: string_name
-        character(len=:), allocatable :: combined_text
-        integer(c_int64_t) :: combined_len
-        type(lr_operand_desc_t) :: alloca_size
-        type(lr_operand_desc_t) :: null_byte_ptr
-        type(lr_operand_desc_t) :: null_dest
-        character(len=64) :: null_name
-        integer(c_int64_t) :: new_storage_class
+        type(lr_operand_desc_t), allocatable :: data_ops(:), len_ops(:)
+        integer, allocatable :: stat_len(:)
+        type(lr_operand_desc_t) :: total_len, operand_len, wider_total
+        type(lr_operand_desc_t) :: alloc_size, buf, null_pos
+        integer :: count, i
 
         call set_empty(error_msg)
-        new_storage_class = LOWERING_CHARACTER_STORAGE_STACK
-        left_is_literal = .false.
-        right_is_literal = .false.
-        left_is_call = .false.
-        right_is_call = .false.
-        left_is_view = .false.
-        right_is_view = .false.
-        is_self_alias = .false.
-
-        ! A fixed-length result (character(len=N) :: s) uses the descriptor
-        ! return ABI but keeps its declared width: the concatenated value pads
-        ! with blanks or truncates to N instead of taking the operand sum.
+        ! A destination that reaches here with a declared width is a
+        ! fixed-length result using the descriptor return ABI. It keeps that
+        ! width: the concatenation pads with blanks or truncates to N instead
+        ! of taking the operand sum, which is what an ordinary fixed-length
+        ! assignment does.
         if (context%symbols(dest_symbol_index)%character_length > 0) then
             call lower_fixed_width_deferred_concat(arena, node, context, &
                                                    dest_symbol_index, error_msg)
             return
         end if
 
-        ! Get the binary // operands from the assignment value.
-        if (.not. is_binary_op(arena, node%value_index)) then
-            error_msg = 'expected binary // operator for deferred character '// &
-                        'concatenation'
-            return
-        end if
-        call get_binary_op_info(arena, node%value_index, bin_op, left_idx, &
-                                right_idx, bin_line, bin_col, error_msg)
+        allocate (data_ops(64), len_ops(64), stat_len(64))
+        count = 0
+        call collect_concat_operands(arena, node%value_index, context, data_ops, &
+                                     len_ops, stat_len, count, error_msg)
         if (len_trim(error_msg) > 0) return
-        if (trim(bin_op) /= '//') then
-            error_msg = 'non-concat operator on deferred character: '// &
-                        trim(bin_op)
+        if (count == 0) then
+            error_msg = 'character concatenation has no operands'
             return
         end if
 
-        ! Resolve left operand: get symbol index or mark as literal
-        left_sym_idx = resolve_concat_operand(arena, left_idx, context, &
-            left_name, left_is_literal, error_msg, left_is_call, left_is_view)
-        if (len_trim(error_msg) > 0) return
-
-        ! Resolve right operand
-        right_sym_idx = resolve_concat_operand(arena, right_idx, context, &
-            right_name, right_is_literal, error_msg, right_is_call, &
-            right_is_view)
-        if (len_trim(error_msg) > 0) return
-
-        ! Detect self-aliasing: dest is one of the operands
-        if (left_sym_idx == dest_symbol_index .or. &
-            right_sym_idx == dest_symbol_index) then
-            is_self_alias = .true.
-        end if
-
-        ! For self-aliasing, we need to capture the old content
-        ! We do this by loading the old data pointer and length
-        if (is_self_alias) then
-            if (.not. emit_ptr_load(context%session,  &
-                context%symbols(dest_symbol_index)%deferred_data, &
-                old_data, error_msg)) return
-            if (.not. emit_i64_load(context%session,  &
-                context%symbols(dest_symbol_index)%deferred_length, &
-                old_len_val, error_msg)) return
-        end if
-
-        ! Get left operand text/content
-        if (left_is_view) then
-            call substring_operands(arena, left_idx, context, left_data, &
-                                    call_len_i32, error_msg)
-            if (len_trim(error_msg) > 0) return
-            if (.not. emit_liric_i32_to_i64(context%session, call_len_i32, &
-                    left_len, error_msg)) return
-        else if (left_is_call) then
-            call char_result_call_operands(arena, left_idx, context, left_data, &
-                                           call_len_i32, error_msg)
-            if (len_trim(error_msg) > 0) return
-            if (.not. emit_liric_i32_to_i64(context%session, call_len_i32, &
-                    left_len, error_msg)) return
-        else if (left_is_literal) then
-            call strip_literal_quotes(left_name, left_text)
-            call materialize_concat_literal(context, left_text, left_data, &
-                left_len, error_msg)
-            if (len_trim(error_msg) > 0) return
-        else
-            ! For self-aliasing, use captured old values
-            ! For non-self-aliasing, load from symbol
-            if (is_self_alias .and. left_sym_idx == dest_symbol_index) then
-                left_data = old_data
-                left_len = old_len_val
+        ! The result length is the sum of the operand lengths. A leaf with a
+        ! known declared width contributes it as a constant, including the
+        ! blank padding of a fixed-length operand; the rest contribute their
+        ! runtime length.
+        total_len = i64_immediate(context%session, 0_c_int64_t)
+        do i = 1, count
+            if (stat_len(i) >= 0) then
+                operand_len = i64_immediate(context%session, &
+                                            int(stat_len(i), c_int64_t))
             else
-                if (.not. emit_ptr_load(context%session,  &
-                    context%symbols(left_sym_idx)%deferred_data, &
-                    left_data, error_msg)) return
-                if (.not. emit_ptr_load(context%session,  &
-                    context%symbols(left_sym_idx)%deferred_length, &
-                    left_len, error_msg)) return
+                if (.not. emit_liric_i32_to_i64(context%session, len_ops(i), &
+                        operand_len, error_msg)) return
             end if
-        end if
+            if (.not. emit_i64_binary(context%session, LR_OP_ADD, total_len, &
+                    operand_len, wider_total, error_msg)) return
+            total_len = wider_total
+        end do
 
-        ! Get right operand text/content
-        if (right_is_view) then
-            call substring_operands(arena, right_idx, context, right_data, &
-                                    call_len_i32, error_msg)
-            if (len_trim(error_msg) > 0) return
-            if (.not. emit_liric_i32_to_i64(context%session, call_len_i32, &
-                    right_len, error_msg)) return
-        else if (right_is_call) then
-            call char_result_call_operands(arena, right_idx, context, right_data, &
-                                           call_len_i32, error_msg)
-            if (len_trim(error_msg) > 0) return
-            if (.not. emit_liric_i32_to_i64(context%session, call_len_i32, &
-                    right_len, error_msg)) return
-        else if (right_is_literal) then
-            call strip_literal_quotes(right_name, right_text)
-            call materialize_concat_literal(context, right_text, right_data, &
-                right_len, error_msg)
-            if (len_trim(error_msg) > 0) return
-        else
-            if (is_self_alias .and. right_sym_idx == dest_symbol_index) then
-                right_data = old_data
-                right_len = old_len_val
-            else
-                if (.not. emit_i64_load(context%session,  &
-                    context%symbols(right_sym_idx)%deferred_data, &
-                    right_data, error_msg)) return
-                if (.not. emit_i64_load(context%session,  &
-                    context%symbols(right_sym_idx)%deferred_length, &
-                    right_len, error_msg)) return
-            end if
-        end if
-
-        ! Compute total length
-        if (left_is_literal .and. right_is_literal) then
-            combined_text = trim(left_text) // trim(right_text)
-            combined_len = int(len(combined_text), c_int64_t)
-        else
-            ! Runtime concatenation: compute lengths and add
-            if (left_is_literal) then
-                left_len = i64_immediate(context%session,  &
-                    int(len(left_text), c_int64_t))
-            end if
-            if (right_is_literal) then
-                right_len = i64_immediate(context%session,  &
-                    int(len(right_text), c_int64_t))
-            end if
-            if (.not. emit_i64_binary(context%session,  &
-                LR_OP_ADD, left_len, right_len, total_len, error_msg)) return
-        end if
-
-        ! For literal-only concat, create a new global string
-        if (left_is_literal .and. right_is_literal) then
-            context%string_literal_count = context%string_literal_count + 1
-            string_name = ffc_unit_global_name( &
-                context, 'cat.', context%string_literal_count)
-            call materialize_liric_string(context%session, trim(string_name), &
-                                          combined_text, new_ptr, error_msg)
-            if (len_trim(error_msg) > 0) return
-
-            ! Store pointer and length in descriptor. The folded literal is a
-            ! global, so this is a borrow; release any owned block first.
-            call release_owned_character_storage(context, dest_symbol_index, &
-                                                 error_msg)
-            if (len_trim(error_msg) > 0) return
-            if (.not. emit_ptr_store(context%session,  &
-                new_ptr, &
-                context%symbols(dest_symbol_index)%deferred_data, error_msg)) return
-            if (.not. emit_i64_store(context%session,  &
-                i64_immediate(context%session, combined_len), &
-                context%symbols(dest_symbol_index)%deferred_length, error_msg)) return
-            call set_character_storage(context, dest_symbol_index, &
-                i64_immediate(context%session, combined_len), &
-                LOWERING_CHARACTER_STORAGE_STATIC, error_msg)
-            if (len_trim(error_msg) > 0) return
-
-            context%symbols(dest_symbol_index)%value = new_ptr
-            context%symbols(dest_symbol_index)%has_character_value = .true.
-            call set_empty(error_msg)
-            return
-        end if
-
-        ! Runtime concatenation: alloca (total_len + 1) for trailing null,
-        ! memcpy operands, then write null byte so %s printers stay bounded.
-        if (.not. emit_i64_binary(context%session,  &
-            LR_OP_ADD, total_len, &
-            i64_immediate(context%session, 1_c_int64_t), &
-            alloca_size, error_msg)) return
-
-        if (context%in_internal_function .and. &
-            dest_symbol_index == context%current_function_result_index) then
-            if (.not. emit_malloc(context%session, alloca_size, new_ptr, &
+        ! One trailing NUL so the %s printers stop at the result's end.
+        if (.not. emit_i64_binary(context%session, LR_OP_ADD, total_len, &
+                i64_immediate(context%session, 1_c_int64_t), alloc_size, &
                 error_msg)) return
-            new_storage_class = LOWERING_CHARACTER_STORAGE_OWNED
-        else
-            if (.not. emit_alloca_bytes(context%session, alloca_size, new_ptr, &
-                error_msg)) return
-            new_storage_class = LOWERING_CHARACTER_STORAGE_STACK
-        end if
+        if (.not. emit_malloc(context%session, alloc_size, buf, error_msg)) return
 
-        if (.not. emit_memcpy(context%session,  &
-            new_ptr, left_data, left_len, error_msg)) return
-
-        if (.not. emit_i64_binary(context%session,  &
-            LR_OP_ADD, new_ptr, left_len, running_offset, error_msg)) return
-
-        if (.not. emit_memcpy(context%session,  &
-            running_offset, right_data, right_len, error_msg)) return
-
-        if (.not. emit_i64_binary(context%session,  &
-            LR_OP_ADD, running_offset, right_len, null_dest, &
-            error_msg)) return
-
-        context%string_literal_count = context%string_literal_count + 1
-        null_name = ffc_unit_global_name( &
-            context, 'cat.term.', context%string_literal_count)
-        call materialize_liric_string(context%session, trim(null_name), &
-                                      '', null_byte_ptr, error_msg)
+        ! A deferred destination takes the whole concatenation, so nothing is
+        ! clamped to a declared width here.
+        call emit_concat_copies(context, data_ops, len_ops, stat_len, count, &
+                                CONCAT_NO_CLAMP, buf, error_msg)
         if (len_trim(error_msg) > 0) return
 
-        if (.not. emit_memcpy(context%session,  &
-            null_dest, null_byte_ptr, &
-            i64_immediate(context%session, 1_c_int64_t), error_msg)) return
+        if (.not. emit_i64_binary(context%session, LR_OP_ADD, buf, total_len, &
+                null_pos, error_msg)) return
+        if (.not. emit_liric_store_char_byte(context%session, null_pos, &
+                i32_immediate(context%session, 0_c_int64_t), &
+                i32_immediate(context%session, 0_c_int64_t), error_msg)) return
 
-        ! Both operands have been copied out by now, so releasing the former
-        ! owned block here is safe even when the destination is also an operand
-        ! (s = s // suffix).
+        ! Every operand has been copied out, so the former block can go.
         call release_owned_character_storage(context, dest_symbol_index, error_msg)
         if (len_trim(error_msg) > 0) return
-        if (.not. emit_ptr_store(context%session,  &
-            new_ptr, context%symbols(dest_symbol_index)%deferred_data, &
-            error_msg)) return
-
-        if (.not. emit_i64_store(context%session,  &
-            total_len, context%symbols(dest_symbol_index)%deferred_length, &
-            error_msg)) return
+        if (.not. emit_ptr_store(context%session, buf, &
+                context%symbols(dest_symbol_index)%deferred_data, error_msg)) return
+        if (.not. emit_i64_store(context%session, total_len, &
+                context%symbols(dest_symbol_index)%deferred_length, error_msg)) return
         call set_character_storage(context, dest_symbol_index, total_len, &
-                                   new_storage_class, error_msg)
+                                   LOWERING_CHARACTER_STORAGE_OWNED, error_msg)
         if (len_trim(error_msg) > 0) return
 
-        context%symbols(dest_symbol_index)%value = new_ptr
+        context%symbols(dest_symbol_index)%value = buf
         context%symbols(dest_symbol_index)%has_character_value = .true.
         call set_empty(error_msg)
     end subroutine lower_deferred_concat_assignment
@@ -1172,6 +987,10 @@ integer function resolve_concat_operand(arena, node_index, context, &
     ! operand present (trim), the lazy target is sized to fit, so copy in full.
     subroutine emit_concat_copies(context, data_ops, len_ops, stat_len, count, &
                                   dest_len, buf, error_msg)
+        ! Copy each operand into buf end to end. dest_len is the destination's
+        ! declared width, which a fixed-length destination clamps to; a
+        ! deferred-length destination passes CONCAT_NO_CLAMP because it takes
+        ! the whole concatenation whatever its length.
         use, intrinsic :: iso_c_binding, only: c_int64_t
         type(lowering_context_t), intent(inout) :: context
         type(lr_operand_desc_t), intent(in) :: data_ops(:), len_ops(:)
@@ -1184,7 +1003,7 @@ integer function resolve_concat_operand(arena, node_index, context, &
         logical :: all_static
 
         call set_empty(error_msg)
-        all_static = all(stat_len(1:count) >= 0)
+        all_static = all(stat_len(1:count) >= 0) .and. dest_len /= CONCAT_NO_CLAMP
         offset = buf
         written = 0
         do i = 1, count

--- a/test/conformance/xfail_lfortran.txt
+++ b/test/conformance/xfail_lfortran.txt
@@ -2285,8 +2285,6 @@ modules_61.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module e
 modules_62.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
 modules_62_parser.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
 modules_62_terminal.f90 # owner=lazy-fortran/ffc#342; reason=centralize array element-expression lowering
-modules_63.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports
-modules_63_module.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 modules_64.f90 # owner=lazy-fortran/ffc#412; reason=fold typed scalar and array named constants
 modules_65.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
 modules_65_worker.f90 # owner=lazy-fortran/ffc#419; reason=lower runtime SELECT TYPE guards
@@ -3099,13 +3097,11 @@ string_90.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length cha
 string_91.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 string_92.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 string_93.f90 # owner=lazy-fortran/ffc#424; reason=lower PACK UNPACK MERGE and SPREAD
-string_94.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 string_95.f90 # owner=lazy-fortran/ffc#428; reason=provide descriptor-backed runtime allocation helpers
 string_96.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 string_97.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 string_99.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 string_array_concat_01.f90 # owner=lazy-fortran/ffc#447; reason=centralize typed scalar expression lowering
-string_concat_deferred_len.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 str_to_char.f90 # owner=lazy-fortran/ffc#350; reason=centralize runtime-length character operations
 struct_allocate.f90 # owner=lazy-fortran/ffc#335; reason=migrate runtime automatic arrays to descriptors
 struct_type_01.f90 # owner=lazy-fortran/ffc#328; reason=map USE bindings to module exports

--- a/test/test_session_deferred_char_compiler.f90
+++ b/test/test_session_deferred_char_compiler.f90
@@ -43,6 +43,11 @@ program test_session_deferred_char_compiler
     if (.not. test_substring_constant_bound_past_end_is_rejected()) &
         all_passed = .false.
     if (.not. test_substring_with_stride_is_rejected()) all_passed = .false.
+    if (.not. test_nested_concat_three_operands()) all_passed = .false.
+    if (.not. test_nested_concat_mixed_kinds()) all_passed = .false.
+    if (.not. test_nested_concat_self_append()) all_passed = .false.
+    if (.not. test_nested_concat_into_shorter_fixed()) all_passed = .false.
+    if (.not. test_nested_concat_does_not_leak()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: deferred-char function result ABI'
@@ -270,6 +275,130 @@ contains
             source, 'a substring has no stride', &
             '/tmp/ffc_session_substring_stride_test')
     end function test_substring_with_stride_is_rejected
+
+    logical function test_nested_concat_three_operands()
+        ! Three or more non-literal operands: the concatenation tree flattens
+        ! and the result is the operands joined in order.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: a, b, s'//new_line('a')// &
+            '  a = "AB"'//new_line('a')// &
+            '  b = "CD"'//new_line('a')// &
+            '  s = a // "-" // b'//new_line('a')// &
+            '  print *, len(s), "[", s, "]"'//new_line('a')// &
+            '  s = a // b // a // b'//new_line('a')// &
+            '  print *, len(s), "[", s, "]"'//new_line('a')// &
+            '  deallocate(a)'//new_line('a')// &
+            '  deallocate(b)'//new_line('a')// &
+            '  deallocate(s)'//new_line('a')// &
+            'end program main'
+
+        test_nested_concat_three_operands = expect_output( &
+            source, &
+            '           5 [AB-CD]'//new_line('a')// &
+            '           8 [ABCDABCD]'//new_line('a'), &
+            '/tmp/ffc_session_nested_concat_test')
+    end function test_nested_concat_three_operands
+
+    logical function test_nested_concat_mixed_kinds()
+        ! Fixed-length, deferred-length and assumed-length operands in one
+        ! chain. A fixed-length operand contributes its declared width
+        ! including its blank padding, which is what gfortran does.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: d'//new_line('a')// &
+            '  character(len=4) :: f'//new_line('a')// &
+            '  d = "xy"'//new_line('a')// &
+            '  f = "PQ"'//new_line('a')// &
+            '  call show(d, f)'//new_line('a')// &
+            '  deallocate(d)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine show(dd, ff)'//new_line('a')// &
+            '    character(len=*), intent(in) :: dd'//new_line('a')// &
+            '    character(len=*), intent(in) :: ff'//new_line('a')// &
+            '    character(len=:), allocatable :: s'//new_line('a')// &
+            '    s = dd // "-" // ff // "-" // dd'//new_line('a')// &
+            '    print *, len(s), "[", s, "]"'//new_line('a')// &
+            '    deallocate(s)'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end program main'
+
+        test_nested_concat_mixed_kinds = expect_output( &
+            source, '          10 [xy-PQ  -xy]'//new_line('a'), &
+            '/tmp/ffc_session_nested_concat_kinds_test')
+    end function test_nested_concat_mixed_kinds
+
+    logical function test_nested_concat_self_append()
+        ! The destination is also an operand. Every operand must be copied out
+        ! before the destination releases the block it currently holds, or the
+        ! result reads freed bytes.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: s, t'//new_line('a')// &
+            '  s = "ab"'//new_line('a')// &
+            '  t = "cd"'//new_line('a')// &
+            '  s = s // "-" // t'//new_line('a')// &
+            '  print *, len(s), "[", s, "]"'//new_line('a')// &
+            '  s = s // s'//new_line('a')// &
+            '  print *, len(s), "[", s, "]"'//new_line('a')// &
+            '  deallocate(s)'//new_line('a')// &
+            '  deallocate(t)'//new_line('a')// &
+            'end program main'
+
+        test_nested_concat_self_append = expect_output( &
+            source, &
+            '           5 [ab-cd]'//new_line('a')// &
+            '          10 [ab-cdab-cd]'//new_line('a'), &
+            '/tmp/ffc_session_nested_concat_self_test')
+    end function test_nested_concat_self_append
+
+    logical function test_nested_concat_into_shorter_fixed()
+        ! The intermediate result is longer than the fixed destination, so the
+        ! assignment truncates to the declared width; a shorter one pads.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: a, b'//new_line('a')// &
+            '  character(len=5) :: short'//new_line('a')// &
+            '  character(len=14) :: wide'//new_line('a')// &
+            '  a = "ABC"'//new_line('a')// &
+            '  b = "DEF"'//new_line('a')// &
+            '  short = a // "-" // b'//new_line('a')// &
+            '  print *, "[", short, "]"'//new_line('a')// &
+            '  wide = a // "-" // b'//new_line('a')// &
+            '  print *, "[", wide, "]"'//new_line('a')// &
+            '  deallocate(a)'//new_line('a')// &
+            '  deallocate(b)'//new_line('a')// &
+            'end program main'
+
+        test_nested_concat_into_shorter_fixed = expect_output( &
+            source, &
+            ' [ABC-D]'//new_line('a')// &
+            ' [ABC-DEF       ]'//new_line('a'), &
+            '/tmp/ffc_session_nested_concat_fixed_test')
+    end function test_nested_concat_into_shorter_fixed
+
+    logical function test_nested_concat_does_not_leak()
+        ! Each result replaces the previous one, and a chain inside a loop must
+        ! release what it replaces rather than accumulate.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: a, b, s'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  a = "AB"'//new_line('a')// &
+            '  b = "CD"'//new_line('a')// &
+            '  do i = 1, 4'//new_line('a')// &
+            '    s = a // "-" // b // "-" // a'//new_line('a')// &
+            '    print *, len(s)'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            '  deallocate(a)'//new_line('a')// &
+            '  deallocate(b)'//new_line('a')// &
+            '  deallocate(s)'//new_line('a')// &
+            '  stop 0'//new_line('a')// &
+            'end program main'
+
+        test_nested_concat_does_not_leak = expect_no_leaks( &
+            source, '/tmp/ffc_session_nested_concat_leak_test')
+    end function test_nested_concat_does_not_leak
 
     logical function test_assumed_length_len_inside_callee()
         ! len(s) inside a callee returns the actual length of a literal actual.


### PR DESCRIPTION
Closes #613.

`a // "-" // b` did not lower: `expected identifier or literal in concat operand`.
The deferred-length destination had its own two-operand concatenation lowering
that resolved each side to a symbol or a literal, so a concatenation whose
operand was itself a concatenation had nowhere to go. Two operands worked, and
all-literal chains of any depth worked because they fold to a single literal
before reaching this path, which is why the gap looked narrow.

## One flattening, not two

The fixed-length destination already flattened an arbitrary concatenation tree
through `collect_concat_operands`, resolving each leaf with
`char_expr_operands`. The deferred destination now uses that same flattening,
and its bespoke two-operand resolution is **deleted** rather than kept as a
fast path. The two destinations now agree on what a concatenation is instead of
each carrying its own idea of one, and every leaf kind `char_expr_operands`
understands — variable, literal, substring, function result, `trim`/`adjustl`/
`repeat` — becomes an operand here for free.

`emit_concat_copies` gained an explicit no-clamp contract for this.
A fixed-length destination clamps copying to its declared width; a deferred one
must not, so it passes `CONCAT_NO_CLAMP` instead of relying on the previous
implicit behaviour of a zero width.

## Behaviour preserved

- **Padding and truncation.** A destination that reaches the deferred path with
  a declared width is a fixed-length result using the descriptor return ABI, and
  it still delegates to `lower_fixed_width_deferred_concat` so the value pads or
  truncates to N rather than taking the operand sum. I dropped that delegation
  in a first cut and `test_session_fixed_char_function_result_compiler`
  (`concat_pad`) caught it — the direct-call print returned length 6 instead of
  the declared 12. Restored, with the case now covered from both directions.
- **Fixed-length operands contribute their declared width**, blank padding
  included, which is what gfortran does: `dd // "-" // ff // "-" // dd` with a
  `character(len=4)` operand holding `"PQ"` gives `xy-PQ  -xy`.
- **Copy before release.** Every operand is copied into the new buffer before
  the destination releases the block it currently holds, so an operand that
  aliases that block stays valid. `s = s // "-" // t` and `s = s // s` are both
  covered and both match gfortran.
- **Ownership.** The result is heap storage the destination owns
  (`CHARACTER_STORAGE_OWNED`), so #349's release-on-replace frees it. That also
  means a chain inside a loop releases each iteration instead of growing the
  stack, which the previous program-scope `alloca` did not.

## Coverage

Five cases, expectations taken from gfortran:

- three and four non-literal operands;
- mixed fixed-, assumed- and deferred-length operands in one chain;
- self-append `s = s // "-" // t` and `s = s // s`;
- an intermediate result longer than the fixed destination, so it truncates,
  plus a longer destination so it pads;
- a chain in a `do` loop under valgrind, requiring release per iteration.

Four of the five fail on the parent commit with
`expected identifier or literal in concat operand`; the fixed-destination one
passes there, since that path already flattened.

## Conformance gauntlet

Per ffc#642, two clean worktrees at the same commit are not trustworthy for A/B,
so this is a **same-worktree before/after**: measure the branch, revert `src/`
and `test/conformance/` to the parent commit, rebuild, measure again, restore.

| Suite | before | after |
|---|---|---|
| lfortran | PASS=875 XFAIL=3287 XPASS=110 FAIL=7 | PASS=879 XFAIL=3283 XPASS=110 FAIL=7 |
| gfortran-dg | PASS=1355 XFAIL=2072 XPASS=57 FAIL=155 | PASS=1355 XFAIL=2072 XPASS=57 FAIL=155 |
| fortfront-f90 | PASS=450 XFAIL=93 XPASS=0 FAIL=10 | PASS=450 XFAIL=93 XPASS=0 FAIL=10 |
| fortfront-lf | PASS=211 XFAIL=51 XPASS=3 FAIL=0 | PASS=211 XFAIL=51 XPASS=3 FAIL=0 |

lfortran gains exactly the four promoted cases. gfortran-dg is unchanged
per case. Nothing lost PASS anywhere.

Two single-run artefacts, both re-measured three times rather than reported:

- `issue_2971_callsite_rename.lf` showed FAIL once in the first after-run. It is
  PASS in 3/3 re-runs and compiles 5/5 directly on the same binary, and it
  contains no concatenation. The table shows the re-measured `FAIL=0`.
- `issue_1324_if_inside_do_loop.f90` showed PASS once, which would have looked
  like a gain. It is FAIL in 3/3 re-runs, so it is itself flaky and no f90 gain
  is claimed.

## Cases promoted out of the xfail manifest

| Case | Manifest owner | Failed before with |
|---|---|---|
| `string_94.f90` | ffc#350 | expected identifier or literal in concat operand |
| `string_concat_deferred_len.f90` | ffc#350 | expected identifier or literal in concat operand |
| `modules_63_module.f90` | ffc#350 | expected identifier or literal in concat operand |
| `modules_63.f90` | ffc#328 | (pair of the above) |

All four are XFAIL in the before-run and PASS in 3/3 after-runs on the final
build. `file_open_08.f90` was **not** promoted: ffc#644 records it segfaulting
7 runs in 8.

`fo` is green apart from `test_parity_dashboard`,
`test_fortfront_corpus_conformance`, `test_session_lazy_monomorph_compiler` and
`test_session_type_extends_compiler`, all four of which fail identically in the
same worktree with `src/` reverted to the parent commit.
