### PR TITLE
fix: deep-copy rank-1 derived allocatable arrays

### DIFF
--- a/src/session_program_lowering_derived_ctor.inc
+++ b/src/session_program_lowering_derived_ctor.inc
@@ -84,10 +84,17 @@
         source_index = find_symbol_compat(context, source_name)
         if (source_index <= 0) return
         if (.not. context%symbols(source_index)%is_derived) return
-        if (context%symbols(source_index)%is_array) return
         type_index = context%symbols(symbol_index)%derived_type_index
         if (type_index <= 0 .or. context%symbols(source_index)%derived_type_index &
             /= type_index) return
+
+        if (context%symbols(source_index)%is_array) then
+            if (context%symbols(source_index)%is_allocatable) then
+                call lower_derived_alloc_array_copy(arena, node, context, &
+                    symbol_index, source_index, handled, error_msg)
+            end if
+            return
+        end if
 
         slots = total_component_slots(context, type_index)
         if (slots <= 0) return
@@ -160,6 +167,154 @@
         handled = .true.
         call set_empty(error_msg)
     end subroutine lower_derived_array_whole_assignment
+
+    subroutine lower_derived_alloc_array_copy(arena, node, context, target_index, &
+                                               source_index, handled, error_msg)
+        ! Copy one rank-1 allocatable derived array into another.  The target
+        ! receives the source descriptor shape and a fresh data block; each
+        ! element is copied by value and allocatable components are re-owned by
+        ! deep_copy_derived_array_element_components.  This is deliberately a
+        ! descriptor-level path rather than a fixed-size array expression so a
+        ! runtime source extent does not become a compiler-time assumption.
+        type(ast_arena_t), intent(in) :: arena
+        type(assignment_node), intent(in) :: node
+        type(lowering_context_t), intent(inout) :: context
+        integer, intent(in) :: target_index, source_index
+        logical, intent(out) :: handled
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(lr_operand_desc_t) :: source_desc, target_desc
+        type(lr_operand_desc_t) :: source_data, old_target_data, target_data
+        type(lr_operand_desc_t) :: extent64, lower64, extent32
+        type(lr_operand_desc_t) :: element_bytes, index64, byte_offset
+        type(lr_operand_desc_t) :: source_element, target_element
+        type(lr_operand_desc_t) :: entry_index, header_index, next_index
+        type(lr_operand_desc_t) :: condition
+        integer(c_int32_t) :: entry_block, header_block, body_block
+        integer(c_int32_t) :: latch_block, exit_block, index_vreg
+        integer :: type_index, slots
+        logical :: has_alloc_component
+
+        handled = .false.
+        call set_empty(error_msg)
+        if (context%symbols(target_index)%array_rank /= 1 .or. &
+            context%symbols(source_index)%array_rank /= 1) return
+        if (.not. context%symbols(target_index)%is_allocatable .or. &
+            .not. context%symbols(source_index)%is_allocatable) return
+        if (target_index == source_index) then
+            ! Intrinsic self-assignment is a no-op, including the descriptor.
+            handled = .true.
+            return
+        end if
+        type_index = context%symbols(target_index)%derived_type_index
+        if (type_index <= 0) return
+        slots = total_component_slots(context, type_index)
+        if (slots <= 0) return
+
+        source_desc = context%symbols(source_index)% &
+            allocatable_descriptor_address
+        target_desc = context%symbols(target_index)% &
+            allocatable_descriptor_address
+        if (.not. emit_ptr_load(context%session, source_desc, source_data, &
+                                error_msg)) return
+        if (.not. emit_i64_load_at(context%session, source_desc, &
+                alloc_desc_dim_offset(1, int(ARRAY_DIMENSION_EXTENT_OFFSET, &
+                c_int64_t)), extent64, error_msg)) return
+        if (.not. emit_i64_load_at(context%session, source_desc, &
+                alloc_desc_dim_offset(1, int(ARRAY_DIMENSION_LOWER_OFFSET, &
+                c_int64_t)), lower64, error_msg)) return
+
+        ! Assignment to an allocated target first releases its old outer block.
+        ! A fresh zeroed block means allocatable component descriptors are null
+        ! before the per-element copy re-owns any source component storage.
+        if (.not. emit_ptr_load(context%session, target_desc, old_target_data, &
+                                error_msg)) return
+        if (.not. emit_free(context%session, old_target_data, error_msg)) return
+        element_bytes = i64_immediate(context%session, &
+            int(slots, c_int64_t) * 4_c_int64_t)
+        has_alloc_component = .false.
+        block
+            integer :: c
+            do c = 1, context%derived_types(type_index)%component_count
+                if (component_is_allocatable(context, type_index, c) .or. &
+                    component_is_alloc_array(context, type_index, c)) then
+                    has_alloc_component = .true.
+                    exit
+                end if
+            end do
+        end block
+        if (has_alloc_component) then
+            if (.not. emit_calloc(context%session, extent64, element_bytes, &
+                                  target_data, error_msg)) return
+        else
+            if (.not. emit_malloc(context%session, extent64, target_data, &
+                                  error_msg, elem_size=element_bytes)) return
+        end if
+        if (.not. emit_ptr_store(context%session, target_data, target_desc, &
+                                 error_msg)) return
+        context%symbols(target_index)%element_address = target_data
+        call emit_alloc_desc_allocate_shape(context, target_desc, VALUE_DERIVED, 1, &
+            [extent64], error_msg, lowers_i64=[lower64], &
+            element_bytes=int(slots, c_int64_t) * 4_c_int64_t)
+        if (len_trim(error_msg) > 0) return
+
+        if (.not. emit_liric_i64_to_i32(context%session, extent64, extent32, &
+                                        error_msg)) return
+        entry_index = i32_immediate(context%session, 0_c_int64_t)
+        entry_block = context%current_block_id
+        header_block = create_liric_block(context%session)
+        body_block = create_liric_block(context%session)
+        latch_block = create_liric_block(context%session)
+        exit_block = create_liric_block(context%session)
+        if (.not. emit_liric_br(context%session, header_block, error_msg)) return
+
+        if (.not. set_liric_block(context%session, header_block, error_msg)) return
+        context%current_block_id = header_block
+        context%current_block_terminated = .false.
+        index_vreg = reserve_i32_vreg(context%session)
+        if (index_vreg <= 0_c_int32_t) then
+            error_msg = 'LIRIC could not reserve a derived array copy index'
+            return
+        end if
+        index64 = i32_vreg(context%session, index_vreg)
+        if (.not. emit_liric_i32_phi(context%session, entry_index, entry_block, &
+                index64, latch_block, header_index, error_msg)) return
+        if (.not. emit_liric_i32_icmp(context%session, LR_CMP_SLT, header_index, &
+                extent32, condition, error_msg)) return
+        if (.not. emit_liric_condbr(context%session, condition, body_block, &
+                                    exit_block, error_msg)) return
+
+        if (.not. set_liric_block(context%session, body_block, error_msg)) return
+        context%current_block_id = body_block
+        context%current_block_terminated = .false.
+        if (.not. emit_liric_i32_to_i64(context%session, header_index, index64, &
+                                        error_msg)) return
+        if (.not. emit_i64_binary(context%session, LR_OP_MUL, index64, &
+                element_bytes, byte_offset, error_msg)) return
+        if (.not. emit_ptr_offset_dyn(context%session, source_data, byte_offset, &
+                                      source_element, error_msg)) return
+        if (.not. emit_ptr_offset_dyn(context%session, target_data, byte_offset, &
+                                      target_element, error_msg)) return
+        if (.not. emit_memcpy(context%session, target_element, source_element, &
+                              element_bytes, error_msg)) return
+        call deep_copy_derived_array_element_components(context, target_element, &
+            source_element, type_index, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. emit_liric_br(context%session, latch_block, error_msg)) return
+
+        if (.not. set_liric_block(context%session, latch_block, error_msg)) return
+        context%current_block_id = latch_block
+        context%current_block_terminated = .false.
+        if (.not. emit_i32_binary_into(context%session, LR_OP_ADD, header_index, &
+                i32_immediate(context%session, 1_c_int64_t), index_vreg, &
+                next_index, error_msg)) return
+        if (.not. emit_liric_br(context%session, header_block, error_msg)) return
+
+        if (.not. set_liric_block(context%session, exit_block, error_msg)) return
+        context%current_block_id = exit_block
+        context%current_block_terminated = .false.
+        handled = .true.
+        call set_empty(error_msg)
+    end subroutine lower_derived_alloc_array_copy
 
     subroutine release_derived_array_element_components(context, element_address, &
                                                         type_index, error_msg)

