### PR TITLE
fix: export WHERE submodule host helpers

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -483,6 +483,16 @@ module session_program_lowering_impl
     public :: lower_elementwise_user_call
     public :: lower_elementwise_type_bound_user_call
     public :: is_elemental_minmax_call, lower_elementwise_minmax_call
+    ! WHERE's typed descendant also uses these host-side array, elemental, and
+    ! polymorphic helpers.  Export them so GCC cold submodule links cannot
+    ! resolve private ancestor definitions as local-only symbols.
+    public :: lower_array_elementwise_value, build_array_expression
+    public :: cached_array_expression_symbol, is_elementwise_array_operand
+    public :: character_array_symbol_element_operands
+    public :: class_dummy_declared_type_index, emit_class_scalar_descriptor
+    public :: total_component_slots, class_receiver_dispatches_dynamically
+    public :: class_dispatch_callee, contained_elemental_signature
+    public :: method_call_info
     public :: lower_select_case, lower_select_type, lower_select_type_default
     public :: lower_select_rank, allocate_targets_class_star
     public :: lower_class_star_allocate


### PR DESCRIPTION
## Summary
- export the ancestor array, elemental, polymorphic, and derived-type helpers referenced by the typed WHERE submodule
- repair GCC cold fpm links after the WHERE extraction (#720)

## Validation
- clean `fo clean && fo build`: 453/453
- focused `fo test test_session_where_compiler`: PASS
- focused `fo test test_session_whole_array_minmax_compiler`: PASS
- independent gfortran-vs-ffc WHERE oracle: exact output `2 3 30 40`
- independent SELECT CASE/TYPE oracle remains exact output `27` on this base

This is a linkage-contract repair only; no aggregate corpus PASS or XFAIL changes are claimed.