### PR TITLE
[arrayexpr-02] make overlapping array assignment alias-safe (closes #344)

### DIFF
--- a/src/session_program_lowering_array_elements.inc
+++ b/src/session_program_lowering_array_elements.inc
@@ -1316,6 +1316,7 @@
 
         type(array_section_info_t) :: tinfo, sinfo
         type(lr_operand_desc_t) :: value
+        type(lr_operand_desc_t), allocatable :: rhs_values(:)
         integer :: k, k2, n
         integer(c_int64_t) :: tgt_lin, src_lin
 
@@ -1337,18 +1338,13 @@
                     error_msg = 'array section length does not match constructor'
                     return
                 end if
+                allocate (rhs_values(n))
                 do k = 0, n - 1
                     call lower_i32_expression(arena, rhs%element_indices(k + 1), &
-                                              context, value, error_msg)
-                    if (len_trim(error_msg) > 0) return
-                    tgt_lin = tinfo%section_lowers(1) + &
-                              int(k, c_int64_t) * tinfo%section_strides(1) - &
-                              tinfo%source_lowers(1)
-                    call store_array_linear_element(context, tinfo%source_index, &
-                                                    tgt_lin, value, error_msg)
+                                              context, rhs_values(k + 1), error_msg)
                     if (len_trim(error_msg) > 0) return
                 end do
-                call set_empty(error_msg)
+                call store_section_elements(context, tinfo, rhs_values, error_msg)
                 return
             type is (array_slice_node)
                 call describe_array_section(arena, rhs, context, sinfo, error_msg)
@@ -1359,21 +1355,17 @@
                                 'rank-1 shapes'
                     return
                 end if
+                allocate (rhs_values(n))
                 do k = 0, n - 1
                     src_lin = sinfo%section_lowers(1) + &
                               int(k, c_int64_t) * sinfo%section_strides(1) - &
                               sinfo%source_lowers(1)
                     call load_array_linear_element(context, sinfo%source_index, &
-                                                   src_lin, value, error_msg)
-                    if (len_trim(error_msg) > 0) return
-                    tgt_lin = tinfo%section_lowers(1) + &
-                              int(k, c_int64_t) * tinfo%section_strides(1) - &
-                              tinfo%source_lowers(1)
-                    call store_array_linear_element(context, tinfo%source_index, &
-                                                    tgt_lin, value, error_msg)
+                                                   src_lin, rhs_values(k + 1), &
+                                                   error_msg)
                     if (len_trim(error_msg) > 0) return
                 end do
-                call set_empty(error_msg)
+                call store_section_elements(context, tinfo, rhs_values, error_msg)
                 return
             end select
         end if
@@ -1425,6 +1417,30 @@
         end if
         call set_empty(error_msg)
     end subroutine lower_array_section_assignment
