### PR TITLE
refactor: extract intrinsic-extra lowering into submodule

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -539,6 +539,8 @@ module session_program_lowering_impl
     public :: lower_i32_len_intrinsic, lower_i32_len_trim_intrinsic
     public :: lower_i32_proc_ptr_call, lower_iachar_intrinsic
     public :: lower_index_intrinsic, lower_lbound_intrinsic
+    public :: lower_comparison_mask_element, lower_repeat_deferred
+    public :: lower_f32_real_conversion, lower_f64_real_conversion
     public :: lower_logical_array_all_intrinsic
     public :: lower_logical_array_any_intrinsic
     public :: lower_logical_array_count_intrinsic, lower_method_call_i32
@@ -546,6 +548,8 @@ module session_program_lowering_impl
     public :: lower_scan_intrinsic, lower_statement_function_call
     public :: lower_ubound_intrinsic
     public :: lower_verify_intrinsic, overloaded_operator_slot
+    public :: is_logical_reduction_call, real_compare_predicate
+    public :: resolve_comparison_mask, try_alloc_component_mask_reduction
     public :: parse_i32_literal, prepare_reference_args
     public :: reject_monomorphized_call, set_empty
     public :: unsupported_array_subscript, unsupported_intrinsic_error
@@ -3843,6 +3847,235 @@ module session_program_lowering_impl
             integer, allocatable, intent(out) :: body(:)
         end subroutine select_type_guard_body
     end interface
+    ! Additional intrinsic lowering lives in a typed descendant.  Keep the
+    ! complete contracts here so the host implementation and cold submodule
+    ! links agree without textual include fragments.
+    interface
+        module subroutine lower_lbound_intrinsic(arena, node, context, value, &
+                                                 error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_lbound_intrinsic
+        module subroutine lower_ubound_intrinsic(arena, node, context, value, &
+                                                 error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_ubound_intrinsic
+        module subroutine resolve_comparison_mask(arena, node_index, context, &
+                                                   mask_sym, scalar_index, &
+                                                   array_on_left, source_op, &
+                                                   error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            type(lowering_context_t), intent(in) :: context
+            integer, intent(out) :: mask_sym
+            integer, intent(out) :: scalar_index
+            logical, intent(out) :: array_on_left
+            character(len=:), allocatable, intent(out) :: source_op
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine resolve_comparison_mask
+        module subroutine lower_comparison_mask_element(context, mask_sym, &
+                                                         scalar_index, &
+                                                         array_on_left, source_op, &
+                                                         arena, linear_index, value, &
+                                                         error_msg)
+            type(lowering_context_t), intent(inout) :: context
+            integer, intent(in) :: mask_sym
+            integer, intent(in) :: scalar_index
+            logical, intent(in) :: array_on_left
+            character(len=*), intent(in) :: source_op
+            type(ast_arena_t), intent(in) :: arena
+            integer(c_int64_t), intent(in) :: linear_index
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_comparison_mask_element
+        module subroutine real_compare_predicate(source_op, predicate, error_msg)
+            character(len=*), intent(in) :: source_op
+            integer(c_int), intent(out) :: predicate
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine real_compare_predicate
+        module function is_logical_reduction_call(arena, node_index, context) &
+            result(is_call)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            type(lowering_context_t), intent(in) :: context
+            logical :: is_call
+        end function is_logical_reduction_call
+        module subroutine lower_logical_array_count_intrinsic(arena, node, &
+                                                              context, value, &
+                                                              error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_logical_array_count_intrinsic
+        module subroutine lower_logical_array_any_intrinsic(arena, node, context, &
+                                                            value, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_logical_array_any_intrinsic
+        module subroutine lower_logical_array_all_intrinsic(arena, node, context, &
+                                                            value, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_logical_array_all_intrinsic
+        module subroutine try_alloc_component_mask_reduction(arena, node, context, &
+                                                             is_all, handled, value, &
+                                                             error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            logical, intent(in) :: is_all
+            logical, intent(out) :: handled
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine try_alloc_component_mask_reduction
+        module subroutine classify_mask_operands(arena, left_idx, right_idx, &
+                                                  context, comp_access, arr_sym, &
+                                                  comp_on_left)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: left_idx, right_idx
+            type(lowering_context_t), intent(in) :: context
+            integer, intent(out) :: comp_access, arr_sym
+            logical, intent(out) :: comp_on_left
+        end subroutine classify_mask_operands
+        module function operand_is_alloc_component(arena, idx, context) &
+            result(is_comp)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: idx
+            type(lowering_context_t), intent(in) :: context
+            logical :: is_comp
+        end function operand_is_alloc_component
+        module function whole_array_symbol(arena, idx, context) result(sym)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: idx
+            type(lowering_context_t), intent(in) :: context
+            integer :: sym
+        end function whole_array_symbol
+        module subroutine lower_array_locate_intrinsic(arena, node, context, &
+                                                        value, error_msg, want_max)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+            logical, intent(in) :: want_max
+        end subroutine lower_array_locate_intrinsic
+        module subroutine resolve_locate_arguments(arena, node, context, which, &
+                                                   sym, mask_sym, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            type(lowering_context_t), intent(in) :: context
+            character(len=*), intent(in) :: which
+            integer, intent(out) :: sym, mask_sym
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine resolve_locate_arguments
+        module subroutine emit_locate_scan(context, want_max, sym, mask_sym, value, &
+                                           error_msg)
+            type(lowering_context_t), intent(inout) :: context
+            logical, intent(in) :: want_max
+            integer, intent(in) :: sym, mask_sym
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine emit_locate_scan
+        module subroutine emit_character_locate_scan(context, want_max, sym, &
+                                                     mask_sym, value, error_msg)
+            type(lowering_context_t), intent(inout) :: context
+            logical, intent(in) :: want_max
+            integer, intent(in) :: sym, mask_sym
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine emit_character_locate_scan
+        module subroutine locate_is_better_char(context, want_max, cand_data, &
+                                                cand_len, best_data, best_len, &
+                                                best_idx, better, error_msg)
+            type(lowering_context_t), intent(inout) :: context
+            logical, intent(in) :: want_max
+            type(lr_operand_desc_t), intent(in) :: cand_data, cand_len
+            type(lr_operand_desc_t), intent(in) :: best_data, best_len, best_idx
+            type(lr_operand_desc_t), intent(out) :: better
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine locate_is_better_char
+        module subroutine locate_is_better(context, want_max, vk, cand, best_val, &
+                                           best_idx, better, error_msg)
+            type(lowering_context_t), intent(inout) :: context
+            logical, intent(in) :: want_max
+            integer, intent(in) :: vk
+            type(lr_operand_desc_t), intent(in) :: cand, best_val, best_idx
+            type(lr_operand_desc_t), intent(out) :: better
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine locate_is_better
+        module function locate_arg_value_node(arena, arg_index) result(value_node)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: arg_index
+            integer :: value_node
+        end function locate_arg_value_node
+        module subroutine lower_scan_intrinsic(arena, node, context, value, &
+                                               error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_scan_intrinsic
+        module subroutine lower_verify_intrinsic(arena, node, context, value, &
+                                                 error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_verify_intrinsic
+        module subroutine lower_repeat_deferred(arena, node, context, out_data, &
+                                                out_length, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: out_data, out_length
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_repeat_deferred
+        module subroutine check_real_conversion_args(arena, node, context, &
+                                                     wide_kind, argument_index, &
+                                                     kind_index, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            type(lowering_context_t), intent(in) :: context
+            logical, intent(out) :: wide_kind
+            integer, intent(out) :: argument_index, kind_index
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine check_real_conversion_args
+        module subroutine lower_f32_real_conversion(arena, node, libm_name, &
+                                                    context, value, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            character(len=*), intent(in) :: libm_name
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_f32_real_conversion
+        module subroutine lower_f64_real_conversion(arena, node, libm_name, &
+                                                    context, value, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            character(len=*), intent(in) :: libm_name
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_f64_real_conversion
+    end interface
     interface
         module subroutine lower_associate(arena, node, node_index, context, &
                                           error_msg)
@@ -5732,7 +5965,6 @@ contains
     include 'session_program_lowering_expr_lowering.inc'
     include 'session_program_lowering_complex_arrays.inc'
     include 'session_program_lowering_intrinsics.inc'
-    include 'session_program_lowering_intrinsics_extra.inc'
     include 'session_program_lowering_logical_reduction.inc'
     include 'session_program_lowering_pointer.inc'
     include 'session_program_lowering_proc_dummy.inc'

--- a/src/session_program_lowering_intrinsics_extra.f90
+++ b/src/session_program_lowering_intrinsics_extra.f90
@@ -1,3 +1,6 @@
+submodule (session_program_lowering_impl) session_program_lowering_intrinsics_extra
+    implicit none
+contains
     ! lbound(a, dim): lower bound of array dimension dim (1-based).
     subroutine lower_lbound_intrinsic(arena, node, context, value, error_msg)
         type(ast_arena_t), intent(in) :: arena
@@ -28,7 +31,7 @@
         dim_val = 1_c_int64_t
         if (size(node%arg_indices) >= 2) then
             call eval_i32_constant(arena, node%arg_indices(2), context, dim_val, &
-                                   error_msg)
+                error_msg)
             if (len_trim(error_msg) > 0) return
         end if
         if (dim_val < 1 .or. dim_val > context%symbols(sym)%array_rank) then
@@ -41,13 +44,13 @@
                 int(dim_val), lower64, error_msg)
             if (len_trim(error_msg) > 0) return
             if (.not. emit_liric_i64_to_i32(context%session, lower64, value, &
-                    error_msg)) return
+                error_msg)) return
             call set_empty(error_msg)
             return
         end if
         value = i32_immediate(context%session, &
-                    int(context%symbols(sym)%array_dim_lowers(int(dim_val)), &
-                        c_int64_t))
+            int(context%symbols(sym)%array_dim_lowers(int(dim_val)), &
+            c_int64_t))
         call set_empty(error_msg)
     end subroutine lower_lbound_intrinsic
 
@@ -82,7 +85,7 @@
         dim_val = 1_c_int64_t
         if (size(node%arg_indices) >= 2) then
             call eval_i32_constant(arena, node%arg_indices(2), context, dim_val, &
-                                   error_msg)
+                error_msg)
             if (len_trim(error_msg) > 0) return
         end if
         if (dim_val < 1 .or. dim_val > context%symbols(sym)%array_rank) then
@@ -99,12 +102,12 @@
                 int(dim_val), extent64, error_msg)
             if (len_trim(error_msg) > 0) return
             if (.not. emit_i64_binary(context%session, LR_OP_ADD, lower64, &
-                    extent64, sum64, error_msg)) return
+                extent64, sum64, error_msg)) return
             if (.not. emit_i64_binary(context%session, LR_OP_SUB, sum64, &
-                    i64_immediate(context%session, 1_c_int64_t), upper64, &
-                    error_msg)) return
+                i64_immediate(context%session, 1_c_int64_t), upper64, &
+                error_msg)) return
             if (.not. emit_liric_i64_to_i32(context%session, upper64, value, &
-                    error_msg)) return
+                error_msg)) return
             call set_empty(error_msg)
             return
         end if
@@ -121,9 +124,9 @@
                     value = context%symbols(sym)%runtime_dim_size(int(dim_val))
                 else
                     if (.not. emit_i32_binary(context%session, LR_OP_ADD, &
-                            context%symbols(sym)%runtime_dim_size(int(dim_val)), &
-                            i32_immediate(context%session, &
-                            int(lower - 1, c_int64_t)), value, error_msg)) return
+                        context%symbols(sym)%runtime_dim_size(int(dim_val)), &
+                        i32_immediate(context%session, &
+                        int(lower - 1, c_int64_t)), value, error_msg)) return
                 end if
                 call set_empty(error_msg)
                 return
