### PR TITLE
docs: pin current ffc merge head

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,8 @@ uncertainty.
 
 ## Audited state: do not infer a percentage
 
-The current implementation heads for this gate are ffc `91a2cff` (typed array-
+The current implementation heads for this gate are ffc `b93514b` (roadmap
+refresh on top of the typed array-
 shape extraction plus the GCC14 descendant-link export fix), FortFront
 `193457a9` (implicit DIMENSION dummy preservation, IMPLICIT NONE
 undeclared-name diagnostics, nested binding identity, continuation-comment,
@@ -51,9 +52,10 @@ the checked-in parity snapshot remains stale and is not a release baseline.
 The final local `fo` gate at `10b2af1` built 435/435 units and ran 350 tests;
 the observation smoke passed and the run retains 26 named pre-existing
 compiler/dashboard failures. That exit is not a clean release gate.
-The current ffc merge CI is [run 31136103142](https://github.com/lazy-fortran/ffc/actions/runs/31136103142)
-(in progress; its format job is already a known failure and its build/test job
-is still running); FortFront merge CI is [run 31136399036](https://github.com/lazy-fortran/fortfront/actions/runs/31136399036)
+The current ffc merge CI is [run 31136716925](https://github.com/lazy-fortran/ffc/actions/runs/31136716925)
+(pending); the prior run [31136459600](https://github.com/lazy-fortran/ffc/actions/runs/31136459600)
+was docs-only and had the known formatting failure while its build/test job
+continued. FortFront merge CI is [run 31136399036](https://github.com/lazy-fortran/fortfront/actions/runs/31136399036)
 (pending for current main `2179929e`); and
 the last checked fo ancestor was `e3cff007` (run 31122586327, failed/cancelled).
 The external pins are LFortran


### PR DESCRIPTION
Refreshes the ffc roadmap after docs PR #680 and records the current merge CI.