### PR TITLE
refactor: extract array reduction expression lowering

### DIFF
--- a/src/session_program_lowering.f90
+++ b/src/session_program_lowering.f90
@@ -552,6 +552,15 @@ module session_program_lowering_impl
     public :: resolve_comparison_mask, try_alloc_component_mask_reduction
     public :: parse_i32_literal, prepare_reference_args
     public :: reject_monomorphized_call, set_empty
+    ! Reduction-expression submodule calls these host lowering helpers.  Keep
+    ! them externally linkable on GCC 14, where private ancestor procedures can
+    ! otherwise receive local linkage in a cold submodule build.
+    public :: alloc_array_result_info, alloc_array_result_static_size
+    public :: allocatable_descriptor_extent_i32, emit_allocatable_element_load
+    public :: enter_liric_block, load_array_element_at_operand
+    public :: lower_array_section_element_from_info
+    public :: real_opcode, reduction_combine, reduction_identity
+    public :: reduction_is_mask_valued, reduction_operation
     public :: unsupported_array_subscript, unsupported_intrinsic_error
     public :: unsupported_feature_error
 
@@ -4310,6 +4319,185 @@ module session_program_lowering_impl
             character(len=:), allocatable, intent(out) :: error_msg
         end subroutine lower_elementwise_minmax_call
     end interface
