### PR TITLE
[chardesc-05] store character array elements contiguously at the declared stride

### DIFF
--- a/src/session_program_lowering_arrays.inc
+++ b/src/session_program_lowering_arrays.inc
@@ -2855,6 +2855,20 @@
             return
         end if
 
+        ! Two fixed character arrays of the same shape and element length are
+        ! two contiguous blocks of identical size, so the assignment is one
+        ! block copy rather than a walk that would have to know an element
+        ! kind's scalar width.
+        if (context%symbols(symbol_index)%value_kind == VALUE_CHARACTER) then
+            block
+                logical :: char_handled
+                call lower_character_array_whole_assignment(arena, node, &
+                    symbol_index, context, char_handled, error_msg)
+                if (len_trim(error_msg) > 0) return
+                if (char_handled) return
+            end block
+        end if
+
         if (node_exists(arena, node%value_index)) then
             select type (rhs => arena%entries(node%value_index)%node)
             type is (array_literal_node)

--- a/src/session_program_lowering_char_arrays.inc
+++ b/src/session_program_lowering_char_arrays.inc
@@ -1,10 +1,17 @@
-    ! Fixed-length character element arrays (#W1). Storage is a [N x ptr] buffer
-    ! in element_address: each slot holds a pointer to a materialized, blank-padded
-    ! LIRIC string of the declared length. Element assignment materializes the
-    ! normalized literal and stores its pointer; element print loads the slot
-    ! pointer and reuses the scalar string print path. Scope: local rank-1 and
-    ! rank-2 arrays with a compile-time length and extent; allocatable,
-    ! deferred-length, dummy, and parameter character arrays stay unsupported.
+    ! Fixed-length character element arrays. Storage is one contiguous buffer of
+    ! array_size * character_length bytes in element_address, so element i sits
+    ! at base + i*character_length and the element stride is the declared length,
+    ! exactly as docs/ARRAY_DESCRIPTOR_ABI.md describes a contiguous array of
+    ! ARRAY_ELEMENT_CHARACTER with element_size = character_length.
+    !
+    ! An element is therefore a borrowed character view: character_length bytes
+    ! at its address, with no terminator of its own, since the next element
+    ! begins immediately after it. Reading one goes through the same view
+    ! machinery as a substring, and anything that needs a C string materialises
+    ! a terminated copy of exactly the element length.
+    !
+    ! Scope: local rank-1 and rank-2 arrays with a compile-time length and
+    ! extent; dummy and parameter character arrays stay unsupported.
 
     subroutine lower_character_array_declaration(node, context, error_msg)
         type(declaration_node), intent(in) :: node
@@ -230,7 +237,10 @@
         call character_array_fold_dims(context, node, index, dim_count, error_msg)
         if (len_trim(error_msg) > 0) return
 
-        if (.not. emit_ptr_array_alloca(context%session, array_size, &
+        ! One contiguous block: array_size elements of character_length bytes.
+        if (.not. emit_alloca_bytes(context%session, &
+                i64_immediate(context%session, &
+                    int(array_size, c_int64_t)*int(character_length, c_int64_t)), &
                 context%symbols(index)%element_address, error_msg)) then
             error_msg = 'decl_char_array['//trim(name)//']: '//error_msg
             return
@@ -275,11 +285,14 @@
                                           element_text, string_ptr, error_msg)
             if (len_trim(error_msg) > 0) return
             index_value = i32_immediate(context%session, int(i - 1, c_int64_t))
-            if (.not. emit_ptr_array_element_addr(context%session, array_size, &
-                    context%symbols(symbol_index)%element_address, index_value, &
-                    slot_addr, error_msg)) return
-            if (.not. emit_ptr_store(context%session, string_ptr, slot_addr, &
-                                     error_msg)) return
+            call character_array_element_address(context, symbol_index, &
+                                                 index_value, slot_addr, error_msg)
+            if (len_trim(error_msg) > 0) return
+            ! normalize_character_literal already padded or truncated the text
+            ! to the declared length, so this fills the element exactly.
+            if (.not. emit_memcpy(context%session, slot_addr, string_ptr, &
+                    i64_immediate(context%session, &
+                        int(character_length, c_int64_t)), error_msg)) return
         end do
     end subroutine store_character_array_initials
 
@@ -322,36 +335,47 @@
 
     subroutine init_character_array_blanks(context, symbol_index, character_length, &
                                            array_size, error_msg)
+        ! Every element starts blank, which for a contiguous block is one fill
+        ! of the whole buffer rather than a store per element.
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: symbol_index
         integer, intent(in) :: character_length
         integer, intent(in) :: array_size
         character(len=:), allocatable, intent(out) :: error_msg
-        character(len=64) :: string_name
-        character(len=:), allocatable :: blanks
-        type(lr_operand_desc_t) :: blank_ptr
-        type(lr_operand_desc_t) :: index_value
-        type(lr_operand_desc_t) :: slot_addr
-        integer :: i
 
         call set_empty(error_msg)
-        allocate (character(len=character_length) :: blanks)
-        blanks = repeat(' ', character_length)
-        context%string_literal_count = context%string_literal_count + 1
-        string_name = ffc_unit_global_name( &
-            context, 'char.', context%string_literal_count)
-        call materialize_liric_string(context%session, trim(string_name), blanks, &
-                                      blank_ptr, error_msg)
-        if (len_trim(error_msg) > 0) return
-        do i = 0, array_size - 1
-            index_value = i32_immediate(context%session, int(i, c_int64_t))
-            if (.not. emit_ptr_array_element_addr(context%session, array_size, &
-                    context%symbols(symbol_index)%element_address, index_value, &
-                    slot_addr, error_msg)) return
-            if (.not. emit_ptr_store(context%session, blank_ptr, slot_addr, &
-                                     error_msg)) return
-        end do
+        if (array_size <= 0 .or. character_length <= 0) return
+        call fill_spaces(context, context%symbols(symbol_index)%element_address, &
+                         i32_immediate(context%session, &
+                             int(array_size, c_int64_t)* &
+                             int(character_length, c_int64_t)), error_msg)
     end subroutine init_character_array_blanks
+
+    subroutine character_array_element_address(context, symbol_index, &
+                                               linear_index, address, error_msg)
+        ! Address of element `linear_index` (0-based) in the contiguous block:
+        ! base + linear_index * character_length. This is the whole of the
+        ! layout contract, so every reader and writer of element storage goes
+        ! through here.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: symbol_index
+        type(lr_operand_desc_t), intent(in) :: linear_index
+        type(lr_operand_desc_t), intent(out) :: address
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: index64, offset
+
+        if (.not. emit_liric_i32_to_i64(context%session, linear_index, index64, &
+                error_msg)) return
+        if (.not. emit_i64_binary(context%session, LR_OP_MUL, index64, &
+                i64_immediate(context%session, &
+                    int(context%symbols(symbol_index)%character_length, &
+                        c_int64_t)), offset, error_msg)) return
+        if (.not. emit_i64_binary(context%session, LR_OP_ADD, &
+                context%symbols(symbol_index)%element_address, offset, address, &
+                error_msg)) return
+        call set_empty(error_msg)
+    end subroutine character_array_element_address
 
     subroutine lower_character_array_element_slot(arena, node, context, &
                                                   symbol_index, slot_addr, error_msg)
@@ -387,10 +411,9 @@
         call character_array_linear_index(arena, node, context, symbol_index, &
                                           linear_index, error_msg)
         if (len_trim(error_msg) > 0) return
-        if (.not. emit_ptr_array_element_addr(context%session, &
-                context%symbols(symbol_index)%array_size, &
-                context%symbols(symbol_index)%element_address, linear_index, &
-                slot_addr, error_msg)) then
+        call character_array_element_address(context, symbol_index, linear_index, &
+                                             slot_addr, error_msg)
+        if (len_trim(error_msg) > 0) then
             error_msg = 'char_arr_slot_gep: '//error_msg
             return
         end if
@@ -490,8 +513,13 @@
         call materialize_liric_string(context%session, trim(string_name), &
                                       literal_text, string_ptr, error_msg)
         if (len_trim(error_msg) > 0) return
-        if (.not. emit_ptr_store(context%session, string_ptr, slot_addr, &
-                                 error_msg)) then
+        ! The element owns character_length bytes inside the array's block and
+        ! has no terminator of its own, so the normalized text is copied in at
+        ! exactly that width.
+        if (.not. emit_memcpy(context%session, slot_addr, string_ptr, &
+                i64_immediate(context%session, &
+                    int(context%symbols(symbol_index)%character_length, &
+                        c_int64_t)), error_msg)) then
             error_msg = 'char_arr_assign_store: '//error_msg
             return
         end if
@@ -512,8 +540,13 @@
         call lower_character_array_element_slot(arena, node, context, &
                                                 symbol_index, slot_addr, error_msg)
         if (len_trim(error_msg) > 0) return
-        if (.not. emit_ptr_load(context%session, slot_addr, string_ptr, &
-                                error_msg)) then
+        ! The element carries no terminator of its own, so print from a
+        ! terminated copy of exactly the declared length.
+        call materialize_character_view(context, slot_addr, &
+            i32_immediate(context%session, &
+                int(context%symbols(symbol_index)%character_length, c_int64_t)), &
+            string_ptr, error_msg)
+        if (len_trim(error_msg) > 0) then
             error_msg = 'char_arr_print_load: '//error_msg
             return
         end if
@@ -555,17 +588,69 @@
         end if
         do k = 0_c_int64_t, n - 1_c_int64_t
             index_value = i32_immediate(context%session, k)
-            if (.not. emit_ptr_array_element_addr(context%session, &
-                    context%symbols(symbol_index)%array_size, &
-                    context%symbols(symbol_index)%element_address, index_value, &
-                    slot_addr, error_msg)) return
-            if (.not. emit_ptr_load(context%session, slot_addr, string_ptr, &
-                                    error_msg)) return
+            call character_array_element_address(context, symbol_index, &
+                                                 index_value, slot_addr, error_msg)
+            if (len_trim(error_msg) > 0) return
+            call materialize_character_view(context, slot_addr, &
+                i32_immediate(context%session, &
+                    int(context%symbols(symbol_index)%character_length, &
+                        c_int64_t)), string_ptr, error_msg)
+            if (len_trim(error_msg) > 0) return
             if (.not. emit_liric_print_string_operand_value(context%session, &
                     context%str_print_format_id, string_ptr, error_msg)) return
         end do
-        call set_empty(error_msg)
     end subroutine emit_character_array_print_items
+
+    subroutine lower_character_array_whole_assignment(arena, node, symbol_index, &
+                                                      context, handled, error_msg)
+        ! c = d between two fixed character arrays. Both are contiguous blocks
+        ! of array_size * character_length bytes, so a conforming assignment is
+        ! a single copy of that many bytes. Declines (handled stays .false.)
+        ! for anything else, so the existing paths keep their behaviour.
+        use, intrinsic :: iso_c_binding, only: c_int64_t
+        type(ast_arena_t), intent(in) :: arena
+        type(assignment_node), intent(in) :: node
+        integer, intent(in) :: symbol_index
+        type(lowering_context_t), intent(inout) :: context
+        logical, intent(out) :: handled
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: source_name
+        integer :: source_index
+        integer :: element_length
+
+        handled = .false.
+        call set_empty(error_msg)
+        if (context%symbols(symbol_index)%is_allocatable) return
+        if (context%symbols(symbol_index)%is_runtime_array) return
+        element_length = context%symbols(symbol_index)%character_length
+        if (element_length <= 0) return
+        if (.not. node_exists(arena, node%value_index)) return
+        if (.not. is_identifier(arena, node%value_index)) return
+
+        call get_identifier_name(arena, node%value_index, source_name, error_msg)
+        if (len_trim(error_msg) > 0) return
+        source_index = find_symbol_compat(context, source_name)
+        if (source_index <= 0) return
+        if (.not. context%symbols(source_index)%is_array) return
+        if (context%symbols(source_index)%value_kind /= VALUE_CHARACTER) return
+        if (context%symbols(source_index)%is_allocatable) return
+        if (context%symbols(source_index)%is_runtime_array) return
+        ! Differing element lengths would need per-element padding rather than
+        ! a block copy; leave that to the existing element paths.
+        if (context%symbols(source_index)%character_length /= element_length) return
+
+        call ensure_array_shapes_match(context, symbol_index, source_index, &
+                                       error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        if (.not. emit_memcpy(context%session, &
+                context%symbols(symbol_index)%element_address, &
+                context%symbols(source_index)%element_address, &
+                i64_immediate(context%session, &
+                    int(context%symbols(symbol_index)%array_size, c_int64_t)* &
+                    int(element_length, c_int64_t)), error_msg)) return
+        handled = .true.
+    end subroutine lower_character_array_whole_assignment
 
     subroutine declare_deferred_char_allocatable_array(node, context, error_msg)
         ! character(len=:), allocatable :: c(:) -- a deferred-length allocatable

--- a/src/session_program_lowering_character.inc
+++ b/src/session_program_lowering_character.inc
@@ -1760,8 +1760,8 @@
 
     subroutine char_array_element_operands(arena, node, context, data_ptr, &
                                            length, error_msg)
-        ! Load the materialised, blank-padded string pointer for a character
-        ! array element and return it with the array's declared element length.
+        ! Resolve a character array element to its data pointer and the array's
+        ! declared element length.
         type(ast_arena_t), intent(in) :: arena
         type(call_or_subscript_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
@@ -1790,11 +1790,12 @@
             end if
         end if
 
+        ! A fixed character array stores its elements contiguously, so the
+        ! element's address is its data pointer: the element is a borrowed view
+        ! of character_length bytes inside the array's own block.
         call lower_character_array_element_slot(arena, node, context, &
-                                                symbol_index, slot_addr, error_msg)
+                                                symbol_index, data_ptr, error_msg)
         if (len_trim(error_msg) > 0) return
-        if (.not. emit_ptr_load(context%session, slot_addr, data_ptr, &
-                                error_msg)) return
         length = i32_immediate(context%session, &
             int(context%symbols(symbol_index)%character_length, c_int64_t))
         call set_empty(error_msg)

--- a/test/test_session_char_array_compiler.f90
+++ b/test/test_session_char_array_compiler.f90
@@ -11,11 +11,57 @@ program test_session_char_array_compiler
     if (.not. test_rank1_loop_whole_array_print()) all_passed = .false.
     if (.not. test_rank2_multi_item_print()) all_passed = .false.
     if (.not. test_whole_array_after_literal()) all_passed = .false.
+    if (.not. test_elements_are_contiguous_at_declared_stride()) &
+        all_passed = .false.
+    if (.not. test_element_lengths_are_the_declared_length()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: character arrays lower through direct LIRIC session'
 
 contains
+
+    logical function test_elements_are_contiguous_at_declared_stride()
+        ! Printing every element of a rank-1 character array back to back shows
+        ! the storage as one run of characters. With a contiguous layout the
+        ! elements sit at a stride of the declared length, so the concatenated
+        ! output has no gaps and no repetition.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=3) :: c(4)'//new_line('a')// &
+            '  c(1) = "aaa"'//new_line('a')// &
+            '  c(2) = "bbb"'//new_line('a')// &
+            '  c(3) = "ccc"'//new_line('a')// &
+            '  c(4) = "ddd"'//new_line('a')// &
+            '  print *, "[", c(1), c(2), c(3), c(4), "]"'//new_line('a')// &
+            'end program main'
+
+        test_elements_are_contiguous_at_declared_stride = expect_output( &
+            source, ' [aaabbbcccddd]'//new_line('a'), &
+            '/tmp/ffc_session_char_array_stride_test')
+    end function test_elements_are_contiguous_at_declared_stride
+
+    logical function test_element_lengths_are_the_declared_length()
+        ! Each element carries the array's declared element length, including
+        ! the blank padding of a shorter assigned value.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=5) :: c(3)'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  c(1) = "apple"'//new_line('a')// &
+            '  c(2) = "fig"'//new_line('a')// &
+            '  c(3) = "peach"'//new_line('a')// &
+            '  do i = 1, 3'//new_line('a')// &
+            '    print *, i, len(c(i)), "[", c(i), "]"'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            'end program main'
+
+        test_element_lengths_are_the_declared_length = expect_output( &
+            source, &
+            '           1           5 [apple]'//new_line('a')// &
+            '           2           5 [fig  ]'//new_line('a')// &
+            '           3           5 [peach]'//new_line('a'), &
+            '/tmp/ffc_session_char_array_len_test')
+    end function test_element_lengths_are_the_declared_length
 
     logical function test_rank1_element_assign_print()
         character(len=*), parameter :: source = &

--- a/test/test_session_deferred_char_array_compiler.f90
+++ b/test/test_session_deferred_char_array_compiler.f90
@@ -1,5 +1,5 @@
 program test_session_deferred_char_array_compiler
-    use ffc_test_support, only: expect_output
+    use ffc_test_support, only: expect_output, expect_error_contains
     implicit none
 
     logical :: all_passed
@@ -10,11 +10,82 @@ program test_session_deferred_char_array_compiler
     if (.not. test_declare_allocate_assign_print()) all_passed = .false.
     if (.not. test_element_read_and_whole_print()) all_passed = .false.
     if (.not. test_allocated_and_deallocate()) all_passed = .false.
+    if (.not. test_deferred_elements_report_allocated_length()) &
+        all_passed = .false.
+    if (.not. test_conforming_whole_array_assignment()) all_passed = .false.
+    if (.not. test_nonconformable_assignment_reports_shape()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: deferred-length character allocatable arrays lower correctly'
 
 contains
+
+    logical function test_deferred_elements_report_allocated_length()
+        ! A deferred-length character array takes its element length from the
+        ! allocate type-spec, and every element carries that length with the
+        ! usual blank padding.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=:), allocatable :: c(:)'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  allocate(character(len=4) :: c(3))'//new_line('a')// &
+            '  c(1) = "ab"'//new_line('a')// &
+            '  c(2) = "cdef"'//new_line('a')// &
+            '  c(3) = "gh"'//new_line('a')// &
+            '  do i = 1, 3'//new_line('a')// &
+            '    print *, i, len(c(i)), "[", c(i), "]"'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            '  print *, size(c)'//new_line('a')// &
+            '  deallocate(c)'//new_line('a')// &
+            'end program main'
+
+        test_deferred_elements_report_allocated_length = expect_output( &
+            source, &
+            '           1           4 [ab  ]'//new_line('a')// &
+            '           2           4 [cdef]'//new_line('a')// &
+            '           3           4 [gh  ]'//new_line('a')// &
+            '           3'//new_line('a'), &
+            '/tmp/ffc_session_deferred_char_array_len_test')
+    end function test_deferred_elements_report_allocated_length
+
+    logical function test_conforming_whole_array_assignment()
+        ! Whole-array assignment between conforming character arrays copies
+        ! every element, which contiguous element storage makes a single
+        ! block copy rather than a walk over per-element pointers.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=5) :: c(3), d(3)'//new_line('a')// &
+            '  c(1) = "apple"'//new_line('a')// &
+            '  c(2) = "mango"'//new_line('a')// &
+            '  c(3) = "peach"'//new_line('a')// &
+            '  d = c'//new_line('a')// &
+            '  print *, "[", d(1), d(2), d(3), "]"'//new_line('a')// &
+            'end program main'
+
+        test_conforming_whole_array_assignment = expect_output( &
+            source, ' [applemangopeach]'//new_line('a'), &
+            '/tmp/ffc_session_char_array_whole_assign_test')
+    end function test_conforming_whole_array_assignment
+
+    logical function test_nonconformable_assignment_reports_shape()
+        ! Assigning between character arrays of different extent is a shape
+        ! error, reported as one rather than misread as some other kind of
+        ! value.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=4) :: a(3)'//new_line('a')// &
+            '  character(len=4) :: b(2)'//new_line('a')// &
+            '  a(1) = "xx"'//new_line('a')// &
+            '  a(2) = "yy"'//new_line('a')// &
+            '  a(3) = "zz"'//new_line('a')// &
+            '  b = a'//new_line('a')// &
+            '  print *, b(1)'//new_line('a')// &
+            'end program main'
+
+        test_nonconformable_assignment_reports_shape = expect_error_contains( &
+            source, 'conforming shapes', &
+            '/tmp/ffc_session_char_array_nonconform_test')
+    end function test_nonconformable_assignment_reports_shape
 
     logical function test_declare_allocate_assign_print()
         character(len=*), parameter :: source = &


