### PR TITLE
[print-dispatch-01] give an implied-do print item a single owning path

### DIFF
--- a/src/session_program_lowering_character.inc
+++ b/src/session_program_lowering_character.inc
@@ -1749,12 +1749,30 @@
         integer, intent(in) :: node_index
         type(lowering_context_t), intent(in) :: context
 
+        integer :: sym
+
         is_elem = .false.
         if (.not. node_exists(arena, node_index)) return
         select type (n => arena%entries(node_index)%node)
         type is (call_or_subscript_node)
-            if (n%is_array_access) &
+            ! The symbol table decides what the name is. The parser's
+            ! is_array_access flag is not set on every subscripted reference
+            ! (an implied-do object, for one), so trusting it made the same
+            ! reference a character element in one context and not in another.
+            if (n%is_array_access) then
                 is_elem = array_access_value_kind(n, context) == VALUE_CHARACTER
+                return
+            end if
+            ! An implied-do object reaches here without the flag set, so fall
+            ! back on the symbol table for a fixed character array, whose
+            ! elements live in this file's contiguous block. An allocatable
+            ! character array keeps its own descriptor-based element path.
+            if (.not. allocated(n%name)) return
+            sym = find_symbol_compat(context, n%name)
+            if (sym <= 0) return
+            if (.not. context%symbols(sym)%is_array) return
+            if (context%symbols(sym)%is_allocatable) return
+            is_elem = context%symbols(sym)%value_kind == VALUE_CHARACTER
         end select
     end function is_character_array_element
 

--- a/src/session_program_lowering_io_implied_do.inc
+++ b/src/session_program_lowering_io_implied_do.inc
@@ -14,7 +14,7 @@
 
     recursive subroutine emit_io_implied_do_print_items(arena, item_index, &
                                                         context, handled, &
-                                                        error_msg)
+                                                        error_msg, prev_is_char)
         !! List-directed print of an I/O implied-do item,
         !! print *, (obj, ..., i = lo, hi [, step]).
         !! The trip count must fold at compile time; the control variable is
@@ -26,6 +26,11 @@
         type(lowering_context_t), intent(inout) :: context
         logical, intent(out) :: handled
         character(len=:), allocatable, intent(out) :: error_msg
+        !! Carries the list-directed separator state in and out, so the rule
+        !! that no blank is written between two consecutive character values
+        !! holds across the boundary of this item as well as inside it.
+        logical, intent(inout), optional :: prev_is_char
+        logical :: char_state
         integer(c_int64_t) :: lo, hi, step, ival
         integer :: vsym, b
         logical :: created_temp
@@ -34,6 +39,8 @@
 
         handled = .false.
         call set_empty(error_msg)
+        char_state = .false.
+        if (present(prev_is_char)) char_state = prev_is_char
         if (.not. node_exists(arena, item_index)) return
 
         select type (idn => arena%entries(item_index)%node)
@@ -76,7 +83,7 @@
                 context%symbols(vsym)%is_reference = .false.
                 do b = 1, size(objects)
                     call emit_io_implied_do_object(arena, objects(b), &
-                                                   context, error_msg)
+                                                   context, char_state, error_msg)
                     if (len_trim(error_msg) > 0) then
                         call release_io_implied_do_var(context, vsym, &
                                                        created_temp, saved_sym)
@@ -86,19 +93,24 @@
                 ival = ival + step
             end do
             call release_io_implied_do_var(context, vsym, created_temp, saved_sym)
+            if (present(prev_is_char)) prev_is_char = char_state
             handled = .true.
         end select
     end subroutine emit_io_implied_do_print_items
 
     recursive subroutine emit_io_implied_do_object(arena, object_index, context, &
-                                                   error_msg)
+                                                   prev_is_char, error_msg)
         !! One object of an unrolled I/O implied-do: a nested implied-do
-        !! recurses, anything else prints as a list-directed scalar item.
+        !! recurses through the same path, anything else prints as a
+        !! list-directed scalar item. The item's type decides how it prints,
+        !! which is the one place that decision is made for an implied-do.
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: object_index
         type(lowering_context_t), intent(inout) :: context
+        logical, intent(inout) :: prev_is_char
         character(len=:), allocatable, intent(out) :: error_msg
         logical :: nested_handled
+        logical :: this_is_char
 
         call set_empty(error_msg)
         if (node_exists(arena, object_index)) then
@@ -106,15 +118,27 @@
             type is (io_implied_do_node)
                 call emit_io_implied_do_print_items(arena, object_index, &
                                                     context, nested_handled, &
-                                                    error_msg)
+                                                    error_msg, prev_is_char)
                 if (len_trim(error_msg) > 0) return
                 if (.not. nested_handled) &
                     error_msg = 'nested io implied-do is not supported'
                 return
             end select
         end if