--- a/test/test_session_derived_alloc_array_compiler.f90
+++ b/test/test_session_derived_alloc_array_compiler.f90
@@ -4,13 +4,17 @@ program test_session_derived_alloc_array_compiler
     ! one canonical descriptor while each element retains its concrete layout.
     use ffc_test_support, only: expect_output, expect_exit_status, &
                                 expect_error_contains
+    use fortfront_compiler, only: compiler_frontend_options_t, &
+        compiler_frontend_result_t, compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
+    use session_program_lowering, only: lower_program_to_liric_exe
     implicit none
 
     logical :: all_passed
 
     print *, '=== direct session derived allocatable array test ==='
     all_passed = test_rank1() .and. test_rank2_bounds() .and. test_reallocate() &
-                 .and. test_reject_rank3()
+                 .and. test_deep_copy() .and. test_reject_rank3()
     if (.not. all_passed) stop 1
     print *, 'PASS: derived allocatable arrays lower through session'
 
@@ -94,6 +98,36 @@ contains
                                               '/tmp/ffc_derived_alloc_array_realloc')
     end function test_reallocate
 
+    logical function test_deep_copy()
+        ! Intrinsic assignment of allocatable derived arrays with an allocated
+        ! source owns an independent destination allocation. Mutating the
+        ! source after `b = a` must not change b; the gfortran oracle also checks
+        ! allocatable component ownership.
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  type :: box_t'//new_line('a')// &
+            '    integer :: id'//new_line('a')// &
+            '    integer, allocatable :: values(:)'//new_line('a')// &
+            '  end type box_t'//new_line('a')// &
+            '  type(box_t), allocatable :: a(:), b(:)'//new_line('a')// &
+            '  allocate(a(2))'//new_line('a')// &
+            '  allocate(a(1)%values(2))'//new_line('a')// &
+            '  allocate(a(2)%values(2))'//new_line('a')// &
+            '  a(1)%id = 11'//new_line('a')// &
+            '  a(2)%id = 22'//new_line('a')// &
+            '  a(1)%values = [101, 102]'//new_line('a')// &
+            '  a(2)%values = [201, 202]'//new_line('a')// &
+            '  b = a'//new_line('a')// &
+            '  a(1)%id = 99'//new_line('a')// &
+            '  a(1)%values(1) = 999'//new_line('a')// &
+            '  print *, size(b), b(1)%id, b(2)%id, b(1)%values(1), '// &
+            'b(1)%values(2), b(2)%values(1), b(2)%values(2), '// &
+            'allocated(b)'//new_line('a')// &
+            'end program main'
+
+        test_deep_copy = matches_gfortran(source, 'deep_copy')
+    end function test_deep_copy
+
     logical function test_reject_rank3()
         ! The first descriptor slice deliberately exposes ranks one and two;
         ! rank three must remain a diagnosed unsupported operation rather than
