### PR TITLE
[arrayexpr-04] route WHERE and ELSEWHERE through array expressions (#345)

### DIFF
--- a/src/session_program_lowering_where.inc
+++ b/src/session_program_lowering_where.inc
@@ -161,31 +161,73 @@
 
     subroutine lower_where_masked_assignment(arena, assign_index, masks, &
                                              context, error_msg)
-        ! Lower one WHERE body assignment under the conjunction of masks. For
-        ! each element where every mask is true:
-        !   lhs(i) := rhs(i)   otherwise lhs(i) keeps its current value.
-        ! The kept branch reads the current element, so an earlier WHERE result
-        ! survives into a complementary ELSEWHERE pass over the same target.
+        ! WHERE body assignment: apply the right-hand side where every
+        ! enclosing mask is true and keep the current element elsewhere.
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: assign_index
         integer, intent(in) :: masks(:)
         type(lowering_context_t), intent(inout) :: context
         character(len=:), allocatable, intent(out) :: error_msg
-        integer :: target_symbol, value_index, i, array_size
-        type(lr_operand_desc_t) :: cond, rhs_val, cur_val, selected
+
+        call lower_where_selected_assignment(arena, assign_index, masks, &
+                                             .false., context, error_msg)
+    end subroutine lower_where_masked_assignment
+
+    subroutine lower_where_complement_assignment(arena, assign_index, &
+                                                 mask_index, context, error_msg)
+        ! ELSEWHERE body: the complement of the WHERE mask. The kept branch
+        ! preserves the WHERE-true result computed in the prior pass.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: assign_index
+        integer, intent(in) :: mask_index
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call lower_where_selected_assignment(arena, assign_index, &
+                                             [mask_index], .true., context, &
+                                             error_msg)
+    end subroutine lower_where_complement_assignment
+
+    subroutine lower_where_selected_assignment(arena, assign_index, masks, &
+                                               complement, context, error_msg)
+        ! The one masked array assignment WHERE and ELSEWHERE share:
+        !   lhs(i) := mask(i) ? rhs(i) : lhs(i)          (complement = .false.)
+        !   lhs(i) := mask(i) ? lhs(i) : rhs(i)          (complement = .true.)
+        !
+        ! Every mask value, right-hand-side element, and kept current element
+        ! is produced before the first store, so the assignment behaves as if
+        ! the mask and the right-hand side were fully evaluated before any
+        ! element of the target changed (Fortran 2018 clause 10.2.3.1). A mask
+        ! or a right-hand side that overlaps the target -- `where (m == 1)
+        ! a = a(n:1:-1)` -- therefore reads pre-assignment values regardless of
+        ! traversal order.
+        !
+        ! The iteration comes from the target's array-expression plan, so the
+        ! shape, the element type, and the column-major linear index are the
+        ! same ones every other array expression uses.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: assign_index
+        integer, intent(in) :: masks(:)
+        logical, intent(in) :: complement
+        type(lowering_context_t), intent(inout) :: context
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(array_expr_plan_t) :: plan
+        type(lr_operand_desc_t), allocatable :: selected(:)
+        type(lr_operand_desc_t) :: cond, rhs_val, cur_val
+        integer :: target_symbol, value_index, i, n
 
         call set_empty(error_msg)
         call where_assignment_target(arena, assign_index, context, &
                                      target_symbol, value_index, error_msg)
         if (len_trim(error_msg) > 0) return
 
-        array_size = context%symbols(target_symbol)%array_size
-        if (array_size <= 0) then
-            error_msg = 'WHERE assignment requires a positive array size'
-            return
-        end if
+        call build_array_expression(context, target_symbol, value_index, plan, &
+                                    error_msg)
+        if (len_trim(error_msg) > 0) return
+        n = plan%element_count()
+        allocate (selected(n))
 
-        do i = 0, array_size - 1
+        do i = 0, n - 1
             call lower_where_mask_conjunction(arena, masks, i, context, cond, &
                                               error_msg)
             if (len_trim(error_msg) > 0) return
@@ -196,57 +238,24 @@
             call load_array_linear_element(context, target_symbol, &
                                            int(i, c_int64_t), cur_val, error_msg)
             if (len_trim(error_msg) > 0) return
-            call select_value(context, cond, rhs_val, cur_val, selected, &
-                              error_msg)
-            if (len_trim(error_msg) > 0) return
-            call store_array_linear_element(context, target_symbol, &
-                                            int(i, c_int64_t), selected, error_msg)
+            if (complement) then
+                call select_value(context, cond, cur_val, rhs_val, &
+                                  selected(i + 1), error_msg)
+            else
+                call select_value(context, cond, rhs_val, cur_val, &
+                                  selected(i + 1), error_msg)
+            end if
             if (len_trim(error_msg) > 0) return
         end do
-    end subroutine lower_where_masked_assignment
 
-    subroutine lower_where_complement_assignment(arena, assign_index, &
-                                                 mask_index, context, error_msg)
-        ! ELSEWHERE body: lhs(i) := mask(i) ? lhs(i) : rhs(i). The kept branch
-        ! preserves the WHERE-true result computed in the prior pass.
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: assign_index
-        integer, intent(in) :: mask_index
-        type(lowering_context_t), intent(inout) :: context
-        character(len=:), allocatable, intent(out) :: error_msg
-        integer :: target_symbol, value_index, i, array_size
-        type(lr_operand_desc_t) :: cond, rhs_val, cur_val, selected
-
+        do i = 0, n - 1
+            call store_array_linear_element(context, target_symbol, &
+                                            int(i, c_int64_t), selected(i + 1), &
+                                            error_msg)
+            if (len_trim(error_msg) > 0) return
+        end do
         call set_empty(error_msg)
-        call where_assignment_target(arena, assign_index, context, &
-                                     target_symbol, value_index, error_msg)
-        if (len_trim(error_msg) > 0) return
-
-        array_size = context%symbols(target_symbol)%array_size
-        if (array_size <= 0) then
-            error_msg = 'WHERE assignment requires a positive array size'
-            return
-        end if
-
-        do i = 0, array_size - 1
-            call lower_where_mask_element(arena, mask_index, i, context, cond, &
-                                          error_msg)
-            if (len_trim(error_msg) > 0) return
-            call lower_array_elementwise_value(arena, value_index, &
-                                               target_symbol, i, context, &
-                                               rhs_val, error_msg)
-            if (len_trim(error_msg) > 0) return
-            call load_array_linear_element(context, target_symbol, &
-                                           int(i, c_int64_t), cur_val, error_msg)
-            if (len_trim(error_msg) > 0) return
-            call select_value(context, cond, cur_val, rhs_val, selected, &
-                              error_msg)
-            if (len_trim(error_msg) > 0) return
-            call store_array_linear_element(context, target_symbol, &
-                                            int(i, c_int64_t), selected, error_msg)
-            if (len_trim(error_msg) > 0) return
-        end do
-    end subroutine lower_where_complement_assignment
+    end subroutine lower_where_selected_assignment
 
     subroutine lower_where_mask_conjunction(arena, masks, linear_index, &
                                             context, cond, error_msg)

--- a/test/test_session_where_compiler.f90
+++ b/test/test_session_where_compiler.f90
@@ -10,6 +10,7 @@ program test_session_where_compiler
     all_passed = .true.
     if (.not. test_where_masked_assignment()) all_passed = .false.
     if (.not. test_where_elsewhere()) all_passed = .false.
+    if (.not. test_where_overlapping_section()) all_passed = .false.
 
     if (.not. all_passed) stop 1
     print *, 'PASS: WHERE lowers through direct LIRIC'
@@ -69,5 +70,24 @@ contains
         ok = expect_output(source, i12([1, 2, 30, 40]), &
             '/tmp/ffc_where_elsewhere_test')
     end function test_where_elsewhere
+
+    logical function test_where_overlapping_section() result(ok)
+        ! WHERE whose right-hand side is a reversed section of the target
+        ! itself. Fortran 2018 clause 10.2.3.1 evaluates the mask and the
+        ! right-hand side before any element of the target is assigned, so
+        ! every element must be taken from the pre-assignment array. Expected
+        ! values are the gfortran output for this program.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(4), m(4)'//new_line('a')// &
+            '  a = [1, 2, 3, 4]'//new_line('a')// &
+            '  m = [1, 0, 1, 1]'//new_line('a')// &
+            '  where (m == 1) a = a(4:1:-1)'//new_line('a')// &
+            '  print *, a'//new_line('a')// &
+            'end program main'
+
+        ok = expect_output(source, i12([4, 2, 2, 1]), &
+            '/tmp/ffc_where_overlapping_section_test')
+    end function test_where_overlapping_section
 
 end program test_session_where_compiler


### PR DESCRIPTION
Part of #345 (the WHERE half). The FORALL half is split out as #673 and this
PR does not close #345.

## Bug fixed

A WHERE whose right-hand side overlaps its target compiled cleanly and printed
a wrong answer. On unmodified main:

```fortran
integer :: a(4), m(4)
a = [1, 2, 3, 4]
m = [1, 0, 1, 1]
where (m == 1) a = a(4:1:-1)
```

```
gfortran:  4  2  2  1
ffc:       4  2  2  4
```

## Change

`lower_where_masked_assignment` and `lower_where_complement_assignment` were
two near-identical loops, each interleaving one mask evaluation, one
right-hand-side element, one current-element load, and one store. Both are now
thin wrappers over a single `lower_where_selected_assignment`, which differs
only in which arm of the select is the kept value.

The shared routine builds the target's `array_expr_plan_t` through
`build_array_expression` (#342), so WHERE iterates the same shape, element
type, and column-major linear index as every other array expression rather
than re-reading `array_size` itself. It produces every mask value, every
right-hand-side element, and every kept current element before the first store.

### Deleted

- the duplicated iterate/select/store loop in
  `lower_where_complement_assignment`
- the duplicated loop, extent lookup, and `WHERE assignment requires a positive
  array size` diagnostic in `lower_where_masked_assignment`

Both now share one loop and one shape check, the latter coming from
`build_array_expression`/`validate_conformability`, which fails loudly rather
than selecting a fallback. No compatibility adapter was added: both callers
were changed.

## Invariants

- **Column-major layout**: the linear index comes from the target's plan,
  dimension 1 fastest, matching the descriptor ABI stride rule.
- **Lower bound and extent semantics**: unchanged; extents come from the
  target symbol's plan instead of an ad hoc `array_size` read.
- **Overlap and aliasing**: the mask and the right-hand side are evaluated as
  if fully computed before any element of the target is assigned, so an
  overlapping right-hand side reads pre-assignment values regardless of
  traversal order.
- **Allocation and finalization lifetimes**: unchanged; no temporary storage
  is allocated, values are held in SSA registers.
- **Elemental semantics**: one mask value and one right-hand-side value per
  target element, same element order; masked-off elements keep their current
  value, so an earlier WHERE result still survives into a complementary
  ELSEWHERE pass over the same target.
- **Reduction identity and ordering**: untouched (#343 owns it).

## Behavioral oracle

`test/test_session_where_compiler.f90` gains `test_where_overlapping_section`
(`where (m == 1) a = a(4:1:-1)`), expected values from gfortran. It fails on
unmodified main (`4 2 2 4`) and passes here.

## Split-out work

`forall (i=2:5) b(i) = b(i-1)` prints `1 1 1 1 1` instead of gfortran's
`1 1 2 3 4` — the same silent-wrong-answer class, in
`src/session_program_lowering_forall.inc`, whose header comment wrongly asserts
that a serial nest conforms. FORALL cannot be fixed the same way: its index set
is runtime-valued, so it needs a real temporary (canonical `array_descriptor_t`,
one loop nest per body statement) rather than SSA materialization. Filed as
**#673** with the reduced case and a fix sketch, rather than half-implemented
here.

## Local gates

Merges use `--admin`, so these were run locally rather than relying on CI.

- `fo test test_session_where_compiler`: PASS (including the new case)
- `fo test test_session_forall_compiler`: PASS
- `fo`: static OK, build OK, 328/330 tests pass. `test_fortfront_corpus_conformance`
  and `test_parity_dashboard` fail **pre-existing on unmodified main** (same 9
  corpus FAILs, same `fortfront-lf` XPASS entries, same stale snapshot digest).
- `fo lint`: no findings on any changed file.

## Corpus delta

Zero. `fortfront-f90` is PASS=451 XFAIL=93 XPASS=0 FAIL=9 NOREF=173 TOTAL=553
before and after. No XFAIL manifest entry was added, removed, or weakened, so
no #642 measurement applies.