@@ -140,8 +143,8 @@
     ! AST index, the comparison predicate, and whether the array is on the left.
     ! Leaves mask_sym = 0 when node is not a supported comparison mask.
     subroutine resolve_comparison_mask(arena, node_index, context, mask_sym, &
-                                       scalar_index, array_on_left, source_op, &
-                                       error_msg)
+            scalar_index, array_on_left, source_op, &
+            error_msg)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: node_index
         type(lowering_context_t), intent(in) :: context
@@ -160,7 +163,7 @@
         array_on_left = .true.
         if (.not. is_binary_op(arena, node_index)) return
         call get_binary_op_info(arena, node_index, source_op, left_idx, &
-                                right_idx, line, col, error_msg)
+            right_idx, line, col, error_msg)
         if (len_trim(error_msg) > 0) return
         select case (trim(source_op))
         case ('==', '=', '/=', '!=', '>', '>=', '<', '<=')
@@ -201,8 +204,8 @@
 
     ! Emit the i-th element of a comparison mask as an i32 0/1 operand.
     subroutine lower_comparison_mask_element(context, mask_sym, scalar_index, &
-                                             array_on_left, source_op, arena, &
-                                             linear_index, value, error_msg)
+            array_on_left, source_op, arena, &
+            linear_index, value, error_msg)
         type(lowering_context_t), intent(inout) :: context
         integer, intent(in) :: mask_sym
         integer, intent(in) :: scalar_index
@@ -217,19 +220,19 @@
         integer :: vk
 
         call load_array_linear_element(context, mask_sym, linear_index, elem, &
-                                       error_msg)
+            error_msg)
         if (len_trim(error_msg) > 0) return
         vk = context%symbols(mask_sym)%value_kind
         select case (vk)
         case (VALUE_F32)
             call lower_f32_expression(arena, scalar_index, context, scalar, &
-                                      error_msg)
+                error_msg)
         case (VALUE_F64)
             call lower_f64_expression(arena, scalar_index, context, scalar, &
-                                      error_msg)
+                error_msg)
         case default
             call lower_i32_expression(arena, scalar_index, context, scalar, &
-                                      error_msg)
+                error_msg)
         end select
         if (len_trim(error_msg) > 0) return
 
@@ -246,17 +249,17 @@
             call real_compare_predicate(source_op, predicate, error_msg)
             if (len_trim(error_msg) > 0) return
             if (.not. emit_liric_f32_fcmp(context%session, predicate, lhs, rhs, &
-                                          value, error_msg)) return
+                value, error_msg)) return
         case (VALUE_F64)
             call real_compare_predicate(source_op, predicate, error_msg)
             if (len_trim(error_msg) > 0) return
             if (.not. emit_liric_f64_fcmp(context%session, predicate, lhs, rhs, &
-                                          value, error_msg)) return
+                value, error_msg)) return
         case default
             call integer_compare_predicate(source_op, predicate, error_msg)
             if (len_trim(error_msg) > 0) return
             if (.not. emit_liric_i32_icmp(context%session, predicate, lhs, rhs, &
-                                          value, error_msg)) return
+                value, error_msg)) return
         end select
     end subroutine lower_comparison_mask_element
 
