### PR TITLE
[runtime-05] descriptor-backed runtime allocation helpers (closes #428)

### DIFF
--- a/docs/RUNTIME_ABI.md
+++ b/docs/RUNTIME_ABI.md
@@ -778,8 +778,51 @@ condition rather than being derived independently.
 variables with a declared length; both are rejected with a named diagnostic
 otherwise.
 
-Runtime entry points for descriptor allocation are added by their own issue
-(#428).
+### Descriptor storage allocation (#428)
+
+Allocatable arrays and deferred-length characters reached `malloc` and `free`
+directly from emitted code, so every size computation, every overflow check,
+and every ownership decision was open-coded at each site. The runtime owns
+that now. The compiler still decides shape and type; the runtime decides
+whether a size is representable, whether a pointer may be released, and what
+the status is.
+
+| Symbol | Signature |
+|---|---|
+| `_ffc_alloc` | `void *_ffc_alloc(long long count, long long elem_size)` |
+| `_ffc_calloc` | `void *_ffc_calloc(long long count, long long elem_size)` |
+| `_ffc_realloc` | `void *_ffc_realloc(void *old, long long count, long long elem_size)` |
+| `_ffc_dealloc` | `int _ffc_dealloc(void *p, int owns)` |
+| `_ffc_alloc_status` | `int _ffc_alloc_status(void)` |
+
+Sizes arrive as a separate element count and element size, never as a
+product, so the multiplication that can overflow happens in the runtime, once,
+where it is checked.
+
+A count of zero is a valid request: Fortran allows a zero-sized array, and the
+result is a non-null pointer released exactly like any other. Releasing a null
+pointer succeeds, matching `deallocate` of an unallocated variable.
+
+`owns` is the descriptor's `ARRAY_FLAG_OWNS_DATA` bit. A borrowed descriptor —
+a section view or a dummy argument — never frees, and the runtime reports
+`6005` rather than doing nothing silently. See the ownership and view-lifetime
+rules in `ARRAY_DESCRIPTOR_ABI.md`, which this enforces at run time.
+
+The runtime tracks the allocations it hands out, so releasing a pointer twice
+is reported instead of corrupting the heap. That is also why emitted code must
+not mix allocators: storage from a direct `malloc` is unknown to the runtime,
+and releasing it would be reported as a double free.
+`test_session_runtime_allocation_helpers_compiler` fails if any
+compiler-emitted function still calls `malloc` or `free`.
+
+| Code | Condition |
+|---|---|
+| 0 | success |
+| 6001 | negative count or element size |
+| 6002 | `count * elem_size` is not representable |
+| 6003 | the allocator refused |
+| 6004 | release of a pointer that is not live |
+| 6005 | release of storage the descriptor does not own |
 
 ## Building the runtime
 

--- a/runtime/ffc_runtime.c
+++ b/runtime/ffc_runtime.c
@@ -489,3 +489,234 @@ void _ffc_iomsg(char *dest, int len) {
     }
     dest[len] = '\0';
 }
+
+/* ---- Descriptor storage allocation (issue #428) ----------- */
+
+/* Allocatable arrays and deferred-length characters used to
+ * reach malloc() and free() directly from emitted code, which
+ * meant every size computation, every overflow check, and every
+ * ownership decision was open-coded at each site. These helpers
+ * own that instead: the compiler still decides shape and type,
+ * the runtime decides whether a size is representable, whether
+ * a pointer may be released, and what the status is.
+ *
+ * Sizes arrive as a separate element count and element size, not
+ * as a product, so the multiplication that can overflow happens
+ * here, once, where it is checked. A count of zero is a valid
+ * request: Fortran allows a zero-sized array, and the result is
+ * a non-null pointer that can be released exactly like any
+ * other.
+ *
+ * Status codes are stable, and follow the IOSTAT ranges:
+ *
+ *   0                        success
+ *   FFC_ALLOC_NEGATIVE       negative count or element size
+ *   FFC_ALLOC_OVERFLOW       count * element size is not
+ *                            representable
+ *   FFC_ALLOC_NOMEM          the allocator refused
+ *   FFC_ALLOC_DOUBLE_FREE    release of a pointer that is not
+ *                            live
+ *   FFC_ALLOC_BORROWED       release of storage the descriptor
+ *                            does not own
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#define FFC_ALLOC_NEGATIVE 6001
+#define FFC_ALLOC_OVERFLOW 6002
+#define FFC_ALLOC_NOMEM 6003
+#define FFC_ALLOC_DOUBLE_FREE 6004
+#define FFC_ALLOC_BORROWED 6005
+
+static int ffc_alloc_last_status = 0;
+
+/* Live allocations handed out by _ffc_alloc, so releasing a
+ * pointer twice is reported instead of corrupting the heap.
+ * Open addressing, power-of-two capacity, grown before it is
+ * half full. Tombstones are not needed: a removed entry is
+ * refilled by rehashing its cluster. */
+static void **ffc_live;
+static size_t ffc_live_cap;
+static size_t ffc_live_count;
+
+static size_t ffc_live_slot(void **table, size_t cap, void *p) {
+    size_t mask = cap - 1;
+    size_t i = (size_t)((uintptr_t)p >> 4) & mask;
+    while (table[i] != NULL && table[i] != p) {
+        i = (i + 1) & mask;
+    }
+    return i;
+}
+
+static int ffc_live_grow(void) {
+    size_t new_cap = ffc_live_cap ? ffc_live_cap * 2 : 64;
+    void **fresh = calloc(new_cap, sizeof(*fresh));
+    size_t i;
+    if (fresh == NULL) {
+        return -1;
+    }
+    for (i = 0; i < ffc_live_cap; i++) {
+        if (ffc_live[i] != NULL) {
+            fresh[ffc_live_slot(fresh, new_cap, ffc_live[i])]
+                = ffc_live[i];
+        }
+    }
+    free(ffc_live);
+    ffc_live = fresh;
+    ffc_live_cap = new_cap;
+    return 0;
+}
+
+static int ffc_live_add(void *p) {
+    if (ffc_live_count * 2 + 1 >= ffc_live_cap) {
+        if (ffc_live_grow() != 0) {
+            return -1;
+        }
+    }
+    ffc_live[ffc_live_slot(ffc_live, ffc_live_cap, p)] = p;
+    ffc_live_count++;
+    return 0;
+}
+
+/* Removes p and rehashes the rest of its cluster, so lookups
+ * that probed past p still find their entries. */
+static int ffc_live_remove(void *p) {
+    size_t i, j, mask;
+    if (ffc_live_cap == 0) {
+        return 0;
+    }
+    mask = ffc_live_cap - 1;
+    i = ffc_live_slot(ffc_live, ffc_live_cap, p);
+    if (ffc_live[i] != p) {
+        return 0;
+    }
+    ffc_live[i] = NULL;
+    ffc_live_count--;
+    j = (i + 1) & mask;
+    while (ffc_live[j] != NULL) {
+        void *moved = ffc_live[j];
+        ffc_live[j] = NULL;
+        ffc_live_count--;
+        ffc_live_add(moved);
+        j = (j + 1) & mask;
+    }
+    return 1;
+}
+
+/* Status of the most recent allocation operation. */
+int _ffc_alloc_status(void) {
+    return ffc_alloc_last_status;
+}
+
+/* count elements of elem_size bytes each. Returns NULL and sets
+ * the status on any rejected request. */
+void *_ffc_alloc(long long count, long long elem_size) {
+    size_t bytes;
+    void *p;
+    if (count < 0 || elem_size < 0) {
+        ffc_alloc_last_status = FFC_ALLOC_NEGATIVE;
+        return NULL;
+    }
+    if (elem_size != 0 &&
+        count > (long long)(SIZE_MAX / 2)
+                    / elem_size) {
+        ffc_alloc_last_status = FFC_ALLOC_OVERFLOW;
+        return NULL;
+    }
+    bytes = (size_t)(count * elem_size);
+    /* A zero-sized array still needs a releasable pointer. */
+    p = malloc(bytes != 0 ? bytes : 1);
+    if (p == NULL) {
+        ffc_alloc_last_status = FFC_ALLOC_NOMEM;
+        return NULL;
+    }
+    if (ffc_live_add(p) != 0) {
+        free(p);
+        ffc_alloc_last_status = FFC_ALLOC_NOMEM;
+        return NULL;
+    }
+    ffc_alloc_last_status = 0;
+    return p;
+}
+
+/* Like _ffc_alloc, with the storage zeroed. An allocatable
+ * array of a derived element type needs this: every element's
+ * inline component descriptors must start null. */
+void *_ffc_calloc(long long count, long long elem_size) {
+    void *p = _ffc_alloc(count, elem_size);
+    if (p == NULL) {
+        return NULL;
+    }
+    if (count > 0 && elem_size > 0) {
+        memset(p, 0, (size_t)(count * elem_size));
+    }
+    return p;
+}
+
+/* Resizes an allocation, keeping min(old, new) bytes. old may
+ * be NULL, which makes this a plain allocation. On failure the
+ * old pointer is still live and unchanged. */
+void *_ffc_realloc(void *old, long long count,
+                   long long elem_size) {
+    size_t bytes;
+    void *p;
+    if (old == NULL) {
+        return _ffc_alloc(count, elem_size);
+    }
+    if (count < 0 || elem_size < 0) {
+        ffc_alloc_last_status = FFC_ALLOC_NEGATIVE;
+        return NULL;
+    }
+    if (elem_size != 0 &&
+        count > (long long)(SIZE_MAX / 2)
+                    / elem_size) {
+        ffc_alloc_last_status = FFC_ALLOC_OVERFLOW;
+        return NULL;
+    }
+    /* Drop the old key before realloc, which may free it: a
+     * freed pointer must not be read again, even as a hash
+     * key. A failed realloc leaves it valid, so it goes back. */
+    if (!ffc_live_remove(old)) {
+        ffc_alloc_last_status = FFC_ALLOC_DOUBLE_FREE;
+        return NULL;
+    }
+    bytes = (size_t)(count * elem_size);
+    p = realloc(old, bytes != 0 ? bytes : 1);
+    if (p == NULL) {
+        ffc_live_add(old);
+        ffc_alloc_last_status = FFC_ALLOC_NOMEM;
+        return NULL;
+    }
+    if (ffc_live_add(p) != 0) {
+        ffc_alloc_last_status = FFC_ALLOC_NOMEM;
+        return NULL;
+    }
+    ffc_alloc_last_status = 0;
+    return p;
+}
+
+/* Releases storage. owns is the descriptor's ownership flag: a
+ * borrowed descriptor, such as a section view or a dummy
+ * argument, never frees, and says so rather than doing nothing
+ * silently.
+ *
+ * Releasing a null pointer succeeds, matching Fortran's
+ * deallocate of an unallocated variable and free(NULL). */
+int _ffc_dealloc(void *p, int owns) {
+    if (p == NULL) {
+        ffc_alloc_last_status = 0;
+        return 0;
+    }
+    if (!owns) {
+        ffc_alloc_last_status = FFC_ALLOC_BORROWED;
+        return FFC_ALLOC_BORROWED;
+    }
+    if (!ffc_live_remove(p)) {
+        ffc_alloc_last_status = FFC_ALLOC_DOUBLE_FREE;
+        return FFC_ALLOC_DOUBLE_FREE;
+    }
+    free(p);
+    ffc_alloc_last_status = 0;
+    return 0;
+}

--- a/src/ffc_runtime_link.f90
+++ b/src/ffc_runtime_link.f90
@@ -50,7 +50,7 @@ module ffc_runtime_link
     ! Every runtime entry point the lowerer is allowed to call. Each issue
     ! that moves compiler-emitted code behind the runtime ABI adds its symbols
     ! here and to docs/RUNTIME_ABI.md.
-    character(len=*), parameter :: FFC_RUNTIME_SYMBOLS(21) = &
+    character(len=*), parameter :: FFC_RUNTIME_SYMBOLS(25) = &
         [character(len=32) :: '_ffc_runtime_probe', &
          '_ffc_unit_status', '_ffc_unit_newunit', '_ffc_unit_open', &
          '_ffc_unit_is_open', '_ffc_unit_file', '_ffc_unit_rewind', &
@@ -60,7 +60,9 @@ module ffc_runtime_link
          '_ffc_random_seed_size', '_ffc_random_seed_put', &
          '_ffc_random_seed_get', '_ffc_random_seed_default', &
          '_ffc_iostat', '_ffc_iostat_set_end', '_ffc_iostat_clear', &
-         '_ffc_iomsg']
+         '_ffc_iomsg', &
+         '_ffc_alloc', '_ffc_realloc', '_ffc_dealloc', &
+         '_ffc_alloc_status']
 
 contains
 