-        if (.not. emit_liric_print_space(context%session, error_msg)) return
-        call lower_print_expression_value(arena, object_index, context, error_msg)
+        this_is_char = char_print_item(arena, object_index, context)
+        if (.not. (this_is_char .and. prev_is_char)) then
+            if (.not. emit_liric_print_space(context%session, error_msg)) return
+        end if
+        if (this_is_char) then
+            ! A character object prints its bytes at its own length, not the
+            ! integer those bytes would be read as.
+            call lower_print_char_expr(arena, object_index, context, error_msg)
+        else
+            call lower_print_expression_value(arena, object_index, context, &
+                                              error_msg)
+        end if
+        if (len_trim(error_msg) > 0) return
+        prev_is_char = this_is_char
     end subroutine emit_io_implied_do_object
 
     subroutine bind_io_implied_do_var(context, var_name, vsym, created_temp, &

--- a/src/session_program_lowering_print_expr.inc
+++ b/src/session_program_lowering_print_expr.inc
@@ -839,11 +839,13 @@
         call char_expr_operands(arena, node_index, context, data_ptr, length, &
                                 error_msg)
         if (len_trim(error_msg) > 0) return
-        ! The %s conversion stops at a NUL. A borrowed view (a substring)
-        ! points into the middle of its parent's bytes and carries no
-        ! terminator of its own, so print from a terminated copy of exactly
-        ! the view's length.
-        if (is_character_substring(arena, node_index, context)) then
+        ! The %s conversion stops at a NUL. A borrowed view carries no
+        ! terminator of its own: a substring points into the middle of its
+        ! parent's bytes, and since #347 a character array element is followed
+        ! immediately by the next element. Both print from a terminated copy of
+        ! exactly the view's length.
+        if (is_character_substring(arena, node_index, context) .or. &
+            is_character_array_element(arena, node_index, context)) then
             call materialize_character_view(context, data_ptr, length, view_buf, &
                                             error_msg)
             if (len_trim(error_msg) > 0) return

--- a/src/session_program_lowering_print_ops.inc
+++ b/src/session_program_lowering_print_ops.inc
@@ -32,36 +32,6 @@
         ! one exception: no blank is written between two consecutive character
         ! values, so they print concatenated.
         expr_count = size(node%expression_indices)
-        if (expr_count == 1 .and. &
-            .not. is_io_implied_do_item(arena, node%expression_indices(1))) then
-            ! s(l:u) on a scalar character is a substring, not an array
-            ! section: it prints as one character value, not element by element.
-            if (.not. is_character_substring(arena, node%expression_indices(1), &
-                                             context)) then
-                select type (section_node => arena%entries( &
-                        node%expression_indices(1))%node)
-                type is (array_slice_node)
-                    call lower_array_section_print(arena, section_node, context, &
-                                                   error_msg)
-                    return
-                end select
-            end if
-            block
-                logical :: handled
-                call emit_array_literal_print_items(arena, &
-                    node%expression_indices(1), context, handled, error_msg)
-                if (len_trim(error_msg) > 0) return
-                if (handled) then
-                    if (.not. emit_liric_print_newline(context%session, error_msg)) &
-                        return
-                    call set_empty(error_msg)
-                    return
-                end if
-                call lower_whole_array_print(arena, node%expression_indices(1), &
-                                             context, handled, error_msg)
-                if (handled .or. len_trim(error_msg) > 0) return
-            end block
-        end if
         prev_is_char = .false.
         do i = 1, expr_count
             ! A bare whole array or array section among other items prints each
@@ -84,7 +54,7 @@
                 type is (io_implied_do_node)
                     call emit_io_implied_do_print_items(arena, &
                         node%expression_indices(i), context, array_handled, &
-                        error_msg)
+                        error_msg, prev_is_char)
                 class default
                     call emit_whole_array_print_items(arena, &
                         node%expression_indices(i), context, array_handled, &
@@ -92,8 +62,16 @@
                 end select
                 if (len_trim(error_msg) > 0) return
                 if (array_handled) then
-                    prev_is_char = char_print_item(arena, &
-                        node%expression_indices(i), context)
+                    ! An implied-do reports the separator state of its last
+                    ! object through prev_is_char; every other array item ends
+                    ! with a value of the item's own type.
+                    select type (item => arena%entries( &
+                            node%expression_indices(i))%node)
+                    type is (io_implied_do_node)
+                    class default
+                        prev_is_char = char_print_item(arena, &
+                            node%expression_indices(i), context)
+                    end select
                     cycle
                 end if
             end block
@@ -1030,6 +1008,25 @@
                     is_char = .true.
                     return
                 end if
+            end if
+            ! A subscripted reference to a declared character array is a
+            ! character element whether or not the parser marked the node as an
+            ! array access; the symbol table is the authority on what the name
+            ! is, so ask it rather than trusting the flag.
+            if (allocated(node%name)) then
+                block
+                    integer :: sym
+                    sym = find_symbol_compat(context, node%name)
+                    if (sym > 0) then
+                        if (context%symbols(sym)%is_array) then
+                            if (context%symbols(sym)%value_kind == &
+                                VALUE_CHARACTER) then
+                                is_char = .true.
+                                return
+                            end if
+                        end if
+                    end if
+                end block
             end if
             if (.not. node%is_array_access .and. allocated(node%name)) then
                 if (is_contained_deferred_char_function(context, node%name)) then

--- a/test/test_session_io_implied_do_print_compiler.f90
+++ b/test/test_session_io_implied_do_print_compiler.f90
@@ -1,0 +1,98 @@
+program test_session_io_implied_do_print_compiler
+    ! List-directed print of an I/O implied-do, print *, (obj, ..., i = lo, hi).
+    ! One dispatch path owns an implied-do item whether or not it is the only
+    ! item in the statement, so the element type and the list-directed
+    ! separator rule are decided in exactly one place. Every expectation is
+    ! gfortran's output.
+    use ffc_test_support, only: expect_output
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== direct session I/O implied-do print compiler test ==='
+
+    all_passed = .true.
+    if (.not. test_character_elements_print_as_characters()) all_passed = .false.
+    if (.not. test_integer_elements_still_print_as_integers()) all_passed = .false.
+    if (.not. test_implied_do_among_other_items()) all_passed = .false.
+    if (.not. test_implied_do_with_step()) all_passed = .false.
+
+    if (.not. all_passed) stop 1
+    print *, 'PASS: I/O implied-do print lowers through one dispatch path'
+
+contains
+
+    logical function test_character_elements_print_as_characters()
+        ! A character array element is a character value, so consecutive
+        ! elements print concatenated with no separating blank between them.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=2) :: c(3)'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  c(1) = "ab"'//new_line('a')// &
+            '  c(2) = "cd"'//new_line('a')// &
+            '  c(3) = "ef"'//new_line('a')// &
+            '  print *, (c(i), i=1,3)'//new_line('a')// &
+            'end program main'
+
+        test_character_elements_print_as_characters = expect_output( &
+            source, ' abcdef'//new_line('a'), &
+            '/tmp/ffc_session_implied_do_char_test')
+    end function test_character_elements_print_as_characters
+
+    logical function test_integer_elements_still_print_as_integers()
+        ! Regression guard for the path this shares with characters: an
+        ! integer implied-do keeps a separating blank before every value.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(3)'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  a(1) = 10'//new_line('a')// &
+            '  a(2) = 20'//new_line('a')// &
+            '  a(3) = 30'//new_line('a')// &
+            '  print *, (a(i), i=1,3)'//new_line('a')// &
+            'end program main'
+
+        test_integer_elements_still_print_as_integers = expect_output( &
+            source, &
+            '          10          20          30'//new_line('a'), &
+            '/tmp/ffc_session_implied_do_int_test')
+    end function test_integer_elements_still_print_as_integers
+
+    logical function test_implied_do_among_other_items()
+        ! The same item in a statement with other items: the separator rule
+        ! spans the boundary, so a character item either side of the
+        ! implied-do joins its elements without a blank.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  character(len=3) :: c(2)'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  c(1) = "abc"'//new_line('a')// &
+            '  c(2) = "def"'//new_line('a')// &
+            '  print *, "tag", (c(i), i=1,2), "end"'//new_line('a')// &
+            'end program main'
+
+        test_implied_do_among_other_items = expect_output( &
+            source, ' tagabcdefend'//new_line('a'), &
+            '/tmp/ffc_session_implied_do_mixed_test')
+    end function test_implied_do_among_other_items
+
+    logical function test_implied_do_with_step()
+        ! A non-unit step selects a subset of the elements, in loop order.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  integer :: a(5)'//new_line('a')// &
+            '  integer :: i'//new_line('a')// &
+            '  do i = 1, 5'//new_line('a')// &
+            '    a(i) = i * 100'//new_line('a')// &
+            '  end do'//new_line('a')// &
+            '  print *, (a(i), i=1,5,2)'//new_line('a')// &
+            'end program main'
+
+        test_implied_do_with_step = expect_output( &
+            source, &
+            '         100         300         500'//new_line('a'), &
+            '/tmp/ffc_session_implied_do_step_test')
+    end function test_implied_do_with_step
+
+end program test_session_io_implied_do_print_compiler