@@ -297,18 +300,18 @@
         is_logical_reduction_call = .false.
         if (.not. node_exists(arena, node_index)) return
         select type (node => arena%entries(node_index)%node)
-        type is (call_or_subscript_node)
+            type is (call_or_subscript_node)
             if (.not. allocated(node%name)) return
             if (node%is_array_access) return
             if (is_contained_i32_function(context, node%name)) return
             is_logical_reduction_call = same_name(node%name, 'any') .or. &
-                                        same_name(node%name, 'all')
+                same_name(node%name, 'all')
         end select
     end function is_logical_reduction_call
 
     ! count(mask): number of .true. (nonzero) elements in a logical array.
     subroutine lower_logical_array_count_intrinsic(arena, node, context, value, &
-                                                   error_msg)
+            error_msg)
         type(ast_arena_t), intent(in) :: arena
         type(call_or_subscript_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
@@ -327,15 +330,15 @@
         block
             logical :: handled
             call try_general_mask_reduction(arena, node, context, 'count', &
-                                            handled, value, error_msg)
+                handled, value, error_msg)
             if (handled .or. len_trim(error_msg) > 0) return
         end block
 
         ! A comparison-expression mask (count(a > 2)) reduces over the compared
         ! array's elements; an identifier mask names a declared logical array.
         call resolve_comparison_mask(arena, node%arg_indices(1), context, sym, &
-                                     scalar_index, array_on_left, source_op, &
-                                     error_msg)
+            scalar_index, array_on_left, source_op, &
+            error_msg)
         if (len_trim(error_msg) > 0) return
         if (sym > 0) then
             array_size = context%symbols(sym)%array_size
@@ -346,7 +349,7 @@
                     error_msg)
                 if (len_trim(error_msg) > 0) return
                 if (.not. emit_i32_binary(context%session, LR_OP_ADD, total, &
-                                          elem, next_total, error_msg)) return
+                    elem, next_total, error_msg)) return
                 total = next_total
             end do
             value = total
@@ -369,10 +372,10 @@
         total = i32_immediate(context%session, 0_c_int64_t)
         do i = 0, array_size - 1
             call load_array_linear_element(context, sym, int(i, c_int64_t), &
-                                           elem, error_msg)
+                elem, error_msg)
             if (len_trim(error_msg) > 0) return
             if (.not. emit_i32_binary(context%session, LR_OP_ADD, total, elem, &
-                                      next_total, error_msg)) return
+                next_total, error_msg)) return
             total = next_total
         end do
         value = total
@@ -381,7 +384,7 @@
 
     ! any(mask): 1 if any element nonzero, else 0.
     subroutine lower_logical_array_any_intrinsic(arena, node, context, value, &
-                                                 error_msg)
+            error_msg)
         type(ast_arena_t), intent(in) :: arena
         type(call_or_subscript_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
@@ -400,13 +403,13 @@
         block
             logical :: handled
             call try_array_mask_reduction(arena, node, context, .false., &
-                                          handled, value, error_msg)
+                handled, value, error_msg)
             if (handled .or. len_trim(error_msg) > 0) return
         end block
 
         call resolve_comparison_mask(arena, node%arg_indices(1), context, sym, &
-                                     scalar_index, array_on_left, source_op, &
-                                     error_msg)
+            scalar_index, array_on_left, source_op, &
+            error_msg)
         if (len_trim(error_msg) > 0) return
         ! OR all 0/1 mask elements: nonzero iff any is .true.
         if (sym > 0) then
@@ -418,7 +421,7 @@
                     error_msg)
                 if (len_trim(error_msg) > 0) return
                 if (.not. emit_i32_binary(context%session, LR_OP_OR, acc, elem, &
-                                          next_acc, error_msg)) return
+                    next_acc, error_msg)) return
                 acc = next_acc
             end do
             value = acc
@@ -441,10 +444,10 @@
         acc = i32_immediate(context%session, 0_c_int64_t)
         do i = 0, array_size - 1
             call load_array_linear_element(context, sym, int(i, c_int64_t), &
-                                           elem, error_msg)
+                elem, error_msg)
             if (len_trim(error_msg) > 0) return
             if (.not. emit_i32_binary(context%session, LR_OP_OR, acc, elem, &
-                                      next_acc, error_msg)) return
+                next_acc, error_msg)) return
             acc = next_acc
         end do
         value = acc
@@ -453,7 +456,7 @@
 
     ! all(mask): 1 if all elements nonzero, else 0.
     subroutine lower_logical_array_all_intrinsic(arena, node, context, value, &
-                                                 error_msg)
+            error_msg)
         type(ast_arena_t), intent(in) :: arena
         type(call_or_subscript_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
@@ -472,13 +475,13 @@
         block
             logical :: handled
             call try_array_mask_reduction(arena, node, context, .true., &
-                                          handled, value, error_msg)
+                handled, value, error_msg)
             if (handled .or. len_trim(error_msg) > 0) return
         end block
 
         call resolve_comparison_mask(arena, node%arg_indices(1), context, sym, &
-                                     scalar_index, array_on_left, source_op, &
-                                     error_msg)
+            scalar_index, array_on_left, source_op, &
+            error_msg)
         if (len_trim(error_msg) > 0) return
         ! Normalise each mask element to 0/1, AND them: 1 iff all are .true.
         if (sym > 0) then
@@ -490,10 +493,10 @@
                     error_msg)
                 if (len_trim(error_msg) > 0) return
                 if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, elem, &
-                        i32_immediate(context%session, 0_c_int64_t), cond, &
-                        error_msg)) return
+                    i32_immediate(context%session, 0_c_int64_t), cond, &
+                    error_msg)) return
                 if (.not. emit_i32_binary(context%session, LR_OP_AND, acc, cond, &
-                                          next_acc, error_msg)) return
+                    next_acc, error_msg)) return
                 acc = next_acc
             end do
             value = acc
@@ -517,13 +520,13 @@
         acc = i32_immediate(context%session, 1_c_int64_t)
         do i = 0, array_size - 1
             call load_array_linear_element(context, sym, int(i, c_int64_t), &
-                                           elem, error_msg)
+                elem, error_msg)
             if (len_trim(error_msg) > 0) return
             if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, elem, &
-                    i32_immediate(context%session, 0_c_int64_t), cond, &
-                    error_msg)) return
+                i32_immediate(context%session, 0_c_int64_t), cond, &
+                error_msg)) return
             if (.not. emit_i32_binary(context%session, LR_OP_AND, acc, cond, &
-                                      next_acc, error_msg)) return
+                next_acc, error_msg)) return
             acc = next_acc
         end do
         value = acc
@@ -531,7 +534,7 @@
     end subroutine lower_logical_array_all_intrinsic
 
     subroutine try_alloc_component_mask_reduction(arena, node, context, is_all, &
-                                                  handled, value, error_msg)
+            handled, value, error_msg)
         ! all/any of an elementwise integer comparison where one operand is a
         ! whole rank-1 allocatable array component and the other a compile-time-
         ! sized integer array. Unrolls over the array's static extent (the
@@ -559,7 +562,7 @@
         left_idx = 0
         right_idx = 0
         select type (b => arena%entries(arg_index)%node)
-        type is (binary_op_node)
+            type is (binary_op_node)
             if (.not. is_relational_operator(b%operator)) return
             op = b%operator
             left_idx = b%left_index
