### PR TITLE
refactor: extract DO WHILE lowering into typed submodule

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -473,6 +473,13 @@ module session_program_lowering_impl
     public :: call_emit_name, copy_back_reference_args, eval_kind_of_arg
     public :: degeneric_call_name, fold_named_constant_at_node
     public :: integer_opcode
+    ! Loop helpers referenced by the typed DO WHILE descendant.  These remain
+    ! part of the ancestor implementation API so GCC emits linkable symbols
+    ! for cold submodule builds instead of private local definitions.
+    public :: collect_carried_symbols, reserve_backedge_value
+    public :: carried_backedge_operand, emit_carried_phi, emit_carried_copy
+    public :: begin_loop_exit_tracking, end_loop_exit_tracking
+    public :: merge_loop_exit_values, lower_statement_list
     public :: is_contained_i32_function, is_proc_pointer_call
     public :: is_statement_function_call, is_type_bound_method_call
     public :: lower_array_locate_intrinsic, lower_array_reduction_intrinsic
@@ -2701,6 +2708,15 @@ module session_program_lowering_impl
             type(lr_operand_desc_t), intent(out) :: value
             character(len=:), allocatable, intent(out) :: error_msg
         end subroutine lower_i32_array_element
+    end interface
+    interface
+        module subroutine lower_do_while(arena, node, context, value, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(do_while_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_do_while
     end interface
     interface
         module subroutine check_storage_association_restrictions(arena, error_msg)

--- a/src/session_program_lowering_do_while.f90
+++ b/src/session_program_lowering_do_while.f90
@@ -1,4 +1,7 @@
-    subroutine lower_do_while(arena, node, context, value, error_msg)
+submodule (session_program_lowering_impl) session_program_lowering_do_while
+    implicit none
+contains
+    module subroutine lower_do_while(arena, node, context, value, error_msg)
         type(ast_arena_t), intent(in) :: arena
         type(do_while_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
@@ -32,7 +35,7 @@
         entry_block = context%current_block_id
         initial_symbol_count = context%symbol_count
         call collect_carried_symbols(context, carried_indices, &
-                                     carried_count)
+            carried_count)
         if (carried_count > 0) then
             allocate(entry_values(context%symbol_count))
             allocate(header_values(context%symbol_count))
@@ -45,7 +48,7 @@
             if (len_trim(error_msg) > 0) return
             backedge_values(carried_indices(i)) = &
                 carried_backedge_operand(context, carried_indices(i), &
-                                         reserved_vreg)
+                reserved_vreg)
         end do
 
         header_block = create_liric_block(context%session)
@@ -59,18 +62,18 @@
         context%current_block_terminated = .false.
         do i = 1, carried_count
             if (.not. emit_carried_phi(context, carried_indices(i), &
-                                       entry_values(carried_indices(i)), &
-                                       entry_block, &
-                                       backedge_values(carried_indices(i)), &
-                                       latch_block, &
-                                       header_values(carried_indices(i)), &
-                                       error_msg)) return
+                entry_values(carried_indices(i)), &
+                entry_block, &
+                backedge_values(carried_indices(i)), &
+                latch_block, &
+                header_values(carried_indices(i)), &
+                error_msg)) return
             context%symbols(carried_indices(i))%value = &
                 header_values(carried_indices(i))
         end do
 
         call lower_i1_condition(arena, node%condition_index, context, &
-                                condition, error_msg)
+            condition, error_msg)
         if (len_trim(error_msg) > 0) return
         ! Lowering a condition may materialise an array-valued actual (for
         ! example a character-array comparison passed to a contained function).
@@ -78,7 +81,7 @@
         ! merged on each iteration.
         initial_symbol_count = context%symbol_count
         if (.not. emit_liric_condbr(context%session, condition, body_block, &
-                                    exit_block, error_msg)) return
+            exit_block, error_msg)) return
 
         if (.not. set_liric_block(context%session, body_block, error_msg)) return
         context%current_block_id = body_block
@@ -91,11 +94,11 @@
         context%in_loop = .true.
         context%current_block_exited_loop = .false.
         call begin_loop_exit_tracking(context, saved_loop_exit_blocks, &
-                                      saved_loop_exit_values, &
-                                      saved_loop_exit_count)
+            saved_loop_exit_values, &
+            saved_loop_exit_count)
         if (allocated(node%body_indices)) then
             call lower_statement_list(arena, node%body_indices, context, value, &
-                                      body_terminated, error_msg)
+                body_terminated, error_msg)
             if (len_trim(error_msg) > 0) return
         end if
         body_exited = context%current_block_exited_loop
@@ -105,15 +108,15 @@
         context%current_block_exited_loop = .false.
         if (context%symbol_count /= initial_symbol_count) then
             error_msg = 'direct LIRIC session DO WHILE cannot merge '// &
-                        'loop declarations'
+                'loop declarations'
             return
         end if
         if (body_terminated .and. .not. body_exited) then
             call unsupported_feature_error('terminating do while body', &
-                                           node%line, node%column, &
-                                           'direct LIRIC session does not '// &
-                                           'support stop or return inside '// &
-                                           'do while loops', error_msg)
+                node%line, node%column, &
+                'direct LIRIC session does not '// &
+                'support stop or return inside '// &
+                'do while loops', error_msg)
             return
         end if
         if (.not. body_terminated) then
@@ -138,12 +141,12 @@
         context%current_block_terminated = .false.
         do i = 1, carried_count
             call merge_loop_exit_values(context, carried_indices(i), &
-                                        header_values(carried_indices(i)), &
-                                        header_block, error_msg)
+                header_values(carried_indices(i)), &
+                header_block, error_msg)
             if (len_trim(error_msg) > 0) return
         end do
         call end_loop_exit_tracking(context, saved_loop_exit_blocks, &
-                                    saved_loop_exit_values, saved_loop_exit_count)
+            saved_loop_exit_values, saved_loop_exit_count)
         value = i32_immediate(context%session, 0_c_int64_t)
         if (carried_count > 0) then
             deallocate(entry_values)