### PR DESCRIPTION
Closes #668.

`print *, (c(i), i=1,3)` printed a character array's elements as integers. The
finding behind the issue was structural, not a missing type check: **print
dispatch had two overlapping paths, and which one ran was not obvious from
either.**

## The two paths, and which one survives

`lower_print` had a single-item special case and a general item loop, and both
knew how to print the same node kinds:

| item kind | single-item branch | item loop |
|---|---|---|
| array section | `lower_array_section_print` | `emit_array_section_print_items` |
| array literal | `emit_array_literal_print_items` + newline | `emit_array_literal_print_items` |
| whole array | `lower_whole_array_print` | `emit_whole_array_print_items` |
| implied-do | *(guarded out)* | `emit_io_implied_do_print_items` |

The only real difference was who emitted the record terminator: the single-item
routines each emitted their own newline, the loop emits one after all items.
That is not a second concept, it is the same concept with the newline in a
different place — and it had already produced one visible symptom, a guard
(`.not. is_io_implied_do_item(...)`) bolted onto the single-item condition so an
implied-do would fall through to the loop it actually belonged to.

**The loop now owns every print item and the single-item branch is deleted.**
The loop emits the record terminator once, which is what it already did. No
fallback, no "if the loop cannot handle it" path.

## What that then made fixable

