### PR TITLE
fix: export select value for loop submodule link

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -469,6 +469,7 @@ module session_program_lowering_impl
     public :: lower_i32_pow, lower_i32_call, lower_storage_size_intrinsic
     public :: lower_kind_intrinsic, lower_i32_array_element
     public :: lower_i1_condition
+    public :: select_value
     public :: lower_do_loop, lower_statement_list
     public :: lower_counted_loop
     public :: push_storage_scope, pop_storage_scope


### PR DESCRIPTION
## Summary
- export the existing `select_value` host procedure from `session_program_lowering_impl`
- repair the cold fpm link after counted-loop submodule extraction (#712)

Current main already exports `lower_i1_condition` via #713; this closes the remaining undefined reference observed by CI after #712.

## Validation
- `LIBRARY_PATH=/home/ert/code/liric/build fo clean && fo build` (450/450)
- focused loop/control + independent gfortran oracle suite (8/8 PASS), including #626 nested DO tail and #671 contained-call operand
- `git diff --check`
