### PR TITLE
refactor: extract WHERE lowering submodule

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -477,6 +477,12 @@ module session_program_lowering_impl
     public :: lower_associate, bind_associate_name
     public :: lower_forall, prepare_forall_snapshot, clear_forall_snapshot
     public :: lower_forall_level, lower_forall_body, lower_forall_masked_body
+    public :: lower_where_stmt, lower_where_construct, lower_where_mask_element
+    public :: lower_elementwise_scalar_operand, is_elemental_real_call
+    public :: lower_elementwise_elemental_call, is_elemental_user_call
+    public :: lower_elementwise_user_call
+    public :: lower_elementwise_type_bound_user_call
+    public :: is_elemental_minmax_call, lower_elementwise_minmax_call
     public :: materialize_scalar_associate_source, associate_selector_is_array
     public :: associate_symbol_slot, bind_associate_array_section
     public :: bind_associate_component, bind_associate_alloc_array_component
@@ -3598,6 +3604,109 @@ module session_program_lowering_impl
             type(lowering_context_t), intent(inout) :: context
             character(len=:), allocatable, intent(out) :: error_msg
         end subroutine lower_pause
+    end interface
+    ! WHERE and whole-array elemental helpers are defined in a typed
+    ! descendant. Keep the contracts explicit: ancestor lowering calls
+    ! several of these helpers directly, and GCC 14 otherwise gives the
+    ! cold submodule references local linkage.
+    interface
+        module subroutine lower_where_stmt(arena, node, context, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(where_stmt_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_where_stmt
+        module subroutine lower_where_construct(arena, node, context, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(where_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_where_construct
+        module subroutine lower_where_mask_element(arena, mask_index, &
+                                                   linear_index, context, cond, &
+                                                   error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: mask_index
+            integer, intent(in) :: linear_index
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: cond
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_where_mask_element
+        module subroutine lower_elementwise_scalar_operand(arena, node_index, &
+                                                           target_symbol_index, &
+                                                           context, value, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            integer, intent(in) :: target_symbol_index
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_elementwise_scalar_operand
+        module function is_elemental_real_call(arena, node_index) result(is_call)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            logical :: is_call
+        end function is_elemental_real_call
+        module subroutine lower_elementwise_elemental_call(arena, node_index, &
+                                                           target_symbol_index, &
+                                                           linear_index, context, &
+                                                           value, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            integer, intent(in) :: target_symbol_index
+            integer, intent(in) :: linear_index
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_elementwise_elemental_call
+        module function is_elemental_user_call(arena, node_index, context) &
+            result(is_call)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            type(lowering_context_t), intent(in) :: context
+            logical :: is_call
+        end function is_elemental_user_call
+        module subroutine lower_elementwise_user_call(arena, node_index, &
+                                                      target_symbol_index, &
+                                                      linear_index, context, value, &
+                                                      error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            integer, intent(in) :: target_symbol_index
+            integer, intent(in) :: linear_index
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_elementwise_user_call
+        module subroutine lower_elementwise_type_bound_user_call(arena, node_index, &
+                                                                 target_symbol_index, &
+                                                                 linear_index, context, &
+                                                                 value, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            integer, intent(in) :: target_symbol_index
+            integer, intent(in) :: linear_index
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_elementwise_type_bound_user_call
+        module function is_elemental_minmax_call(arena, node_index) result(is_call)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            logical :: is_call
+        end function is_elemental_minmax_call
+        module subroutine lower_elementwise_minmax_call(arena, node_index, &
+                                                        target_symbol_index, &
+                                                        linear_index, context, value, &
+                                                        error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            integer, intent(in) :: target_symbol_index
+            integer, intent(in) :: linear_index
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_elementwise_minmax_call
     end interface
 contains
     include 'session_program_lowering_top.inc'

--- a/src/session_program_lowering_top.inc
+++ b/src/session_program_lowering_top.inc
@@ -1320,7 +1320,6 @@
     include 'session_program_lowering_save_static.inc'
     include 'session_program_lowering_common.inc'
     include 'session_program_lowering_equivalence.inc'
-    include 'session_program_lowering_where.inc'
     include 'session_program_lowering_namelist.inc'
     subroutine lower_statement_list(arena, node_indices, context, value, &
                                     terminated, error_msg)

--- a/src/session_program_lowering_where.f90
+++ b/src/session_program_lowering_where.f90
@@ -1,3 +1,6 @@
+submodule (session_program_lowering_impl) session_program_lowering_where
+    implicit none
+contains
     ! WHERE construct and statement: masked elementwise array assignment.
     !
     ! A WHERE assigns to array elements only where a conformable logical mask is
@@ -1273,3 +1276,5 @@
             libm32 = 'roundf'; libm64 = 'round'
         end if
     end subroutine elemental_real_libm_names
+
+end submodule session_program_lowering_where


### PR DESCRIPTION
## Summary
- extract WHERE and whole-array elemental lowering from the monolithic include into a typed submodule
- declare explicit ancestor interfaces and exports for cold GCC14 links
- preserve existing WHERE/ELSEWHERE/nested-mask and whole-array elemental behavior

## Validation
- `fo clean && fo build` 452/452
- `fo test test_session_where_compiler` PASS
- `fo test test_session_structured_control_compiler` PASS
- independent gfortran WHERE oracle matched masked, ELSEWHERE, and overlapping-section outputs
- `git diff --check` PASS

Full `fo check` retains the repository baseline failures outside this slice.