@@ -568,7 +571,7 @@
             return
         end select
         call classify_mask_operands(arena, left_idx, right_idx, context, &
-                                    comp_access, arr_sym, comp_on_left)
+            comp_access, arr_sym, comp_on_left)
         if (comp_access <= 0 .or. arr_sym <= 0) return
         if (derived_component_access_kind_at(arena, comp_access, context) &
             /= VALUE_I32) return
@@ -582,7 +585,7 @@
         call integer_compare_predicate(op, predicate, error_msg)
         if (len_trim(error_msg) > 0) return
         call alloc_array_component_descriptor(arena, comp_access, context, &
-                                              desc_addr, error_msg)
+            desc_addr, error_msg)
         if (len_trim(error_msg) > 0) return
         if (is_all) then
             acc = i32_immediate(context%session, 1_c_int64_t)
@@ -595,7 +598,7 @@
                 error_msg)
             if (len_trim(error_msg) > 0) return
             call load_array_linear_element(context, arr_sym, int(i, c_int64_t), &
-                                           arr_elem, error_msg)
+                arr_elem, error_msg)
             if (len_trim(error_msg) > 0) return
             if (comp_on_left) then
                 lhs = comp_elem
@@ -605,13 +608,13 @@
                 rhs = comp_elem
             end if
             if (.not. emit_liric_i32_icmp(context%session, predicate, lhs, rhs, &
-                    cond, error_msg)) return
+                cond, error_msg)) return
             if (is_all) then
                 if (.not. emit_i32_binary(context%session, LR_OP_AND, acc, cond, &
-                        next_acc, error_msg)) return
+                    next_acc, error_msg)) return
             else
                 if (.not. emit_i32_binary(context%session, LR_OP_OR, acc, cond, &
-                        next_acc, error_msg)) return
+                    next_acc, error_msg)) return
             end if
             acc = next_acc
         end do
@@ -621,7 +624,7 @@
     end subroutine try_alloc_component_mask_reduction
 
     subroutine classify_mask_operands(arena, left_idx, right_idx, context, &
-                                      comp_access, arr_sym, comp_on_left)
+            comp_access, arr_sym, comp_on_left)
         ! comp_access = arena index of a whole alloc-array-component operand (or
         ! 0); arr_sym = symbol of a whole intrinsic array operand (or 0).
         type(ast_arena_t), intent(in) :: arena
@@ -652,7 +655,7 @@
         is_comp = .false.
         if (.not. node_exists(arena, idx)) return
         select type (acc => arena%entries(idx)%node)
-        type is (component_access_node)
+            type is (component_access_node)
             is_comp = component_access_is_alloc_array(arena, acc, context)
         end select
     end function operand_is_alloc_component
@@ -678,7 +681,7 @@
     ! considered; if none qualify the result is 0 (F2018 semantics). A scalar
     ! dim argument, when present, must select the single rank-1 dimension.
     subroutine lower_array_locate_intrinsic(arena, node, context, value, &
-                                            error_msg, want_max)
+            error_msg, want_max)
         type(ast_arena_t), intent(in) :: arena
         type(call_or_subscript_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
@@ -695,7 +698,7 @@
         end if
 
         call resolve_locate_arguments(arena, node, context, which, sym, mask_sym, &
-                                      error_msg)
+            error_msg)
         if (len_trim(error_msg) > 0) return
         if (context%symbols(sym)%array_size <= 0) then
             error_msg = trim(which)//' requires a non-empty array'
@@ -703,10 +706,10 @@
         end if
         if (context%symbols(sym)%value_kind == VALUE_CHARACTER) then
             call emit_character_locate_scan(context, want_max, sym, mask_sym, &
-                                            value, error_msg)
+                value, error_msg)
         else
             call emit_locate_scan(context, want_max, sym, mask_sym, value, &
-                                  error_msg)
+                error_msg)
         end if
     end subroutine lower_array_locate_intrinsic
 
@@ -715,7 +718,7 @@
     ! Keyword arguments (dim=, mask=) arrive as keyword assignment nodes that
     ! are unwrapped to their value node before classifying.
     subroutine resolve_locate_arguments(arena, node, context, which, sym, &
-                                        mask_sym, error_msg)
+            mask_sym, error_msg)
         type(ast_arena_t), intent(in) :: arena
         type(call_or_subscript_node), intent(in) :: node
         type(lowering_context_t), intent(in) :: context
@@ -800,24 +803,24 @@
         best_val = i32_immediate(context%session, 0_c_int64_t)
         do i = 0, array_size - 1
             call load_array_linear_element(context, sym, int(i, c_int64_t), &
-                                           cand, error_msg)
+                cand, error_msg)
             if (len_trim(error_msg) > 0) return
             cand_idx = i32_immediate(context%session, int(i + 1, c_int64_t))
 
             call locate_is_better(context, want_max, &
-                                  context%symbols(sym)%value_kind, cand, best_val, &
-                                  best_idx, better, error_msg)
+                context%symbols(sym)%value_kind, cand, best_val, &
+                best_idx, better, error_msg)
             if (len_trim(error_msg) > 0) return
             take = better
             if (mask_sym > 0) then
                 call load_array_linear_element(context, mask_sym, &
-                                               int(i, c_int64_t), mask_elem, error_msg)
+                    int(i, c_int64_t), mask_elem, error_msg)
                 if (len_trim(error_msg) > 0) return
                 if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, &
-                        mask_elem, i32_immediate(context%session, 0_c_int64_t), &
-                        masked, error_msg)) return
+                    mask_elem, i32_immediate(context%session, 0_c_int64_t), &
+                    masked, error_msg)) return
                 if (.not. emit_i32_binary(context%session, LR_OP_AND, take, &
-                                          masked, sel_idx, error_msg)) return
+                    masked, sel_idx, error_msg)) return
                 take = sel_idx
             end if
 
@@ -838,7 +841,7 @@
     ! integer.  Keep the same first-match and mask semantics as the numeric
     ! scan while comparing the complete fixed-width character values.
     subroutine emit_character_locate_scan(context, want_max, sym, mask_sym, &
-                                          value, error_msg)
+            value, error_msg)
         type(lowering_context_t), intent(inout) :: context
         logical, intent(in) :: want_max
         integer, intent(in) :: sym, mask_sym