--- a/src/ffc_runtime_source.f90
+++ b/src/ffc_runtime_source.f90
@@ -959,6 +959,453 @@ contains
             '    dest[len] = ''\0'';'//NL
         text = text// &
             '}'//NL
+        text = text//NL
+        text = text// &
+            '/* ---- Descriptor storage allocation (issue #428) ----------- */'//NL
+        text = text//NL
+        text = text// &
+            '/* Allocatable arrays and deferred-length characters used to'//NL
+        text = text// &
+            ' * reach malloc() and free() directly from emitted code, which'//NL
+        text = text// &
+            ' * meant every size computation, every overflow check, and every'//NL
+        text = text// &
+            ' * ownership decision was open-coded at each site. These helpers'//NL
+        text = text// &
+            ' * own that instead: the compiler still decides shape and type,'//NL
+        text = text// &
+            ' * the runtime decides whether a size is representable, whether'//NL
+        text = text// &
+            ' * a pointer may be released, and what the status is.'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' * Sizes arrive as a separate element count and element size, not'//NL
+        text = text// &
+            ' * as a product, so the multiplication that can overflow happens'//NL
+        text = text// &
+            ' * here, once, where it is checked. A count of zero is a valid'//NL
+        text = text// &
+            ' * request: Fortran allows a zero-sized array, and the result is'//NL
+        text = text// &
+            ' * a non-null pointer that can be released exactly like any'//NL
+        text = text// &
+            ' * other.'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' * Status codes are stable, and follow the IOSTAT ranges:'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' *   0                        success'//NL
+        text = text// &
+            ' *   FFC_ALLOC_NEGATIVE       negative count or element size'//NL
+        text = text// &
+            ' *   FFC_ALLOC_OVERFLOW       count * element size is not'//NL
+        text = text// &
+            ' *                            representable'//NL
+        text = text// &
+            ' *   FFC_ALLOC_NOMEM          the allocator refused'//NL
+        text = text// &
+            ' *   FFC_ALLOC_DOUBLE_FREE    release of a pointer that is not'//NL
+        text = text// &
+            ' *                            live'//NL
+        text = text// &
+            ' *   FFC_ALLOC_BORROWED       release of storage the descriptor'//NL
+        text = text// &
+            ' *                            does not own'//NL
+        text = text// &
+            ' */'//NL
+        text = text//NL
+        text = text// &
+            '#include <stdint.h>'//NL
+        text = text// &
+            '#include <string.h>'//NL
+        text = text//NL
+        text = text// &
+            '#define FFC_ALLOC_NEGATIVE 6001'//NL
+        text = text// &
+            '#define FFC_ALLOC_OVERFLOW 6002'//NL
+        text = text// &
+            '#define FFC_ALLOC_NOMEM 6003'//NL
+        text = text// &
+            '#define FFC_ALLOC_DOUBLE_FREE 6004'//NL
+        text = text// &
+            '#define FFC_ALLOC_BORROWED 6005'//NL
+        text = text//NL
+        text = text// &
+            'static int ffc_alloc_last_status = 0;'//NL
+        text = text//NL
+        text = text// &
+            '/* Live allocations handed out by _ffc_alloc, so releasing a'//NL
+        text = text// &
+            ' * pointer twice is reported instead of corrupting the heap.'//NL
+        text = text// &
+            ' * Open addressing, power-of-two capacity, grown before it is'//NL
+        text = text// &
+            ' * half full. Tombstones are not needed: a removed entry is'//NL
+        text = text// &
+            ' * refilled by rehashing its cluster. */'//NL
+        text = text// &
+            'static void **ffc_live;'//NL
+        text = text// &
+            'static size_t ffc_live_cap;'//NL
+        text = text// &
+            'static size_t ffc_live_count;'//NL
+        text = text//NL
+        text = text// &
+            'static size_t ffc_live_slot(void **table, size_t cap, void *p) {'//NL
+        text = text// &
+            '    size_t mask = cap - 1;'//NL
+        text = text// &
+            '    size_t i = (size_t)((uintptr_t)p >> 4) & mask;'//NL
+        text = text// &
+            '    while (table[i] != NULL && table[i] != p) {'//NL
+        text = text// &
+            '        i = (i + 1) & mask;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    return i;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            'static int ffc_live_grow(void) {'//NL
+        text = text// &
+            '    size_t new_cap = ffc_live_cap ? ffc_live_cap * 2 : 64;'//NL
+        text = text// &
+            '    void **fresh = calloc(new_cap, sizeof(*fresh));'//NL
+        text = text// &
+            '    size_t i;'//NL
+        text = text// &
+            '    if (fresh == NULL) {'//NL
+        text = text// &
+            '        return -1;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    for (i = 0; i < ffc_live_cap; i++) {'//NL
+        text = text// &
+            '        if (ffc_live[i] != NULL) {'//NL
+        text = text// &
+            '            fresh[ffc_live_slot(fresh, new_cap, ffc_live[i])]'//NL
+        text = text// &
+            '                = ffc_live[i];'//NL
+        text = text// &
+            '        }'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    free(ffc_live);'//NL
+        text = text// &
+            '    ffc_live = fresh;'//NL
+        text = text// &
+            '    ffc_live_cap = new_cap;'//NL
+        text = text// &
+            '    return 0;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            'static int ffc_live_add(void *p) {'//NL
+        text = text// &
+            '    if (ffc_live_count * 2 + 1 >= ffc_live_cap) {'//NL
+        text = text// &
+            '        if (ffc_live_grow() != 0) {'//NL
+        text = text// &
+            '            return -1;'//NL
+        text = text// &
+            '        }'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    ffc_live[ffc_live_slot(ffc_live, ffc_live_cap, p)] = p;'//NL
+        text = text// &
+            '    ffc_live_count++;'//NL
+        text = text// &
+            '    return 0;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Removes p and rehashes the rest of its cluster, so lookups'//NL
+        text = text// &
+            ' * that probed past p still find their entries. */'//NL
+        text = text// &
+            'static int ffc_live_remove(void *p) {'//NL
+        text = text// &
+            '    size_t i, j, mask;'//NL
+        text = text// &
+            '    if (ffc_live_cap == 0) {'//NL
+        text = text// &
+            '        return 0;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    mask = ffc_live_cap - 1;'//NL
+        text = text// &
+            '    i = ffc_live_slot(ffc_live, ffc_live_cap, p);'//NL
+        text = text// &
+            '    if (ffc_live[i] != p) {'//NL
+        text = text// &
+            '        return 0;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    ffc_live[i] = NULL;'//NL
+        text = text// &
+            '    ffc_live_count--;'//NL
+        text = text// &
+            '    j = (i + 1) & mask;'//NL
+        text = text// &
+            '    while (ffc_live[j] != NULL) {'//NL
+        text = text// &
+            '        void *moved = ffc_live[j];'//NL
+        text = text// &
+            '        ffc_live[j] = NULL;'//NL
+        text = text// &
+            '        ffc_live_count--;'//NL
+        text = text// &
+            '        ffc_live_add(moved);'//NL
+        text = text// &
+            '        j = (j + 1) & mask;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    return 1;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Status of the most recent allocation operation. */'//NL
+        text = text// &
+            'int _ffc_alloc_status(void) {'//NL
+        text = text// &
+            '    return ffc_alloc_last_status;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* count elements of elem_size bytes each. Returns NULL and sets'//NL
+        text = text// &
+            ' * the status on any rejected request. */'//NL
+        text = text// &
+            'void *_ffc_alloc(long long count, long long elem_size) {'//NL
+        text = text// &
+            '    size_t bytes;'//NL
+        text = text// &
+            '    void *p;'//NL
+        text = text// &
+            '    if (count < 0 || elem_size < 0) {'//NL
+        text = text// &
+            '        ffc_alloc_last_status = FFC_ALLOC_NEGATIVE;'//NL
+        text = text// &
+            '        return NULL;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (elem_size != 0 &&'//NL
+        text = text// &
+            '        count > (long long)(SIZE_MAX / 2)'//NL
+        text = text// &
+            '                    / elem_size) {'//NL
+        text = text// &
+            '        ffc_alloc_last_status = FFC_ALLOC_OVERFLOW;'//NL
+        text = text// &
+            '        return NULL;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    bytes = (size_t)(count * elem_size);'//NL
+        text = text// &
+            '    /* A zero-sized array still needs a releasable pointer. */'//NL
+        text = text// &
+            '    p = malloc(bytes != 0 ? bytes : 1);'//NL
+        text = text// &
+            '    if (p == NULL) {'//NL
+        text = text// &
+            '        ffc_alloc_last_status = FFC_ALLOC_NOMEM;'//NL
+        text = text// &
+            '        return NULL;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (ffc_live_add(p) != 0) {'//NL
+        text = text// &
+            '        free(p);'//NL
+        text = text// &
+            '        ffc_alloc_last_status = FFC_ALLOC_NOMEM;'//NL
+        text = text// &
+            '        return NULL;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    ffc_alloc_last_status = 0;'//NL
+        text = text// &
+            '    return p;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Like _ffc_alloc, with the storage zeroed. An allocatable'//NL
+        text = text// &
+            ' * array of a derived element type needs this: every element''s'//NL
+        text = text// &
+            ' * inline component descriptors must start null. */'//NL
+        text = text// &
+            'void *_ffc_calloc(long long count, long long elem_size) {'//NL
+        text = text// &
+            '    void *p = _ffc_alloc(count, elem_size);'//NL
+        text = text// &
+            '    if (p == NULL) {'//NL
+        text = text// &
+            '        return NULL;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (count > 0 && elem_size > 0) {'//NL
+        text = text// &
+            '        memset(p, 0, (size_t)(count * elem_size));'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    return p;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Resizes an allocation, keeping min(old, new) bytes. old may'//NL
+        text = text// &
+            ' * be NULL, which makes this a plain allocation. On failure the'//NL
+        text = text// &
+            ' * old pointer is still live and unchanged. */'//NL
+        text = text// &
+            'void *_ffc_realloc(void *old, long long count,'//NL
+        text = text// &
+            '                   long long elem_size) {'//NL
+        text = text// &
+            '    size_t bytes;'//NL
+        text = text// &
+            '    void *p;'//NL
+        text = text// &
+            '    if (old == NULL) {'//NL
+        text = text// &
+            '        return _ffc_alloc(count, elem_size);'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (count < 0 || elem_size < 0) {'//NL
+        text = text// &
+            '        ffc_alloc_last_status = FFC_ALLOC_NEGATIVE;'//NL
+        text = text// &
+            '        return NULL;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (elem_size != 0 &&'//NL
+        text = text// &
+            '        count > (long long)(SIZE_MAX / 2)'//NL
+        text = text// &
+            '                    / elem_size) {'//NL
+        text = text// &
+            '        ffc_alloc_last_status = FFC_ALLOC_OVERFLOW;'//NL
+        text = text// &
+            '        return NULL;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    /* Drop the old key before realloc, which may free it: a'//NL
+        text = text// &
+            '     * freed pointer must not be read again, even as a hash'//NL
+        text = text// &
+            '     * key. A failed realloc leaves it valid, so it goes back. */'//NL
+        text = text// &
+            '    if (!ffc_live_remove(old)) {'//NL
+        text = text// &
+            '        ffc_alloc_last_status = FFC_ALLOC_DOUBLE_FREE;'//NL
+        text = text// &
+            '        return NULL;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    bytes = (size_t)(count * elem_size);'//NL
+        text = text// &
+            '    p = realloc(old, bytes != 0 ? bytes : 1);'//NL
+        text = text// &
+            '    if (p == NULL) {'//NL
+        text = text// &
+            '        ffc_live_add(old);'//NL
+        text = text// &
+            '        ffc_alloc_last_status = FFC_ALLOC_NOMEM;'//NL
+        text = text// &
+            '        return NULL;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (ffc_live_add(p) != 0) {'//NL
+        text = text// &
+            '        ffc_alloc_last_status = FFC_ALLOC_NOMEM;'//NL
+        text = text// &
+            '        return NULL;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    ffc_alloc_last_status = 0;'//NL
+        text = text// &
+            '    return p;'//NL
+        text = text// &
+            '}'//NL
+        text = text//NL
+        text = text// &
+            '/* Releases storage. owns is the descriptor''s ownership flag: a'//NL
+        text = text// &
+            ' * borrowed descriptor, such as a section view or a dummy'//NL
+        text = text// &
+            ' * argument, never frees, and says so rather than doing nothing'//NL
+        text = text// &
+            ' * silently.'//NL
+        text = text// &
+            ' *'//NL
+        text = text// &
+            ' * Releasing a null pointer succeeds, matching Fortran''s'//NL
+        text = text// &
+            ' * deallocate of an unallocated variable and free(NULL). */'//NL
+        text = text// &
+            'int _ffc_dealloc(void *p, int owns) {'//NL
+        text = text// &
+            '    if (p == NULL) {'//NL
+        text = text// &
+            '        ffc_alloc_last_status = 0;'//NL
+        text = text// &
+            '        return 0;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (!owns) {'//NL
+        text = text// &
+            '        ffc_alloc_last_status = FFC_ALLOC_BORROWED;'//NL
+        text = text// &
+            '        return FFC_ALLOC_BORROWED;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    if (!ffc_live_remove(p)) {'//NL
+        text = text// &
+            '        ffc_alloc_last_status = FFC_ALLOC_DOUBLE_FREE;'//NL
+        text = text// &
+            '        return FFC_ALLOC_DOUBLE_FREE;'//NL
+        text = text// &
+            '    }'//NL
+        text = text// &
+            '    free(p);'//NL
+        text = text// &
+            '    ffc_alloc_last_status = 0;'//NL
+        text = text// &
+            '    return 0;'//NL
+        text = text// &
+            '}'//NL
     end subroutine ffc_runtime_source_text
 
 end module ffc_runtime_source

--- a/src/liric_session_memory_bindings.f90
+++ b/src/liric_session_memory_bindings.f90
@@ -700,19 +700,30 @@ contains
         emit_alloca_bytes = .true.
     end function emit_alloca_bytes
 
-    logical function emit_malloc(session, size, result, error_msg)
+    logical function emit_malloc(session, size, result, error_msg, elem_size)
+        ! Heap storage through the runtime allocator (#428). `size` is an
+        ! element count and `elem_size` the bytes per element, so the
+        ! multiplication that can overflow happens in the runtime where it is
+        ! checked. A caller that already holds a byte count omits elem_size,
+        ! which then defaults to 1.
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: size
         type(lr_operand_desc_t), intent(out) :: result
         character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t), intent(in), optional :: elem_size
         type(lr_error_t) :: error
-        type(lr_operand_desc_t) :: args(1)
+        type(lr_operand_desc_t) :: args(2)
         integer(c_int32_t) :: vreg
 
         emit_malloc = .false.
         if (.not. require_open_session(session, error_msg)) return
 
         args(1) = size
+        if (present(elem_size)) then
+            args(2) = elem_size
+        else
+            args(2) = i64_immediate(session, 1_c_int64_t)
+        end if
         vreg = emit_malloc_call(session%handle, args, error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
@@ -774,35 +785,49 @@ contains
         emit_strnlen = .true.
     end function emit_strnlen
 
-    logical function emit_free(session, ptr, error_msg)
-        ! free(ptr). free(NULL) is a no-op, so callers need not null-check.
+    logical function emit_free(session, ptr, error_msg, owns)
+        ! Release heap storage through the runtime (#428). Releasing a null
+        ! pointer succeeds, so callers need not null-check, matching Fortran's
+        ! deallocate of an unallocated variable.
+        !
+        ! `owns` is the descriptor's ownership flag. A borrowed descriptor --
+        ! a section view or a dummy argument -- never frees, and the runtime
+        ! says so rather than doing nothing silently. It defaults to true
+        ! because every current caller releases storage it owns.
         type(liric_session_t), intent(inout) :: session
         type(lr_operand_desc_t), intent(in) :: ptr
         character(len=:), allocatable, intent(out) :: error_msg
+        logical, intent(in), optional :: owns
         type(lr_error_t) :: error
+        type(lr_operand_desc_t) :: owns_op
         integer(c_int32_t) :: vreg
 
         emit_free = .false.
         if (.not. require_open_session(session, error_msg)) return
 
-        vreg = emit_free_call(session%handle, ptr, error)
+        owns_op = i32_immediate(session, 1_c_int64_t)
+        if (present(owns)) then
+            if (.not. owns) owns_op = i32_immediate(session, 0_c_int64_t)
+        end if
+        vreg = emit_free_call(session%handle, ptr, owns_op, error)
         if (.not. status_ok(error%code, error, error_msg)) return
 
         call set_empty(error_msg)
         emit_free = .true.
     end function emit_free
 
-    function emit_free_call(handle, ptr, error) result(vreg)
+    function emit_free_call(handle, ptr, owns, error) result(vreg)
         type(c_ptr), intent(in) :: handle
         type(lr_operand_desc_t), intent(in) :: ptr
+        type(lr_operand_desc_t), intent(in) :: owns
         type(lr_error_t), intent(inout) :: error
         integer(c_int32_t) :: vreg
-        type(lr_operand_desc_t), target :: operands(2)
+        type(lr_operand_desc_t), target :: operands(3)
         type(lr_inst_desc_t) :: inst
         character(kind=c_char), allocatable :: c_name(:)
         integer(c_int32_t) :: symbol_id
 
-        call to_c_chars('free', c_name)
+        call to_c_chars('_ffc_dealloc', c_name)
         symbol_id = lr_session_intern(handle, c_name)
         if (symbol_id < 0_c_int32_t) then
             call clear_liric_error(error)
@@ -812,12 +837,13 @@ contains
 
         operands(1) = ptr_global_operand(handle, symbol_id)
         operands(2) = ptr
+        operands(3) = owns
 
         inst%op = LR_OP_CALL
-        inst%typ = c_null_ptr
+        inst%typ = lr_type_i32_s(handle)
         inst%dest = 0_c_int32_t
         inst%operands = c_loc(operands)
-        inst%num_operands = 2_c_int32_t
+        inst%num_operands = 3_c_int32_t
         inst%indices = c_null_ptr
         inst%num_indices = 0_c_int32_t
         inst%align = 0_c_int32_t
@@ -825,7 +851,7 @@ contains
         inst%fcmp_pred = 0_c_int
         inst%call_external_abi = c_true
         inst%call_vararg = c_false
-        inst%call_fixed_args = 1_c_int32_t
+        inst%call_fixed_args = 2_c_int32_t
 
         call clear_liric_error(error)
         vreg = lr_session_emit(handle, inst, error)

--- a/src/liric_session_memory_bindings_tail.inc
+++ b/src/liric_session_memory_bindings_tail.inc
@@ -250,14 +250,19 @@
         type(lr_operand_desc_t), intent(in) :: args(:)
         type(lr_error_t), intent(inout) :: error
         integer(c_int32_t) :: vreg
-        type(lr_operand_desc_t), target :: operands(2)
+        type(lr_operand_desc_t), target :: operands(3)
         type(lr_inst_desc_t) :: inst
         character(kind=c_char), allocatable :: c_name(:)
         integer(c_int32_t) :: symbol_id
 
-        call to_c_chars('malloc', c_name)
+        ! _ffc_alloc(count, elem_size) rather than malloc(bytes): the
+        ! runtime validates the size and tracks the allocation so a double
+        ! release is reported instead of corrupting the heap (#428). A
+        ! caller with only a byte count passes it as the count with an
+        ! element size of 1.
+        call to_c_chars('_ffc_alloc', c_name)
         symbol_id = lr_session_intern(handle, c_name)
-        if (symbol_id < 0_c_int32_t .or. size(args) /= 1) then
+        if (symbol_id < 0_c_int32_t .or. size(args) /= 2) then
             call clear_liric_error(error)
             error%code = 1_c_int
             return
@@ -265,12 +270,13 @@
 
         operands(1) = ptr_global_operand(handle, symbol_id)
         operands(2) = args(1)
+        operands(3) = args(2)
 
         inst%op = LR_OP_CALL
         inst%typ = lr_type_ptr_s(handle)
         inst%dest = 0_c_int32_t
         inst%operands = c_loc(operands)
-        inst%num_operands = 2_c_int32_t
+        inst%num_operands = 3_c_int32_t
         inst%indices = c_null_ptr
         inst%num_indices = 0_c_int32_t
         inst%align = 0_c_int32_t
@@ -278,7 +284,7 @@
         inst%fcmp_pred = 0_c_int
         inst%call_external_abi = c_true
         inst%call_vararg = c_false
-        inst%call_fixed_args = 1_c_int32_t
+        inst%call_fixed_args = 2_c_int32_t
 
         call clear_liric_error(error)
         vreg = lr_session_emit(handle, inst, error)
@@ -334,7 +340,7 @@
         character(kind=c_char), allocatable :: c_name(:)
         integer(c_int32_t) :: symbol_id
 
-        call to_c_chars('calloc', c_name)
+        call to_c_chars('_ffc_calloc', c_name)
         symbol_id = lr_session_intern(handle, c_name)
         if (symbol_id < 0_c_int32_t .or. size(args) /= 2) then
             call clear_liric_error(error)

--- a/src/session_program_lowering_allocatable.inc
+++ b/src/session_program_lowering_allocatable.inc
@@ -944,7 +944,7 @@
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t) :: m_i32, n_i32, m_i64, n_i64
-        type(lr_operand_desc_t) :: total_i64, bytes_i64, data_ptr, descriptor
+        type(lr_operand_desc_t) :: total_i64, data_ptr, descriptor
         type(lr_operand_desc_t) :: extents_i64(2)
 
         call lower_i32_expression(arena, size_index1, context, m_i32, error_msg)
@@ -956,15 +956,14 @@
         if (.not. emit_liric_i32_to_i64(context%session, n_i32, n_i64, error_msg)) &
             return
 
-        ! bytes = M * N * 4 (all in i64 to avoid overflow and reuse issues)
+        ! count = M * N; the element size goes to the runtime separately so
+        ! the byte product is formed and range-checked there (#428).
         if (.not. emit_i64_binary(context%session, LR_OP_MUL, m_i64, n_i64, &
                 total_i64, error_msg)) return
-        if (.not. emit_i64_binary(context%session, LR_OP_MUL, total_i64, &
-                i64_immediate(context%session, &
-                    allocatable_elem_size(context%symbols(symbol_index)%value_kind)), &
-                bytes_i64, error_msg)) return
-        if (.not. emit_malloc(context%session, bytes_i64, data_ptr, error_msg)) &
-            return
+        if (.not. emit_malloc(context%session, total_i64, data_ptr, error_msg, &
+                elem_size=i64_immediate(context%session, &
+                    allocatable_elem_size( &
+                        context%symbols(symbol_index)%value_kind)))) return
 
         descriptor = context%symbols(symbol_index)%allocatable_descriptor_address
         if (.not. emit_ptr_store(context%session, data_ptr, descriptor, &
@@ -983,21 +982,21 @@
         integer, intent(in) :: symbol_index
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: bytes_i32, bytes_i64, n_i64, data_ptr
+        type(lr_operand_desc_t) :: n_i64, data_ptr
         type(lr_operand_desc_t) :: descriptor
         type(lr_operand_desc_t) :: extents_i64(2)
 
         descriptor = context%symbols(symbol_index)%allocatable_descriptor_address
-        if (.not. emit_i32_binary(context%session, LR_OP_MUL, n_i32, &
-                i32_immediate(context%session, &
-                    allocatable_elem_size(context%symbols(symbol_index)%value_kind)), &
-                bytes_i32, error_msg)) return
-        if (.not. emit_liric_i32_to_i64(context%session, bytes_i32, bytes_i64, &
-                error_msg)) return
-        if (.not. emit_malloc(context%session, bytes_i64, data_ptr, error_msg)) &
-            return
         if (.not. emit_liric_i32_to_i64(context%session, n_i32, n_i64, error_msg)) &
             return
+        ! The element count and the element size go to the runtime separately,
+        ! so the product is formed and range-checked there (#428). The former
+        ! i32 multiply here silently wrapped for a large extent.
+        if (.not. emit_malloc(context%session, n_i64, data_ptr, error_msg, &
+                elem_size=i64_immediate(context%session, &
+                    int(allocatable_elem_size( &
+                        context%symbols(symbol_index)%value_kind), &
+                        c_int64_t)))) return
 
         if (.not. emit_ptr_store(context%session, data_ptr, descriptor, &
                 error_msg)) return

--- a/test/test_session_runtime_allocation_helpers_compiler.f90
+++ b/test/test_session_runtime_allocation_helpers_compiler.f90
@@ -1,0 +1,259 @@
+! Issue #428: descriptor storage is allocated, resized, and freed through
+! runtime entry points.
+!
+! Behavioral oracle, two halves.
+!
+! The runtime half drives the helpers from C and pins the contract the
+! compiler now depends on: a negative extent, a size that would overflow, a
+! double release, and a release through a borrowed descriptor each return
+! their own stable code instead of corrupting the heap or succeeding quietly.
+! These are the cases emitted code could not check for itself when it called
+! malloc and free directly.
+!
+! The compiler half is the end-to-end guarantee: an emitted program allocates,
+! reallocates and frees integer arrays and deferred-length characters through
+! the runtime, values survive the transitions, and the program's symbols name
+! the runtime helpers rather than malloc and free. The symbol check fails on
+! the pre-#428 compiler.
+program test_session_runtime_allocation_helpers_compiler
+    use ffc_runtime_link, only: ffc_runtime_link_input
+    use ffc_test_support, only: expect_output, compile_to_exe
+    implicit none
+
+    character(len=*), parameter :: WORK = '/tmp/ffc_alloc_helpers_428'
+    logical :: all_passed
+
+    print *, '=== runtime allocation helper tests (#428) ==='
+
+    call run_quiet('rm -rf '//WORK//' && mkdir -p '//WORK)
+
+    all_passed = .true.
+    if (.not. test_runtime_contract()) all_passed = .false.
+    if (.not. test_values_survive_transitions()) all_passed = .false.
+    if (.not. test_lowering_calls_the_runtime()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: descriptor storage goes through the runtime'
+
+contains
+
+    subroutine run_quiet(command)
+        character(len=*), intent(in) :: command
+        integer :: exit_stat, cmd_stat
+
+        call execute_command_line(command, exitstat=exit_stat, &
+                                  cmdstat=cmd_stat)
+    end subroutine run_quiet
+
+    integer function status_of(command) result(status)
+        character(len=*), intent(in) :: command
+        character(len=*), parameter :: rc_file = WORK//'/rc'
+        integer :: unit, ios, exit_stat, cmd_stat
+
+        status = -1
+        call execute_command_line('{ '//command//' ; } > '//WORK// &
+                                  '/out 2>&1; echo $? > '//rc_file, &
+                                  exitstat=exit_stat, cmdstat=cmd_stat)
+        if (cmd_stat /= 0) return
+        open (newunit=unit, file=rc_file, status='old', iostat=ios)
+        if (ios /= 0) return
+        read (unit, *, iostat=ios) status
+        close (unit)
+        if (ios /= 0) status = -1
+    end function status_of
+
+    subroutine read_text_file(path, text, ok)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: text
+        logical, intent(out) :: ok
+        integer :: unit, ios
+        integer(kind=8) :: nbytes
+
+        ok = .false.
+        open (newunit=unit, file=path, access='stream', form='unformatted', &
+              status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            text = ''
+            return
+        end if
+        inquire (unit=unit, size=nbytes)
+        if (nbytes <= 0) then
+            close (unit)
+            text = ''
+            return
+        end if
+        allocate (character(len=nbytes) :: text)
+        read (unit, iostat=ios) text
+        close (unit)
+        ok = ios == 0
+    end subroutine read_text_file
+
+    ! Each failing check exits with its own number, so a failure names the
+    ! contract that broke rather than only that something did.
+    logical function test_runtime_contract() result(ok)
+        character(len=*), parameter :: driver = WORK//'/alloc_driver.c'
+        character(len=*), parameter :: exe = WORK//'/alloc_driver'
+        character(len=:), allocatable :: link_input, error_msg
+        integer :: unit, ios, status
+
+        ok = .false.
+        call ffc_runtime_link_input(link_input, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: runtime link input: ', trim(error_msg)
+            return
+        end if
+        open (newunit=unit, file=driver, status='replace', iostat=ios)
+        if (ios /= 0) then
+            print *, 'FAIL: cannot write the allocation driver'
+            return
+        end if
+        write (unit, '(a)') '#include <stddef.h>'
+        write (unit, '(a)') 'void *_ffc_alloc(long long, long long);'
+        write (unit, '(a)') 'void *_ffc_calloc(long long, long long);'
+        write (unit, '(a)') 'void *_ffc_realloc(void *, long long,'
+        write (unit, '(a)') '                   long long);'
+        write (unit, '(a)') 'int _ffc_dealloc(void *, int);'
+        write (unit, '(a)') 'int _ffc_alloc_status(void);'
+        write (unit, '(a)') 'int main(void) {'
+        write (unit, '(a)') '    char *p, *q;'
+        write (unit, '(a)') '    int i;'
+        write (unit, '(a)') '    p = _ffc_alloc(4, 8);'
+        write (unit, '(a)') '    if (p == 0) return 1;'
+        write (unit, '(a)') '    if (_ffc_alloc_status() != 0) return 2;'
+        write (unit, '(a)') '    for (i = 0; i < 32; i++) p[i] = (char) i;'
+        write (unit, '(a)') '    /* resize keeps the leading bytes */'
+        write (unit, '(a)') '    q = _ffc_realloc(p, 16, 8);'
+        write (unit, '(a)') '    if (q == 0) return 3;'
+        write (unit, '(a)') '    for (i = 0; i < 32; i++)'
+        write (unit, '(a)') '        if (q[i] != (char) i) return 4;'
+        write (unit, '(a)') '    /* zeroed allocation */'
+        write (unit, '(a)') '    p = _ffc_calloc(4, 8);'
+        write (unit, '(a)') '    if (p == 0) return 5;'
+        write (unit, '(a)') '    for (i = 0; i < 32; i++)'
+        write (unit, '(a)') '        if (p[i] != 0) return 6;'
+        write (unit, '(a)') '    if (_ffc_dealloc(p, 1) != 0) return 7;'
+        write (unit, '(a)') '    /* a second release is reported */'
+        write (unit, '(a)') '    if (_ffc_dealloc(p, 1) != 6004) return 8;'
+        write (unit, '(a)') '    if (_ffc_alloc_status() != 6004) return 9;'
+        write (unit, '(a)') '    /* a borrowed descriptor never frees */'
+        write (unit, '(a)') '    if (_ffc_dealloc(q, 0) != 6005) return 10;'
+        write (unit, '(a)') '    if (_ffc_dealloc(q, 1) != 0) return 11;'
+        write (unit, '(a)') '    /* releasing nothing succeeds */'
+        write (unit, '(a)') '    if (_ffc_dealloc(0, 1) != 0) return 12;'
+        write (unit, '(a)') '    /* a negative extent is rejected */'
+        write (unit, '(a)') '    if (_ffc_alloc(-1, 4) != 0) return 13;'
+        write (unit, '(a)') '    if (_ffc_alloc_status() != 6001) return 14;'
+        write (unit, '(a)') '    /* an unrepresentable size is rejected */'
+        write (unit, '(a)') '    if (_ffc_alloc(1LL << 62, 64) != 0)'
+        write (unit, '(a)') '        return 15;'
+        write (unit, '(a)') '    if (_ffc_alloc_status() != 6002) return 16;'
+        write (unit, '(a)') '    /* a zero-sized array is still releasable */'
+        write (unit, '(a)') '    p = _ffc_alloc(0, 4);'
+        write (unit, '(a)') '    if (p == 0) return 17;'
+        write (unit, '(a)') '    if (_ffc_dealloc(p, 1) != 0) return 18;'
+        write (unit, '(a)') '    return 0;'
+        write (unit, '(a)') '}'
+        close (unit)
+
+        status = status_of('cc -o '//exe//' '//driver//' '//link_input)
+        if (status /= 0) then
+            print *, 'FAIL: the allocation driver does not build'
+            return
+        end if
+        status = status_of(exe)
+        if (status /= 0) then
+            print *, 'FAIL: allocation contract check ', status, ' failed'
+            return
+        end if
+        ok = .true.
+    end function test_runtime_contract
+
+    ! Allocate, reallocate and free from Fortran; values survive.
+    logical function test_values_survive_transitions() result(ok)
+        character(len=*), parameter :: Q = achar(39)
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, allocatable :: a(:)'//new_line('a')// &
+            '  character(len=:), allocatable :: s'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  allocate(a(4))'//new_line('a')// &
+            '  do i = 1, 4'//new_line('a')// &
+            '     a(i) = i * 10'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            '  print *, a(1), a(4), size(a)'//new_line('a')// &
+            '  deallocate(a)'//new_line('a')// &
+            '  allocate(a(2))'//new_line('a')// &
+            '  a = [5, 6]'//new_line('a')// &
+            '  print *, a(1) + a(2), size(a)'//new_line('a')// &
+            '  deallocate(a)'//new_line('a')// &
+            '  allocate(character(len=3) :: s)'//new_line('a')// &
+            '  s = '//Q//'xyz'//Q//new_line('a')// &
+            '  print *, s'//new_line('a')// &
+            '  deallocate(s)'//new_line('a')// &
+            'end program main'
+
+        ok = expect_output(source, &
+            '          10          40           4'//new_line('a')// &
+            '          11           2'//new_line('a')// &
+            ' xyz'//new_line('a'), &
+            WORK//'/transitions')
+    end function test_values_survive_transitions
+
+    ! Emitted code must reach the runtime helpers, not malloc and free.
+    logical function test_lowering_calls_the_runtime() result(ok)
+        character(len=*), parameter :: exe = WORK//'/symbols'
+        character(len=*), parameter :: nm_out = WORK//'/symbols.nm'
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer, allocatable :: a(:)'//new_line('a')// &
+            '  allocate(a(3))'//new_line('a')// &
+            '  a(1) = 1'//new_line('a')// &
+            '  print *, a(1)'//new_line('a')// &
+            '  deallocate(a)'//new_line('a')// &
+            'end program main'
+        character(len=:), allocatable :: error_msg, symbols
+        logical :: read_ok
+        integer :: status
+
+        ok = .false.
+        call compile_to_exe(source, exe, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: compiling the probe program: ', trim(error_msg)
+            return
+        end if
+        status = status_of('nm '//exe//' > '//nm_out)
+        if (status /= 0) then
+            print *, 'FAIL: cannot list the emitted symbols'
+            return
+        end if
+        call read_text_file(nm_out, symbols, read_ok)
+        if (.not. read_ok) then
+            print *, 'FAIL: cannot read the emitted symbol list'
+            return
+        end if
+        if (index(symbols, '_ffc_alloc') == 0) then
+            print *, 'FAIL: allocation does not call the runtime'
+            return
+        end if
+        if (index(symbols, '_ffc_dealloc') == 0) then
+            print *, 'FAIL: deallocation does not call the runtime'
+            return
+        end if
+        ! A leftover direct malloc or free in compiler-emitted code would be
+        ! a second convention for the same storage, and the two allocators do
+        ! not interoperate: storage from malloc is not known to the runtime,
+        ! so releasing it would be reported as a double free. The runtime's
+        ! own functions are where malloc and free belong, so the check is on
+        ! the calling function, not on the mere presence of the call.
+        status = status_of('objdump -d '//exe//' | awk '''// &
+            '/^[0-9a-f]+ </ { fn = $2 } '// &
+            '/call.*<(malloc|free)@plt>/ { if (fn !~ /ffc_/) found = 1 } '// &
+            'END { exit found ? 0 : 1 }'//''' ')
+        if (status == 0) then
+            print *, 'FAIL: emitted code still calls malloc or free directly'
+            return
+        end if
+        ok = .true.
+    end function test_lowering_calls_the_runtime
+
+end program test_session_runtime_allocation_helpers_compiler


### PR DESCRIPTION
Closes #428. Completes the runtime-ABI chain after #565 (#603), #396 (#624),
#423 (#645) and #427 (#659).

## What moved

Allocatable arrays and deferred-length characters reached `malloc` and `free`
directly from emitted code, so every size computation, every overflow check
and every ownership decision was open-coded at each site. The runtime owns
that now. The compiler still decides shape and type metadata.

| Symbol | Signature |
|---|---|
| `_ffc_alloc` | `void *_ffc_alloc(long long count, long long elem_size)` |
| `_ffc_calloc` | `void *_ffc_calloc(long long count, long long elem_size)` |
| `_ffc_realloc` | `void *_ffc_realloc(void *old, long long count, long long elem_size)` |
| `_ffc_dealloc` | `int _ffc_dealloc(void *p, int owns)` |
| `_ffc_alloc_status` | `int _ffc_alloc_status(void)` |

**Sizes arrive as a count and an element size, never as a product**, so the
multiplication that can overflow happens in the runtime, once, where it is
checked. That also fixes a real defect: `lower_allocate_i32_1d_operand`
multiplied the extent by the element size in **i32** and only then widened, so
a large extent wrapped silently and allocated far too little. It now passes
the widened count and the element size separately.

## Invariants preserved and stated

- **Versioned public interfaces.** No LIRIC ABI declaration changed.
- **Verified ABI declarations.** The five new symbols are in
  `FFC_RUNTIME_SYMBOLS`, so `test_runtime_link_compiler` fails unless the
  runtime defines each one. That check earned its keep here: it caught a stale
  embedded runtime source mid-change, before it could become an undefined
  symbol at link time.
- **Matching runtime.** Unchanged from #565.
- **Canonical ownership.** `owns` is the descriptor's `ARRAY_FLAG_OWNS_DATA`
  bit, and a borrowed descriptor never frees — it gets `6005` rather than
  silently doing nothing. This enforces at run time the ownership rule
  `ARRAY_DESCRIPTOR_ABI.md` states: exactly one descriptor owns any
  allocation, and dropping a view never frees storage.
- **View lifetimes.** A section view holds a `base` into another descriptor's
  allocation and never owns it, so releasing a view cannot shorten the parent
  allocation's lifetime; the runtime now refuses the release outright instead
  of relying on every call site to have got the flag right.
- **Stable status codes.** 0 success, 6001 negative count or element size,
  6002 unrepresentable size, 6003 allocator refused, 6004 release of a pointer
  that is not live, 6005 release of storage the descriptor does not own.
- **One allocator.** The two do not interoperate — storage from a direct
  `malloc` is unknown to the runtime, so releasing it would be reported as a
  double free. `emit_malloc`, `emit_calloc` and `emit_free` all route to the
  runtime, and the oracle fails if any compiler-emitted function still calls
  `malloc` or `free`.
- **Zero-sized and null cases.** A zero count is a valid request and yields a
  releasable pointer, because Fortran allows a zero-sized array. Releasing a
  null pointer succeeds, matching `deallocate` of an unallocated variable.

## Behavioral oracle

`test/test_session_runtime_allocation_helpers_compiler.f90` (new):

- A C driver linked against the runtime pins the contract: a negative extent
  is 6001, `_ffc_alloc(1LL << 62, 64)` is 6002, a second release is 6004, a
  release through a borrowed descriptor is 6005 and leaves the storage intact
  so the owning release still succeeds, releasing null succeeds, a resize
  keeps the leading bytes, and `_ffc_calloc` returns zeroed storage. Each
  check exits with its own number, so a failure names the contract that broke.
- A Fortran program allocates, deallocates, reallocates and frees an integer
  array and a deferred-length character; values survive every transition.
- An emitted program's symbols must name `_ffc_alloc` and `_ffc_dealloc`, and
  no compiler-emitted function may call `malloc` or `free`. The check is on
  the calling function, not the presence of the call, because the runtime's
  own functions are exactly where `malloc` and `free` belong.

## Corpus delta

Measured **before and after in the same worktree** at the same commit, per
#642.

| suite | pass | xfail | xpass | fail | noref | skip |
|---|---|---|---|---|---|---|
| lfortran, base | 876 | 3286 | 111 | 6 | 165 | 1 |
| lfortran, this PR | 876 | 3286 | 111 | 6 | 165 | 1 |
| gfortran-dg, base | 1351 | 2070 | 59 | 159 | 6 | 2299 |
| gfortran-dg, this PR | 1351 | 2071 | 58 | 159 | 6 | 2299 |

lfortran is identical file for file. The single gfortran-dg delta is
`minmaxloc_11.f90` XPASS→XFAIL, the case whose compiled program's exit status
varies run to run independently of any change here — it has flipped in both
directions across this chain and is not promoted. No PASS regressed.

`test_session_lazy_monomorph_compiler`, `test_fortfront_corpus_conformance`
and `test_parity_dashboard` fail on this branch and fail identically on `main`
at the same commit in the same worktree.
