### PR TITLE
[arrayexpr-03] lower reductions through descriptor iteration (closes #343)

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -376,6 +376,8 @@ module session_program_lowering
     integer, parameter :: DIM_REDUCE_ANY = 4
     integer, parameter :: DIM_REDUCE_ALL = 5
     integer, parameter :: DIM_REDUCE_NORM2 = 6
+    integer, parameter :: DIM_REDUCE_MIN = 7
+    integer, parameter :: DIM_REDUCE_MAX = 8
 
     ! Pull-based cursor over a DATA value list. A scalar value yields once; an
     ! implied-do value (e.g. (i*1.0, i=1,2)) unrolls its inner expression,

--- a/src/session_program_lowering_array_elements.inc
+++ b/src/session_program_lowering_array_elements.inc
@@ -2434,7 +2434,8 @@
                 if (len_trim(error_msg) > 0) return
                 cycle
             end if
-            call dim_reduction_identity(context, reduce_op, source_vk, acc)
+            call reduction_identity(context, reduce_op, source_vk, acc, error_msg)
+            if (len_trim(error_msg) > 0) return
             do j = 0, reduce_extent - 1
                 if (dim_value == 1_c_int64_t) then
                     lin = int(j, c_int64_t) + int(i, c_int64_t) * int(d1, c_int64_t)
@@ -2446,16 +2447,16 @@
                     call load_array_linear_element(context, src_sym, lin, elem, &
                                                    error_msg)
                     if (len_trim(error_msg) > 0) return
-                    call dim_reduction_accumulate_numeric(context, reduce_op, &
-                        source_vk, acc, elem, error_msg)
+                    call reduction_combine(context, reduce_op, source_vk, acc, &
+                                           elem, error_msg)
                     if (len_trim(error_msg) > 0) return
                 else
                     call dim_reduction_mask_element(arena, context, is_comparison, &
                         cmp_lsym, cmp_lscalar, cmp_rsym, cmp_rscalar, src_sym, &
                         compare_vk, predicate, lin, cond, error_msg)
                     if (len_trim(error_msg) > 0) return
-                    call dim_reduction_accumulate_mask(context, reduce_op, acc, &
-                        cond, error_msg)
+                    call reduction_combine(context, reduce_op, source_vk, acc, &
+                                           cond, error_msg)
                     if (len_trim(error_msg) > 0) return
                 end if
             end do
@@ -2610,70 +2611,6 @@
 
     ! Seed a reduction accumulator: 0/1 for sum/product, 0 count, 0 (false) any,
     ! 1 (true) all. Mask accumulators always start in i32.
-    subroutine dim_reduction_identity(context, reduce_op, source_vk, acc)
-        type(lowering_context_t), intent(inout) :: context
-        integer, intent(in) :: reduce_op, source_vk
-        type(lr_operand_desc_t), intent(out) :: acc
-
-        select case (reduce_op)
-        case (DIM_REDUCE_SUM)
-            select case (source_vk)
-            case (VALUE_F32); acc = liric_f32_immediate(context%session, 0.0_c_float)
-            case (VALUE_F64); acc = liric_f64_immediate(context%session, 0.0_c_double)
-            case default; acc = i32_immediate(context%session, 0_c_int64_t)
-            end select
-        case (DIM_REDUCE_PROD)
-            select case (source_vk)
-            case (VALUE_F32); acc = liric_f32_immediate(context%session, 1.0_c_float)
-            case (VALUE_F64); acc = liric_f64_immediate(context%session, 1.0_c_double)
-            case default; acc = i32_immediate(context%session, 1_c_int64_t)
-            end select
-        case (DIM_REDUCE_ALL)
-            acc = i32_immediate(context%session, 1_c_int64_t)
-        case default
-            acc = i32_immediate(context%session, 0_c_int64_t)
-        end select
-    end subroutine dim_reduction_identity
-
-    subroutine dim_reduction_accumulate_numeric(context, reduce_op, source_vk, &
-                                                acc, elem, error_msg)
-        type(lowering_context_t), intent(inout) :: context
-        integer, intent(in) :: reduce_op, source_vk
-        type(lr_operand_desc_t), intent(inout) :: acc
-        type(lr_operand_desc_t), intent(in) :: elem
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: next
-
-        call set_empty(error_msg)
-        select case (source_vk)
-        case (VALUE_F32)
-            if (reduce_op == DIM_REDUCE_SUM) then
-                if (.not. emit_liric_f32_binary(context%session, LR_OP_FADD, acc, &
-                                                elem, next, error_msg)) return
-            else
-                if (.not. emit_liric_f32_binary(context%session, LR_OP_FMUL, acc, &
-                                                elem, next, error_msg)) return
-            end if
-        case (VALUE_F64)
-            if (reduce_op == DIM_REDUCE_SUM) then
-                if (.not. emit_liric_f64_binary(context%session, LR_OP_FADD, acc, &
-                                                elem, next, error_msg)) return
-            else
-                if (.not. emit_liric_f64_binary(context%session, LR_OP_FMUL, acc, &
-                                                elem, next, error_msg)) return
-            end if
-        case default
-            if (reduce_op == DIM_REDUCE_SUM) then
-                if (.not. emit_i32_binary(context%session, LR_OP_ADD, acc, elem, &
-                                          next, error_msg)) return
-            else
-                if (.not. emit_i32_binary(context%session, LR_OP_MUL, acc, elem, &
-                                          next, error_msg)) return
-            end if
-        end select
-        acc = next
-    end subroutine dim_reduction_accumulate_numeric
-
     ! Produce the i32 0/1 mask element at linear index lin: a compare for the
     ! relational-source form (each side either a rank-2 array at lin or a
     ! broadcast scalar), or a direct logical load otherwise.
@@ -2715,26 +2652,3 @@
         end select
     end subroutine dim_reduction_mask_element
 
-    subroutine dim_reduction_accumulate_mask(context, reduce_op, acc, cond, &
-                                             error_msg)
-        type(lowering_context_t), intent(inout) :: context
-        integer, intent(in) :: reduce_op
-        type(lr_operand_desc_t), intent(inout) :: acc
-        type(lr_operand_desc_t), intent(in) :: cond
-        character(len=:), allocatable, intent(out) :: error_msg
-        type(lr_operand_desc_t) :: next
-
-        call set_empty(error_msg)
-        select case (reduce_op)
-        case (DIM_REDUCE_ANY)
-            if (.not. emit_i32_binary(context%session, LR_OP_OR, acc, cond, next, &
-                                      error_msg)) return
-        case (DIM_REDUCE_ALL)
-            if (.not. emit_i32_binary(context%session, LR_OP_AND, acc, cond, next, &
-                                      error_msg)) return
-        case default
-            if (.not. emit_i32_binary(context%session, LR_OP_ADD, acc, cond, next, &
-                                      error_msg)) return
-        end select
-        acc = next
-    end subroutine dim_reduction_accumulate_mask

--- a/src/session_program_lowering_intrinsics.inc
+++ b/src/session_program_lowering_intrinsics.inc
@@ -1307,6 +1307,163 @@
                                         error_msg)) return
     end subroutine lower_f64_intrinsic_arg
 