@@ -853,44 +856,44 @@
 
         array_size = context%symbols(sym)%array_size
         call character_array_symbol_element_operands(context, sym, 0, best_data, &
-                                                     best_len, error_msg)
+            best_len, error_msg)
         if (len_trim(error_msg) > 0) return
         if (.not. emit_ptr_alloca(context%session, best_data_addr, error_msg)) &
             return
         if (.not. emit_i32_alloca(context%session, best_idx_addr, error_msg)) &
             return
         if (.not. emit_ptr_store(context%session, best_data, best_data_addr, &
-                error_msg)) return
+            error_msg)) return
         if (.not. emit_i32_store(context%session, &
-                i32_immediate(context%session, 0_c_int64_t), best_idx_addr, &
-                error_msg)) return
+            i32_immediate(context%session, 0_c_int64_t), best_idx_addr, &
+            error_msg)) return
 
         do i = 0, array_size - 1
             call character_array_symbol_element_operands(context, sym, i, &
-                                                         cand_data, cand_len, &
-                                                         error_msg)
+                cand_data, cand_len, &
+                error_msg)
             if (len_trim(error_msg) > 0) return
             cand_idx = i32_immediate(context%session, int(i + 1, c_int64_t))
             if (.not. emit_ptr_load(context%session, best_data_addr, best_data, &
-                    error_msg)) return
+                error_msg)) return
             if (.not. emit_i32_load(context%session, best_idx_addr, best_idx, &
-                    error_msg)) return
+                error_msg)) return
 
             call locate_is_better_char(context, want_max, cand_data, cand_len, &
-                                       best_data, best_len, best_idx, better, &
-                                       error_msg)
+                best_data, best_len, best_idx, better, &
+                error_msg)
             if (len_trim(error_msg) > 0) return
             take = better
             if (mask_sym > 0) then
                 call load_array_linear_element(context, mask_sym, &
-                                               int(i, c_int64_t), mask_elem, &
-                                               error_msg)
+                    int(i, c_int64_t), mask_elem, &
+                    error_msg)
                 if (len_trim(error_msg) > 0) return
                 if (.not. emit_liric_i32_icmp(context%session, LR_CMP_NE, &
-                        mask_elem, i32_immediate(context%session, 0_c_int64_t), &
-                        masked, error_msg)) return
+                    mask_elem, i32_immediate(context%session, 0_c_int64_t), &
+                    masked, error_msg)) return
                 if (.not. emit_i32_binary(context%session, LR_OP_AND, take, &
-                                          masked, masked_take, error_msg)) return
+                    masked, masked_take, error_msg)) return
                 take = masked_take
             end if
 
@@ -898,14 +901,14 @@
             keep_block = create_liric_block(context%session)
             merge_block = create_liric_block(context%session)
             if (.not. emit_liric_condbr(context%session, take, update_block, &
-                                        keep_block, error_msg)) return
+                keep_block, error_msg)) return
             if (.not. set_liric_block(context%session, update_block, error_msg)) &
                 return
             context%current_block_id = update_block
             if (.not. emit_ptr_store(context%session, cand_data, best_data_addr, &
-                    error_msg)) return
+                error_msg)) return
             if (.not. emit_i32_store(context%session, cand_idx, best_idx_addr, &
-                    error_msg)) return
+                error_msg)) return
             if (.not. emit_liric_br(context%session, merge_block, error_msg)) &
                 return
             if (.not. set_liric_block(context%session, keep_block, error_msg)) &
@@ -928,8 +931,8 @@
     ! best_idx==0 forces the first eligible element even when its bytes are
     ! equal to the placeholder element used to initialize best_data.
     subroutine locate_is_better_char(context, want_max, cand_data, cand_len, &
-                                     best_data, best_len, best_idx, better, &
-                                     error_msg)
+            best_data, best_len, best_idx, better, &
+            error_msg)
         type(lowering_context_t), intent(inout) :: context
         logical, intent(in) :: want_max
         type(lr_operand_desc_t), intent(in) :: cand_data, cand_len
@@ -940,7 +943,7 @@
         integer(c_int) :: predicate
 
         call char_compare(context, cand_data, cand_len, best_data, best_len, &
-                          cmp, error_msg)
+            cmp, error_msg)
         if (len_trim(error_msg) > 0) return
         if (want_max) then
             predicate = LR_CMP_SGT
@@ -948,20 +951,20 @@
             predicate = LR_CMP_SLT
         end if
         if (.not. emit_liric_i32_icmp(context%session, predicate, cmp, &
-                i32_immediate(context%session, 0_c_int64_t), better, &
-                error_msg)) return
+            i32_immediate(context%session, 0_c_int64_t), better, &
+            error_msg)) return
         if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, best_idx, &
-                i32_immediate(context%session, 0_c_int64_t), unset, error_msg)) &
+            i32_immediate(context%session, 0_c_int64_t), unset, error_msg)) &
             return
         if (.not. emit_i32_binary(context%session, LR_OP_OR, better, unset, &
-                                  combined, error_msg)) return
+            combined, error_msg)) return
         better = combined
         call set_empty(error_msg)
     end subroutine locate_is_better_char
 
     ! better = (best_idx == 0) .or. (want_max ? cand > best_val : cand < best_val)
     subroutine locate_is_better(context, want_max, vk, cand, best_val, best_idx, &
-                                better, error_msg)
+            better, error_msg)
         type(lowering_context_t), intent(inout) :: context
         logical, intent(in) :: want_max
         integer, intent(in) :: vk
@@ -978,7 +981,7 @@
                 predicate = LR_FCMP_OLT
             end if
             if (.not. emit_liric_f32_fcmp(context%session, predicate, cand, &
-                                          best_val, cmp, error_msg)) return
+                best_val, cmp, error_msg)) return
         else if (vk == VALUE_F64) then
             if (want_max) then
                 predicate = LR_FCMP_OGT
@@ -986,7 +989,7 @@
                 predicate = LR_FCMP_OLT
             end if
             if (.not. emit_liric_f64_fcmp(context%session, predicate, cand, &
-                                          best_val, cmp, error_msg)) return
+                best_val, cmp, error_msg)) return
         else
             if (want_max) then
                 predicate = LR_CMP_SGT
@@ -994,14 +997,14 @@
                 predicate = LR_CMP_SLT
             end if
             if (.not. emit_liric_i32_icmp(context%session, predicate, cand, &
-                                          best_val, cmp, error_msg)) return
+                best_val, cmp, error_msg)) return
         end if
 
         ! No element chosen yet (best_idx == 0) forces the candidate in.
         if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, best_idx, &
-                i32_immediate(context%session, 0_c_int64_t), unset, error_msg)) return
+            i32_immediate(context%session, 0_c_int64_t), unset, error_msg)) return
         if (.not. emit_i32_binary(context%session, LR_OP_OR, cmp, unset, better, &
-                                  error_msg)) return
+            error_msg)) return
         call set_empty(error_msg)
     end subroutine locate_is_better
 
@@ -1016,7 +1019,7 @@
         value_node = arg_index
         if (.not. node_exists(arena, arg_index)) return
         select type (n => arena%entries(arg_index)%node)
-        type is (assignment_node)
+            type is (assignment_node)
             if (n%value_index > 0) value_node = n%value_index
         end select
     end function locate_arg_value_node
@@ -1039,21 +1042,21 @@
             return
         end if
         call char_expr_operands(arena, node%arg_indices(1), context, s_data, &
-                                s_len, error_msg)
+            s_len, error_msg)
         if (len_trim(error_msg) > 0) return
         call char_expr_operands(arena, node%arg_indices(2), context, set_data, &
-                                set_len, error_msg)
+            set_len, error_msg)
         if (len_trim(error_msg) > 0) return
 
         if (.not. emit_i32_alloca(context%session, i_addr, error_msg)) return
         if (.not. emit_i32_alloca(context%session, j_addr, error_msg)) return
         if (.not. emit_i32_alloca(context%session, res_addr, error_msg)) return
         if (.not. emit_i32_store(context%session, &
-                i32_immediate(context%session, 0_c_int64_t), i_addr, &
-                error_msg)) return
+            i32_immediate(context%session, 0_c_int64_t), i_addr, &
+            error_msg)) return
         if (.not. emit_i32_store(context%session, &
-                i32_immediate(context%session, 0_c_int64_t), res_addr, &
-                error_msg)) return
+            i32_immediate(context%session, 0_c_int64_t), res_addr, &
+            error_msg)) return
 
         outer_hdr = create_liric_block(context%session)
         outer_body = create_liric_block(context%session)