@@ -110,5 +144,75 @@ contains
             'direct LIRIC session supports rank-1 and rank-2 derived', &
             '/tmp/ffc_derived_alloc_array_rank3')
     end function test_reject_rank3
+
+    logical function matches_gfortran(source, stem)
+        ! Compile and run both front ends, then compare their complete output.
+        ! gfortran is the independent behavioural oracle for this descriptor
+        ! contract; no hard-coded expected output can hide a shape mismatch.
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: stem
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: frontend_result
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: base, src, exe, ref, ffc_out, ref_out
+        integer :: unit, exit_stat, status
+
+        matches_gfortran = .false.
+        base = '/var/tmp/ert/ffc_derived_alloc_array_'//trim(stem)
+        src = base//'.f90'
+        exe = base//'.ffc'
+        ref = base//'.gf'
+        ffc_out = base//'.ffc.out'
+        ref_out = base//'.gf.out'
+
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        call compile_frontend_from_string(source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            print *, 'FAIL[', trim(stem), ']: FortFront rejected source: ', &
+                trim(frontend_result%diagnostic_text)
+            return
+        end if
+        call lower_program_to_liric_exe(frontend_result%arena, &
+            frontend_result%root_index, exe, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL[', trim(stem), ']: ffc lowering failed: ', &
+                trim(error_msg)
+            return
+        end if
+
+        open (newunit=unit, file=src, status='replace', action='write')
+        write (unit, '(A)') source
+        close (unit)
+        call execute_command_line('gfortran -w '//src//' -o '//ref, &
+            exitstat=exit_stat)
+        if (exit_stat /= 0) then
+            print *, 'FAIL[', trim(stem), ']: gfortran rejected source'
+            return
+        end if
+        call execute_command_line(exe//' > '//ffc_out//' 2>&1', &
+            exitstat=exit_stat)
+        if (exit_stat /= 0) then
+            print *, 'FAIL[', trim(stem), ']: ffc executable failed'
+            return
+        end if
+        call execute_command_line(ref//' > '//ref_out//' 2>&1', &
+            exitstat=exit_stat)
+        if (exit_stat /= 0) then
+            print *, 'FAIL[', trim(stem), ']: gfortran executable failed'
+            return
+        end if
+        call execute_command_line('diff '//ffc_out//' '//ref_out// &
+            ' > /dev/null 2>&1', exitstat=status)
+        if (status /= 0) then
+            print *, 'FAIL[', trim(stem), ']: ffc output differs from gfortran'
+            call execute_command_line('diff '//ffc_out//' '//ref_out)
+            return
+        end if
+        call execute_command_line('rm -f '//src//' '//exe//' '//ref//' '// &
+            ffc_out//' '//ref_out)
+        matches_gfortran = .true.
+    end function matches_gfortran
 
 end program test_session_derived_alloc_array_compiler


### PR DESCRIPTION
Partially addresses #643 (rank-1 deep-copy slice).

What changed:
- Add descriptor-level rank-1 allocatable derived-array assignment for an allocated source.
- Preserve source lower bound/runtime extent and allocate fresh target storage.
- Copy complete elements and re-own allocatable components.
- Add ffc-vs-gfortran differential oracle (including allocatable component ownership) and update ROADMAP.md.

Validation:
- `fo test test_session_derived_alloc_array_compiler` PASS.
- faepkub4 GCC 14.2 reference PASS (`/var/tmp/ert/ffc_643_deep_copy.out`, SHA-256 `cb75b2f28d60ed3c3c8b70bac3ce40a1dfff61f5ba2aa8610f8f5b18962d8568`).
- `fo fmt --check` remains blocked by repository-wide baseline formatting drift (fo #117); changed lines pass `git diff --check`.

Unallocated-RHS deallocation, rank-2 whole-array assignment, finalization, SOURCE/MOLD, polymorphic dynamic element sizes, and non-unit-bound addressing remain separate #643 gates.