### PR TITLE
[reject-decl-02] reject conflicting declarations and mismatched constructors (#580)

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -2847,4 +2847,5 @@ contains
     include 'session_program_lowering_reject_alloc.inc'
     include 'session_program_lowering_reject_result.inc'
     include 'session_program_lowering_reject_generic.inc'
+    include 'session_program_lowering_reject_decl_conflict.inc'
 end module session_program_lowering

--- a/src/session_program_lowering_reject_array_ctor.inc
+++ b/src/session_program_lowering_reject_array_ctor.inc
@@ -59,6 +59,11 @@
                                                is_lazy, nd%line, nd%column, &
                                                error_msg)
                 if (len_trim(error_msg) > 0) return
+                if (.not. is_lazy) then
+                    call check_ctor_char_lengths(arena, nd%element_indices, &
+                                                 nd%line, nd%column, error_msg)
+                    if (len_trim(error_msg) > 0) return
+                end if
             end select
         end do
     end subroutine check_array_ctor_element_agreement
@@ -102,6 +107,65 @@
             return
         end do
     end subroutine check_ctor_elements_agree
+
+    ! Rule 5 (standard mode only): without a type-spec the character length of
+    ! an array
+    ! constructor is that of its values, so character literals of differing
+    ! length leave the element length undetermined (F2018 7.8, gfortran
+    ! "Different CHARACTER lengths in array constructor"). A type-spec fixes
+    ! the length and pads shorter values, which the caller already skips.
+    subroutine check_ctor_char_lengths(arena, elems, line, col, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: elems(:)
+        integer, intent(in) :: line, col
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=64) :: location
+        integer :: i, elem_len, first_len, first_pos
+
+        call set_empty(error_msg)
+        first_len = -1
+        first_pos = 0
+        do i = 1, size(elems)
+            elem_len = ctor_char_literal_length(arena, elems(i))
+            if (elem_len < 0) cycle
+            if (first_len < 0) then
+                first_len = elem_len
+                first_pos = i
+                cycle
+            end if
+            if (elem_len == first_len) cycle
+            if (line > 0 .and. col > 0) then
+                write (location, '(" at line ",I0,", column ",I0)') line, col
+            else
+                location = ''
+            end if
+            error_msg = 'array constructor'//trim(location)// &
+                        ' has different CHARACTER lengths ('// &
+                        int_to_text(first_len)//'/'//int_to_text(elem_len)// &
+                        ') in element '//int_to_text(first_pos)//' and '// &
+                        'element '//int_to_text(i)// &
+                        ': a constructor without a type-spec has one '// &
+                        'element length'
+            return
+        end do
+    end subroutine check_ctor_char_lengths
+
+    ! Length of a character literal ac-value, or -1 when the value is not a
+    ! character literal the driver can measure statically.
+    integer function ctor_char_literal_length(arena, idx) result(char_len)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        character(len=:), allocatable :: value, literal_type, err, text
+
+        char_len = -1
+        if (idx <= 0) return
+        if (.not. node_exists(arena, idx)) return
+        if (.not. is_character_literal(arena, idx)) return
+        call get_literal_info(arena, idx, value, literal_type, err)
+        if (len_trim(err) > 0) return
+        call strip_literal_quotes(value, text)
+        char_len = len(text)
+    end function ctor_char_literal_length
 
     ! The intrinsic type of a literal ac-value, distinguishing integer from
     ! real (cmp_class_name lumps both into "numeric", which is too coarse to

--- a/src/session_program_lowering_reject_decl_conflict.inc
+++ b/src/session_program_lowering_reject_decl_conflict.inc
@@ -1,0 +1,301 @@
+    ! Conflicting declarations and NULL(MOLD) pointer assignments (#580).
+    !
+    ! Two rules live here:
+    !   1. A name shall not be declared both by a PROCEDURE statement that
+    !      carries an interface and by a type declaration in the same scope:
+    !      the PROCEDURE statement already fixes the interface, so a later or
+    !      earlier type declaration contradicts it (F2018 15.4.3.6, gfortran
+    !      "already has basic type of" / "may not have basic type of"). A
+    !      PROCEDURE statement with an empty interface, procedure() :: e,
+    !      leaves the type open and stays compatible with a type declaration.
+    !   2. NULL(MOLD) acquires the type and rank of MOLD, so in a pointer
+    !      assignment p => null(mold) the declared type and rank of mold shall
+    !      agree with those of p (F2018 16.9.144, gfortran "Different types in
+    !      pointer assignment" / "Different ranks in pointer assignment").
+    !
+    ! The checks run from validate_program, before any lowering, so they see
+    ! the declaration list of every scope.
+
+    subroutine check_declaration_conflicts(arena, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: n
+
+        call set_empty(error_msg)
+        do n = 1, arena%size
+            if (.not. node_exists(arena, n)) cycle
+            select type (nd => arena%entries(n)%node)
+            type is (program_node)
+                if (allocated(nd%body_indices)) then
+                    call check_scope_decl_conflicts(arena, nd%body_indices, &
+                                                    error_msg)
+                end if
+            type is (module_node)
+                if (allocated(nd%declaration_indices)) then
+                    call check_scope_decl_conflicts(arena, &
+                                                    nd%declaration_indices, &
+                                                    error_msg)
+                end if
+            type is (function_def_node)
+                if (allocated(nd%body_indices)) then
+                    call check_scope_decl_conflicts(arena, nd%body_indices, &
+                                                    error_msg)
+                end if
+            type is (subroutine_def_node)
+                if (allocated(nd%body_indices)) then
+                    call check_scope_decl_conflicts(arena, nd%body_indices, &
+                                                    error_msg)
+                end if
+            type is (multi_unit_container_node)
+                if (allocated(nd%body_indices)) then
+                    call check_scope_decl_conflicts(arena, nd%body_indices, &
+                                                    error_msg)
+                end if
+                ! A source without a PROGRAM statement keeps its specification
+                ! part in the container, not in a program node.
+            type is (mixed_construct_container_node)
+                if (allocated(nd%implicit_declaration_indices)) then
+                    call check_scope_decl_conflicts( &
+                        arena, nd%implicit_declaration_indices, error_msg)
+                end if
+            end select
+            if (len_trim(error_msg) > 0) return
+        end do
+    end subroutine check_declaration_conflicts
+
+    subroutine check_scope_decl_conflicts(arena, indices, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call set_empty(error_msg)
+        call check_procedure_type_conflicts(arena, indices, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call check_null_mold_assignments(arena, indices, error_msg)
+    end subroutine check_scope_decl_conflicts
+
+    ! Rule 1: PROCEDURE with an interface versus a type declaration.
+    subroutine check_procedure_type_conflicts(arena, indices, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: name
+        character(len=64) :: location
+        integer :: i, k, line, column
+
+        call set_empty(error_msg)
+        do i = 1, size(indices)
+            if (.not. node_exists(arena, indices(i))) cycle
+            select type (decl => arena%entries(indices(i))%node)
+            type is (declaration_node)
+                if (.not. procedure_decl_has_interface(decl)) cycle
+                do k = 1, proc_decl_name_count(decl)
+                    name = proc_decl_name_at(decl, k)
+                    if (len_trim(name) == 0) cycle
+                    call typed_declaration_position(arena, indices, name, &
+                                                    line, column)
+                    if (line <= 0) cycle
+                    write (location, '(" at line ",I0,", column ",I0)') &
+                        line, column
+                    error_msg = 'name '''//trim(name)// &
+                                ''' is declared both by a PROCEDURE '// &
+                                'statement with an interface and by a type '// &
+                                'declaration'//trim(location)
+                    return
+                end do
+            end select
+        end do
+    end subroutine check_procedure_type_conflicts
+
+    ! True for procedure(iface) :: p, false for procedure() :: p and for any
+    ! declaration that is not a PROCEDURE statement.
+    logical function procedure_decl_has_interface(decl) result(has_iface)
+        type(declaration_node), intent(in) :: decl
+        character(len=:), allocatable :: lowered, inner
+        integer :: open_pos, close_pos
+
+        has_iface = .false.
+        if (.not. allocated(decl%type_name)) return
+        lowered = trim(lowercase_text(decl%type_name))
+        if (.not. starts_with_word(lowered, 'procedure')) return
+        open_pos = index(lowered, '(')
+        close_pos = index(lowered, ')', back=.true.)
+        if (open_pos <= 0) return
+        if (close_pos <= open_pos) return
+        inner = lowered(open_pos + 1:close_pos - 1)
+        has_iface = len_trim(inner) > 0
+    end function procedure_decl_has_interface
+
+    ! Line and column of the first type declaration of name in this scope,
+    ! or 0 when the name has no type declaration here.
+    subroutine typed_declaration_position(arena, indices, name, line, column)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        character(len=*), intent(in) :: name
+        integer, intent(out) :: line, column
+        character(len=:), allocatable :: lname
+        integer :: i
+
+        line = 0
+        column = 0
+        lname = trim(lowercase_text(name))
+        do i = 1, size(indices)
+            if (.not. node_exists(arena, indices(i))) cycle
+            select type (decl => arena%entries(indices(i))%node)
+            type is (declaration_node)
+                if (decl%is_external) cycle
+                if (.not. allocated(decl%type_name)) cycle
+                if (len_trim(decl%type_name) == 0) cycle
+                if (starts_with_word(lowercase_text(decl%type_name), &
+                                     'procedure')) cycle
+                if (.not. declaration_declares_name(decl, lname)) cycle
+                line = decl%line
+                column = decl%column
+                return
+            end select
+        end do
+    end subroutine typed_declaration_position
+
+    integer function proc_decl_name_count(decl) result(count)
+        type(declaration_node), intent(in) :: decl
+
+        count = 0
+        if (decl%is_multi_declaration) then
+            if (allocated(decl%var_names)) count = size(decl%var_names)
+            return
+        end if
+        if (allocated(decl%var_name)) count = 1
+    end function proc_decl_name_count
+
+    function proc_decl_name_at(decl, k) result(name)
+        type(declaration_node), intent(in) :: decl
+        integer, intent(in) :: k
+        character(len=:), allocatable :: name
+
+        name = ''
+        if (decl%is_multi_declaration) then
+            if (.not. allocated(decl%var_names)) return
+            if (k < 1 .or. k > size(decl%var_names)) return
+            name = trim(decl%var_names(k))
+            return
+        end if
+        if (.not. allocated(decl%var_name)) return
+        if (k /= 1) return
+        name = trim(decl%var_name)
+    end function proc_decl_name_at
+
+    ! Rule 2: p => null(mold) agrees with mold in type and rank.
+    subroutine check_null_mold_assignments(arena, indices, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: ptr_name, mold_name
+        character(len=:), allocatable :: ptr_type, mold_type
+        character(len=64) :: location
+        logical :: ptr_found, mold_found, ptr_array, mold_array
+        integer :: i
+
+        call set_empty(error_msg)
+        do i = 1, size(indices)
+            if (.not. node_exists(arena, indices(i))) cycle
+            select type (pa => arena%entries(indices(i))%node)
+            type is (pointer_assignment_node)
+                call identifier_name_at(arena, pa%pointer_index, ptr_name)
+                if (len_trim(ptr_name) == 0) cycle
+                call null_mold_name(arena, pa%target_index, mold_name)
+                if (len_trim(mold_name) == 0) cycle
+                call declared_type_and_rank(arena, indices, ptr_name, &
+                                            ptr_type, ptr_array, ptr_found)
+                if (.not. ptr_found) cycle
+                call declared_type_and_rank(arena, indices, mold_name, &
+                                            mold_type, mold_array, mold_found)
+                if (.not. mold_found) cycle
+                write (location, '(" at line ",I0,", column ",I0)') &
+                    pa%line, pa%column
+                if (ptr_array .neqv. mold_array) then
+                    error_msg = 'different ranks in pointer assignment'// &
+                                trim(location)//': NULL('//trim(mold_name)// &
+                                ') has the rank of '''//trim(mold_name)// &
+                                ''', not that of '''//trim(ptr_name)//''''
+                    return
+                end if
+                if (ptr_type == mold_type) cycle
+                error_msg = 'different types in pointer assignment'// &
+                            trim(location)//': NULL('//trim(mold_name)// &
+                            ') is '//mold_type//' but '''//trim(ptr_name)// &
+                            ''' is '//ptr_type
+                return
+            end select
+        end do
+    end subroutine check_null_mold_assignments
+
+    ! Name of the single MOLD argument of a NULL(MOLD) reference, empty when
+    ! the target is not NULL(...) or the argument is not a bare name.
+    subroutine null_mold_name(arena, idx, name)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: idx
+        character(len=:), allocatable, intent(out) :: name
+
+        name = ''
+        if (idx <= 0) return
+        if (.not. node_exists(arena, idx)) return
+        select type (nd => arena%entries(idx)%node)
+        type is (call_or_subscript_node)
+            if (.not. allocated(nd%name)) return
+            if (trim(lowercase_text(nd%name)) /= 'null') return
+            if (.not. allocated(nd%arg_indices)) return
+            if (size(nd%arg_indices) /= 1) return
+            call identifier_name_at(arena, nd%arg_indices(1), name)
+        end select
+    end subroutine null_mold_name
+
+    ! Base intrinsic or derived type name and array rank flag of the first
+    ! declaration of name in this scope.
+    subroutine declared_type_and_rank(arena, indices, name, type_name, &
+                                      is_array, found)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable, intent(out) :: type_name
+        logical, intent(out) :: is_array
+        logical, intent(out) :: found
+        character(len=:), allocatable :: lname
+        integer :: i
+
+        type_name = ''
+        is_array = .false.
+        found = .false.
+        lname = trim(lowercase_text(name))
+        do i = 1, size(indices)
+            if (.not. node_exists(arena, indices(i))) cycle
+            select type (decl => arena%entries(indices(i))%node)
+            type is (declaration_node)
+                if (.not. allocated(decl%type_name)) cycle
+                if (.not. declaration_declares_name(decl, lname)) cycle
+                type_name = base_type_name(decl%type_name)
+                is_array = decl%is_array
+                found = len_trim(type_name) > 0
+                return
+            end select
+        end do
+    end subroutine declared_type_and_rank
+
+    ! real(kind=8) -> real; type(box_t) -> box_t.
+    function base_type_name(text) result(base)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: base
+        character(len=:), allocatable :: lowered
+        integer :: open_pos, close_pos
+
+        lowered = trim(lowercase_text(text))
+        open_pos = index(lowered, '(')
+        if (open_pos <= 0) then
+            base = lowered
+            return
+        end if
+        base = trim(lowered(:open_pos - 1))
+        if (base /= 'type' .and. base /= 'class') return
+        close_pos = index(lowered, ')', back=.true.)
+        if (close_pos <= open_pos + 1) return
+        base = trim(adjustl(lowered(open_pos + 1:close_pos - 1)))
+    end function base_type_name

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -702,6 +702,8 @@
         if (len_trim(error_msg) > 0) return
         call check_pointer_target_contracts(arena, error_msg)
         if (len_trim(error_msg) > 0) return
+        call check_declaration_conflicts(arena, error_msg)
+        if (len_trim(error_msg) > 0) return
         call check_constant_initialization_exprs(arena, error_msg)
         if (len_trim(error_msg) > 0) return
         call check_constant_expression_overflow(arena, error_msg)

--- a/test/test_session_char_array_initializer_compiler.f90
+++ b/test/test_session_char_array_initializer_compiler.f90
@@ -33,7 +33,9 @@ contains
     logical function test_padding_and_len_trim()
         character(len=*), parameter :: source = &
             'program main'//new_line('a')// &
-            '  character(len=6) :: m(2) = ["ab", "cdef"]'//new_line('a')// &
+            ! Without a type-spec the ac-values would need equal lengths.
+            '  character(len=6) :: m(2) = [character(len=4) :: "ab", "cdef"]'// &
+            new_line('a')// &
             '  if (len_trim(m(1)) /= 2) error stop'//new_line('a')// &
             '  if (len_trim(m(2)) /= 4) error stop'//new_line('a')// &
             '  if (m(1) /= "ab") error stop'//new_line('a')// &

--- a/test/test_session_reject_decl_02_compiler.f90
+++ b/test/test_session_reject_decl_02_compiler.f90
@@ -1,0 +1,199 @@
+program test_session_reject_decl_02_compiler
+    use ffc_test_support, only: expect_error_contains, expect_exit_status
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== conflicting declaration and constructor rejection test ==='
+
+    all_passed = .true.
+    if (.not. test_procedure_then_type_rejected()) all_passed = .false.
+    if (.not. test_type_then_procedure_rejected()) all_passed = .false.
+    if (.not. test_typeless_procedure_accepted()) all_passed = .false.
+    if (.not. test_char_ctor_length_mismatch_rejected()) all_passed = .false.
+    if (.not. test_char_ctor_assignment_mismatch_rejected()) all_passed = .false.
+    if (.not. test_char_ctor_type_spec_accepted()) all_passed = .false.
+    if (.not. test_char_ctor_equal_lengths_accepted()) all_passed = .false.
+    if (.not. test_null_mold_type_mismatch_rejected()) all_passed = .false.
+    if (.not. test_null_mold_rank_mismatch_rejected()) all_passed = .false.
+    if (.not. test_null_mold_matching_accepted()) all_passed = .false.
+    if (.not. test_lazy_char_ctor_accepted()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: conflicting declarations and constructors are rejected'
+
+contains
+
+    ! Rule 1: a PROCEDURE statement with an interface and a type declaration
+    ! may not declare the same name (gfortran "already has basic type of").
+    logical function test_procedure_then_type_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  procedure(iabs) :: c'//new_line('a')// &
+            '  integer :: c'//new_line('a')// &
+            '  print *, 1'//new_line('a')// &
+            'end program main'
+
+        test_procedure_then_type_rejected = expect_error_contains( &
+            source, 'declared both by a PROCEDURE statement', &
+            '/tmp/ffc_reject_decl_02_proc_first')
+    end function test_procedure_then_type_rejected
+
+    logical function test_type_then_procedure_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: d'//new_line('a')// &
+            '  procedure(iabs) :: d'//new_line('a')// &
+            '  print *, 1'//new_line('a')// &
+            'end program main'
+
+        test_type_then_procedure_rejected = expect_error_contains( &
+            source, 'declared both by a PROCEDURE statement', &
+            '/tmp/ffc_reject_decl_02_type_first')
+    end function test_type_then_procedure_rejected
+
+    ! A PROCEDURE statement without an interface leaves the type open, so it
+    ! may be combined with a type declaration (gfortran accepts this).
+    logical function test_typeless_procedure_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: e'//new_line('a')// &
+            '  procedure() :: e'//new_line('a')// &
+            '  stop 3'//new_line('a')// &
+            'end program main'
+
+        test_typeless_procedure_accepted = expect_exit_status( &
+            source, 3, '/tmp/ffc_reject_decl_02_typeless')
+    end function test_typeless_procedure_accepted
+
+    ! Rule 2: without a type-spec every character ac-value of an array
+    ! constructor has the same length (gfortran "Different CHARACTER lengths").
+    logical function test_char_ctor_length_mismatch_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=8) :: arr(2) = (/ "abc", "foobar" /)'// &
+            new_line('a')// &
+            '  print *, arr(1)'//new_line('a')// &
+            'end program main'
+
+        test_char_ctor_length_mismatch_rejected = expect_error_contains( &
+            source, 'different CHARACTER lengths', &
+            '/tmp/ffc_reject_decl_02_char_init')
+    end function test_char_ctor_length_mismatch_rejected
+
+    logical function test_char_ctor_assignment_mismatch_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=8) :: arr(2)'//new_line('a')// &
+            '  arr = (/ "abc", "foobar" /)'//new_line('a')// &
+            '  print *, arr(1)'//new_line('a')// &
+            'end program main'
+
+        test_char_ctor_assignment_mismatch_rejected = expect_error_contains( &
+            source, 'different CHARACTER lengths', &
+            '/tmp/ffc_reject_decl_02_char_assign')
+    end function test_char_ctor_assignment_mismatch_rejected
+
+    ! A type-spec fixes the element length, so unequal values are padded.
+    logical function test_char_ctor_type_spec_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=6) :: arr(2)'//new_line('a')// &
+            '  arr = (/ character(len=6) :: "abc", "foobar" /)'// &
+            new_line('a')// &
+            '  if (arr(2) == "foobar") stop 4'//new_line('a')// &
+            'end program main'
+
+        test_char_ctor_type_spec_accepted = expect_exit_status( &
+            source, 4, '/tmp/ffc_reject_decl_02_char_spec')
+    end function test_char_ctor_type_spec_accepted
+
+    logical function test_char_ctor_equal_lengths_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=3) :: arr(2)'//new_line('a')// &
+            '  arr = (/ "abc", "def" /)'//new_line('a')// &
+            '  if (arr(2) == "def") stop 5'//new_line('a')// &
+            'end program main'
+
+        test_char_ctor_equal_lengths_accepted = expect_exit_status( &
+            source, 5, '/tmp/ffc_reject_decl_02_char_equal')
+    end function test_char_ctor_equal_lengths_accepted
+
+    ! Rule 3: NULL(MOLD) takes the type and rank of MOLD, and those must
+    ! match the pointer (gfortran "Different types in pointer assignment").
+    logical function test_null_mold_type_mismatch_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, pointer :: i => null()'//new_line('a')// &
+            '  real, pointer :: x => null()'//new_line('a')// &
+            '  x => null(i)'//new_line('a')// &
+            '  print *, associated(x)'//new_line('a')// &
+            'end program main'
+
+        test_null_mold_type_mismatch_rejected = expect_error_contains( &
+            source, 'different types in pointer assignment', &
+            '/tmp/ffc_reject_decl_02_null_type')
+    end function test_null_mold_type_mismatch_rejected
+
+    logical function test_null_mold_rank_mismatch_rejected()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  real, pointer :: x => null()'//new_line('a')// &
+            '  real, pointer :: z(:) => null()'//new_line('a')// &
+            '  x => null(z)'//new_line('a')// &
+            '  print *, associated(x)'//new_line('a')// &
+            'end program main'
+
+        test_null_mold_rank_mismatch_rejected = expect_error_contains( &
+            source, 'different ranks in pointer assignment', &
+            '/tmp/ffc_reject_decl_02_null_rank')
+    end function test_null_mold_rank_mismatch_rejected
+
+    logical function test_null_mold_matching_accepted()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  real, pointer :: x => null()'//new_line('a')// &
+            '  real, pointer :: w => null()'//new_line('a')// &
+            '  x => null(w)'//new_line('a')// &
+            '  if (.not. associated(x)) stop 6'//new_line('a')// &
+            'end program main'
+
+        test_null_mold_matching_accepted = expect_exit_status( &
+            source, 6, '/tmp/ffc_reject_decl_02_null_ok')
+    end function test_null_mold_matching_accepted
+
+    ! Lazy Fortran pads character array values to the longest value, so the
+    ! standard-mode length rule must not fire on a .lf source (this is the
+    ! shape of fortfront/examples/lf/docs_character_arrays.lf).
+    logical function test_lazy_char_ctor_accepted()
+        character(len=*), parameter :: source = &
+            'names = ["alice", "bob", "charlie"]'//new_line('a')// &
+            'print *, trim(names(2))'//new_line('a')
+        character(len=*), parameter :: stem = '/tmp/ffc_reject_decl_02_lazy'
+        character(len=:), allocatable :: command
+        integer :: exit_stat, cmd_stat, unit
+
+        test_lazy_char_ctor_accepted = .false.
+        open (newunit=unit, file=stem//'.lf', status='replace', action='write')
+        write (unit, '(A)') source
+        close (unit)
+        command = "sh -c 'exe=$(ls -t build/*/app/ffc build/fo/bin/ffc "// &
+                  "2>/dev/null | head -n 1); test -n ""$exe"" && "// &
+                  """$exe"" "//stem//'.lf -o '//stem//".exe'"
+        call execute_command_line(command, exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0 .or. exit_stat /= 0) then
+            print *, 'FAIL: lazy character array constructor was rejected'
+            return
+        end if
+        call execute_command_line(stem//'.exe', exitstat=exit_stat, &
+                                  cmdstat=cmd_stat)
+        call execute_command_line('rm -f '//stem//'.lf '//stem//'.exe')
+        if (cmd_stat /= 0 .or. exit_stat /= 0) then
+            print *, 'FAIL: lazy character array executable did not run'
+            return
+        end if
+        test_lazy_char_ctor_accepted = .true.
+    end function test_lazy_char_ctor_accepted
+
+end program test_session_reject_decl_02_compiler


### PR DESCRIPTION
Closes #580 for three of its six files; the other three are FortFront gaps (below).

## Invariant preserved

ffc must not compile a program that gfortran rejects, and must keep compiling
everything valid. Three new checks run in `validate_program`, before lowering:

1. A name declared both by a `PROCEDURE` statement **with an interface** and by
   a type declaration in the same scope (gfortran "already has basic type of" /
   "may not have basic type of"). `procedure() :: e` alongside `integer :: e`
   stays legal, exactly as in the "allowed" section of `proc_decl_21.f90`.
2. A character array constructor **without a type-spec** whose ac-values have
   different lengths (gfortran "Different CHARACTER lengths"). A type-spec fixes
   the element length and keeps padding legal. Standard mode only: Lazy Fortran
   pads to the longest value, so `names = ["alice", "bob", "charlie"]` in a
   `.lf` source must keep compiling.
3. `p => NULL(mold)` where mold disagrees with `p` in declared type or rank
   (gfortran "Different types/ranks in pointer assignment").

## Red evidence (origin/main build, `.wt/ffc-580-baseline`)

`ffc <file>` exits 0 on `proc_decl_21.f90`, `bounds_check_array_ctor_3.f90` and
`null_1.f90`, all of which `gfortran -fsyntax-only` rejects — gauntlet verdict
`negative test accepted`. The new test
`test/test_session_reject_decl_02_compiler.f90` fails on that build.

## Green evidence

- `fo test test_session_reject_decl_02_compiler` PASS. Eleven cases: six
  rejections, five acceptances (typeless PROCEDURE + type declaration,
  type-spec constructor, equal-length constructor, matching NULL(mold), and the
  lazy `.lf` character array shape taken from
  `fortfront/examples/lf/docs_character_arrays.lf`).
- All three target dg files now exit 1 with the new diagnostics.

## Rejection gate: zero valid files newly rejected

Swept every corpus file (gfortran.dg, lfortran integration tests, fortfront
examples f90 + lf) containing `procedure(`, `null(<name>`, or a character array
constructor — 899 files — with the origin/main binary and the new binary. Files
that main accepted and this branch rejects:

```
gcc/gcc/testsuite/gfortran.dg/null_1.f90
gcc/gcc/testsuite/gfortran.dg/bounds_check_array_ctor_3.f90
gcc/gcc/testsuite/gfortran.dg/proc_decl_21.f90
```

All three are gfortran-invalid (`gfortran -fsyntax-only` exits 1). Zero valid
files. Gauntlet totals unchanged apart from those promotions; `fortfront-lf`
went from 1 FAIL (`docs_character_arrays.lf`, an over-rejection caught during
this work) to 0 once the length rule was gated to standard mode.

## Not fixed here: FortFront representation gaps

- lazy-fortran/fortfront#2986 — `PARAMETER`/`DIMENSION` statements overwrite an
  existing initializer in place, so `initialization_17.f90` cannot be diagnosed.
- lazy-fortran/fortfront#2987 — malformed procedure-pointer components
  (`nopass ptr4` without `::`, duplicate `POINTER`) and an empty derived-type
  parameter list parse without a diagnostic: `proc_ptr_comp_3.f90`, `pdt_30.f90`.

## Pipeline

Full `fo` green except two failures reproduced identically on an origin/main
worktree: `test_fortfront_corpus_conformance` (pre-existing fortfront-f90
failures plus fortfront-lf corpus drift) and `test_parity_dashboard`
(resolves `../fortfront` from `.wt/`).