With one owner, the element-type decision has one home, and two predicates were
found to be answering the same question inconsistently:

- `char_print_item` and `is_character_array_element` both keyed off the parser's
  `is_array_access` flag, which is not set on an implied-do object. The same
  reference `c(i)` was therefore a character element in one context and not in
  another. Both now ask the symbol table, which is the authority on what a name
  is.
- `lower_print_char_expr` materialised a terminated copy only for a substring.
  Since #347 a character array element is also a borrowed view — the next
  element begins immediately after it, so there is no terminator — and printing
  one ran past its end (`abcdef` came out as `abcdefcdefef`). Both views now go
  through the same materialisation.

The list-directed separator rule is now carried through the implied-do as
`prev_is_char`, so "no blank between two consecutive character values" holds
across the item's boundary as well as inside it: `print *, "tag", (c(i), i=1,2),
"end"` gives `tagabcdefend`.

## Deletions

- the `expr_count == 1` dispatch block in `lower_print`;
- its `is_io_implied_do_item` guard, which existed only to steer around it.

`lower_array_section_print` and `lower_whole_array_print` are **kept**: they
have other callers (formatted print, write). They are no longer reachable from
list-directed print, which is the duplication that mattered.

## Behaviour preserved

Integer implied-do output is unchanged, including a non-unit step — both are
regression guards in the new suite, and they cover the path characters now
share. Array literal, array section, multi-value, character-literal and
formatted print suites all pass untouched.

## Scope I did not take

Nested implied-do (`print *, ((a(i,j), j=1,3), i=1,2)`) is still wrong: it emits
4 values instead of 6. It is a defect in the unroll, not in dispatch, and it was
equally wrong before this change. I wrote the fixture, could not reduce the
cause within this change, and **removed the case rather than leave a red test or
guess at a fix** — the same call as on #347. It wants its own issue; I have not
filed it.

## Gates run locally

Squash-merge with `--admin` does not wait for CI, so these were run here:

- Full `fo test`: 377 passed, 3 failed — `test_fortfront_corpus_conformance`,
  `test_parity_dashboard`, `test_session_type_extends_compiler`, all three
  failing identically at the pinned parent commit.
- Rejection sweep (ffc#663): the four-suite before/after below is that sweep; a
  newly rejected valid file appears as a lost PASS, and there are none.

## Conformance gauntlet

Same-worktree before/after per ffc#642, baseline pinned to the explicit parent
commit `25306dc`, both halves fully rebuilt.

| Suite | before | after |
|---|---|---|
| lfortran | PASS=880 XFAIL=3282 XPASS=111 FAIL=6 | PASS=880 XFAIL=3282 XPASS=111 FAIL=6 |
| gfortran-dg | PASS=1354 XFAIL=2071 XPASS=58 FAIL=156 | PASS=1354 XFAIL=2071 XPASS=58 FAIL=156 |
| fortfront-f90 | PASS=450 XFAIL=93 XPASS=0 FAIL=10 | PASS=450 XFAIL=93 XPASS=0 FAIL=10 |
| fortfront-lf | PASS=211 XFAIL=51 XPASS=3 FAIL=0 | PASS=211 XFAIL=51 XPASS=3 FAIL=0 |

Per case, all four suites: no new FAIL, no case lost PASS, no case gained PASS.
Deleting a whole dispatch branch moving nothing in the corpus is the evidence
that it was duplication; the behavioural evidence for the fixes is the new
suite.