+    ! General array-expression reductions and NORM2 are implemented in their
+    ! own typed descendant.  Keep every procedure contract explicit so cold
+    ! submodule builds do not rely on textual include host association.
+    interface
+        recursive module function reduction_arg_extent(arena, node_index, context, &
+                                                       vk, extent) result(ok)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            type(lowering_context_t), intent(in) :: context
+            integer, intent(in) :: vk
+            integer, intent(out) :: extent
+            logical :: ok
+        end function reduction_arg_extent
+        recursive module function reduction_expression_has_kind(arena, node_index, &
+                                                                 context, vk) result(has)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            type(lowering_context_t), intent(in) :: context
+            integer, intent(in) :: vk
+            logical :: has
+        end function reduction_expression_has_kind
+        module function reduction_expression_is_abs_call(arena, node_index) &
+                result(is_abs)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            logical :: is_abs
+        end function reduction_expression_is_abs_call
+        recursive module function reduction_expression_extent_operand(arena, &
+                node_index, context, extent, error_msg) result(has_array)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: extent
+            character(len=:), allocatable, intent(out) :: error_msg
+            logical :: has_array
+        end function reduction_expression_extent_operand
+        recursive module subroutine lower_runtime_reduction_arg_element(arena, &
+                node_index, linear_index, vk, context, value, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            type(lr_operand_desc_t), intent(in) :: linear_index
+            integer, intent(in) :: vk
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_runtime_reduction_arg_element
+        module subroutine lower_runtime_general_expr_reduction(arena, arg_index, &
+                vk, context, value, error_msg, reduction_name)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: arg_index, vk
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+            character(len=*), intent(in) :: reduction_name
+        end subroutine lower_runtime_general_expr_reduction
+        recursive module subroutine lower_reduction_arg_element(arena, node_index, &
+                linear_index, vk, context, value, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            integer(c_int64_t), intent(in) :: linear_index
+            integer, intent(in) :: vk
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_reduction_arg_element
+        module subroutine lower_reduction_scalar(arena, node_index, vk, context, &
+                                                 value, error_msg)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            integer, intent(in) :: vk
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_reduction_scalar
+        module subroutine lower_general_expr_reduction(arena, arg_index, extent, &
+                vk, context, value, error_msg, reduction_name)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: arg_index
+            integer, intent(in) :: extent
+            integer, intent(in) :: vk
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+            character(len=*), intent(in) :: reduction_name
+        end subroutine lower_general_expr_reduction
+        module subroutine alloc_array_result_kind(arena, context, name, elem_kind, &
+                                                   rank, ok)
+            type(ast_arena_t), intent(in) :: arena
+            type(lowering_context_t), intent(in) :: context
+            character(len=*), intent(in) :: name
+            integer, intent(out) :: elem_kind
+            integer, intent(out) :: rank
+            logical, intent(out) :: ok
+        end subroutine alloc_array_result_kind
+        module subroutine alloc_array_result_call_info(arena, value_index, context, &
+                                                        elem_kind, rank, ok)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: value_index
+            type(lowering_context_t), intent(in) :: context
+            integer, intent(out) :: elem_kind
+            integer, intent(out) :: rank
+            logical, intent(out) :: ok
+        end subroutine alloc_array_result_call_info
+        module subroutine lower_alloc_call_reduction(arena, node, context, value, &
+                                                      error_msg, reduction_name)
+            type(ast_arena_t), intent(in) :: arena
+            type(call_or_subscript_node), intent(in) :: node
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+            character(len=*), intent(in) :: reduction_name
+        end subroutine lower_alloc_call_reduction
+        module subroutine norm2_real_immediate(context, vk, val, value)
+            type(lowering_context_t), intent(inout) :: context
+            integer, intent(in) :: vk
+            real(c_double), intent(in) :: val
+            type(lr_operand_desc_t), intent(out) :: value
+        end subroutine norm2_real_immediate
+        module function norm2_binary(context, vk, op, lhs, rhs, value, error_msg)
+            type(lowering_context_t), intent(inout) :: context
+            integer, intent(in) :: vk
+            integer(c_int), intent(in) :: op
+            type(lr_operand_desc_t), intent(in) :: lhs
+            type(lr_operand_desc_t), intent(in) :: rhs
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+            logical :: norm2_binary
+        end function norm2_binary
+        module function norm2_libm(context, vk, name32, name64, arg, value, error_msg)
+            type(lowering_context_t), intent(inout) :: context
+            integer, intent(in) :: vk
+            character(len=*), intent(in) :: name32
+            character(len=*), intent(in) :: name64
+            type(lr_operand_desc_t), intent(in) :: arg
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+            logical :: norm2_libm
+        end function norm2_libm
+        module function norm2_fcmp(context, vk, predicate, lhs, rhs, value, error_msg)
+            type(lowering_context_t), intent(inout) :: context
+            integer, intent(in) :: vk
+            integer(c_int), intent(in) :: predicate
+            type(lr_operand_desc_t), intent(in) :: lhs
+            type(lr_operand_desc_t), intent(in) :: rhs
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+            logical :: norm2_fcmp
+        end function norm2_fcmp
+        module subroutine norm2_scale_factor(context, vk, elems, scale, error_msg)
+            type(lowering_context_t), intent(inout) :: context
+            integer, intent(in) :: vk
+            type(lr_operand_desc_t), intent(in) :: elems(:)
+            type(lr_operand_desc_t), intent(out) :: scale
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine norm2_scale_factor
+        module subroutine emit_norm2_from_elements(context, vk, elems, value, &
+                                                    error_msg)
+            type(lowering_context_t), intent(inout) :: context
+            integer, intent(in) :: vk
+            type(lr_operand_desc_t), intent(in) :: elems(:)
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine emit_norm2_from_elements
+        module subroutine lower_symbol_norm2(context, source_index, array_size, &
+                                             value, error_msg)
+            type(lowering_context_t), intent(inout) :: context
+            integer, intent(in) :: source_index
+            integer, intent(in) :: array_size
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_symbol_norm2
+        module subroutine lower_section_norm2(info, total, context, value, error_msg)
+            type(array_section_info_t), intent(in) :: info
+            integer(c_int64_t), intent(in) :: total
+            type(lowering_context_t), intent(inout) :: context
+            type(lr_operand_desc_t), intent(out) :: value
+            character(len=:), allocatable, intent(out) :: error_msg
+        end subroutine lower_section_norm2
+    end interface
 contains
     include 'session_program_lowering_top.inc'
     subroutine lower_declaration(node_in, node_index, context, error_msg)
@@ -5094,7 +5282,6 @@ contains
     include 'session_program_lowering_allocatable.inc'
     include 'session_program_lowering_runtime_alloc.inc'
     include 'session_program_lowering_alloc_array_result.inc'
-    include 'session_program_lowering_reduction_expr.inc'
     include 'session_program_lowering_io_implied_do.inc'
     include 'session_program_lowering_scalar_allocatable.inc'
     include 'session_program_lowering_internal_write.inc'

--- a/src/session_program_lowering_reduction_expr.f90
+++ b/src/session_program_lowering_reduction_expr.f90
@@ -1,3 +1,7 @@
+submodule (session_program_lowering_impl) session_program_lowering_reduction_expr
+    implicit none
+contains
+
     ! sum() (and friends) over a general array-valued expression argument:
     ! a binary-op combination of arrays/sections (sum(a + b), sum(a(1:3) +
     ! b(1:3))), or a bare call to a contained function that returns an
@@ -952,3 +956,5 @@
                                       context%symbols(info%source_index)%value_kind, &
                                       elems, value, error_msg)
     end subroutine lower_section_norm2
+
+end submodule session_program_lowering_reduction_expr

--- a/test/test_session_reduction_expr_oracle_compiler.f90
+++ b/test/test_session_reduction_expr_oracle_compiler.f90
@@ -1,0 +1,92 @@
+program test_session_reduction_expr_oracle_compiler
+    ! Differential oracle for an allocatable-array function result used as a
+    ! reduction argument.  The function mutates host state, so evaluating the
+    ! reduction expression more than once changes the observable result.
+    use ffc_test_support, only: compile_to_exe
+    implicit none
+
+    character(len=*), parameter :: source = &
+        'program main'//new_line('a')// &
+        '  implicit none'//new_line('a')// &
+        '  integer :: calls, total'//new_line('a')// &
+        '  calls = 0'//new_line('a')// &
+        '  total = sum(make())'//new_line('a')// &
+        '  print *, calls, total'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function make() result(v)'//new_line('a')// &
+        '    integer, allocatable :: v(:)'//new_line('a')// &
+        '    calls = calls + 1'//new_line('a')// &
+        '    allocate(v(3))'//new_line('a')// &
+        '    v = [1, 2, 3]'//new_line('a')// &
+        '  end function make'//new_line('a')// &
+        'end program main'
+
+    print *, '=== reduction expression gfortran oracle test ==='
+    if (.not. matches_gfortran(source)) stop 1
+    print *, 'PASS: allocatable reduction argument evaluates exactly once'
+
+contains
+
+    logical function matches_gfortran(program_source)
+        character(len=*), intent(in) :: program_source
+        character(len=:), allocatable :: error_msg, source_path, ffc_exe
+        character(len=:), allocatable :: gfortran_exe, ffc_out, gfortran_out
+        integer :: unit, ffc_status, gfortran_status, command_status
+
+        matches_gfortran = .false.
+        source_path = '/tmp/ffc_reduction_expr_oracle.f90'
+        ffc_exe = '/tmp/ffc_reduction_expr_oracle.ffc'
+        gfortran_exe = '/tmp/ffc_reduction_expr_oracle.gfortran'
+        ffc_out = '/tmp/ffc_reduction_expr_oracle.ffc.out'
+        gfortran_out = '/tmp/ffc_reduction_expr_oracle.gfortran.out'
+
+        call compile_to_exe(program_source, ffc_exe, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: ffc lowering failed: ', trim(error_msg)
+            call cleanup()
+            return
+        end if
+
+        open (newunit=unit, file=source_path, status='replace', action='write')
+        write (unit, '(A)') program_source
+        close (unit)
+        call execute_command_line('gfortran -w '//source_path//' -o '// &
+            gfortran_exe, exitstat=gfortran_status, &
+            cmdstat=command_status)
+        if (command_status /= 0 .or. gfortran_status /= 0) then
+            print *, 'FAIL: gfortran rejected the regression source'
+            call cleanup()
+            return
+        end if
+
+        call execute_command_line('timeout 5s '//ffc_exe//' > '//ffc_out, &
+            exitstat=ffc_status, cmdstat=command_status)
+        if (command_status /= 0 .or. ffc_status /= 0) then
+            print *, 'FAIL: ffc regression executable could not run'
+            call cleanup()
+            return
+        end if
+        call execute_command_line('timeout 5s '//gfortran_exe//' > '// &
+            gfortran_out, exitstat=gfortran_status, &
+            cmdstat=command_status)
+        if (command_status /= 0 .or. gfortran_status /= 0) then
+            print *, 'FAIL: gfortran regression executable could not run'
+            call cleanup()
+            return
+        end if
+        call execute_command_line('diff -u '//gfortran_out//' '//ffc_out, &
+            exitstat=command_status)
+        if (command_status /= 0) then
+            print *, 'FAIL: ffc output differs from gfortran'
+            call cleanup()
+            return
+        end if
+        call cleanup()
+        matches_gfortran = .true.
+    end function matches_gfortran
+
+    subroutine cleanup()
+        call execute_command_line('rm -f /tmp/ffc_reduction_expr_oracle.*')
+    end subroutine cleanup
+
+end program test_session_reduction_expr_oracle_compiler


### PR DESCRIPTION
## Summary
- move `session_program_lowering_reduction_expr.inc` into a dedicated typed submodule
- add explicit ancestor interfaces and GCC14 cold-link exports for reduction helpers
- add a gfortran differential oracle proving allocatable reduction arguments evaluate exactly once

## Verification
- `fo clean && fo build` — 455/455
- `fo test test_session_array_expr_reduction_compiler` — PASS
- `fo test test_session_sum_expr_compiler` — PASS
- `fo test test_session_norm2_compiler` — PASS
- `fo test test_session_reduction_expr_oracle_compiler` — PASS (ffc/gfortran output diff)
- `fo test test_runtime_link_compiler` — PASS
- `fo test test_session_separate_compilation_compiler` — PASS

This is a code/tests-only PR; aggregate corpus status is unchanged and not claimed green.