@@ -1070,16 +1073,16 @@
         context%current_block_id = outer_hdr
         if (.not. emit_i32_load(context%session, i_addr, i_val, error_msg)) return
         if (.not. emit_liric_i32_icmp(context%session, LR_CMP_SLT, i_val, &
-                s_len, cond, error_msg)) return
+            s_len, cond, error_msg)) return
         if (.not. emit_liric_condbr(context%session, cond, outer_body, done, &
-                error_msg)) return
+            error_msg)) return
 
         ! outer_body: reset j=0 and enter inner loop.
         if (.not. set_liric_block(context%session, outer_body, error_msg)) return
         context%current_block_id = outer_body
         if (.not. emit_i32_store(context%session, &
-                i32_immediate(context%session, 0_c_int64_t), j_addr, &
-                error_msg)) return
+            i32_immediate(context%session, 0_c_int64_t), j_addr, &
+            error_msg)) return
         if (.not. emit_liric_br(context%session, inner_hdr, error_msg)) return
 
         ! inner_hdr: if j < set_len, compare; else advance_i.
@@ -1087,29 +1090,29 @@
         context%current_block_id = inner_hdr
         if (.not. emit_i32_load(context%session, j_addr, j_val, error_msg)) return
         if (.not. emit_liric_i32_icmp(context%session, LR_CMP_SLT, j_val, &
-                set_len, cond, error_msg)) return
+            set_len, cond, error_msg)) return
         if (.not. emit_liric_condbr(context%session, cond, inner_body, advance_i, &
-                error_msg)) return
+            error_msg)) return
 
         ! inner_body: if s[i] == set[j] goto matched else advance_j.
         if (.not. set_liric_block(context%session, inner_body, error_msg)) return
         context%current_block_id = inner_body
         if (.not. emit_i32_load(context%session, i_addr, i_val, error_msg)) return
         if (.not. emit_liric_char_byte_zext(context%session, s_data, i_val, sb, &
-                error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_char_byte_zext(context%session, set_data, j_val, &
-                tb, error_msg)) return
+            tb, error_msg)) return
         if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, sb, tb, cond, &
-                error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_condbr(context%session, cond, matched, advance_j, &
-                error_msg)) return
+            error_msg)) return
 
         ! matched: result = i + 1; goto done.
         if (.not. set_liric_block(context%session, matched, error_msg)) return
         context%current_block_id = matched
         if (.not. emit_i32_load(context%session, i_addr, i_val, error_msg)) return
         if (.not. emit_i32_binary(context%session, LR_OP_ADD, i_val, &
-                i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
+            i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
             return
         if (.not. emit_i32_store(context%session, tmp, res_addr, error_msg)) return
         if (.not. emit_liric_br(context%session, done, error_msg)) return
@@ -1118,7 +1121,7 @@
         if (.not. set_liric_block(context%session, advance_j, error_msg)) return
         context%current_block_id = advance_j
         if (.not. emit_i32_binary(context%session, LR_OP_ADD, j_val, &
-                i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
+            i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
             return
         if (.not. emit_i32_store(context%session, tmp, j_addr, error_msg)) return
         if (.not. emit_liric_br(context%session, inner_hdr, error_msg)) return
@@ -1128,7 +1131,7 @@
         context%current_block_id = advance_i
         if (.not. emit_i32_load(context%session, i_addr, i_val, error_msg)) return
         if (.not. emit_i32_binary(context%session, LR_OP_ADD, i_val, &
-                i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
+            i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
             return
         if (.not. emit_i32_store(context%session, tmp, i_addr, error_msg)) return
         if (.not. emit_liric_br(context%session, outer_hdr, error_msg)) return
@@ -1161,10 +1164,10 @@
             return
         end if
         call char_expr_operands(arena, node%arg_indices(1), context, s_data, &
-                                s_len, error_msg)
+            s_len, error_msg)
         if (len_trim(error_msg) > 0) return
         call char_expr_operands(arena, node%arg_indices(2), context, set_data, &
-                                set_len, error_msg)
+            set_len, error_msg)
         if (len_trim(error_msg) > 0) return
 
         if (.not. emit_i32_alloca(context%session, i_addr, error_msg)) return
@@ -1172,11 +1175,11 @@
         if (.not. emit_i32_alloca(context%session, res_addr, error_msg)) return
         if (.not. emit_i32_alloca(context%session, found_addr, error_msg)) return
         if (.not. emit_i32_store(context%session, &
-                i32_immediate(context%session, 0_c_int64_t), i_addr, &
-                error_msg)) return
+            i32_immediate(context%session, 0_c_int64_t), i_addr, &
+            error_msg)) return
         if (.not. emit_i32_store(context%session, &
-                i32_immediate(context%session, 0_c_int64_t), res_addr, &
-                error_msg)) return
+            i32_immediate(context%session, 0_c_int64_t), res_addr, &
+            error_msg)) return
 
         outer_hdr = create_liric_block(context%session)
         outer_body = create_liric_block(context%session)
@@ -1195,19 +1198,19 @@
         context%current_block_id = outer_hdr
         if (.not. emit_i32_load(context%session, i_addr, i_val, error_msg)) return
         if (.not. emit_liric_i32_icmp(context%session, LR_CMP_SLT, i_val, &
-                s_len, cond, error_msg)) return
+            s_len, cond, error_msg)) return
         if (.not. emit_liric_condbr(context%session, cond, outer_body, done, &
-                error_msg)) return
+            error_msg)) return
 
         ! outer_body: found=0; j=0; enter inner loop.
         if (.not. set_liric_block(context%session, outer_body, error_msg)) return
         context%current_block_id = outer_body
         if (.not. emit_i32_store(context%session, &
-                i32_immediate(context%session, 0_c_int64_t), found_addr, &
-                error_msg)) return
+            i32_immediate(context%session, 0_c_int64_t), found_addr, &
+            error_msg)) return
         if (.not. emit_i32_store(context%session, &
-                i32_immediate(context%session, 0_c_int64_t), j_addr, &
-                error_msg)) return
+            i32_immediate(context%session, 0_c_int64_t), j_addr, &
+            error_msg)) return
         if (.not. emit_liric_br(context%session, inner_hdr, error_msg)) return
 
         ! inner_hdr: if j < set_len, compare; else check_found.
@@ -1215,36 +1218,36 @@
         context%current_block_id = inner_hdr
         if (.not. emit_i32_load(context%session, j_addr, j_val, error_msg)) return
         if (.not. emit_liric_i32_icmp(context%session, LR_CMP_SLT, j_val, &
-                set_len, cond, error_msg)) return
+            set_len, cond, error_msg)) return
         if (.not. emit_liric_condbr(context%session, cond, inner_body, check_found, &
-                error_msg)) return
+            error_msg)) return
 
         ! inner_body: if s[i] == set[j] goto set_found else advance_j.
         if (.not. set_liric_block(context%session, inner_body, error_msg)) return
         context%current_block_id = inner_body
         if (.not. emit_i32_load(context%session, i_addr, i_val, error_msg)) return
         if (.not. emit_liric_char_byte_zext(context%session, s_data, i_val, sb, &
-                error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_char_byte_zext(context%session, set_data, j_val, &
-                tb, error_msg)) return
+            tb, error_msg)) return
         if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, sb, tb, cond, &