@@ -155,3 +158,4 @@
         end if
         call set_empty(error_msg)
     end subroutine lower_do_while
+end submodule session_program_lowering_do_while

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -1311,7 +1311,6 @@
     include 'session_program_lowering_goto.inc'
     include 'session_program_lowering_associate.inc'
     include 'session_program_lowering_loops.inc'
-    include 'session_program_lowering_do_while.inc'
     include 'session_program_lowering_interface.inc'
     include 'session_program_lowering_derived_types.inc'
     include 'session_program_lowering_pdt.inc'

--- a/test/test_session_do_while_gfortran_compiler.f90
+++ b/test/test_session_do_while_gfortran_compiler.f90
@@ -1,0 +1,84 @@
+program test_session_do_while_gfortran_compiler
+    ! Independent oracle for the typed DO WHILE descendant: compile the same
+    ! source with gfortran and require byte-identical list-directed output.
+    use fortfront_compiler, only: compiler_frontend_options_t, &
+        compiler_frontend_result_t, compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
+    use session_program_lowering, only: lower_program_to_liric_exe
+    implicit none
+
+    type(compiler_frontend_options_t) :: options
+    type(compiler_frontend_result_t) :: frontend_result
+    character(len=:), allocatable :: source, base, src, ffc_exe, gfortran_exe
+    character(len=:), allocatable :: ffc_out, gfortran_out, error_msg
+    integer :: unit, exit_stat, diff_status
+
+    print *, '=== do while module gfortran oracle test ==='
+    source = 'program main'//new_line('a')// &
+        'integer :: i, total'//new_line('a')// &
+        'i = 0'//new_line('a')// &
+        'total = 0'//new_line('a')// &
+        'do while (i < 4)'//new_line('a')// &
+        '    i = i + 1'//new_line('a')// &
+        '    if (i == 2) cycle'//new_line('a')// &
+        '    total = total + i'//new_line('a')// &
+        'end do'//new_line('a')// &
+        'print *, i, total'//new_line('a')// &
+        'end program main'
+    base = '/var/tmp/ert/ffc_do_while_module_oracle'
+    src = base//'.f90'
+    ffc_exe = base//'.ffc'
+    gfortran_exe = base//'.gfortran'
+    ffc_out = base//'.ffc.out'
+    gfortran_out = base//'.gfortran.out'
+
+    call execute_command_line('mkdir -p /var/tmp/ert')
+    call execute_command_line('rm -f '//src//' '//ffc_exe//' '//gfortran_exe// &
+        ' '//ffc_out//' '//gfortran_out)
+    options = compiler_frontend_options_t()
+    options%run_semantics = .true.
+    options%input_mode = INPUT_MODE_STANDARD
+    call compile_frontend_from_string(source, frontend_result, options)
+    if (.not. frontend_result%success()) then
+        print *, 'FAIL: FortFront rejected DO WHILE oracle source: ', &
+            trim(frontend_result%diagnostic_text)
+        stop 1
+    end if
+    call lower_program_to_liric_exe(frontend_result%arena, &
+        frontend_result%root_index, ffc_exe, error_msg)
+    if (len_trim(error_msg) > 0) then
+        print *, 'FAIL: ffc DO WHILE lowering failed: ', trim(error_msg)
+        stop 1
+    end if
+
+    open (newunit=unit, file=src, status='replace', action='write')
+    write (unit, '(A)') source
+    close (unit)
+    call execute_command_line('gfortran -w '//src//' -o '//gfortran_exe, &
+        exitstat=exit_stat)
+    if (exit_stat /= 0) then
+        print *, 'FAIL: gfortran rejected DO WHILE oracle source'
+        stop 1
+    end if
+    call execute_command_line(ffc_exe//' > '//ffc_out, exitstat=exit_stat)
+    if (exit_stat /= 0) then
+        print *, 'FAIL: ffc DO WHILE oracle executable failed'
+        stop 1
+    end if
+    call execute_command_line(gfortran_exe//' > '//gfortran_out, &
+        exitstat=exit_stat)
+    if (exit_stat /= 0) then
+        print *, 'FAIL: gfortran DO WHILE oracle executable failed'
+        stop 1
+    end if
+    call execute_command_line('diff '//ffc_out//' '//gfortran_out// &
+        ' > /dev/null 2>&1', exitstat=diff_status)
+    if (diff_status /= 0) then
+        print *, 'FAIL: typed DO WHILE output differs from gfortran'
+        call execute_command_line('diff '//ffc_out//' '//gfortran_out)
+        stop 1
+    end if
+    call execute_command_line('rm -f '//src//' '//ffc_exe//' '//gfortran_exe// &
+        ' '//ffc_out//' '//gfortran_out)
+    print *, 'PASS: typed DO WHILE module matches gfortran'
+end program test_session_do_while_gfortran_compiler


### PR DESCRIPTION
## Summary
- replace production `session_program_lowering_do_while.inc` with typed `session_program_lowering_do_while` descendant
- declare the module-procedure contract and export loop helpers required by GCC 14 cold links
- add an independent gfortran output oracle for a carried-state DO WHILE with CYCLE

## Evidence
- clean `fo build` 445/445 before the docs-only rebase
- `fo test test_session_do_while_compiler` PASS
- `fo test test_session_do_while_conditional_stop_compiler` PASS
- `fo test test_session_do_while_gfortran_compiler` PASS (byte-identical output)
- `git diff --check` PASS

The branch is rebased directly onto current `origin/main` (`968ae4a`).