+    integer function reduction_operation(name) result(op)
+        !! Map an intrinsic reduction name onto its DIM_REDUCE_* operation.
+        !! Returns 0 for a name that is not a reduction.
+        character(len=*), intent(in) :: name
+
+        select case (trim(adjustl(lowercase_text(name))))
+        case ('sum'); op = DIM_REDUCE_SUM
+        case ('product'); op = DIM_REDUCE_PROD
+        case ('count'); op = DIM_REDUCE_COUNT
+        case ('any'); op = DIM_REDUCE_ANY
+        case ('all'); op = DIM_REDUCE_ALL
+        case ('norm2'); op = DIM_REDUCE_NORM2
+        case ('minval'); op = DIM_REDUCE_MIN
+        case ('maxval'); op = DIM_REDUCE_MAX
+        case default; op = 0
+        end select
+    end function reduction_operation
+
+    logical function reduction_is_mask_valued(op) result(is_mask)
+        !! COUNT, ANY, and ALL consume a logical element and accumulate an i32
+        !! 0/1 value; the other reductions consume an element of the source's
+        !! own type.
+        integer, intent(in) :: op
+
+        is_mask = (op == DIM_REDUCE_COUNT .or. op == DIM_REDUCE_ANY .or. &
+                   op == DIM_REDUCE_ALL)
+    end function reduction_is_mask_valued
+
+    subroutine reduction_identity(context, op, vk, acc, error_msg)
+        !! The identity element of one reduction over element kind vk. Folding
+        !! starts here, so this is also the value of the reduction over an
+        !! empty array, which is what the intrinsic definitions require:
+        !! SUM 0, PRODUCT 1, COUNT 0, ANY false, ALL true, MINVAL HUGE, and
+        !! MAXVAL -HUGE for the kind involved.
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: op
+        integer, intent(in) :: vk
+        type(lr_operand_desc_t), intent(out) :: acc
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call set_empty(error_msg)
+        if (reduction_is_mask_valued(op)) then
+            if (op == DIM_REDUCE_ALL) then
+                acc = i32_immediate(context%session, 1_c_int64_t)
+            else
+                acc = i32_immediate(context%session, 0_c_int64_t)
+            end if
+            return
+        end if
+        select case (op)
+        case (DIM_REDUCE_SUM)
+            select case (vk)
+            case (VALUE_F32); acc = liric_f32_immediate(context%session, 0.0_c_float)
+            case (VALUE_F64); acc = liric_f64_immediate(context%session, 0.0_c_double)
+            case default; acc = i32_immediate(context%session, 0_c_int64_t)
+            end select
+        case (DIM_REDUCE_PROD)
+            select case (vk)
+            case (VALUE_F32); acc = liric_f32_immediate(context%session, 1.0_c_float)
+            case (VALUE_F64); acc = liric_f64_immediate(context%session, 1.0_c_double)
+            case default; acc = i32_immediate(context%session, 1_c_int64_t)
+            end select
+        case (DIM_REDUCE_MIN)
+            select case (vk)
+            case (VALUE_F32)
+                acc = liric_f32_immediate(context%session, huge(0.0_c_float))
+            case (VALUE_F64)
+                acc = liric_f64_immediate(context%session, huge(0.0_c_double))
+            case default
+                acc = i32_immediate(context%session, 2147483647_c_int64_t)
+            end select
+        case (DIM_REDUCE_MAX)
+            select case (vk)
+            case (VALUE_F32)
+                acc = liric_f32_immediate(context%session, -huge(0.0_c_float))
+            case (VALUE_F64)
+                acc = liric_f64_immediate(context%session, -huge(0.0_c_double))
+            case default
+                acc = i32_immediate(context%session, -2147483648_c_int64_t)
+            end select
+        case default
+            error_msg = 'reduction has no identity element for this operation'
+        end select
+    end subroutine reduction_identity
+
+    subroutine reduction_combine(context, op, vk, acc, elem, error_msg)
+        !! Fold one element into the accumulator. Every reduction here is
+        !! associative and commutative over its identity, so the standard
+        !! leaves the traversal order unspecified and the fold runs in
+        !! ascending linear-index order. Integer SUM and PRODUCT wrap exactly
+        !! as the source operations do; real SUM and PRODUCT accumulate in
+        !! that same order, which fixes the rounding sequence.
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: op
+        integer, intent(in) :: vk
+        type(lr_operand_desc_t), intent(inout) :: acc
+        type(lr_operand_desc_t), intent(in) :: elem
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: next, cond
+
+        call set_empty(error_msg)
+        if (reduction_is_mask_valued(op)) then
+            select case (op)
+            case (DIM_REDUCE_ANY)
+                if (.not. emit_i32_binary(context%session, LR_OP_OR, acc, elem, &
+                                          next, error_msg)) return
+            case (DIM_REDUCE_ALL)
+                if (.not. emit_i32_binary(context%session, LR_OP_AND, acc, elem, &
+                                          next, error_msg)) return
+            case default
+                if (.not. emit_i32_binary(context%session, LR_OP_ADD, acc, elem, &
+                                          next, error_msg)) return
+            end select
+            acc = next
+            return
+        end if
+
+        select case (op)
+        case (DIM_REDUCE_SUM, DIM_REDUCE_PROD)
+            select case (vk)
+            case (VALUE_F32)
+                if (.not. emit_liric_f32_binary(context%session, &
+                        merge(LR_OP_FADD, LR_OP_FMUL, op == DIM_REDUCE_SUM), &
+                        acc, elem, next, error_msg)) return
+            case (VALUE_F64)
+                if (.not. emit_liric_f64_binary(context%session, &
+                        merge(LR_OP_FADD, LR_OP_FMUL, op == DIM_REDUCE_SUM), &
+                        acc, elem, next, error_msg)) return
+            case default
+                if (.not. emit_i32_binary(context%session, &
+                        merge(LR_OP_ADD, LR_OP_MUL, op == DIM_REDUCE_SUM), &
+                        acc, elem, next, error_msg)) return
+            end select
+        case (DIM_REDUCE_MIN, DIM_REDUCE_MAX)
+            select case (vk)
+            case (VALUE_F32)
+                if (.not. emit_liric_f32_call(context%session, &
+                        merge('fminf', 'fmaxf', op == DIM_REDUCE_MIN), &
+                        [acc, elem], next, error_msg)) return
+            case (VALUE_F64)
+                if (.not. emit_liric_f64_call(context%session, &
+                        merge('fmin', 'fmax', op == DIM_REDUCE_MIN), &
+                        [acc, elem], next, error_msg)) return
+            case default
+                if (.not. emit_liric_i32_icmp(context%session, &
+                        merge(LR_CMP_SLT, LR_CMP_SGT, op == DIM_REDUCE_MIN), &
+                        elem, acc, cond, error_msg)) return
+                call select_value(context, cond, elem, acc, next, error_msg)
+                if (len_trim(error_msg) > 0) return
+            end select
+        case default
+            error_msg = 'reduction operation has no element combine rule'
+            return
+        end select
+        acc = next
+    end subroutine reduction_combine
+
     subroutine select_value(context, condition, true_value, false_value, value, &
                             error_msg)
         type(lowering_context_t), intent(inout) :: context