-                error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_condbr(context%session, cond, set_found, advance_j, &
-                error_msg)) return
+            error_msg)) return
 
         ! set_found: found=1; skip remainder of inner loop.
         if (.not. set_liric_block(context%session, set_found, error_msg)) return
         context%current_block_id = set_found
         if (.not. emit_i32_store(context%session, &
-                i32_immediate(context%session, 1_c_int64_t), found_addr, &
-                error_msg)) return
+            i32_immediate(context%session, 1_c_int64_t), found_addr, &
+            error_msg)) return
         if (.not. emit_liric_br(context%session, check_found, error_msg)) return
 
         ! advance_j: j = j + 1; continue inner loop.
         if (.not. set_liric_block(context%session, advance_j, error_msg)) return
         context%current_block_id = advance_j
         if (.not. emit_i32_binary(context%session, LR_OP_ADD, j_val, &
-                i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
+            i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
             return
         if (.not. emit_i32_store(context%session, tmp, j_addr, error_msg)) return
         if (.not. emit_liric_br(context%session, inner_hdr, error_msg)) return
@@ -1253,19 +1256,19 @@
         if (.not. set_liric_block(context%session, check_found, error_msg)) return
         context%current_block_id = check_found
         if (.not. emit_i32_load(context%session, found_addr, found_val, &
-                error_msg)) return
+            error_msg)) return
         if (.not. emit_liric_i32_icmp(context%session, LR_CMP_EQ, found_val, &
-                i32_immediate(context%session, 0_c_int64_t), cond, error_msg)) &
+            i32_immediate(context%session, 0_c_int64_t), cond, error_msg)) &
             return
         if (.not. emit_liric_condbr(context%session, cond, store_result, &
-                advance_i, error_msg)) return
+            advance_i, error_msg)) return
 
         ! store_result: result = i + 1; goto done.
         if (.not. set_liric_block(context%session, store_result, error_msg)) return
         context%current_block_id = store_result
         if (.not. emit_i32_load(context%session, i_addr, i_val, error_msg)) return
         if (.not. emit_i32_binary(context%session, LR_OP_ADD, i_val, &
-                i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
+            i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
             return
         if (.not. emit_i32_store(context%session, tmp, res_addr, error_msg)) return
         if (.not. emit_liric_br(context%session, done, error_msg)) return
@@ -1275,7 +1278,7 @@
         context%current_block_id = advance_i
         if (.not. emit_i32_load(context%session, i_addr, i_val, error_msg)) return
         if (.not. emit_i32_binary(context%session, LR_OP_ADD, i_val, &
-                i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
+            i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
             return
         if (.not. emit_i32_store(context%session, tmp, i_addr, error_msg)) return
         if (.not. emit_liric_br(context%session, outer_hdr, error_msg)) return
@@ -1291,7 +1294,7 @@
 
     ! repeat(s, n): character result of s repeated n times.
     subroutine lower_repeat_deferred(arena, node, context, out_data, out_length, &
-                                     error_msg)
+            error_msg)
         type(ast_arena_t), intent(in) :: arena
         type(call_or_subscript_node), intent(in) :: node
         type(lowering_context_t), intent(inout) :: context
@@ -1309,32 +1312,32 @@
             return
         end if
         call char_expr_operands(arena, node%arg_indices(1), context, s_data, &
-                                s_len, error_msg)
+            s_len, error_msg)
         if (len_trim(error_msg) > 0) return
         call lower_i32_expression(arena, node%arg_indices(2), context, n_val, &
-                                  error_msg)
+            error_msg)
         if (len_trim(error_msg) > 0) return
 
         ! total_len = s_len * n_val; allocate buf[total_len + 1].
         if (.not. emit_i32_binary(context%session, LR_OP_MUL, s_len, n_val, &
-                total_len, error_msg)) return
+            total_len, error_msg)) return
         if (.not. emit_liric_i32_to_i64(context%session, total_len, total_len64, &
-                error_msg)) return
+            error_msg)) return
         if (context%in_internal_function) then
             if (.not. emit_malloc(context%session, &
-                    emit_or_add1(context, total_len64), buf, error_msg)) return
+                emit_or_add1(context, total_len64), buf, error_msg)) return
         else
             if (.not. emit_alloca_bytes(context%session, &
-                    emit_or_add1(context, total_len64), buf, error_msg)) return
+                emit_or_add1(context, total_len64), buf, error_msg)) return
         end if
 
         if (.not. emit_liric_i32_to_i64(context%session, s_len, s_len64, &
-                error_msg)) return
+            error_msg)) return
 
         if (.not. emit_i32_alloca(context%session, i_addr, error_msg)) return
         if (.not. emit_i32_store(context%session, &
-                i32_immediate(context%session, 0_c_int64_t), i_addr, &
-                error_msg)) return
+            i32_immediate(context%session, 0_c_int64_t), i_addr, &
+            error_msg)) return
 
         hdr = create_liric_block(context%session)
         body = create_liric_block(context%session)
@@ -1346,23 +1349,23 @@
         context%current_block_id = hdr
         if (.not. emit_i32_load(context%session, i_addr, i_val, error_msg)) return
         if (.not. emit_liric_i32_icmp(context%session, LR_CMP_SLT, i_val, n_val, &
-                cond, error_msg)) return
+            cond, error_msg)) return
         if (.not. emit_liric_condbr(context%session, cond, body, done, &
-                error_msg)) return
+            error_msg)) return
 
         ! body: dst = buf + i*s_len; memcpy(dst, s_data, s_len); i++.
         if (.not. set_liric_block(context%session, body, error_msg)) return
         context%current_block_id = body
         if (.not. emit_i32_binary(context%session, LR_OP_MUL, i_val, s_len, &
-                off_i32, error_msg)) return
+            off_i32, error_msg)) return
         if (.not. emit_liric_i32_to_i64(context%session, off_i32, off64, &
-                error_msg)) return
+            error_msg)) return
         if (.not. emit_i64_binary(context%session, LR_OP_ADD, buf, off64, &
-                dst, error_msg)) return
+            dst, error_msg)) return
         if (.not. emit_memcpy(context%session, dst, s_data, s_len64, &
-                error_msg)) return
+            error_msg)) return
         if (.not. emit_i32_binary(context%session, LR_OP_ADD, i_val, &
-                i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
+            i32_immediate(context%session, 1_c_int64_t), tmp, error_msg)) &
             return
         if (.not. emit_i32_store(context%session, tmp, i_addr, error_msg)) return
         if (.not. emit_liric_br(context%session, hdr, error_msg)) return
@@ -1372,10 +1375,10 @@
         context%current_block_id = done
         context%current_block_terminated = .false.
         if (.not. emit_i64_binary(context%session, LR_OP_ADD, buf, total_len64, &
-                null_pos, error_msg)) return
+            null_pos, error_msg)) return
         if (.not. emit_liric_store_char_byte(context%session, null_pos, &
-                i32_immediate(context%session, 0_c_int64_t), &
-                i32_immediate(context%session, 0_c_int64_t), error_msg)) return
+            i32_immediate(context%session, 0_c_int64_t), &
+            i32_immediate(context%session, 0_c_int64_t), error_msg)) return
 
         out_data = buf
         out_length = total_len
@@ -1383,7 +1386,7 @@
     end subroutine lower_repeat_deferred
 
     subroutine check_real_conversion_args(arena, node, context, wide_kind, &
-                                          argument_index, kind_index, error_msg)
+            argument_index, kind_index, error_msg)
         !! Shared argument check for AINT(A [,KIND]) and ANINT(A [,KIND]).
         !! A must be real, and a foldable KIND must name a supported real kind.
         !! wide_kind reports whether the KIND selector requests real(8).
