### PR TITLE
docs: pin FortFront implicit-dimension head

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,10 +39,11 @@ uncertainty.
 
 ## Audited state: do not infer a percentage
 
-The current implementation heads for this gate are ffc `eb39ce6` (typed array-
+The current implementation heads for this gate are ffc `91a2cff` (typed array-
 shape extraction plus the GCC14 descendant-link export fix), FortFront
-`4bd83caf` (IMPLICIT NONE undeclared-name diagnostics, nested binding identity,
-continuation-comment, and inline-IF fixes), fo `32ef96d`,
+`193457a9` (implicit DIMENSION dummy preservation, IMPLICIT NONE
+undeclared-name diagnostics, nested binding identity, continuation-comment,
+and inline-IF fixes), fo `32ef96d`,
 and LIRIC `3facb898`. The code baselines are not green: ffc and fo still lack
 a completed current-head suite, while the latest FortFront run is pending.
 The ffc focused observation gate is green locally;
@@ -50,10 +51,10 @@ the checked-in parity snapshot remains stale and is not a release baseline.
 The final local `fo` gate at `10b2af1` built 435/435 units and ran 350 tests;
 the observation smoke passed and the run retains 26 named pre-existing
 compiler/dashboard failures. That exit is not a clean release gate.
-The current ffc merge CI is [run 31136014863](https://github.com/lazy-fortran/ffc/actions/runs/31136014863)
-(in progress; the corresponding pull-request run is [31136006054](https://github.com/lazy-fortran/ffc/actions/runs/31136006054)); FortFront
-merge CI is [run 31135930489](https://github.com/lazy-fortran/fortfront/actions/runs/31135930489)
-(in progress); and
+The current ffc merge CI is [run 31136103142](https://github.com/lazy-fortran/ffc/actions/runs/31136103142)
+(in progress; its format job is already a known failure and its build/test job
+is still running); FortFront merge CI is [run 31136399036](https://github.com/lazy-fortran/fortfront/actions/runs/31136399036)
+(pending for current main `2179929e`); and
 the last checked fo ancestor was `e3cff007` (run 31122586327, failed/cancelled).
 The external pins are LFortran
 `caf87b660f803148f000046392a5da803f9fc630` and GCC
@@ -620,7 +621,7 @@ Architectural supersets guide implementation, not issue closure:
 
 | Owner | Active contract before ffc can close the dependent work |
 | --- | --- |
-| FortFront | rejection/accepted-side correctness [#2883](https://github.com/lazy-fortran/fortfront/issues/2883), [#2897](https://github.com/lazy-fortran/fortfront/issues/2897), [#2924](https://github.com/lazy-fortran/fortfront/issues/2924), [#2951](https://github.com/lazy-fortran/fortfront/issues/2951), [#2970](https://github.com/lazy-fortran/fortfront/issues/2970), [#2986](https://github.com/lazy-fortran/fortfront/issues/2986), and [#2987](https://github.com/lazy-fortran/fortfront/issues/2987). #2993 is landed in FortFront `4bd83caf`; continuation-comment lexer defect [#2996](https://github.com/lazy-fortran/fortfront/issues/2996) and parser/identity [#2973](https://github.com/lazy-fortran/fortfront/issues/2973), [#2975](https://github.com/lazy-fortran/fortfront/issues/2975), [#2980](https://github.com/lazy-fortran/fortfront/issues/2980), [#2994](https://github.com/lazy-fortran/fortfront/issues/2994) remain active |
+| FortFront | rejection/accepted-side correctness [#2883](https://github.com/lazy-fortran/fortfront/issues/2883), [#2897](https://github.com/lazy-fortran/fortfront/issues/2897), [#2924](https://github.com/lazy-fortran/fortfront/issues/2924), [#2951](https://github.com/lazy-fortran/fortfront/issues/2951), [#2970](https://github.com/lazy-fortran/fortfront/issues/2970), [#2986](https://github.com/lazy-fortran/fortfront/issues/2986), and [#2987](https://github.com/lazy-fortran/fortfront/issues/2987). #2993 is landed in FortFront `193457a9`; the implicit-DIMENSION preservation oracle is landed in `e5e8157b`; continuation-comment lexer defect [#2996](https://github.com/lazy-fortran/fortfront/issues/2996) and parser/identity [#2973](https://github.com/lazy-fortran/fortfront/issues/2973), [#2975](https://github.com/lazy-fortran/fortfront/issues/2975), [#2980](https://github.com/lazy-fortran/fortfront/issues/2980), [#2994](https://github.com/lazy-fortran/fortfront/issues/2994) remain active |
 | LIRIC | Restore producer artifacts and explicit build-failure reporting in [#533](https://github.com/krystophny/liric/issues/533) before relying on the semantic public-session gate [#523](https://github.com/krystophny/liric/issues/523); current Bench Matrix, scheduled compatibility, and nightly runs are red |
 | fo | [#117](https://github.com/lazy-fortran/fo/issues/117) for the assignment-name-ending-in-function oracle before formatting changes, [#119](https://github.com/lazy-fortran/fo/issues/119) for unbounded JSON results, and [#103](https://github.com/lazy-fortran/fo/issues/103) for diagnostics; the parent/submodule DAG and ffc order-shim prerequisite are already landed in fo `32ef96d`/ffc `763ba0c` |
 | fluff | [#262](https://github.com/lazy-fortran/fluff/issues/262): verify every test executable can fail the build before fo #59 consumes deep-lint JSON |


### PR DESCRIPTION
Refreshes the ffc roadmap after FortFront implicit-DIMENSION preservation and current merge CI.