### PR TITLE
Fix implicit bare DIMENSION array lowering (#2848)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,6 +143,14 @@ The current state is not a valid parity baseline:
   PASS: the last completed merge observation still records the known fo #117
   formatter mismatch and fpm/corpus failures; current-head run `31144484273`
   is still waiting for its build/fpm job.
+
+- FortFront corpus case `issue_2848_dimension_statement.f90` is now traced to
+  the ffc provider boundary: lazy-inserted declarations and bare `DIMENSION`
+  nodes were incorrectly treated as explicit, so no inferred scalar/array
+  storage was available. The focused branch fix defers the bare-array alloca
+  until the active main block and compares the emitted exit status with
+  gfortran; promote the row only after the rebased gauntlet removes its XFAIL
+  and the focused regression remains green.
 - FortFront's strict `IMPLICIT NONE` gate had a second GCC14 portability
   defect: `INTENT(OUT)` context construction did not portably apply default
   component initialization. FortFront `229f5f11` assigns the mode policy

--- a/src/session_program_lowering_array_elements.inc
+++ b/src/session_program_lowering_array_elements.inc
@@ -3464,6 +3464,70 @@
                                        error_msg)
     end subroutine load_i32_array_element
 
+    subroutine materialize_bare_dimension_array(arena, target, context, &
+                                                symbol_index, error_msg)
+        ! A standalone DIMENSION statement supplies shape but no type-spec.
+        ! FortFront inserts inferred metadata for the name, while ffc's
+        ! declaration prepass intentionally skips the bare node. Materialize
+        ! the default-typed array at the first executable reference, when the
+        ! main LIRIC block is active (#2848).
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: target
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(out) :: symbol_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(declaration_node) :: declaration
+        integer :: i, array_lower_bound, array_size, value_kind
+        character(len=:), allocatable :: shape_error
+
+        call set_empty(error_msg)
+        symbol_index = 0
+        if (.not. allocated(target%name)) return
+        symbol_index = find_symbol_compat(context, target%name)
+        if (symbol_index > 0) then
+            if (context%symbols(symbol_index)%is_array) return
+            ! A scalar inferred seed must not mask the array declaration.
+            symbol_index = 0
+        end if
+        value_kind = VALUE_F32
+        select case (target%resolved_type_kind)
+        case (TINT); value_kind = VALUE_I32
+        case (TREAL); value_kind = VALUE_F32
+        case (TDOUBLE); value_kind = VALUE_F64
+        case (TLOGICAL); value_kind = VALUE_LOGICAL
+        case (TCOMPLEX); value_kind = VALUE_C4
+        end select
+        do i = 1, arena%size
+            if (.not. node_exists(arena, i)) cycle
+            select type (candidate => arena%entries(i)%node)
+            type is (declaration_node)
+                if (.not. declaration_is_bare_dimension(candidate)) cycle
+                if (.not. allocated(candidate%var_name)) cycle
+                if (.not. same_name(candidate%var_name, target%name)) cycle
+                declaration = candidate
+                declaration%type_name = 'real'
+                select case (value_kind)
+                case (VALUE_I32); declaration%type_name = 'integer'
+                case (VALUE_F64); declaration%type_name = 'double precision'
+                case (VALUE_LOGICAL); declaration%type_name = 'logical'
+                end select
+                call get_array_bounds(declaration, context, array_lower_bound, &
+                    array_size, shape_error)
+                if (len_trim(shape_error) > 0) then
+                    error_msg = shape_error
+                    return
+                end if
+                call define_declared_array_symbol(context, declaration, &
+                    target%name, array_lower_bound, array_size, value_kind, &
+                    error_msg)
+                if (len_trim(error_msg) == 0) then
+                    symbol_index = find_symbol_compat(context, target%name)
+                end if
+                return
+            end select
+        end do
+    end subroutine materialize_bare_dimension_array
+
     subroutine lower_array_element_assignment(arena, node, target, context, value, &
                                               error_msg)
         type(ast_arena_t), intent(in) :: arena
@@ -3479,6 +3543,11 @@
         vk = VALUE_I32
         if (allocated(target%name)) then
             sym_idx = find_symbol_compat(context, target%name)
+            if (sym_idx <= 0 .or. .not. context%symbols(sym_idx)%is_array) then
+                call materialize_bare_dimension_array(arena, target, context, &
+                    sym_idx, error_msg)
+                if (len_trim(error_msg) > 0) return
+            end if
             if (sym_idx > 0) vk = context%symbols(sym_idx)%value_kind
         end if
 
@@ -3717,6 +3786,11 @@
         end if
 
         symbol_index = find_symbol_compat(context, node%name)
+        if (symbol_index <= 0 .or. .not. context%symbols(symbol_index)%is_array) then
+            call materialize_bare_dimension_array(arena, node, context, &
+                symbol_index, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end if
         if (symbol_index <= 0) then
             error_msg = 'array identifier was not declared: '//trim(node%name)
             return
@@ -4005,6 +4079,11 @@
             return
         end if
         symbol_index = find_symbol_compat(context, node%name)
+        if (symbol_index <= 0 .or. .not. context%symbols(symbol_index)%is_array) then
+            call materialize_bare_dimension_array(arena, node, context, &
+                symbol_index, error_msg)
+            if (len_trim(error_msg) > 0) return
+        end if
         if (symbol_index <= 0) then
             error_msg = 'real array identifier was not declared: '//trim(node%name)
             return

--- a/src/session_program_lowering_inferred.f90
+++ b/src/session_program_lowering_inferred.f90
@@ -100,15 +100,22 @@ contains
     if (.not. node_exists(arena, node_index)) return
     select type (node => arena%entries(node_index)%node)
         type is (declaration_node)
-        if (allocated(node%var_name) .and. len_trim(node%var_name) > 0) then
-            call add_explicit_decl_name(context, node%var_name)
-        end if
-        if (allocated(node%var_names)) then
-            do i = 1, size(node%var_names)
-                if (len_trim(node%var_names(i)) > 0) then
-                    call add_explicit_decl_name(context, node%var_names(i))
-                end if
-            end do
+        ! FortFront inserts `is_inferred` declarations during lazy
+        ! standardization. They are metadata for the type-inference pass, not
+        ! user declarations and have no collected binding/storage record in
+        ! ffc. Treating them as explicit here suppresses the inferred-symbol
+        ! seed that executable references need (#2848).
+        if (.not. node%is_inferred .and. .not. declaration_is_bare_dimension(node)) then
+            if (allocated(node%var_name) .and. len_trim(node%var_name) > 0) then
+                call add_explicit_decl_name(context, node%var_name)
+            end if
+            if (allocated(node%var_names)) then
+                do i = 1, size(node%var_names)
+                    if (len_trim(node%var_names(i)) > 0) then
+                        call add_explicit_decl_name(context, node%var_names(i))
+                    end if
+                end do
+            end if
         end if
         type is (do_loop_node)
         if (allocated(node%body_indices)) then
@@ -270,9 +277,33 @@ contains
     if (.not. allocated(inferred)) return
     if (inferred%kind <= 0) return
     value_kind = inferred_type_to_value_kind(inferred, context)
+    ! A bare DIMENSION's shape is materialized when its first executable
+    ! reference is lowered (after the main function is active). Defining its
+    ! alloca during this metadata prepass would fail with "no active block".
+    if (inferred%kind == TARRAY .and. has_bare_dimension(arena, name)) return
     if (value_kind <= 0) return
     call define_symbol(context, name, value_kind, error_msg)
     end procedure try_seed_inferred_symbol
+
+    logical function has_bare_dimension(arena, name) result(found)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer :: i
+
+        found = .false.
+        do i = 1, arena%size
+            if (.not. node_exists(arena, i)) cycle
+            select type (node => arena%entries(i)%node)
+            type is (declaration_node)
+                if (declaration_is_bare_dimension(node) .and. &
+                    allocated(node%var_name) .and. &
+                    same_name(node%var_name, name)) then
+                    found = .true.
+                    return
+                end if
+            end select
+        end do
+    end function has_bare_dimension
 
     module procedure inferred_type_to_value_kind
     ! Map a FortFront mono_type_t kind to the ffc value_kind constant.

--- a/src/session_program_lowering_inferred.f90
+++ b/src/session_program_lowering_inferred.f90
@@ -294,7 +294,7 @@ contains
         do i = 1, arena%size
             if (.not. node_exists(arena, i)) cycle
             select type (node => arena%entries(i)%node)
-            type is (declaration_node)
+                type is (declaration_node)
                 if (declaration_is_bare_dimension(node) .and. &
                     allocated(node%var_name) .and. &
                     same_name(node%var_name, name)) then

--- a/test/conformance/xfail_fortfront_f90.txt
+++ b/test/conformance/xfail_fortfront_f90.txt
@@ -102,7 +102,6 @@ issue_2819_implied_do_index_shadow.f90 # scope=harness; reason=FortFront semanti
 issue_2819_pure_with_print.f90 # scope=harness; reason=FortFront semantic rejection fixture
 issue_2836_io_expression_format.f90 # owner=lazy-fortran/ffc#427; reason=return stable IOSTAT and IOMSG values
 issue_2836_io_keyword_unit_format.f90 # owner=lazy-fortran/ffc#434; reason=read A and L fixed-width fields
-issue_2848_dimension_statement.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
 issue_2850_bare_function_interface.f90 # owner=lazy-fortran/ffc#457; reason=register resolved declarations once
 issue_2850_bare_subroutine_interface.f90 # owner=lazy-fortran/ffc#430; reason=classify undefined and unlinked reference cases
 issue_2855_external_intrinsic_conflict.f90 # scope=harness; reason=FortFront semantic rejection fixture

--- a/test/test_session_dimension_statement_compiler.f90
+++ b/test/test_session_dimension_statement_compiler.f90
@@ -1,5 +1,6 @@
 program test_session_dimension_statement_compiler
     use ffc_test_support, only: expect_exit_status
+    use fortfront_compiler, only: INPUT_MODE_LAZY
     implicit none
 
     print *, '=== DIMENSION statement separate from type declaration ==='
@@ -18,6 +19,15 @@ program test_session_dimension_statement_compiler
         '    if (abs(arr(3) - 4.0d0) > 1.0d-9) error stop'//new_line('a')// &
         'end program', 0, &
         '/tmp/ffc_session_dimension_statement_test')) stop 1
+
+    ! A standalone DIMENSION also supplies the only declaration. Its implicit
+    ! real array must be materialized when the executable body becomes active;
+    ! gfortran accepts this standard source and exits normally (#2848).
+    if (.not. expect_exit_status( &
+        'dimension values(5)'//new_line('a')// &
+        'values(1) = 1.0'//new_line('a')// &
+        'end', 0, '/tmp/ffc_session_dimension_statement_implicit_test', &
+        INPUT_MODE_LAZY)) stop 1
 
     print *, 'PASS: DIMENSION statement merges with typed declaration'
 end program test_session_dimension_statement_compiler


### PR DESCRIPTION
## Summary

- Fix lazy inferred-symbol collection for FortFront-inserted declarations and bare `DIMENSION` nodes.
- Materialize an implicit DIMENSION array only after the main LIRIC block is active, preserving default implicit type and shape.
- Promote the FortFront corpus row and add a direct regression test.

## Verification

- `fo test test_session_dimension_statement_compiler`
- `FFC_FORTFRONT_DIR=/mnt/storage/code/lazy-fortran/fortfront scripts/conformance_gauntlet.sh --suite fortfront-f90 --file issue_2848_dimension_statement.f90 --ffc build/fo/bin/ffc --report /var/tmp/ert/ffc-2848-fixed2.jsonl --observations /var/tmp/ert/ffc-2848-fixed2.obs.jsonl --timeout 30`

The focused differential row is `PASS` with ffc and gfortran compile/run exit status 0 and matching output.