@@ -1400,7 +1403,7 @@
         wide_kind = .false.
         if (.not. require_intrinsic_arg_count(node, 1, 2, error_msg)) return
         call intrinsic_real_conversion_args(arena, node, argument_index, &
-                                            kind_index)
+            kind_index)
         if (argument_index <= 0) then
             error_msg = trim(node%name)//' requires a value argument'
             return
@@ -1417,7 +1420,7 @@
 
         if (kind_index <= 0) return
         call parse_i32_constant(arena, kind_index, kind_value, &
-                                'real kind', kind_error)
+            'real kind', kind_error)
         if (len_trim(kind_error) > 0) then
             ! An unfoldable selector keeps the conservative wide result.
             wide_kind = .true.
@@ -1434,7 +1437,7 @@
     end subroutine check_real_conversion_args
 
     subroutine lower_f32_real_conversion(arena, node, libm_name, context, &
-                                         value, error_msg)
+            value, error_msg)
         !! AINT/ANINT with a real(4) result. The argument is converted to the
         !! result kind first and then truncated or rounded there, matching the
         !! gfortran reference output for AINT(A, 4) on a real(8) argument.
@@ -1449,18 +1452,18 @@
         integer :: argument_index, kind_index
 
         call check_real_conversion_args(arena, node, context, wide_kind, &
-                                        argument_index, kind_index, error_msg)
+            argument_index, kind_index, error_msg)
         if (len_trim(error_msg) > 0) return
 
         call lower_f32_intrinsic_arg(arena, argument_index, context, &
-                                     args(1), error_msg)
+            args(1), error_msg)
         if (len_trim(error_msg) > 0) return
         if (.not. emit_liric_f32_call(context%session, libm_name, args, value, &
-                                      error_msg)) return
+            error_msg)) return
     end subroutine lower_f32_real_conversion
 
     subroutine lower_f64_real_conversion(arena, node, libm_name, context, &
-                                         value, error_msg)
+            value, error_msg)
         !! AINT/ANINT with a real(8) result. Widening a real(4) argument first
         !! is exact, so the f64 libm call alone gives the standard result.
         type(ast_arena_t), intent(in) :: arena
@@ -1474,12 +1477,13 @@
         integer :: argument_index, kind_index
 
         call check_real_conversion_args(arena, node, context, wide_kind, &
-                                        argument_index, kind_index, error_msg)
+            argument_index, kind_index, error_msg)
         if (len_trim(error_msg) > 0) return
 
         call lower_f64_intrinsic_arg(arena, argument_index, context, &
-                                     args(1), error_msg)
+            args(1), error_msg)
         if (len_trim(error_msg) > 0) return
         if (.not. emit_liric_f64_call(context%session, libm_name, args, value, &
-                                      error_msg)) return
+            error_msg)) return
     end subroutine lower_f64_real_conversion
+end submodule session_program_lowering_intrinsics_extra

--- a/test/test_session_intrinsics_extra_compiler.f90
+++ b/test/test_session_intrinsics_extra_compiler.f90
@@ -1,0 +1,88 @@
+program test_session_intrinsics_extra_compiler
+    use fortfront, only: compile_frontend_from_string, &
+        compiler_frontend_options_t, compiler_frontend_result_t
+    use session_program_lowering, only: lower_program_to_liric_exe
+    implicit none
+
+    character(len=*), parameter :: source = &
+        'program main'//new_line('a')// &
+        '  integer :: a(4) = [3, 1, 4, 2]'//new_line('a')// &
+        '  logical :: m(4) = [.false., .true., .true., .false.]'//new_line('a')// &
+        '  character(len=4) :: s'//new_line('a')// &
+        '  s = repeat("ab", 2)'//new_line('a')// &
+        '  print *, lbound(a, 1)'//new_line('a')// &
+        '  print *, ubound(a, 1)'//new_line('a')// &
+        '  print *, count(m)'//new_line('a')// &
+        '  print *, minloc(a, dim=1), maxloc(a, dim=1, mask=m)'//new_line('a')// &
+        '  print *, scan("abcde", "dx"), verify("abc", "abc")'//new_line('a')// &
+        '  print *, s'//new_line('a')// &
+        'end program main'
+
+    print *, '=== intrinsic-extra gfortran differential test ==='
+    if (.not. matches_gfortran(source)) stop 1
+    print *, 'PASS: intrinsic-extra lowering matches gfortran'
+
+contains
+
+    logical function matches_gfortran(program_source)
+        character(len=*), intent(in) :: program_source
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: frontend_result
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: base, src, exe, ref
+        character(len=:), allocatable :: ffc_out, ref_out
+        integer :: unit, exit_stat, diff_status
+
+        matches_gfortran = .false.
+        call execute_command_line('mkdir -p /var/tmp/ert')
+        base = '/var/tmp/ert/ffc_intrinsics_extra_differential'
+        src = base//'.f90'
+        exe = base//'.ffc'
+        ref = base//'.gfortran'
+        ffc_out = base//'.ffc.out'
+        ref_out = base//'.gfortran.out'
+
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        call compile_frontend_from_string(program_source, frontend_result, options)
+        if (.not. frontend_result%success()) then
+            print *, 'FAIL: FortFront rejected intrinsic-extra source'
+            print *, trim(frontend_result%diagnostic_text)
+            return
+        end if
+
+        call lower_program_to_liric_exe(frontend_result%arena, &
+            frontend_result%root_index, exe, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: ffc lowering failed: ', trim(error_msg)
+            return
+        end if
+
+        open (newunit=unit, file=src, status='replace', action='write')
+        write (unit, '(A)') program_source
+        close (unit)
+        call execute_command_line('gfortran -w '//src//' -o '//ref, &
+            exitstat=exit_stat)
+        if (exit_stat /= 0) then
+            print *, 'FAIL: gfortran rejected intrinsic-extra source'
+            return
+        end if
+
+        call execute_command_line(exe//' > '//ffc_out//' 2>&1', &
+            exitstat=exit_stat)
+        call execute_command_line(ref//' > '//ref_out//' 2>&1', &
+            exitstat=exit_stat)
+        call execute_command_line('diff '//ffc_out//' '//ref_out// &
+            ' > /dev/null 2>&1', exitstat=diff_status)
+        if (diff_status /= 0) then
+            print *, 'FAIL: ffc intrinsic-extra output differs from gfortran'
+            call execute_command_line('diff '//ffc_out//' '//ref_out)
+            return
+        end if
+
+        call execute_command_line('rm -f '//src//' '//exe//' '//ref//' '// &
+            ffc_out//' '//ref_out)
+        matches_gfortran = .true.
+    end function matches_gfortran
+
+end program test_session_intrinsics_extra_compiler


### PR DESCRIPTION
## Summary
- move `session_program_lowering_intrinsics_extra.inc` into a proper typed submodule with explicit ancestor contracts
- export cross-include helpers needed by cold submodule links and remove the production include
- add an intrinsic-extra differential test comparing ffc output byte-for-byte with gfortran

## Verification
- `fo clean && fo build` — PASS (455/455)
- `fo test test_session_intrinsics_extra_compiler` — PASS; independent gfortran differential
- `fo test test_session_integer_intrinsic_compiler` — PASS
- `fo test test_session_character_locate_compiler` — PASS
- `fo test test_session_array_intrinsics_cluster_compiler` — PASS
- `fo fmt --check src/session_program_lowering_intrinsics_extra.f90 test/test_session_intrinsics_extra_compiler.f90` — PASS
- `fo check` reached 365/365 but reports the repository's existing 23 unrelated failures; no intrinsic-extra focused failure was observed.

Rebased onto `origin/main` 76c5ae9 before commit.
