### PR TITLE
fix: guard integer8 external call dispatch

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,6 +108,24 @@ The current state is not a valid parity baseline:
   new module-regression signal. Preserve the exact log and normalized failure
   set under `/var/tmp/ert/ffc-31142048669-failed.log` for the next locked
   baseline comparison.
+- The integer(8) transfer/function crash cluster from that run has a bounded
+  backend fix in branch `luna/descriptor-integer8-20260807`.
+  `lower_i64_expression` and `lower_i64_call` previously relied on C-like
+  short-circuit evaluation: a contained or module procedure with no external
+  ABI record evaluated `external_procedures(0)` inside `.AND.`/`.OR.` probes,
+  causing a compiler SIGSEGV before code emission. The fix computes the
+  external index once and nests every indexed lookup behind `ext_idx > 0`; an
+  un-named call/subscript now reports a lowering diagnostic instead of
+  dereferencing an invalid node. The independent existing oracles
+  `test_session_integer8_function_compiler` and
+  `test_session_transfer_compiler` both pass locally after the fix (the former
+  had failed with exit 139 before it; the latter had failed in its
+  `integer(8)`/`TRANSFER` case). A direct differential probe compiled both
+  cases with ffc and gfortran and compared output byte-for-byte:
+  `4000000000` for the module function and `4607182418800017408` for
+  `TRANSFER`. No XFAIL, manifest, or expectation row changed; rerun the
+  focused pair first, then refresh the full locked CI failure set before
+  promoting this slice.
 - FortFront's strict `IMPLICIT NONE` gate had a second GCC14 portability
   defect: `INTENT(OUT)` context construction did not portably apply default
   component initialization. FortFront `229f5f11` assigns the mode policy

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -3774,6 +3774,7 @@ contains
         call set_empty(error_msg)
     end subroutine lower_parameter_declaration
     ! Array lowering is included here; keep this unit invalidated when the include changes.
+    ! Integer(8) call/index guards and transfer dispatch are part of this unit.
     ! Typed TRANSPOSE also shares this include's complex and logical paths.
     ! Parameter TRANSPOSE initialization uses the same typed array stores.
     ! Typed integer MIN/MAX calls use the i64 comparison wrapper.

--- a/src/session_program_lowering_expr_lowering.inc
+++ b/src/session_program_lowering_expr_lowering.inc
@@ -1350,6 +1350,10 @@
 
         select type (node => arena%entries(node_index)%node)
         type is (call_or_subscript_node)
+            if (.not. allocated(node%name)) then
+                error_msg = 'integer(8) call/subscript expression has no name'
+                return
+            end if
             if (node%base_expr_index <= 0 .and. &
                 .not. is_contained_function_reference(node, context) .and. &
                 (node%is_array_access .or. &
@@ -1383,11 +1387,19 @@
                     return
                 end if
                 ext_idx = external_procedure_index(context, node%name)
-                if (contained_function_kind(context, node%name) == VALUE_I64 .or. &
-                    (ext_idx > 0 .and. context%external_procedures(ext_idx)% &
-                        return_value_kind == VALUE_I64)) then
+                ! Fortran does not short-circuit .AND./.OR. expressions.  Do
+                ! not index external_procedures(0) while probing a contained
+                ! or module procedure that has no external ABI record.
+                if (contained_function_kind(context, node%name) == VALUE_I64) then
                     call lower_i64_call(arena, node, context, value, error_msg)
                     return
+                end if
+                if (ext_idx > 0) then
+                    if (context%external_procedures(ext_idx)%return_value_kind == &
+                        VALUE_I64) then
+                        call lower_i64_call(arena, node, context, value, error_msg)
+                        return
+                    end if
                 end if
                 if (same_name(node%name, 'transfer') .and. &
                     contained_function_kind(context, node%name) == 0) then
@@ -1417,28 +1429,27 @@
         character(len=:), allocatable, intent(out) :: error_msg
         type(lr_operand_desc_t), allocatable :: args(:)
         integer, allocatable :: copyback_indices(:)
+        integer :: ext_idx
 
-        if (external_procedure_index(context, node%name) > 0 .and. &
-            (context%external_procedures( &
-                external_procedure_index(context, node%name))%is_bind_c .or. &
-             .not. context%external_procedures( &
-                external_procedure_index(context, node%name))%by_reference)) then
-            if (allocated(node%arg_indices)) then
-                call prepare_bind_c_args(arena, node%arg_indices, &
-                    external_procedure_index(context, node%name), context, args, &
-                    copyback_indices, error_msg)
-            else
-                call prepare_bind_c_args(arena, NO_ACTUAL_ARGS, &
-                    external_procedure_index(context, node%name), context, args, &
-                    copyback_indices, error_msg)
+        ext_idx = external_procedure_index(context, node%name)
+        if (ext_idx > 0) then
+            if (context%external_procedures(ext_idx)%is_bind_c .or. &
+                .not. context%external_procedures(ext_idx)%by_reference) then
+                if (allocated(node%arg_indices)) then
+                    call prepare_bind_c_args(arena, node%arg_indices, &
+                        ext_idx, context, args, copyback_indices, error_msg)
+                else
+                    call prepare_bind_c_args(arena, NO_ACTUAL_ARGS, &
+                        ext_idx, context, args, copyback_indices, error_msg)
+                end if
+                if (len_trim(error_msg) > 0) return
+                if (.not. emit_c_i64_call(context%session, &
+                        trim(context%external_procedures(ext_idx)%c_name), args, &
+                        value, error_msg)) return
+                call copy_back_reference_args(context, args, copyback_indices, &
+                                              error_msg)
+                return
             end if
-            if (len_trim(error_msg) > 0) return
-            if (.not. emit_c_i64_call(context%session, &
-                    trim(context%external_procedures( &
-                    external_procedure_index(context, node%name))%c_name), args, &
-                    value, error_msg)) return
-            call copy_back_reference_args(context, args, copyback_indices, error_msg)
-            return
         end if
 
         if (allocated(node%arg_indices)) then


### PR DESCRIPTION
## Summary

Guard the integer(8) expression/call lowering path against invalid external-procedure index probes. Fortran `.AND.`/`.OR.` expressions do not short-circuit, so the previous code indexed `external_procedures(0)` while resolving contained/module procedures without an external ABI record. That caused a compiler SIGSEGV in the integer(8) module-function and TRANSFER tests.

The patch computes the external index once, nests every indexed access behind `ext_idx > 0`, and rejects an unnamed call/subscript expression with a diagnostic. No corpus expectation, XFAIL, manifest, or skip changed. ROADMAP records the root cause and evidence.

## Verification

- `fo build` — PASS (440/440).
- `fo test test_session_integer8_function_compiler` — PASS (1/1); before this patch it exited 139.
- `fo test test_session_transfer_compiler` — PASS (1/1); before this patch it crashed in the integer(8)/TRANSFER case.
- Independent gfortran differential probes — PASS byte-for-byte:
  - module `integer(8)` function: `4000000000`
  - `TRANSFER(real(8), integer(8))`: `4607182418800017408`

The full corpus/CI gate remains intentionally separate and is not claimed green by this PR.
