### PR TITLE
fix: remove duplicate DO WHILE export after extraction

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -479,7 +479,7 @@ module session_program_lowering_impl
     public :: collect_carried_symbols, reserve_backedge_value
     public :: carried_backedge_operand, emit_carried_phi, emit_carried_copy
     public :: begin_loop_exit_tracking, end_loop_exit_tracking
-    public :: merge_loop_exit_values, lower_statement_list
+    public :: merge_loop_exit_values
     public :: is_contained_i32_function, is_proc_pointer_call
     public :: is_statement_function_call, is_type_bound_method_call
     public :: lower_array_locate_intrinsic, lower_array_reduction_intrinsic


### PR DESCRIPTION
The DO WHILE extraction (#705) landed on top of #704, which already exports `lower_statement_list`. The extraction added the same name a second time, and gfortran rejects the ancestor module with `ACCESS specification ... already specified`. Remove the duplicate public item.

Evidence: clean `fo clean && fo build` 446/446 on current main plus expected existing warnings.
