### PR TITLE
Export bare DIMENSION predicate for inferred submodule

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -144,6 +144,15 @@ The current state is not a valid parity baseline:
   formatter mismatch and fpm/corpus failures; current-head run `31144484273`
   is still waiting for its build/fpm job.
 
+- Post-merge CI [run `31144972941`](https://github.com/lazy-fortran/ffc/actions/runs/31144972941)
+  reached ffc main `8a43a3c` and failed at link: the new inferred-symbol
+  descendant called host predicate `declaration_is_bare_dimension`, but the
+  host module did not export it. The repair is a single explicit host export;
+  it is validated with a clean `fo clean`/`fo build` and focused DIMENSION,
+  Lazy-array, and gfortran differential oracles. The current production
+  inventory remains exactly 65 `.inc` files and 76,696 lines; this is a link
+  correctness repair, not an aggregate corpus PASS claim.
+
 - FortFront corpus case `issue_2848_dimension_statement.f90` is now traced to
   the ffc provider boundary: lazy-inserted declarations and bare `DIMENSION`
   nodes were incorrectly treated as explicit, so no inferred scalar/array

--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -380,6 +380,7 @@ module session_program_lowering_impl
     public :: component_element_access_kind, component_slot_width
     public :: declaration_declares_name, declaration_index_for_name
     public :: declaration_is_assumed_rank, declaration_is_assumed_shape
+    public :: declaration_is_bare_dimension
     public :: declaration_named, declaration_value_kind
     public :: derived_component_access_kind, dim_is_assumed_shape
     public :: dim_is_assumed_size, dummy_explicit_element_count


### PR DESCRIPTION
## Summary

- Export the host `declaration_is_bare_dimension` predicate used by the inferred-symbol submodule.
- Record CI run `31144972941`'s link failure and the exact production include inventory in `ROADMAP.md`.

## Verification

From a fresh worktree at ffc `8a43a3c`:

- `fo clean && fo build` — 442/442 units, clean link
- `fo test test_session_dimension_statement_compiler` — PASS
- `fo test test_session_lazy_array_inference_compiler` — PASS
- gfortran-backed DIMENSION gauntlet — PASS=1, FAIL=0, XFAIL=0