--- a/src/session_program_lowering_reduction_expr.inc
+++ b/src/session_program_lowering_reduction_expr.inc
@@ -205,8 +205,11 @@
     subroutine lower_general_expr_reduction(arena, arg_index, extent, vk, &
                                             context, value, error_msg, &
                                             reduction_name)
-        ! sum() (only) over a binary-op array expression argument, unrolled
-        ! over the compile-time extent determined by reduction_arg_extent.
+        !! Fold one reduction over an array-expression argument by iterating
+        !! the expression's elements, starting from the reduction's identity
+        !! and combining one element at a time. SUM, PRODUCT, MINVAL, MAXVAL,
+        !! COUNT, ANY, and ALL all share this loop; the operation appears only
+        !! in `reduction_identity` and `reduction_combine`.
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: arg_index
         integer, intent(in) :: extent
@@ -215,47 +218,36 @@
         type(lr_operand_desc_t), intent(out) :: value
         character(len=:), allocatable, intent(out) :: error_msg
         character(len=*), intent(in) :: reduction_name
-        type(lr_operand_desc_t) :: candidate, next_value
-        integer :: i
+        type(lr_operand_desc_t) :: candidate, cond, one, zero
+        integer :: i, op
 
-        if (trim(reduction_name) /= 'sum') then
+        op = reduction_operation(reduction_name)
+        if (op == 0 .or. op == DIM_REDUCE_NORM2) then
             error_msg = trim(reduction_name)//' of a general array expression '// &
                         'is not supported'
             return
         end if
