### PR TITLE
[arrayexpr-01] centralize array element-expression lowering (closes #342)

### DIFF
--- a/src/session_array_expr_types.f90
+++ b/src/session_array_expr_types.f90
@@ -1,0 +1,77 @@
+module session_array_expr_types
+    !! Typed plan for one array-valued expression.
+    !!
+    !! A plan records the rank, shape, element type, and element-producer
+    !! metadata of an array expression once, before any element is emitted.
+    !! Element lowering then reads the plan instead of re-deriving the element
+    !! kind and the iteration extent at every operand site.
+    !!
+    !! The plan describes an expression, not storage: the canonical
+    !! `array_descriptor_t` of `docs/ARRAY_DESCRIPTOR_ABI.md` stays the single
+    !! representation for array *objects*, and a plan never becomes a second
+    !! descriptor. Extents are held in Fortran column-major dimension order,
+    !! so dimension 1 varies fastest over the linear element index.
+    implicit none
+    private
+
+    integer, parameter, public :: ARRAY_EXPR_MAX_RANK = 7
+
+    type, public :: array_expr_plan_t
+        !! Rank, shape, element type, and element-producer metadata of one
+        !! array-valued expression.
+        integer :: rank = 0
+        !! Number of dimensions, 1 to ARRAY_EXPR_MAX_RANK.
+        integer :: extents(ARRAY_EXPR_MAX_RANK) = 0
+        !! Extent per dimension, dimension 1 first. Entries beyond `rank` are
+        !! not part of the value.
+        integer :: element_kind = 0
+        !! Element type of every value the producer yields, as a lowering
+        !! VALUE_* code.
+        integer :: target_symbol = 0
+        !! Symbol the producer resolves operand kinds and broadcasts against.
+        integer :: expr_index = 0
+        !! Arena index of the expression the producer walks.
+    contains
+        procedure :: element_count => array_expr_plan_element_count
+    end type array_expr_plan_t
+
+    public :: array_expr_plans_conform
+
+contains
+
+    pure integer function array_expr_plan_element_count(self) result(n)
+        !! Number of elements the plan iterates: the product of its extents.
+        !! A rank-0 or negative-extent plan yields zero elements.
+        class(array_expr_plan_t), intent(in) :: self
+        integer :: d
+
+        n = 0
+        if (self%rank < 1 .or. self%rank > ARRAY_EXPR_MAX_RANK) return
+        n = 1
+        do d = 1, self%rank
+            if (self%extents(d) < 0) then
+                n = 0
+                return
+            end if
+            n = n*self%extents(d)
+        end do
+    end function array_expr_plan_element_count
+
+    pure logical function array_expr_plans_conform(left, right) result(conform)
+        !! Two plans conform when they have equal rank and equal extents in
+        !! every dimension. Conformance is a property of the shape alone; the
+        !! element kinds may differ and are reconciled by assignment.
+        type(array_expr_plan_t), intent(in) :: left
+        type(array_expr_plan_t), intent(in) :: right
+        integer :: d
+
+        conform = .false.
+        if (left%rank /= right%rank) return
+        if (left%rank < 1 .or. left%rank > ARRAY_EXPR_MAX_RANK) return
+        do d = 1, left%rank
+            if (left%extents(d) /= right%extents(d)) return
+        end do
+        conform = .true.
+    end function array_expr_plans_conform
+
+end module session_array_expr_types

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -212,6 +212,9 @@ module session_program_lowering
         emit_random_seed_default
     use session_lowering_ops, only: integer_compare_predicate, &
         integer_opcode, parse_i32_literal
+    use session_array_expr_types, only: array_expr_plan_t, &
+                                        array_expr_plans_conform, &
+                                        ARRAY_EXPR_MAX_RANK
     use ffc_strings, only: set_empty
     use ast_arena_source_text, only: get_source_text
     use fortfront_compiler, only: query_io_statement, io_statement_query_t, &

--- a/src/session_program_lowering_allocatable.inc
+++ b/src/session_program_lowering_allocatable.inc
@@ -1130,8 +1130,7 @@
         integer, intent(in) :: symbol_index
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: value
-        integer :: i
+        type(array_expr_plan_t) :: plan
         integer :: array_size
         integer :: rhs_extent
 
@@ -1160,16 +1159,10 @@
                         'requires a previously allocated constant extent'
             return
         end if
-        do i = 1, array_size
-            call lower_array_elementwise_value(arena, node%value_index, &
-                                               symbol_index, i - 1, context, &
-                                               value, error_msg)
-            if (len_trim(error_msg) > 0) return
-            call store_array_linear_element(context, symbol_index, &
-                                            int(i - 1, c_int64_t), value, error_msg)
-            if (len_trim(error_msg) > 0) return
-        end do
-        call set_empty(error_msg)
+        call build_array_expression(context, symbol_index, node%value_index, &
+                                    plan, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call emit_array_expression_assignment(arena, plan, context, error_msg)
     end subroutine lower_allocatable_elementwise_assignment
 
     subroutine reallocate_allocatable_extent(symbol_index, n, context, error_msg)

--- a/src/session_program_lowering_array_elements.inc
+++ b/src/session_program_lowering_array_elements.inc
@@ -778,6 +778,94 @@
         call set_empty(error_msg)
     end subroutine emit_allocatable_print_items
 
+    subroutine build_array_expression(context, target_symbol_index, expr_index, &
+                                      plan, error_msg)
+        !! Derive the rank, shape, and element type of one array-valued
+        !! expression once, before any element is emitted. The shape and the
+        !! element type of a whole-array assignment are those of its target:
+        !! array-array operands must conform to it and a scalar operand
+        !! broadcasts, both of which are checked as operands are reached by
+        !! `ensure_array_shapes_match`.
+        type(lowering_context_t), intent(in) :: context
+        integer, intent(in) :: target_symbol_index
+        integer, intent(in) :: expr_index
+        type(array_expr_plan_t), intent(out) :: plan
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer :: d
+
+        plan%target_symbol = target_symbol_index
+        plan%expr_index = expr_index
+        plan%element_kind = context%symbols(target_symbol_index)%value_kind
+        plan%rank = context%symbols(target_symbol_index)%array_rank
+        if (plan%rank < 1 .or. plan%rank > ARRAY_EXPR_MAX_RANK) then
+            error_msg = 'array expression requires a rank between 1 and 7'
+            return
+        end if
+        if (context%symbols(target_symbol_index)%is_allocatable) then
+            ! An allocatable carries a single flattened extent, so its plan is
+            ! the rank-1 view of that extent.
+            plan%rank = 1
+            plan%extents(1) = &
+                context%symbols(target_symbol_index)%allocatable_static_size
+        else
+            do d = 1, plan%rank
+                plan%extents(d) = &
+                    context%symbols(target_symbol_index)%array_dim_sizes(d)
+            end do
+        end if
+        call validate_conformability(plan, error_msg)
+    end subroutine build_array_expression
+
+    subroutine validate_conformability(plan, error_msg)
+        !! Reject a plan that cannot be iterated. An expression whose shape is
+        !! not known to be positive fails here rather than emitting an
+        !! iteration over an unknown extent.
+        type(array_expr_plan_t), intent(in) :: plan
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        if (plan%element_count() <= 0) then
+            error_msg = 'array expression requires a positive element count'
+            return
+        end if
+        call set_empty(error_msg)
+    end subroutine validate_conformability
+
+    subroutine emit_array_expression_assignment(arena, plan, context, error_msg)
+        !! Iterate the plan's elements, produce every right-hand-side element
+        !! value, and only then store them into the target.
+        !!
+        !! Producing all values before the first store is what makes the
+        !! assignment behave as if the right-hand side were fully computed
+        !! first (Fortran 2018 clause 10.2.1.3), so a right-hand side that
+        !! overlaps the target -- `a = a(n:1:-1)` -- reads pre-assignment
+        !! values regardless of traversal order.
+        !!
+        !! The linear index runs over the plan's extents in column-major
+        !! order, so dimension 1 varies fastest.
+        type(ast_arena_t), intent(in) :: arena
+        type(array_expr_plan_t), intent(in) :: plan
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t), allocatable :: values(:)
+        integer :: i, n
+
+        n = plan%element_count()
+        allocate (values(n))
+        do i = 1, n
+            call lower_array_elementwise_value(arena, plan%expr_index, &
+                                               plan%target_symbol, i - 1, &
+                                               context, values(i), error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+        do i = 1, n
+            call store_array_linear_element(context, plan%target_symbol, &
+                                            int(i - 1, c_int64_t), values(i), &
+                                            error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
+        call set_empty(error_msg)
+    end subroutine emit_array_expression_assignment
+
     recursive subroutine lower_array_elementwise_value(arena, node_index, &
                                                        target_symbol_index, &
                                                        linear_index, context, &

--- a/src/session_program_lowering_arrays.inc
+++ b/src/session_program_lowering_arrays.inc
@@ -2822,6 +2822,7 @@
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t) :: value, wide_value, narrow_value
+        type(array_expr_plan_t) :: plan
         integer :: i
         integer :: array_size
         logical :: reduction_handled
@@ -3033,16 +3034,10 @@
             return
         end if
 
-        do i = 1, array_size
-            call lower_array_elementwise_value(arena, node%value_index, &
-                                               symbol_index, i - 1, context, &
-                                               value, error_msg)
-            if (len_trim(error_msg) > 0) return
-            call store_array_linear_element(context, symbol_index, &
-                                            int(i - 1, c_int64_t), value, error_msg)
-            if (len_trim(error_msg) > 0) return
-        end do
-        call set_empty(error_msg)
+        call build_array_expression(context, symbol_index, node%value_index, &
+                                    plan, error_msg)
+        if (len_trim(error_msg) > 0) return
+        call emit_array_expression_assignment(arena, plan, context, error_msg)
     end subroutine lower_array_whole_assignment
 
     recursive logical function is_scalar_broadcast_rhs(arena, node_index, &

--- a/test/test_session_array_alias_assignment_compiler.f90
+++ b/test/test_session_array_alias_assignment_compiler.f90
@@ -10,6 +10,7 @@ program test_session_array_alias_assignment_compiler
     if (.not. test_forward_overlap()) stop 1
     if (.not. test_backward_overlap()) stop 1
     if (.not. test_strided_overlap()) stop 1
+    if (.not. test_whole_array_reverse_self()) stop 1
     print *, 'PASS: overlapping array section assignment is alias-safe'
 
 contains
@@ -67,5 +68,23 @@ contains
             '           3'//new_line('a'), &
             '/tmp/ffc_session_array_alias_strided_test')
     end function test_strided_overlap
+
+    logical function test_whole_array_reverse_self()
+        !! a = a(n:1:-1): a whole-array assignment whose right-hand side is a
+        !! reversed section of the target itself. Every element value must come
+        !! from the pre-assignment array.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(4)'//new_line('a')// &
+            '  a = [1, 2, 3, 4]'//new_line('a')// &
+            '  a = a(4:1:-1)'//new_line('a')// &
+            '  print *, a(1), a(2), a(3), a(4)'//new_line('a')// &
+            'end program main'
+
+        test_whole_array_reverse_self = expect_output( &
+            source, &
+            '           4           3           2           1'//new_line('a'), &
+            '/tmp/ffc_session_array_alias_whole_reverse_test')
+    end function test_whole_array_reverse_self
 
 end program test_session_array_alias_assignment_compiler


### PR DESCRIPTION
Closes #342.

## Change

NEW `src/session_array_expr_types.f90` holds `array_expr_plan_t`: the rank,
shape, element type, and element-producer metadata of one array-valued
expression, derived **once** before any element is emitted. `build_array_expression`
constructs it, `validate_conformability` rejects a plan that cannot be
iterated, and `emit_array_expression_assignment` drives the single
element-at-index producer `lower_array_elementwise_value` from the plan.

The plan describes an *expression*, never storage. The canonical
`array_descriptor_t` of `docs/ARRAY_DESCRIPTOR_ABI.md` remains the only
representation for array objects; no second descriptor is introduced and no
expression temporary carries its own layout metadata.

### Deleted

Both duplicated iterate-and-store loops that each array-expression driver
carried privately:

- the tail of `lower_array_whole_assignment` in
  `src/session_program_lowering_arrays.inc`
- the tail of `lower_allocatable_elementwise_assignment` in
  `src/session_program_lowering_allocatable.inc`

together with their private `value`/`i`/extent bookkeeping. Both now build a
plan and call the shared emitter; there is one array-expression assignment loop
in the compiler instead of two. No compatibility adapter and no fallback path
was added: `build_array_expression` fails loudly on a rank outside 1..7 or a
non-positive element count rather than selecting an alternate lowering.

## Bug fixed

Centralizing the loop made it alias-safe, which the per-driver copies were not.
On unmodified main:

```fortran
integer :: a(4)
a = [1, 2, 3, 4]
a = a(4:1:-1)
```

printed `4 3 3 4` instead of gfortran's `4 3 2 1`, because the driver
interleaved one element load with one element store. This is the same silent
wrong-answer class as #344 on a different path. The shared emitter produces
every right-hand-side element value before the first store, so the assignment
behaves as if the right-hand side were fully computed first.

## Invariants

- **Column-major layout**: the plan holds extents in dimension order and the
  linear index runs dimension 1 fastest, matching the descriptor ABI's stride
  rule. Element addressing is unchanged.
- **Lower bound and extent semantics**: extents come from the target symbol's
  declared dimension sizes (or an allocatable's flattened extent); bounds are
  carried, not normalized, exactly as before.
- **Overlap and aliasing**: the right-hand side is evaluated as if fully
  computed before any assignment, so an overlapping right-hand side reads
  pre-assignment values regardless of traversal direction.
- **Allocation and finalization lifetimes**: unchanged. The plan owns nothing,
  allocates no storage, and the allocatable path still reallocates to the
  right-hand side's shape (F2018 10.2.1.3) before the plan is built.
- **Elemental semantics**: array-array operands must conform and a scalar
  operand broadcasts; one right-hand-side value per target element, same order.
- **Reduction identity and ordering**: untouched by this issue (#343 owns it).

## Behavioral oracle

`test/test_session_array_alias_assignment_compiler.f90` gains
`test_whole_array_reverse_self` (`a = a(4:1:-1)`), expected values taken from
gfortran. It fails on unmodified main (`4 3 3 4`) and passes here.
Nonconformable operands still produce a shape diagnostic rather than memory
corruption, via `ensure_array_shapes_match`.

## Local gates

Merges use `--admin`, so these were run locally rather than relying on CI.

- `fo test test_session_whole_array_arithmetic_compiler`: PASS
- `fo test test_session_whole_array_compare_compiler`: PASS
- `fo test test_session_whole_array_div_pow_compiler`: PASS
- `fo test test_session_whole_array_not_compiler`: PASS
- `fo test test_session_allocatable_reduction_compiler`: PASS
- `fo test test_session_where_compiler`: PASS
- `fo test test_session_array_alias_assignment_compiler`: PASS (4 cases)
- `fo`: build OK, 328/330 tests pass. `test_fortfront_corpus_conformance` and
  `test_parity_dashboard` fail **pre-existing on unmodified main** (identical
  `fortfront-lf` XPASS entries and the same stale snapshot manifest digest).
- `fo lint`: no findings on any changed file.

## Corpus delta

`fortfront-f90` improves: **PASS 451 -> 452, FAIL 9 -> 8**
(XFAIL=93, XPASS=0, NOREF=173, TOTAL=553 unchanged).
`issue_1324_if_inside_do_loop.f90`, previously an output mismatch against
gfortran, now matches. No XFAIL manifest entry was added, removed, or weakened,
and nothing was promoted out of a manifest, so no #642 measurement applies.
The checked-in parity snapshot is left alone: it is already stale on main for
an unrelated digest reason and regenerating it here would mix two changes.