### PR TITLE
[arraydesc-04] migrate allocatable arrays to the canonical descriptor

### DIFF
--- a/docs/ARRAY_DESCRIPTOR_ABI.md
+++ b/docs/ARRAY_DESCRIPTOR_ABI.md
@@ -117,9 +117,12 @@ so the pointer reaches the runtime deallocator exactly once. For a borrowed
 descriptor it returns a null pointer and still resets the descriptor, so
 dropping a view never frees storage.
 
-- An allocatable array's descriptor owns its allocation. `deallocate`
-  releases the descriptor and frees the returned pointer. Finalization order
-  is unchanged: elements are finalized before the base pointer is released.
+- An allocatable array's descriptor owns its allocation and is the entity's
+  only representation (#336): `allocate` installs the shape and the owning
+  flag, `deallocate` frees the base pointer and returns the descriptor to the
+  unallocated state, and `move_alloc` copies the whole record and clears the
+  source. Finalization order is unchanged: elements are finalized before the
+  base pointer is released.
 - A pointer array's descriptor never owns storage acquired by pointer
   assignment. Ownership stays with the target's own descriptor. A pointer
   that acquired storage through `allocate` does own it and is the descriptor
@@ -158,6 +161,11 @@ associated, and every subscript is out of bounds.
 
 ## Scope
 
-Defining this contract changes no lowering. Automatic, assumed-shape,
-allocatable, pointer, and section paths migrate in their own issues.
-Coarray codimensions are outside this descriptor.
+Migrated onto this contract so far: assumed-shape dummy arguments (#334),
+runtime-sized automatic arrays (#335), and allocatable arrays (#336). Pointer
+arrays and section views migrate in their own issues, as does retiring the
+last of the legacy runtime-shape metadata.
+
+Allocatable **components** of a derived type keep their own inline
+`{data, extent}` record for now; that representation is not part of this
+contract yet. Coarray codimensions are outside this descriptor.

--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -50,39 +50,56 @@ is closed with ABI documentation and executable tests.
 
 ### Allocatable array descriptor
 
-The canonical array descriptor for new runtime interfaces is specified in
-`ARRAY_DESCRIPTOR_ABI.md`. Current lowering paths use the following
-representation until their descriptor migration issues land.
+An `integer/real/logical, allocatable :: a(:)` or `a(:,:)` declaration lowers to
+one canonical array descriptor, specified in full by `ARRAY_DESCRIPTOR_ABI.md`
+(#336). The slot is a 200-byte, 8-byte-aligned record on the stack (or in
+static storage for a module variable), zero-initialised at declaration. The
+bespoke 40-byte `{data, lower1, upper1, lower2, upper2}` record it replaces is
+gone; nothing reads or writes those offsets any more.
 
-An `integer/real/logical, allocatable :: a(:)` declaration lowers to a 40-byte,
-8-byte-aligned descriptor on the stack, zero-initialised at declaration. The
-descriptor is element-kind-agnostic; the element kind lives on the symbol and
-drives the per-element byte stride:
+The descriptor records the element size and type code, so it is no longer
+element-kind-agnostic. Element byte size is 4 for `integer`/`real(4)`/`logical`
+and 8 for `real(8)`/`integer(8)`; logical occupies a 4-byte slot, matching the
+fixed-array representation.
 
-```
-struct ffc_alloc_1d {
-    ptr   data;    // offset 0; 0 means unallocated
-    i64   lower1;  // offset 8;  lower bound (1 once allocated)
-    i64   upper1;  // offset 16; upper bound (0 when unallocated)
-    i64   lower2;  // offset 24; rank-2 only (0 for rank-1)
-    i64   upper2;  // offset 32; rank-2 only (0 for rank-1)
-};
-```
+Field access happens only through the helpers in
+`session_program_lowering_alloc_descriptor.inc`, so the byte offsets appear in
+exactly one place.
 
-The element byte stride is 4 for `integer`/`real(4)`/`logical` and 8 for
-`real(8)`/`integer(8)`. Logical occupies a 4-byte slot, matching the fixed-array
-representation.
+The base pointer stays at offset 0, so `base == 0` still marks the array
+unallocated. What changed is that each dimension records
+`(lower_bound, extent, stride_bytes)` rather than `(lower, upper)`. The upper
+bound is not stored: it is recomputed as `lower + extent - 1`, so the shape has
+a single representation.
 
-`data == 0` marks the array unallocated. `allocate(a(N))` (N a literal or
-runtime integer) calls `malloc(N*stride)`, stores the pointer in `data`, sets
-`lower1 = 1` and `upper1 = N`. `deallocate(a)` calls `free(data)` then zeroes
-`data` and `upper1`. `free(NULL)` is a no-op, so deallocating an unallocated
-variable exits cleanly rather than erroring (a deliberate divergence from the
-standard, which makes it a runtime error).
+`allocate(a(N))` (N a literal or runtime integer) calls `malloc(N*element_size)`,
+stores the pointer at offset 0, and writes unit lower bounds, the requested
+extents, and contiguous column-major byte strides
+(`stride(1) = element_size`, `stride(d) = stride(d-1) * extent(d-1)`). It sets
+the allocated, associated, owning, and contiguous flags.
+
+`deallocate(a)` calls `free(base)` then returns the descriptor to the
+unallocated state: null base, cleared flags, zero extents. The element size,
+type, and rank survive, so a deallocated entity still describes what it can
+hold. `free(NULL)` is a no-op, so deallocating an unallocated variable exits
+cleanly rather than erroring (a deliberate divergence from the standard, which
+makes it a runtime error), and a second `deallocate` frees nothing rather than
+handing the same block to the deallocator twice.
+
+`move_alloc(from, to)` copies the whole descriptor record and then clears
+`from`. Ownership travels with the base pointer, so clearing frees nothing.
+
+Because allocatable arrays and assumed-shape dummies now share this one layout,
+an allocatable actual and the dummy it binds to agree on extents, on
+column-major order, and on element addresses by construction rather than by
+two representations happening to match.
+
+Allocatable **components** of a derived type still use their own inline
+`{data, extent}` record and are not part of this migration.
 
 Element access on an allocated 1-D allocatable is supported as an rvalue and an
-assignment target. `a(i)` loads `data` from offset 0 and `lower1` from offset 8
-at runtime, computes the element address as `data + (i - lower1) * stride`, and
+assignment target. `a(i)` loads the base pointer and dimension 1's lower bound
+at runtime, computes the element address as `base + (i - lower1) * stride`, and
 emits a kind-typed load or store. No alloc/free happens inside element loops:
 `allocate` once and index many. Bounds are not checked.
 

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -334,7 +334,8 @@ module session_program_lowering
         ARRAY_DESCRIPTOR_DIM_OFFSET, ARRAY_DIMENSION_BYTES, &
         ARRAY_DIMENSION_LOWER_OFFSET, ARRAY_DIMENSION_EXTENT_OFFSET, &
         ARRAY_DIMENSION_STRIDE_OFFSET, ARRAY_FLAG_ALLOCATED, &
-        ARRAY_FLAG_ASSOCIATED, ARRAY_FLAG_CONTIGUOUS, ARRAY_ELEMENT_INTEGER, &
+        ARRAY_FLAG_ASSOCIATED, ARRAY_FLAG_CONTIGUOUS, ARRAY_FLAG_OWNS_DATA, &
+        ARRAY_ELEMENT_INTEGER, &
         ARRAY_ELEMENT_REAL, ARRAY_ELEMENT_LOGICAL, ARRAY_ELEMENT_COMPLEX, &
         ARRAY_ELEMENT_CHARACTER, ARRAY_ELEMENT_DERIVED
     use ffc_character_descriptor, only: CHARACTER_STORAGE_STATIC, &
@@ -1724,6 +1725,7 @@ contains
     include 'session_program_lowering_arguments.inc'
     include 'session_program_lowering_assumed_shape_extent.inc'
     include 'session_program_lowering_assumed_shape_descriptor.inc'
+    include 'session_program_lowering_alloc_descriptor.inc'
     include 'session_program_lowering_character.inc'
     include 'session_program_lowering_deferred_char.inc'
     subroutine lower_function_return(node, context, error_msg)

--- a/src/session_program_lowering_alloc_array_result.inc
+++ b/src/session_program_lowering_alloc_array_result.inc
@@ -57,7 +57,8 @@
         end if
 
         if (.not. emit_alloca_bytes(context%session, &
-                i64_immediate(context%session, 40_c_int64_t), temp_desc, &
+                i64_immediate(context%session, &
+                    int(ALLOC_DESCRIPTOR_BYTES, c_int64_t)), temp_desc, &
                 error_msg)) return
         zero = i64_immediate(context%session, 0_c_int64_t)
         do i = 0, 4

--- a/src/session_program_lowering_alloc_descriptor.inc
+++ b/src/session_program_lowering_alloc_descriptor.inc
@@ -1,0 +1,209 @@
+    ! Canonical descriptor access for allocatable arrays (#336).
+    !
+    ! An `allocatable :: a(:)` / `a(:,:)` entity is described by one
+    ! `array_descriptor_t` (`docs/ARRAY_DESCRIPTOR_ABI.md`), replacing the
+    ! bespoke 40-byte `{data, lower1, upper1, lower2, upper2}` record. Every
+    ! read and write of an allocatable's shape goes through the helpers below,
+    ! so the byte offsets appear in exactly one place.
+    !
+    ! The base pointer stays at offset 0, so "unallocated" remains "base is
+    ! null" and no allocation-state test had to change. What changed is that
+    ! each dimension now records `(lower_bound, extent, stride_bytes)` rather
+    ! than `(lower, upper)`, which is what makes the layout shared with
+    ! assumed-shape dummies and automatic arrays.
+
+    integer(c_int64_t) function alloc_desc_dim_offset(dim, field) result(offset)
+        integer, intent(in) :: dim
+        integer(c_int64_t), intent(in) :: field
+
+        offset = int(ARRAY_DESCRIPTOR_DIM_OFFSET, c_int64_t) &
+                 + int(ARRAY_DIMENSION_BYTES, c_int64_t)*int(dim - 1, c_int64_t) &
+                 + field
+    end function alloc_desc_dim_offset
+
+    subroutine emit_alloc_desc_header(context, descriptor, value_kind, rank, &
+                                      error_msg)
+        ! Write the rank-invariant header of an allocatable's descriptor. Called
+        ! where the entity is declared, so the element kind and rank are known
+        ! before any ALLOCATE runs and an unallocated descriptor still describes
+        ! its own type.
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: descriptor
+        integer, intent(in) :: value_kind
+        integer, intent(in) :: rank
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (.not. emit_i64_store_at(context%session, &
+                i64_immediate(context%session, &
+                    allocatable_elem_size(value_kind)), descriptor, &
+                int(ARRAY_DESCRIPTOR_ELEMENT_SIZE_OFFSET, c_int64_t), &
+                error_msg)) return
+        call store_descriptor_i32(context, assumed_shape_element_type(value_kind), &
+            descriptor, int(ARRAY_DESCRIPTOR_ELEMENT_TYPE_OFFSET, c_int64_t), &
+            error_msg)
+        if (len_trim(error_msg) > 0) return
+        call store_descriptor_i32(context, int(rank, c_int32_t), descriptor, &
+            int(ARRAY_DESCRIPTOR_RANK_OFFSET, c_int64_t), error_msg)
+        if (len_trim(error_msg) > 0) return
+        call store_descriptor_i32(context, 0_c_int32_t, descriptor, &
+            int(ARRAY_DESCRIPTOR_RESERVED_OFFSET, c_int64_t), error_msg)
+    end subroutine emit_alloc_desc_header
+
+    subroutine emit_alloc_desc_flags(context, descriptor, allocated_state, &
+                                     error_msg)
+        ! Allocation state. An allocated allocatable array is contiguous and
+        ! owns its heap block, which is precisely what makes DEALLOCATE legal
+        ! on it; an unallocated one carries no flags at all.
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: descriptor
+        logical, intent(in) :: allocated_state
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer(c_int32_t) :: flags
+
+        flags = 0_c_int32_t
+        if (allocated_state) flags = ARRAY_FLAG_ALLOCATED + ARRAY_FLAG_ASSOCIATED &
+                                     + ARRAY_FLAG_OWNS_DATA + ARRAY_FLAG_CONTIGUOUS
+        call store_descriptor_i32(context, flags, descriptor, &
+            int(ARRAY_DESCRIPTOR_FLAGS_OFFSET, c_int64_t), error_msg)
+    end subroutine emit_alloc_desc_flags
+
+    subroutine emit_alloc_desc_set_dim(context, descriptor, dim, lower_i64, &
+                                       extent_i64, stride_i64, error_msg)
+        ! Write one dimension's lower bound, extent, and byte stride.
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: descriptor
+        integer, intent(in) :: dim
+        type(lr_operand_desc_t), intent(in) :: lower_i64
+        type(lr_operand_desc_t), intent(in) :: extent_i64
+        type(lr_operand_desc_t), intent(in) :: stride_i64
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (.not. emit_i64_store_at(context%session, lower_i64, descriptor, &
+                alloc_desc_dim_offset(dim, &
+                    int(ARRAY_DIMENSION_LOWER_OFFSET, c_int64_t)), &
+                error_msg)) return
+        if (.not. emit_i64_store_at(context%session, extent_i64, descriptor, &
+                alloc_desc_dim_offset(dim, &
+                    int(ARRAY_DIMENSION_EXTENT_OFFSET, c_int64_t)), &
+                error_msg)) return
+        if (.not. emit_i64_store_at(context%session, stride_i64, descriptor, &
+                alloc_desc_dim_offset(dim, &
+                    int(ARRAY_DIMENSION_STRIDE_OFFSET, c_int64_t)), &
+                error_msg)) return
+        call set_empty(error_msg)
+    end subroutine emit_alloc_desc_set_dim
+
+    subroutine emit_alloc_desc_load_lower(context, descriptor, dim, lower_i64, &
+                                          error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: descriptor
+        integer, intent(in) :: dim
+        type(lr_operand_desc_t), intent(out) :: lower_i64
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (.not. emit_i64_load_at(context%session, descriptor, &
+                alloc_desc_dim_offset(dim, &
+                    int(ARRAY_DIMENSION_LOWER_OFFSET, c_int64_t)), &
+                lower_i64, error_msg)) return
+        call set_empty(error_msg)
+    end subroutine emit_alloc_desc_load_lower
+
+    subroutine emit_alloc_desc_load_extent(context, descriptor, dim, extent_i64, &
+                                           error_msg)
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: descriptor
+        integer, intent(in) :: dim
+        type(lr_operand_desc_t), intent(out) :: extent_i64
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (.not. emit_i64_load_at(context%session, descriptor, &
+                alloc_desc_dim_offset(dim, &
+                    int(ARRAY_DIMENSION_EXTENT_OFFSET, c_int64_t)), &
+                extent_i64, error_msg)) return
+        call set_empty(error_msg)
+    end subroutine emit_alloc_desc_load_extent
+
+    subroutine emit_alloc_desc_load_upper(context, descriptor, dim, upper_i64, &
+                                          error_msg)
+        ! upper = lower + extent - 1, recomputed rather than stored, so the
+        ! descriptor keeps one representation of the shape.
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: descriptor
+        integer, intent(in) :: dim
+        type(lr_operand_desc_t), intent(out) :: upper_i64
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: lower_i64, extent_i64, sum_i64
+
+        call emit_alloc_desc_load_lower(context, descriptor, dim, lower_i64, &
+                                        error_msg)
+        if (len_trim(error_msg) > 0) return
+        call emit_alloc_desc_load_extent(context, descriptor, dim, extent_i64, &
+                                         error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_i64_binary(context%session, LR_OP_ADD, lower_i64, &
+                extent_i64, sum_i64, error_msg)) return
+        if (.not. emit_i64_binary(context%session, LR_OP_SUB, sum_i64, &
+                i64_immediate(context%session, 1_c_int64_t), upper_i64, &
+                error_msg)) return
+        call set_empty(error_msg)
+    end subroutine emit_alloc_desc_load_upper
+
+    subroutine emit_alloc_desc_allocate_shape(context, descriptor, value_kind, &
+                                              rank, extents_i64, error_msg)
+        ! Install the shape an ALLOCATE just produced: unit lower bounds, the
+        ! requested extents, and contiguous column-major byte strides, with the
+        ! allocated/owning flags set. Storage must already be stored at offset 0.
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: descriptor
+        integer, intent(in) :: value_kind
+        integer, intent(in) :: rank
+        type(lr_operand_desc_t), intent(in) :: extents_i64(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: running, next_running, one
+        integer :: d
+
+        call emit_alloc_desc_header(context, descriptor, value_kind, rank, &
+                                    error_msg)
+        if (len_trim(error_msg) > 0) return
+        call emit_alloc_desc_flags(context, descriptor, .true., error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        one = i64_immediate(context%session, 1_c_int64_t)
+        running = i64_immediate(context%session, &
+                                allocatable_elem_size(value_kind))
+        do d = 1, rank
+            call emit_alloc_desc_set_dim(context, descriptor, d, one, &
+                                         extents_i64(d), running, error_msg)
+            if (len_trim(error_msg) > 0) return
+            if (d < rank) then
+                if (.not. emit_i64_binary(context%session, LR_OP_MUL, running, &
+                        extents_i64(d), next_running, error_msg)) return
+                running = next_running
+            end if
+        end do
+        call set_empty(error_msg)
+    end subroutine emit_alloc_desc_allocate_shape
+
+    subroutine emit_alloc_desc_clear(context, descriptor, error_msg)
+        ! Return the descriptor to the unallocated state: null base, no flags,
+        ! and zero extents. The element size, type, and rank are left in place
+        ! so a deallocated entity still describes what it can hold.
+        type(lowering_context_t), intent(inout) :: context
+        type(lr_operand_desc_t), intent(in) :: descriptor
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: zero
+        integer :: d
+
+        zero = i64_immediate(context%session, 0_c_int64_t)
+        if (.not. emit_i64_store_at(context%session, zero, descriptor, &
+                0_c_int64_t, error_msg)) return
+        call emit_alloc_desc_flags(context, descriptor, .false., error_msg)
+        if (len_trim(error_msg) > 0) return
+        do d = 1, 2
+            if (.not. emit_i64_store_at(context%session, zero, descriptor, &
+                    alloc_desc_dim_offset(d, &
+                        int(ARRAY_DIMENSION_EXTENT_OFFSET, c_int64_t)), &
+                    error_msg)) return
+        end do
+        call set_empty(error_msg)
+    end subroutine emit_alloc_desc_clear

--- a/src/session_program_lowering_allocatable.inc
+++ b/src/session_program_lowering_allocatable.inc
@@ -945,6 +945,7 @@
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t) :: m_i32, n_i32, m_i64, n_i64
         type(lr_operand_desc_t) :: total_i64, bytes_i64, data_ptr, descriptor
+        type(lr_operand_desc_t) :: extents_i64(2)
 
         call lower_i32_expression(arena, size_index1, context, m_i32, error_msg)
         if (len_trim(error_msg) > 0) return
@@ -968,21 +969,11 @@
         descriptor = context%symbols(symbol_index)%allocatable_descriptor_address
         if (.not. emit_ptr_store(context%session, data_ptr, descriptor, &
                 error_msg)) return
-        ! lower1 = 1 at offset 8
-        if (.not. emit_i64_store_at(context%session, &
-                i64_immediate(context%session, 1_c_int64_t), descriptor, &
-                8_c_int64_t, error_msg)) return
-        ! upper1 = M at offset 16
-        if (.not. emit_i64_store_at(context%session, m_i64, descriptor, &
-                16_c_int64_t, error_msg)) return
-        ! lower2 = 1 at offset 24
-        if (.not. emit_i64_store_at(context%session, &
-                i64_immediate(context%session, 1_c_int64_t), descriptor, &
-                24_c_int64_t, error_msg)) return
-        ! upper2 = N at offset 32
-        if (.not. emit_i64_store_at(context%session, n_i64, descriptor, &
-                32_c_int64_t, error_msg)) return
-        call set_empty(error_msg)
+        ! Unit lower bounds with extents M and N, plus column-major strides.
+        extents_i64(1) = m_i64
+        extents_i64(2) = n_i64
+        call emit_alloc_desc_allocate_shape(context, descriptor, &
+            context%symbols(symbol_index)%value_kind, 2, extents_i64, error_msg)
     end subroutine lower_allocate_i32_2d
 
     subroutine lower_allocate_i32_1d_operand(n_i32, symbol_index, context, error_msg)
@@ -994,6 +985,7 @@
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t) :: bytes_i32, bytes_i64, n_i64, data_ptr
         type(lr_operand_desc_t) :: descriptor
+        type(lr_operand_desc_t) :: extents_i64(2)
 
         descriptor = context%symbols(symbol_index)%allocatable_descriptor_address
         if (.not. emit_i32_binary(context%session, LR_OP_MUL, n_i32, &
@@ -1009,12 +1001,9 @@
 
         if (.not. emit_ptr_store(context%session, data_ptr, descriptor, &
                 error_msg)) return
-        if (.not. emit_i64_store_at(context%session, &
-                i64_immediate(context%session, 1_c_int64_t), descriptor, &
-                8_c_int64_t, error_msg)) return
-        if (.not. emit_i64_store_at(context%session, n_i64, descriptor, &
-                16_c_int64_t, error_msg)) return
-        call set_empty(error_msg)
+        extents_i64(1) = n_i64
+        call emit_alloc_desc_allocate_shape(context, descriptor, &
+            context%symbols(symbol_index)%value_kind, 1, extents_i64, error_msg)
     end subroutine lower_allocate_i32_1d_operand
 
     subroutine lower_allocatable_constructor_assignment(arena, ctor, symbol_index, &
@@ -1449,18 +1438,13 @@
                 error_msg)) return
         if (.not. emit_free(context%session, data_ptr, error_msg)) return
 
-        zero = i64_immediate(context%session, 0_c_int64_t)
-        if (.not. emit_i64_store_at(context%session, zero, descriptor, &
-                0_c_int64_t, error_msg)) return
-        if (.not. emit_i64_store_at(context%session, zero, descriptor, &
-                16_c_int64_t, error_msg)) return
-        call set_empty(error_msg)
+        call emit_alloc_desc_clear(context, descriptor, error_msg)
     end subroutine lower_deallocate_i32
 
     subroutine lower_move_alloc(arena, arg_indices, context, error_msg)
-        ! move_alloc(from, to): copy descriptor from -> to, null from.
-        ! Copies all five i64 slots (40 bytes); the rank-1 tail is zero and
-        ! stays zero, so this works for both ranks.
+        ! move_alloc(from, to): copy the canonical descriptor from -> to, then
+        ! return from to the unallocated state. The whole record is copied, so
+        ! this works for every rank the descriptor supports.
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: arg_indices(:)
         type(lowering_context_t), intent(inout) :: context
@@ -1517,20 +1501,19 @@
         to_desc   = context%symbols(to_sym)%allocatable_descriptor_address
         zero = i64_immediate(context%session, 0_c_int64_t)
 
-        ! Copy ptr + four i64 bounds fields from -> to.
-        do k = 0, 4
+        ! Hand the whole descriptor over: base, element metadata, flags, and
+        ! every dimension's lower bound, extent, and stride. Copying only a
+        ! fixed prefix would silently drop the shape.
+        do k = 0, ALLOC_DESCRIPTOR_BYTES/8 - 1
             if (.not. emit_i64_load_at(context%session, from_desc, &
-                    int(k * 8, c_int64_t), val, error_msg)) return
+                    int(k*8, c_int64_t), val, error_msg)) return
             if (.not. emit_i64_store_at(context%session, val, to_desc, &
-                    int(k * 8, c_int64_t), error_msg)) return
+                    int(k*8, c_int64_t), error_msg)) return
         end do
 
-        ! Null the from descriptor.
-        do k = 0, 4
-            if (.not. emit_i64_store_at(context%session, zero, from_desc, &
-                    int(k * 8, c_int64_t), error_msg)) return
-        end do
-        call set_empty(error_msg)
+        ! The source becomes unallocated. Ownership moved with the base
+        ! pointer, so clearing must not free anything.
+        call emit_alloc_desc_clear(context, from_desc, error_msg)
     end subroutine lower_move_alloc
 
     logical function is_allocatable_element_ref(node, context) result(is_ref)
@@ -1633,8 +1616,8 @@
         descriptor = context%symbols(symbol_index)%allocatable_descriptor_address
         if (.not. emit_ptr_load(context%session, descriptor, data_ptr, error_msg)) &
             return
-        if (.not. emit_i64_load_at(context%session, descriptor, 8_c_int64_t, &
-                lower1, error_msg)) return
+        call emit_alloc_desc_load_lower(context, descriptor, 1, lower1, error_msg)
+        if (len_trim(error_msg) > 0) return
         if (.not. emit_liric_i32_to_i64(context%session, idx1_i32, idx1_i64, &
                 error_msg)) return
         if (.not. emit_i64_binary(context%session, LR_OP_SUB, idx1_i64, lower1, &
@@ -1644,17 +1627,14 @@
             linear_i64 = offset1_i64
         else
             ! rank == 2: linear = offset1 + extent1 * (j - lower2)
-            if (.not. emit_i64_load_at(context%session, descriptor, 16_c_int64_t, &
-                    upper1, error_msg)) return
-            if (.not. emit_i64_load_at(context%session, descriptor, 24_c_int64_t, &
-                    lower2, error_msg)) return
-            ! extent1 = upper1 - lower1 + 1
-            ! Use tmp to avoid aliasing (extent1 as both lhs and result is UB).
-            if (.not. emit_i64_binary(context%session, LR_OP_SUB, upper1, lower1, &
-                    tmp, error_msg)) return
-            if (.not. emit_i64_binary(context%session, LR_OP_ADD, tmp, &
-                    i64_immediate(context%session, 1_c_int64_t), extent1, &
-                    error_msg)) return
+            ! The descriptor stores the extent directly, so the old
+            ! upper - lower + 1 reconstruction is gone.
+            call emit_alloc_desc_load_extent(context, descriptor, 1, extent1, &
+                                             error_msg)
+            if (len_trim(error_msg) > 0) return
+            call emit_alloc_desc_load_lower(context, descriptor, 2, lower2, &
+                                            error_msg)
+            if (len_trim(error_msg) > 0) return
             call validate_i32_array_subscript(arena, node%arg_indices(2), context, &
                                               error_msg)
             if (len_trim(error_msg) > 0) return
@@ -1929,13 +1909,22 @@
         call grow_symbols(context)
 
         if (.not. emit_alloca_bytes(context%session, &
-                i64_immediate(context%session, 40_c_int64_t), descriptor, &
+                i64_immediate(context%session, &
+                    int(ALLOC_DESCRIPTOR_BYTES, c_int64_t)), descriptor, &
                 error_msg)) return
+        ! Zero the whole descriptor before installing the header: an
+        ! unallocated allocatable must read as null base, no flags, and zero
+        ! extents, never as whatever the stack slot happened to hold.
         zero = i64_immediate(context%session, 0_c_int64_t)
-        do k = 0, 4
+        do k = 0, ALLOC_DESCRIPTOR_BYTES/8 - 1
             if (.not. emit_i64_store_at(context%session, zero, descriptor, &
-                    int(k * 8, c_int64_t), error_msg)) return
+                    int(k*8, c_int64_t), error_msg)) return
         end do
+        if (rank >= 1) then
+            call emit_alloc_desc_header(context, descriptor, value_kind, rank, &
+                                        error_msg)
+            if (len_trim(error_msg) > 0) return
+        end if
 
         index = context%symbol_count + 1
         context%symbols(index)%name = trim(name)

--- a/src/session_program_lowering_assumed_shape_extent.inc
+++ b/src/session_program_lowering_assumed_shape_extent.inc
@@ -285,11 +285,9 @@
 
     subroutine actual_extent_i64(arena, node_index, context, dim, extent, &
                                  error_msg)
-        ! Runtime extent (i64) of dimension dim of the whole-array actual bound
-        ! to a hidden extent argument. Only a rank-1 or rank-2 allocatable
-        ! identifier is supported; its descriptor bounds give upper - lower + 1.
-        ! Bounds live at descriptor offsets (8, 16) for dim 1 and (24, 32) for
-        ! dim 2 (session_program_lowering_allocatable.inc).
+        ! Runtime extent (i64) of dimension dim of a whole-array allocatable
+        ! actual, read straight out of that allocatable's canonical array
+        ! descriptor (docs/ARRAY_DESCRIPTOR_ABI.md).
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: node_index
         type(lowering_context_t), intent(inout) :: context
@@ -298,8 +296,7 @@
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=:), allocatable :: id_name
         integer :: symbol_index
-        integer(c_int64_t) :: lower_off, upper_off
-        type(lr_operand_desc_t) :: descriptor, lower, upper, span
+        type(lr_operand_desc_t) :: descriptor
 
         if (.not. is_identifier(arena, node_index)) then
             error_msg = 'assumed-shape actual extent must come from a '// &
@@ -318,24 +315,9 @@
                         'whole-array allocatable actual: '//trim(id_name)
             return
         end if
-        if (dim == 1) then
-            lower_off = 8_c_int64_t
-            upper_off = 16_c_int64_t
-        else
-            lower_off = 24_c_int64_t
-            upper_off = 32_c_int64_t
-        end if
         descriptor = context%symbols(symbol_index)%allocatable_descriptor_address
-        if (.not. emit_i64_load_at(context%session, descriptor, lower_off, &
-                                   lower, error_msg)) return
-        if (.not. emit_i64_load_at(context%session, descriptor, upper_off, &
-                                   upper, error_msg)) return
-        if (.not. emit_i64_binary(context%session, LR_OP_SUB, upper, lower, &
-                                  span, error_msg)) return
-        if (.not. emit_i64_binary(context%session, LR_OP_ADD, span, &
-                                  i64_immediate(context%session, 1_c_int64_t), &
-                                  extent, error_msg)) return
-        call set_empty(error_msg)
+        call emit_alloc_desc_load_extent(context, descriptor, dim, extent, &
+                                         error_msg)
     end subroutine actual_extent_i64
 
 

--- a/src/session_program_lowering_reduction_expr.inc
+++ b/src/session_program_lowering_reduction_expr.inc
@@ -371,7 +371,8 @@
         end if
 
         if (.not. emit_alloca_bytes(context%session, &
-                i64_immediate(context%session, 40_c_int64_t), temp_desc, &
+                i64_immediate(context%session, &
+                    int(ALLOC_DESCRIPTOR_BYTES, c_int64_t)), temp_desc, &
                 error_msg)) return
         zero = i64_immediate(context%session, 0_c_int64_t)
         do i = 0, 4

--- a/src/session_program_lowering_runtime_alloc.inc
+++ b/src/session_program_lowering_runtime_alloc.inc
@@ -1,23 +1,16 @@
     subroutine alloc_runtime_extent_i32(context, sym, extent_i32, error_msg)
-        ! Runtime extent of a rank-1 allocatable read from its descriptor:
-        ! (upper@16 - lower@8 + 1), truncated to i32. Used when the preceding
+        ! Runtime extent of a rank-1 allocatable read straight out of its
+        ! canonical descriptor, truncated to i32. Used when the preceding
         ! allocate sized the array from a non-constant expression.
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: sym
         type(lr_operand_desc_t), intent(out) :: extent_i32
         character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: descriptor, lower1, upper1, span, ext64
+        type(lr_operand_desc_t) :: descriptor, ext64
 
         descriptor = context%symbols(sym)%allocatable_descriptor_address
-        if (.not. emit_i64_load_at(context%session, descriptor, 8_c_int64_t, &
-                lower1, error_msg)) return
-        if (.not. emit_i64_load_at(context%session, descriptor, 16_c_int64_t, &
-                upper1, error_msg)) return
-        if (.not. emit_i64_binary(context%session, LR_OP_SUB, upper1, lower1, &
-                span, error_msg)) return
-        if (.not. emit_i64_binary(context%session, LR_OP_ADD, span, &
-                i64_immediate(context%session, 1_c_int64_t), ext64, error_msg)) &
-            return
+        call emit_alloc_desc_load_extent(context, descriptor, 1, ext64, error_msg)
+        if (len_trim(error_msg) > 0) return
         if (.not. emit_liric_i64_to_i32(context%session, ext64, extent_i32, &
                 error_msg)) return
         call set_empty(error_msg)

--- a/src/session_program_lowering_types.f90
+++ b/src/session_program_lowering_types.f90
@@ -191,7 +191,10 @@ module session_program_lowering_types
     integer, parameter, public :: ARRAY_MAX_RANK = 7
     ! Byte size of an allocatable array descriptor: data pointer plus the
     ! lower/upper bound pair of each of the two supported dimensions, all i64.
-    integer, parameter, public :: ALLOC_DESCRIPTOR_BYTES = 40
+    ! Allocatable arrays are described by the canonical array descriptor
+    ! (docs/ARRAY_DESCRIPTOR_ABI.md), so their stack or global slot is that
+    ! record's size (#336).
+    integer, parameter, public :: ALLOC_DESCRIPTOR_BYTES = 200
     type, public :: common_slot_t
         character(len=:), allocatable :: block_name
         character(len=:), allocatable :: var_name

--- a/test/test_session_allocatable_dummy_array_compiler.f90
+++ b/test/test_session_allocatable_dummy_array_compiler.f90
@@ -16,6 +16,8 @@ program test_session_allocatable_dummy_array_compiler
     if (.not. test_allocate_intent_out_dummy()) all_passed = .false.
     if (.not. test_intent_inout_dummy_read()) all_passed = .false.
     if (.not. test_default_intent_dummy_roundtrip()) all_passed = .false.
+    if (.not. test_rank2_allocatable_as_assumed_shape()) all_passed = .false.
+    if (.not. test_double_deallocate_is_not_a_double_free()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: allocatable array dummies alias the caller descriptor'
@@ -87,5 +89,65 @@ contains
         test_default_intent_dummy_roundtrip = expect_exit_status( &
             source, 0, '/tmp/ffc_alloc_dummy_default_test')
     end function test_default_intent_dummy_roundtrip
+
+    logical function test_rank2_allocatable_as_assumed_shape()
+        ! Descriptor interoperability across the two migrated paths: a rank-2
+        ! allocatable, whose shape now lives in a canonical array descriptor
+        ! (#336), is passed to an assumed-shape dummy, which is bound through a
+        ! canonical descriptor too (#334). Both agree on extents, on
+        ! column-major order, and on the address of the last element, which is
+        ! only true if exactly one layout is in use on both sides.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'integer, allocatable :: m(:,:)'//new_line('a')// &
+            'integer :: i, j'//new_line('a')// &
+            'allocate(m(2,3))'//new_line('a')// &
+            'do j = 1, 3'//new_line('a')// &
+            'do i = 1, 2'//new_line('a')// &
+            'm(i,j) = i*10 + j'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'end do'//new_line('a')// &
+            'call show(m)'//new_line('a')// &
+            'print *, size(m), m(2,3), m(1,1)'//new_line('a')// &
+            'deallocate(m)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine show(a)'//new_line('a')// &
+            'integer, intent(in) :: a(:,:)'//new_line('a')// &
+            'print *, size(a), size(a,1), size(a,2), a(size(a,1), size(a,2))'// &
+            new_line('a')// &
+            'end subroutine show'//new_line('a')// &
+            'end program main'
+        character(len=*), parameter :: expected = &
+            '           6           2           3          23'//new_line('a')// &
+            '           6          23          11'//new_line('a')
+
+        test_rank2_allocatable_as_assumed_shape = expect_output(source, &
+            expected, '/tmp/ffc_alloc_rank2_assumed_shape_test')
+    end function test_rank2_allocatable_as_assumed_shape
+
+    logical function test_double_deallocate_is_not_a_double_free()
+        ! Negative control for the descriptor's allocation state. DEALLOCATE
+        ! returns the descriptor to the unallocated state (null base, cleared
+        ! flags, zero extents), so a second DEALLOCATE frees nothing rather
+        ! than handing the same heap block to the deallocator twice.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'integer, allocatable :: v(:)'//new_line('a')// &
+            'allocate(v(4))'//new_line('a')// &
+            'v(1) = 7'//new_line('a')// &
+            'print *, size(v), v(1)'//new_line('a')// &
+            'deallocate(v)'//new_line('a')// &
+            'deallocate(v)'//new_line('a')// &
+            'print *, 42'//new_line('a')// &
+            'end program main'
+        character(len=*), parameter :: expected = &
+            '           4           7'//new_line('a')// &
+            '          42'//new_line('a')
+
+        test_double_deallocate_is_not_a_double_free = expect_output(source, &
+            expected, '/tmp/ffc_alloc_double_deallocate_test')
+    end function test_double_deallocate_is_not_a_double_free
 
 end program test_session_allocatable_dummy_array_compiler


### PR DESCRIPTION
Closes #336.

Rank-1 and rank-2 allocatable arrays now use the canonical array descriptor
(`docs/ARRAY_DESCRIPTOR_ABI.md`). The bespoke 40-byte
`{data, lower1, upper1, lower2, upper2}` record is gone — not deprecated,
gone. Nothing reads or writes those offsets any more.

## What changed

- New `src/session_program_lowering_alloc_descriptor.inc` is the only place
  allocatable descriptor field offsets appear: `emit_alloc_desc_header`,
  `emit_alloc_desc_flags`, `emit_alloc_desc_set_dim`,
  `emit_alloc_desc_load_lower/extent/upper`, `emit_alloc_desc_allocate_shape`,
  `emit_alloc_desc_clear`.
- `ALLOC_DESCRIPTOR_BYTES` is 200, and every former `40_c_int64_t` literal
  (`alloc_array_result`, `reduction_expr`, `allocatable`) now uses it.
- ALLOCATE writes unit lower bounds, extents, contiguous column-major strides,
  and the allocated/associated/owning/contiguous flags.
- DEALLOCATE returns the descriptor to the unallocated state — null base,
  cleared flags, zero extents — while keeping element size, type, and rank, so
  a deallocated entity still describes what it can hold.
- `upper` is no longer stored. It is recomputed as `lower + extent - 1`, so the
  shape has exactly one representation.
- `declare_allocatable` zeroes the whole record before installing the header.
- `docs/RUNTIME_ABI.md` and `docs/ARRAY_DESCRIPTOR_ABI.md` updated.

## Two real bugs this surfaced

**`move_alloc` copied a fixed 40-byte prefix.** Five `i64` slots, hardcoded.
Once the record grew, that silently dropped every dimension's extent, so
`move_alloc(a, b)` produced a `b` with the right data pointer and no shape. It
now copies the whole descriptor and clears the source. This is exactly the
class of defect the descriptor migration exists to eliminate: a second place
that knew the layout by size.

**`declare_allocatable` zeroed only the first 40 bytes.** An unallocated
allocatable would have read its extents out of whatever the stack slot last
held.

## Invariants preserved and how

- **Fortran column-major layout.** ALLOCATE writes
  `stride(1) = element_size`, `stride(d) = stride(d-1) * extent(d-1)`. The new
  `test_rank2_allocatable_as_assumed_shape` allocates `m(2,3)`, fills it, and
  checks both the caller's and the callee's view of `m(2,3)` and `m(1,1)`.
- **Lower-bound and extent semantics.** Lower bounds are stored per dimension
  rather than assumed; element addressing reads the descriptor's lower bound
  and extent directly instead of reconstructing `upper - lower + 1`.
- **Overlap and aliasing.** Allocatable dummies still alias the caller's
  descriptor, so `allocate`/`deallocate` inside a callee remain visible to the
  caller — the pre-existing intent(out)/intent(inout)/default-intent dummy
  tests still pass unchanged.
- **Allocation and finalization lifetimes.** `ARRAY_FLAG_OWNS_DATA` is set on
  allocation and cleared on deallocation, and `move_alloc` transfers the base
  pointer without freeing. `test_double_deallocate_is_not_a_double_free` is the
  negative control this issue asked for: a second DEALLOCATE frees nothing
  rather than handing the same block to the deallocator twice.
- **One convention in the migrated path.** The only surviving `8_c_int64_t`
  offsets in `allocatable.inc` are the element *size* helper and the derived
  type **component** inline `{data, extent}` record, which this issue's
  non-goals put out of scope. Both are called out in the docs.

## Corpus delta

Method, per ffc #642: **same-worktree before/after**, pinned to my parent
commit. Cross-worktree A/B is not trustworthy here, and I also hit a second
trap worth recording — `origin/main` moved twice mid-measurement under
concurrent merges, so a baseline taken with `git checkout origin/main -- src/`
compared against a *different* base than the after-run. Both halves below use
`git checkout HEAD~1 -- src/ test/` for the baseline and `git checkout HEAD`
for the after, each with `rm -rf build` and a full rebuild, so both halves are
pinned to the same commit.

| Suite | PASS | FAIL | XPASS |
|---|---|---|---|
| lfortran | 876 -> 876 | 6 -> 6 | 111 -> 111 |
| fortfront-f90 | 451 -> 452 | 9 -> 8 | 0 -> 0 |

Per case: lfortran is bit-for-bit unchanged — no case changes status in either
direction. In fortfront-f90 the single difference is
`issue_1324_if_inside_do_loop.f90` FAIL -> PASS; the gauntlet itself reports
that case as nondeterministic, so I am not claiming it as a fix. No case
regresses from PASS, and none becomes FAIL from any state.

`test_session_lazy_monomorph_compiler` fails both before and after, at the same
commit in the same worktree — pre-existing and unrelated.

## On the six regressions reported earlier

The earlier XPASS→XFAIL set (`allocate_23`, `allocate_67`, `class_105`,
`class_69`, `pointer_04`, `select_type_14`) had a single shared cause, and it
was not the descriptor migration: restoring my work from a stale file snapshot
had clobbered upstream changes in the same files — the scalar POINTER allocate
branch and the `allocate(t :: x)` type-spec handling from #421. All six failed
on `allocate(a2, source=a1)` for scalar derived allocatables because that
upstream code had been reverted underneath them.

This branch was rebuilt from `origin/main` with each edit reapplied
individually rather than by copying files, and the diff is now exactly nine
files. All six are back to their baseline status.