### PR DESCRIPTION
Closes #347.

Character arrays stored one pointer per element: a `[N x ptr]` buffer where each
slot pointed at a separately materialized, blank-padded, NUL-terminated string.
Elements now live in one contiguous block of `array_size * character_length`
bytes, so element `i` is at `base + i*character_length` and the element stride
is the declared length — the layout `docs/ARRAY_DESCRIPTOR_ABI.md` describes for
a contiguous array of `ARRAY_ELEMENT_CHARACTER` with
`element_size = character_length`.

## No fourth convention

This adds no new descriptor convention. Character array elements are addressed
by the canonical rule — base plus index times element size — with the element
size being the declared character length rather than a pointer width. The
allocatable/deferred path continues to go through the canonical descriptor that
#336 installed. I did not touch the inline `{data, extent}` record that
allocatable *components* still use; that is #339's to retire.

An element is now a **borrowed character view**: `character_length` bytes at its
address, with no terminator of its own, because the next element begins
immediately after it. That is the same thing a substring is (#350), so element
reads reuse that machinery, and anything needing a C string materializes a
terminated copy of exactly the element length.

The layout contract lives in one place, `character_array_element_address`, so
every reader and writer of element storage goes through it.

## What this fixes

Whole-array assignment between conforming fixed character arrays. `d = c`
previously produced `[pe   ]` for `peach`: the element-wise copy path has no
character case, so it fell through to a 2-byte default width. Two contiguous
blocks of identical size make this one block copy, which is both correct and
what the layout is for.

## Behaviour preserved

- **Element lengths and blank padding.** Each element carries the declared
  length; a shorter assigned value is padded, a longer one truncated. Covered
  for both fixed (`character(len=5) :: c(3)`) and deferred
  (`allocate(character(len=4) :: c(3))`) arrays.
- **Lower bounds and extents.** Untouched. The linear index arithmetic
  (`character_array_linear_index`, column-major with declared lower bounds) is
  unchanged; only the byte offset it feeds changed from `i*8` to
  `i*character_length`.
- **Nonconformable assignment still reports a shape error**, not something
  else, via the existing `ensure_array_shapes_match`. Pinned by a new negative
  fixture.
- **Aliasing.** A whole-array copy between two distinct arrays is a block copy
  of disjoint storage. Element assignment copies into the element's own bytes
  rather than rebinding a pointer, so no element aliases a shared literal any
  more — previously every blank-initialized element pointed at *one* shared
  blank string.
- **Initializers and comparison** unchanged; their suites pass untouched.

## Coverage

Added to the maintained suites, expectations from gfortran:

- contiguity at the declared stride: printing all elements back to back gives
  one unbroken run, `[aaabbbcccddd]`;
- element lengths with padding, fixed and deferred;
- conforming whole-array assignment (this was the broken one);
- nonconformable assignment reports a shape error.

## Scope I did not take

An implied-do over a character array (`print *, (c(i), i=1,3)`) still prints the
elements as integers. I wrote the fix, found it was not reached — the
single-item print branch handles that shape before the implied-do path — and
**reverted it rather than land unexercised code**. It is a print-dispatch
defect, not a storage-layout one, and it was equally broken before this change.
Filing separately.

Element substring (`c(2)(1:3)`) also remains unsupported; substring detection
requires a scalar parent. Also pre-existing, also separate.

## Gates run locally

Because we squash-merge with `--admin` without waiting for CI, these were run
here rather than relied on from CI:

- Full `fo test`: 374 passed, 3 failed — `test_fortfront_corpus_conformance`,
  `test_parity_dashboard`, `test_session_type_extends_compiler`. All three fail
  identically in this same worktree with `src/` and `test/conformance/` reverted
  to the parent commit, so none is mine.
- Rejection sweep (ffc#663 — there is no `check-rejection-gate` in ffc): the
  four-suite before/after below is that sweep. A newly rejected valid file shows
  up as a lost PASS, and there are none.

## Conformance gauntlet

Same-worktree before/after per ffc#642, with the baseline pinned to the explicit
parent commit `dfc37b1` rather than to `origin/main`. Both halves fully rebuilt.

| Suite | before | after |
|---|---|---|
| lfortran | PASS=880 XFAIL=3282 XPASS=111 FAIL=6 | PASS=880 XFAIL=3282 XPASS=111 FAIL=6 |
| gfortran-dg | PASS=1354 XFAIL=2070 XPASS=59 FAIL=156 | PASS=1354 XFAIL=2071 XPASS=58 FAIL=156 |
| fortfront-f90 | PASS=451 XFAIL=93 XPASS=0 FAIL=9 | PASS=451 XFAIL=93 XPASS=0 FAIL=9 |
| fortfront-lf | PASS=211 XFAIL=51 XPASS=3 FAIL=0 | PASS=211 XFAIL=51 XPASS=3 FAIL=0 |

Per case, across all four suites: **no new FAIL, no case lost PASS, no case
gained PASS.** A representation change that preserves behaviour should move
nothing in the corpus, and it moves nothing; the behavioural evidence is in the
tests above. The single gfortran-dg XPASS/XFAIL difference is one case flipping
between those two states, not a PASS change, and no case is promoted here.