+
+    subroutine store_section_elements(context, tinfo, values, error_msg)
+        !! Store an already-evaluated rank-1 right-hand side into a rank-1
+        !! section. Every value in `values` was produced before the first store,
+        !! so the assignment behaves as if the right-hand side were fully
+        !! computed first (Fortran 2018 clause 10.2.1.3) even when target and
+        !! source overlap in storage.
+        type(lowering_context_t), intent(inout) :: context
+        type(array_section_info_t), intent(in) :: tinfo
+        type(lr_operand_desc_t), intent(in) :: values(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: k
+        integer(c_int64_t) :: tgt_lin
+
+        do k = 0, size(values) - 1
+            tgt_lin = tinfo%section_lowers(1) + &
+                      int(k, c_int64_t) * tinfo%section_strides(1) - &
+                      tinfo%source_lowers(1)
+            call store_array_linear_element(context, tinfo%source_index, &
+                                            tgt_lin, values(k + 1), error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+        call set_empty(error_msg)
+    end subroutine store_section_elements
 
     subroutine store_array_linear_element(context, symbol_index, linear_index, &
                                           value, error_msg)

--- a/test/test_session_array_alias_assignment_compiler.f90
+++ b/test/test_session_array_alias_assignment_compiler.f90
@@ -1,0 +1,71 @@
+program test_session_array_alias_assignment_compiler
+    !! Overlapping array section assignment must behave as if the right-hand
+    !! side were fully evaluated before any element of the target is written
+    !! (Fortran 2018 clause 10.2.1.3). Expected values are the gfortran output
+    !! for the same program.
+    use ffc_test_support, only: expect_output
+    implicit none
+
+    print *, '=== direct session overlapping array assignment compiler test ==='
+    if (.not. test_forward_overlap()) stop 1
+    if (.not. test_backward_overlap()) stop 1
+    if (.not. test_strided_overlap()) stop 1
+    print *, 'PASS: overlapping array section assignment is alias-safe'
+
+contains
+
+    logical function test_forward_overlap()
+        !! a(2:5) = a(1:4): target starts above the source, so an ascending
+        !! element-by-element copy would read already-overwritten elements.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(6)'//new_line('a')// &
+            '  a = [1, 2, 3, 4, 5, 6]'//new_line('a')// &
+            '  a(2:5) = a(1:4)'//new_line('a')// &
+            '  print *, a(1), a(2), a(3), a(4), a(5), a(6)'//new_line('a')// &
+            'end program main'
+
+        test_forward_overlap = expect_output( &
+            source, &
+            '           1           1           2           3           4'// &
+            '           6'//new_line('a'), &
+            '/tmp/ffc_session_array_alias_forward_test')
+    end function test_forward_overlap
+
+    logical function test_backward_overlap()
+        !! a(1:4) = a(2:5): the reverse overlap direction.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(6)'//new_line('a')// &
+            '  a = [1, 2, 3, 4, 5, 6]'//new_line('a')// &
+            '  a(1:4) = a(2:5)'//new_line('a')// &
+            '  print *, a(1), a(2), a(3), a(4), a(5), a(6)'//new_line('a')// &
+            'end program main'
+
+        test_backward_overlap = expect_output( &
+            source, &
+            '           2           3           4           5           5'// &
+            '           6'//new_line('a'), &
+            '/tmp/ffc_session_array_alias_backward_test')
+    end function test_backward_overlap
+
+    logical function test_strided_overlap()
+        !! A noncontiguous section assigned from a section of the same array.
+        !! a(2:6:2) = a(1:3) writes a(2), a(4), a(6) while reading a(1), a(2),
+        !! a(3), so a(2) must be read at its pre-assignment value.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(6)'//new_line('a')// &
+            '  a = [1, 2, 3, 4, 5, 6]'//new_line('a')// &
+            '  a(2:6:2) = a(1:3)'//new_line('a')// &
+            '  print *, a(1), a(2), a(3), a(4), a(5), a(6)'//new_line('a')// &
+            'end program main'
+
+        test_strided_overlap = expect_output( &
+            source, &
+            '           1           1           3           2           5'// &
+            '           3'//new_line('a'), &
+            '/tmp/ffc_session_array_alias_strided_test')
+    end function test_strided_overlap
+
+end program test_session_array_alias_assignment_compiler


### PR DESCRIPTION
Closes #344.

`a(2:5) = a(1:4)` silently produced a wrong answer. The section-to-section and
section-from-constructor paths in `lower_array_section_assignment` interleaved
one element load with one element store in ascending order, so an overlapping
right-hand side read elements that the same assignment had already overwritten.
The program compiled cleanly and printed garbage.

Recorded on unmodified `origin/main` (6c7dee7), `a(2:5) = a(1:4)` with
`a = [1,2,3,4,5,6]`:

```
expected:  1  1  2  3  4  6     (gfortran)
actual:    1  1  1  1  1  6     (ffc)
```

## Change

The whole right-hand side is now lowered into values before any store happens.
Section extents here are compile-time constants and the assignment is already
unrolled, so "as if fully computed first" is expressed directly in SSA values;
no memory temporary and no runtime overlap predicate is introduced, and no
alternate path is selected on any shape. Both right-hand-side forms now store
through one shared `store_section_elements` helper, which replaces the two
copies of the target-index arithmetic and the interleaved store loops that were
there before.

Deleted: the two interleaved load/store (and evaluate/store) loops in
`lower_array_section_assignment`, together with their duplicated target linear
index computation.

## Invariants

- **Column-major layout**: unchanged; the target linear index arithmetic is
  moved verbatim into the shared helper.
- **Lower bound and extent semantics**: unchanged; section lowers, strides and
  extents come from `describe_array_section` as before, and conformability is
  still enforced (`array section length does not match constructor`, `array
  section assignment requires matching rank-1 shapes`).
- **Overlap and aliasing**: the right-hand side is evaluated as if fully
  computed before assignment, in both overlap directions and for a
  noncontiguous target section, independent of traversal order.
- **Allocation and finalization lifetimes**: unchanged; no temporary storage is
  allocated and no descriptor ownership changes.
- **Elemental semantics**: unchanged; one right-hand-side element value per
  target element, in the same element order.
- **Reduction identity and ordering**: not touched by this change.

## Behavioral oracle

NEW `test/test_session_array_alias_assignment_compiler.f90`, expected values
taken from gfortran output for the same programs:

- forward overlap `a(2:5) = a(1:4)`
- reverse overlap `a(1:4) = a(2:5)`
- noncontiguous section from a section of the same array, `a(2:6:2) = a(1:3)`

All three fail on unmodified main; all three pass with this change.

## Local gates

Merges use `--admin`, so these were run locally rather than relying on CI.

- `fo test test_session_array_alias_assignment_compiler`: 1 passed
- `fo`: build OK, 328/330 tests pass. The two failures,
  `test_fortfront_corpus_conformance` and `test_parity_dashboard`, are
  **pre-existing on unmodified main** — the identical 9 corpus FAILs, the same
  3 `fortfront-lf` XPASS entries, and the same stale snapshot manifest digest
  reproduce on 6c7dee7 with no changes applied.
- `fo lint`: no new findings; all reported items are on untouched lines.

## Corpus delta

Zero. `fortfront-f90` is PASS=451 XFAIL=93 XPASS=0 FAIL=9 NOREF=173 both before
and after. No XFAIL manifest entry was added, removed, or weakened. No
performance claim is made, so no #642 measurement applies.