-
-        select case (vk)
-        case (VALUE_F32)
-            value = liric_f32_immediate(context%session, 0.0_c_float)
-            do i = 0, extent - 1
+        call reduction_identity(context, op, vk, value, error_msg)
+        if (len_trim(error_msg) > 0) return
+        do i = 0, extent - 1
+            if (reduction_is_mask_valued(op)) then
+                ! A mask-valued reduction consumes the logical value of the
+                ! argument at this element, materialized as an i32 0 or 1.
+                call lower_where_mask_element(arena, arg_index, i, context, &
+                                              cond, error_msg)
+                if (len_trim(error_msg) > 0) return
+                one = i32_immediate(context%session, 1_c_int64_t)
+                zero = i32_immediate(context%session, 0_c_int64_t)
+                call select_value(context, cond, one, zero, candidate, error_msg)
+                if (len_trim(error_msg) > 0) return
+            else
                 call lower_reduction_arg_element(arena, arg_index, &
                         int(i, c_int64_t), vk, context, candidate, error_msg)
                 if (len_trim(error_msg) > 0) return
-                if (.not. emit_liric_f32_binary(context%session, LR_OP_FADD, &
-                        value, candidate, next_value, error_msg)) return
-                value = next_value
-            end do
-        case (VALUE_F64)
-            value = liric_f64_immediate(context%session, 0.0_c_double)
-            do i = 0, extent - 1
-                call lower_reduction_arg_element(arena, arg_index, &
-                        int(i, c_int64_t), vk, context, candidate, error_msg)
-                if (len_trim(error_msg) > 0) return
-                if (.not. emit_liric_f64_binary(context%session, LR_OP_FADD, &
-                        value, candidate, next_value, error_msg)) return
-                value = next_value
-            end do
-        case default
-            value = i32_immediate(context%session, 0_c_int64_t)
-            do i = 0, extent - 1
-                call lower_reduction_arg_element(arena, arg_index, &
-                        int(i, c_int64_t), vk, context, candidate, error_msg)
-                if (len_trim(error_msg) > 0) return
-                if (.not. emit_i32_binary(context%session, LR_OP_ADD, value, &
-                        candidate, next_value, error_msg)) return
-                value = next_value
-            end do
-        end select
+            end if
+            call reduction_combine(context, op, vk, value, candidate, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
         call set_empty(error_msg)
     end subroutine lower_general_expr_reduction
 

--- a/test/test_session_array_expr_reduction_compiler.f90
+++ b/test/test_session_array_expr_reduction_compiler.f90
@@ -1,0 +1,73 @@
+program test_session_array_expr_reduction_compiler
+    !! Reductions over an array-valued *expression* argument, folded through
+    !! the shared identity/combine pair. Expected values are the gfortran
+    !! output for the same programs.
+    use ffc_test_support, only: expect_output
+    implicit none
+
+    print *, '=== direct session array-expression reduction compiler test ==='
+    if (.not. test_integer_expression_reductions()) stop 1
+    if (.not. test_real_expression_reductions()) stop 1
+    if (.not. test_mask_expression_reductions()) stop 1
+    print *, 'PASS: reductions fold array expressions through one iterator'
+
+contains
+
+    logical function test_integer_expression_reductions()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(4), b(4)'//new_line('a')// &
+            '  a = [1, 2, 3, 4]'//new_line('a')// &
+            '  b = [4, 3, 2, 1]'//new_line('a')// &
+            '  print *, sum(a*b), product(a+b), maxval(a*b), minval(a+b)'// &
+            new_line('a')// &
+            'end program main'
+
+        test_integer_expression_reductions = expect_output( &
+            source, &
+            '          20         625           6           5'//new_line('a'), &
+            '/tmp/ffc_session_array_expr_reduction_int_test')
+    end function test_integer_expression_reductions
+
+    logical function test_real_expression_reductions()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  real :: x(4), y(4)'//new_line('a')// &
+            '  x = [1.0, 2.0, 3.0, 4.0]'//new_line('a')// &
+            '  y = [4.0, 3.0, 2.0, 1.0]'//new_line('a')// &
+            '  print *, sum(x*y)'//new_line('a')// &
+            '  print *, product(x+y)'//new_line('a')// &
+            '  print *, maxval(x*y)'//new_line('a')// &
+            '  print *, minval(x+y)'//new_line('a')// &
+            'end program main'
+
+        test_real_expression_reductions = expect_output( &
+            source, &
+            '   20.0000000    '//new_line('a')// &
+            '   625.000000    '//new_line('a')// &
+            '   6.00000000    '//new_line('a')// &
+            '   5.00000000    '//new_line('a'), &
+            '/tmp/ffc_session_array_expr_reduction_real_test')
+    end function test_real_expression_reductions
+
+    logical function test_mask_expression_reductions()
+        !! COUNT, ANY, and ALL over a relational array expression.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(4), b(4)'//new_line('a')// &
+            '  a = [1, 2, 3, 4]'//new_line('a')// &
+            '  b = [4, 3, 2, 1]'//new_line('a')// &
+            '  print *, count(a > b)'//new_line('a')// &
+            '  if (any(a > b)) print *, ''any yes'''//new_line('a')// &
+            '  if (.not. all(a > b)) print *, ''all no'''//new_line('a')// &
+            'end program main'
+
+        test_mask_expression_reductions = expect_output( &
+            source, &
+            '           2'//new_line('a')// &
+            ' any yes'//new_line('a')// &
+            ' all no'//new_line('a'), &
+            '/tmp/ffc_session_array_expr_reduction_mask_test')
+    end function test_mask_expression_reductions
+
+end program test_session_array_expr_reduction_compiler


### PR DESCRIPTION
Closes #343.

## Change

Reductions now fold over one shared iteration, with the operation appearing
only in an identity and a combine step, exactly as the issue's scaffold
describes.

NEW in `src/session_program_lowering_intrinsics.inc`:

- `reduction_operation(name)` maps an intrinsic name onto its `DIM_REDUCE_*`
  code, with `DIM_REDUCE_MIN` and `DIM_REDUCE_MAX` added for MINVAL/MAXVAL.
- `reduction_identity(context, op, vk, acc, error_msg)`
- `reduction_combine(context, op, vk, acc, elem, error_msg)`

`lower_general_expr_reduction` in `src/session_program_lowering_reduction_expr.inc`
is now one loop over the argument expression's elements for every reduction.

### Deleted

The per-intrinsic and per-path duplicates in
`src/session_program_lowering_array_elements.inc`:

- `dim_reduction_identity`
- `dim_reduction_accumulate_numeric`
- `dim_reduction_accumulate_mask`

and, in `lower_general_expr_reduction`, the three hand-written kind-specific
accumulation loops (i32 / f32 / f64) that only ever implemented SUM. The DIM
reduction path now calls the same `reduction_identity` / `reduction_combine`
pair as the scalar path; there is one identity table and one combine table in
the compiler instead of two partial ones. No fallback was added:
`reduction_identity` and `reduction_combine` fail loudly on an operation they
do not define rather than defaulting to SUM.

## Behavior fixed

On unmodified main, any reduction other than SUM over an array *expression*
was rejected outright:

```
$ ffc red.f90
red.f90:1:1: error: product of a general array expression is not supported
```

PRODUCT, MINVAL, MAXVAL, COUNT, ANY, and ALL over an array expression now
lower and match gfortran.

## Invariants

- **Column-major layout**: the fold walks the linear element index produced by
  the shared array-expression iterator, dimension 1 fastest; the DIM path's
  own index arithmetic is untouched.
- **Lower bound and extent semantics**: unchanged; extents still come from
  `reduction_arg_extent` and the DIM path's `reduce_extent`.
- **Overlap and aliasing**: a reduction only reads, and its result is a scalar
  materialized before any store, so no aliasing hazard is introduced.
- **Allocation and finalization lifetimes**: unchanged; no temporary storage.
- **Elemental semantics**: one element value per iteration; a scalar operand
  inside the argument expression still broadcasts.
- **Reduction identity and ordering**: the identity is the intrinsic's
  empty-array value for the kind involved -- SUM 0, PRODUCT 1, COUNT 0, ANY
  false, ALL true, MINVAL HUGE, MAXVAL -HUGE. Integer MIN/MAX use a signed
  compare and a branch-selected value; real MIN/MAX use libm `fmin`/`fmax`
  (`fminf`/`fmaxf` for real32). Every operation is associative and commutative
  over its identity, so the standard leaves traversal order unspecified; this
  fold runs in ascending linear-index order, which fixes the rounding sequence
  for real SUM and PRODUCT and makes integer SUM and PRODUCT wrap exactly as
  the corresponding scalar operations do.

## Behavioral oracle

NEW `test/test_session_array_expr_reduction_compiler.f90`, expected values
taken from gfortran output for the same programs:

- integer `sum(a*b), product(a+b), maxval(a*b), minval(a+b)`
- real32 `sum(x*y)`, `product(x+y)`, `maxval(x*y)`, `minval(x+y)`
- mask-valued `count(a > b)`, `any(a > b)`, `.not. all(a > b)`

All of the non-SUM cases fail to compile on unmodified main.

## Local gates

Merges use `--admin`, so these were run locally rather than relying on CI.

- `fo test test_session_scalar_reduction_compiler`: PASS
- `fo test test_session_dim_reduction_compiler`: PASS
- `fo test test_session_allocatable_reduction_compiler`: PASS
- `fo test test_session_array_mask_reduction_compiler`: PASS
- `fo test test_session_array_expr_reduction_compiler`: PASS
- `fo`: static OK, build OK, 328/330 tests pass. `test_fortfront_corpus_conformance`
  and `test_parity_dashboard` fail **pre-existing on unmodified main** (same 9
  corpus FAILs, same `fortfront-lf` XPASS entries, same stale snapshot digest).
- `fo lint`: no findings on any changed file.

## Corpus delta

Zero. `fortfront-f90` is PASS=451 XFAIL=93 XPASS=0 FAIL=9 NOREF=173 TOTAL=553
before and after. No XFAIL manifest entry was added, removed, or weakened, and
nothing was promoted out of a manifest, so no #642 measurement applies.

Note: `issue_1324_if_inside_do_loop.f90` in that corpus calls `random_number`
and so mismatches its gfortran reference nondeterministically. It is the source
of the spurious "PASS 451 -> 452" reported on #670, which is corrected there.
Classifying it NOREF belongs to #430.